### PR TITLE
Added AssertProvider for linking objects to their Assert

### DIFF
--- a/src/main/java/org/assertj/core/api/AssertProvider.java
+++ b/src/main/java/org/assertj/core/api/AssertProvider.java
@@ -1,0 +1,44 @@
+package org.assertj.core.api;
+
+/**
+ * Provides a {@link Assert} for the current object.
+ * 
+ * <p>Used to map an object to its Assert without having to create a new "Assertions" class.</p>
+ * 
+ * Usage: <pre><code class='java'>
+ * public class Button implements AssertProvider<ButtonAssert> {
+ *   public ButtonAssert assertThat() { 
+ *     return new ButtonAssert(this); 
+ *   } 
+ * }
+ * 
+ * public class ButtonAssert extends Assert<ButtonAssert, Button> {
+ *   public ButtonAssert containsText(String text) {
+ *     ...
+ *   }
+ * }
+ * 
+ * void testMethod() {
+ *   Button button = ...;
+ *   // First option
+ *   Assertions.assertThat(button).containsText("Test");
+ *   // Second option
+ *   button.assertThat().containsText("Test");
+ * }
+ * </code></pre>
+ * 
+ * @param <A>
+ *          the type of the assert (not typed - to allow any kind of assert)
+ * 
+ * @author Tobias Liefke
+ */
+public interface AssertProvider<A> {
+
+  /**
+   * Returns the associated {@link Assert} for this object.
+   * 
+   * @return the assert object for use in cunjunction with {@link Assertions#assertThat(AssertProvider)}
+   */
+  A assertThat();
+
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -429,6 +429,19 @@ public class Assertions {
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
+  
+  /**
+   * Delegates the creation of the {@link Assert} to the {@link AssertProvider#assertThat()} of the given component.
+   * 
+   * <p>Read the comments on {@link AssertProvider} for an example of its usage.</p>
+   * 
+   * @param component
+   *          the component that creates its own assert
+   * @return the associated {@link Assert} of the given component
+   */
+  public static <T> T assertThat(final AssertProvider<T> component) {
+    return component.assertThat();
+  }  
 
   /**
    * Creates a new instance of <code>{@link ObjectArrayAssert}</code>.

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_AssertProvider_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_AssertProvider_Test.java
@@ -1,0 +1,46 @@
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.internal.Strings;
+import org.junit.Test;
+
+/**
+ * Tests for {@link Assertions#assertThat(AssertProvider)}.
+ * 
+ * @author Tobias Liefke
+ */
+public class Assertions_assertThat_with_AssertProvider_Test {
+
+  @Test
+  public void should_allow_assert_provider_within_assertThat() {
+    TestedObject object = new TestedObject("Test");
+    assertThat(object).containsText("es");
+  }
+
+  private static class TestedObject implements AssertProvider<TestedObjectAssert> {
+    private final String text;
+
+    public TestedObject(String text) {
+      this.text = text;
+    }
+
+    public TestedObjectAssert assertThat() {
+      return new TestedObjectAssert(this);
+    }
+  }
+
+  private static class TestedObjectAssert extends AbstractAssert<TestedObjectAssert, TestedObject> {
+    private Strings strings = Strings.instance();
+    
+    public TestedObjectAssert(TestedObject testedObject) {
+      super(testedObject, TestedObjectAssert.class);
+    }
+
+    public TestedObjectAssert containsText(String text) {
+      strings.assertContains(info, actual.text, text);
+      return this;
+    }
+  }
+
+}


### PR DESCRIPTION
Currently if I have an additional Assert class, I have to create (or generate) a new Assertions class to allow the fluent form MyAssertions.assertThat(MyObject).condition().

This is ok if the tested object (MyObject) is a real application object, because it can't know anything about the Assert class (which is usually only available during test time).

But if MyObject is an object just for testing as well, e.g. because it is a page object ([see here for an introduction to page objects](https://code.google.com/p/selenium/wiki/PageObjects)), this extra Assertions class is not really necessary and the disadvantage dominates:
You have either more than one custom Assertions class (where you can't use a static import for assertThat in the same test class), or you have to combine all different Assert from different packages into one big Assertions class - what may lead to dependency cycles and other architectural problems.

I know that there is the concept of a AssertDelegateTarget, but if you use that you have to create (and know) the Asserts by yourself. And Assertions.assertThat(new MyDelegateAssert(testObject)).containsText("...") is not as fluent as Assertions.assertThat(testObject).containsText("...").

So I have created a small patch of Assertions, to support the definition of the associated Assert in the tested object.

Here a short example of the usage:
```java
public class Button implements AssertProvider<ButtonAssert> {
  public String getText() {
    return ...;
  }
  public ButtonAssert assertThat() { 
    return new ButtonAssert(this); 
  } 
}

public class ButtonAssert extends Assert<ButtonAssert, Button> {
  ...
  public ButtonAssert containsText(String text) {
    ...
  }
}

void testMethod() {
  Button button = ...;
  Assertions.assertThat(button).containsText("Test");
}
```

I hope you see the advantages of this usecase and add it to AssertJ as well.