### PR TITLE
Helper methods for resource loading

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -18,6 +18,7 @@ package org.assertj.core.api;
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.util.Date;
@@ -950,6 +951,91 @@ public class Assertions {
    */
   public static List<String> linesOf(File file, String charsetName) {
     return Files.linesOf(file, charsetName);
+  }
+
+  // --------------------------------------------------------------------------------------------------
+  // URL/Resource methods : not assertions but here to have a single entry point to all AssertJ features.
+  // --------------------------------------------------------------------------------------------------
+
+  /**
+   * Loads the text content of a URL, so that it can be passed to {@link #assertThat(String)}. <p> Note that this will
+   * load the entire file in memory. </p>
+   *
+   * @param url the URL.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException       if an I/O exception occurs.
+   */
+  public static String contentOf(URL url, Charset charset) {
+    return Files.contentOf(url, charset);
+  }
+
+  /**
+   * Loads the text content of a URL, so that it can be passed to {@link #assertThat(String)}. <p> Note that this will
+   * load the entire file in memory. </p>
+   *
+   * @param url the URL.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws IllegalArgumentException if the given character set is not supported on this platform.
+   * @throws FilesException           if an I/O exception occurs.
+   */
+  public static String contentOf(URL url, String charsetName) {
+    return Files.contentOf(url, charsetName);
+  }
+
+  /**
+   * Loads the text content of a URL with the default character set, so that it can be passed to {@link
+   * #assertThat(String)}. <p> Note that this will load the entire file in memory; for larger files. </p>
+   *
+   * @param url the URL.
+   * @return the content of the file.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static String contentOf(URL url) {
+    return Files.contentOf(url, Charset.defaultCharset());
+  }
+
+  /**
+   * Loads the text content of a URL into a list of strings with the default charset, each string corresponding to a line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param url the URL.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(URL url) {
+    return Files.linesOf(url, Charset.defaultCharset());
+  }
+
+  /**
+   * Loads the text content of a URL into a list of strings, each string corresponding to a line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param url the URL.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(URL url, Charset charset) {
+    return Files.linesOf(url, charset);
+  }
+
+  /**
+   * Loads the text content of a URL into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param url the URL.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(URL url, String charsetName) {
+    return Files.linesOf(url, charsetName);
   }
 
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -367,7 +367,28 @@ public class Files {
   /**
    * Loads the text content of a file into a list of strings, each string corresponding to a line. The line endings are
    * either \n, \r or \r\n.
-   * 
+   *
+   * @param url the URL.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(URL url, Charset charset) {
+    if (charset == null) {
+      throw new NullPointerException("The charset should not be null");
+    }
+    try {
+      return loadLines(url.openStream(), charset);
+    } catch (IOException e) {
+      throw new FilesException("Unable to read " + url, e);
+    }
+  }
+
+  /**
+   * Loads the text content of a file into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
    * @param file the file.
    * @param charsetName the name of the character set to use.
    * @return the content of the file.
@@ -379,6 +400,23 @@ public class Files {
       throw new IllegalArgumentException(String.format("Charset:<'%s'> is not supported on this system", charsetName));
     }
     return linesOf(file, Charset.forName(charsetName));
+  }
+
+  /**
+   * Loads the text content of a file into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   * 
+   * @param url the URL.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(URL url, String charsetName) {
+    if (!Charset.isSupported(charsetName)) {
+      throw new IllegalArgumentException(String.format("Charset:<'%s'> is not supported on this system", charsetName));
+    }
+    return linesOf(url, Charset.forName(charsetName));
   }
 
   private static List<String> loadLines(File file, Charset charset) throws IOException {

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -279,10 +279,9 @@ public class Files {
   }
 
   private static String loadContents(File file, Charset charset) throws IOException {
-    BufferedReader reader = null;
+    BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
     boolean threw = true;
     try {
-      reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
       StringWriter writer = new StringWriter();
       int c;
       while ((c = reader.read()) != -1) {
@@ -291,13 +290,11 @@ public class Files {
       threw = false;
       return writer.toString();
     } finally {
-      if (reader != null) {
-        try {
-          reader.close();
-        } catch (IOException e) {
-          if (!threw) {
-            throw e; // if there was an initial exception, don't hide it
-          }
+      try {
+        reader.close();
+      } catch (IOException e) {
+        if (!threw) {
+          throw e; // if there was an initial exception, don't hide it
         }
       }
     }
@@ -342,11 +339,10 @@ public class Files {
   }
 
   private static List<String> loadLines(File file, Charset charset) throws IOException {
-    BufferedReader reader = null;
+    BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
+
     boolean threw = true;
     try {
-      reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
-
       List<String> strings = Lists.newArrayList();
 
       String line = reader.readLine();
@@ -357,18 +353,16 @@ public class Files {
 
       threw = false;
       return strings;
+
     } finally {
-      if (reader != null) {
-        try {
-          reader.close();
-        } catch (IOException e) {
-          if (!threw) {
-            throw e; // if there was an initial exception, don't hide it
-          }
+      try {
+        reader.close();
+      } catch (IOException e) {
+        if (!threw) {
+          throw e; // if there was an initial exception, don't hide it
         }
       }
     }
-
   }
 
   private Files() {

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -25,6 +25,7 @@ import static org.assertj.core.util.Strings.quote;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
@@ -279,7 +280,11 @@ public class Files {
   }
 
   private static String loadContents(File file, Charset charset) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
+    return loadContents(new FileInputStream(file), charset);
+  }
+
+  private static String loadContents(InputStream stream, Charset charset) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(stream, charset));
     boolean threw = true;
     try {
       StringWriter writer = new StringWriter();
@@ -339,7 +344,11 @@ public class Files {
   }
 
   private static List<String> loadLines(File file, Charset charset) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset));
+    return loadLines(new FileInputStream(file), charset);
+  }
+
+  private static List<String> loadLines(InputStream stream, Charset charset) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(stream, charset));
 
     boolean threw = true;
     try {

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -260,6 +261,22 @@ public class Files {
   }
 
   /**
+   * Loads the text content of a URL into a character string.
+   *
+   * @param url the URL.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws IllegalArgumentException if the given character set is not supported on this platform.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static String contentOf(URL url, String charsetName) {
+    if (!Charset.isSupported(charsetName)) {
+      throw new IllegalArgumentException(String.format("Charset:<'%s'> is not supported on this system", charsetName));
+    }
+    return contentOf(url, Charset.forName(charsetName));
+  }
+
+  /**
    * Loads the text content of a file into a character string.
    * 
    * @param file the file.
@@ -278,6 +295,27 @@ public class Files {
       throw new FilesException("Unable to read " + file.getAbsolutePath(), e);
     }
   }
+
+  /**
+   * Loads the text content of a URL into a character string.
+   *
+   * @param url the URL.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws FilesException if an I/O exception occurs.
+   */
+  public static String contentOf(URL url, Charset charset) {
+    if (charset == null) {
+      throw new NullPointerException("The charset should not be null");
+    }
+    try {
+      return loadContents(url.openStream(), charset);
+    } catch (IOException e) {
+      throw new FilesException("Unable to read " + url, e);
+    }
+  }
+
 
   private static String loadContents(File file, Charset charset) throws IOException {
     return loadContents(new FileInputStream(file), charset);

--- a/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
@@ -19,6 +19,8 @@ import static junit.framework.Assert.assertFalse;
 import static org.junit.rules.ExpectedException.none;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.Charset;
 
 import org.junit.Rule;
@@ -35,6 +37,7 @@ public class Files_contentOf_Test {
   public ExpectedException thrown = none();
 
   private final File sampleFile = new File("src/test/resources/utf8.txt");
+  private final URL sampleResourceURL = ClassLoader.getSystemResource("utf8.txt");
   private final String expectedContent = "A text file encoded in UTF-8, with diacritics:\né à";
 
   @Test
@@ -60,13 +63,33 @@ public class Files_contentOf_Test {
   }
 
   @Test
+  public void should_throw_exception_if_url_not_found() throws MalformedURLException {
+    File missingFile = new File("missing.txt");
+    assertFalse(missingFile.exists());
+
+    thrown.expect(FilesException.class);
+    Files.contentOf(missingFile.toURI().toURL(), Charset.defaultCharset());
+  }
+
+  @Test
   public void should_load_file_using_charset() {
     // NB: UTF-8 must be supported by every Java implementation
     assertEquals(expectedContent, Files.contentOf(sampleFile, Charset.forName("UTF-8")));
   }
 
   @Test
+  public void should_load_resource_from_url_using_charset() {
+    // NB: UTF-8 must be supported by every Java implementation
+    assertEquals(expectedContent, Files.contentOf(sampleResourceURL, Charset.forName("UTF-8")));
+  }
+
+  @Test
   public void should_load_file_using_charset_name() {
     assertEquals(expectedContent, Files.contentOf(sampleFile, "UTF-8"));
+  }
+
+  @Test
+  public void should_load_resource_from_url_using_charset_name() {
+    assertEquals(expectedContent, Files.contentOf(sampleResourceURL, "UTF-8"));
   }
 }

--- a/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
@@ -19,6 +19,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -37,6 +39,7 @@ public class Files_linesOf_Test {
   private static final File SAMPLE_UNIX_FILE = new File("src/test/resources/utf8.txt");
   private static final File SAMPLE_WIN_FILE = new File("src/test/resources/utf8_win.txt");
   private static final File SAMPLE_MAC_FILE = new File("src/test/resources/utf8_mac.txt");
+  private static final URL SAMPLE_RESOURCE_URL = ClassLoader.getSystemResource("utf8.txt");
 
   private static final List<String> EXPECTED_CONTENT = newArrayList("A text file encoded in UTF-8, with diacritics:", "é à");
   public static final String UTF_8 = "UTF-8";
@@ -67,6 +70,15 @@ public class Files_linesOf_Test {
   }
 
   @Test
+  public void should_throw_exception_if_url_not_found() throws MalformedURLException {
+    File missingFile = new File("missing.txt");
+    assertThat(missingFile).doesNotExist();
+
+    thrown.expect(FilesException.class);
+    linesOf(missingFile.toURI().toURL(), Charset.defaultCharset());
+  }
+
+  @Test
   public void should_pass_if_unix_file_is_split_into_lines() {
     assertThat(linesOf(SAMPLE_UNIX_FILE, Charset.forName(UTF_8))).isEqualTo(EXPECTED_CONTENT);
   }
@@ -74,6 +86,16 @@ public class Files_linesOf_Test {
   @Test
   public void should_pass_if_unix_file_is_split_into_lines_using_charset() {
     assertThat(linesOf(SAMPLE_UNIX_FILE, UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  public void should_pass_if_resource_file_is_split_into_lines() {
+    assertThat(linesOf(SAMPLE_RESOURCE_URL, Charset.forName(UTF_8))).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  public void should_pass_if_resource_file_is_split_into_lines_using_charset() {
+    assertThat(linesOf(SAMPLE_RESOURCE_URL, UTF_8)).isEqualTo(EXPECTED_CONTENT);
   }
 
   @Test


### PR DESCRIPTION
This PR adds URL-based `linesOf()` and `contentOf()` methods that can be used to load URLs returned from e.g. `ClassLoader.getResource(...)`.