### PR TITLE
Skeleton PathAssert, plus tests -- NOT FOR INCLUSION. Yet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,22 @@
       <version>2.2.2</version>
       <optional>true</optional>
     </dependency>
+    <!--
+      NEEDED! Unlike File, a Path is not linked to the JRE's filesystem.
+
+      In order to accurately test assertions, we need a decent JSR 203 implementation
+      which lets us test our assertions. Right now, this is memoryfilesystem
+      (https://github.com/marschall/memoryfilesystem).
+
+      Another choice would be jimfs from Google (https://github.com/google/jimfs),
+      but its support for reading/writing file attributes is not as complete as that
+      of memoryfilesystem's.
+    -->
+    <dependency>
+      <groupId>com.github.marschall</groupId>
+      <artifactId>memoryfilesystem</artifactId>
+      <version>0.6.3</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -354,4 +354,52 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsSymbolicLink(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given path is absolute
+     *
+     * <p>Note that the fact that a path is absolute does not mean that it is
+     * {@link Path#normalize() normalized}: {@code /foo/..} is absolute, for
+     * instance, but it is not normalized.</p>
+     *
+     * <p>Sample use:</p>
+     *
+     * <pre><code class="java">
+     * // unixFs is a Unix FileSystem
+     * final Path path1 = unixFs.getPath("/foo/bar");
+     * final Path path2 = unixFs.getPath("foo/bar");
+     *
+     * // The following assertion succeeds:
+     * assertThat(path1).isAbsolute();
+     *
+     * // The following assertion fails:
+     * assertThat(path2).isAbsolute();
+     *
+     * // windowsFs is a Windows FileSystem
+     * final Path path3 = windowsFs.getPath("c:\\foo");
+     * final Path path4 = windowsFs.getPath("foo\\bar");
+     * final Path path5 = windowsFs.getPath("c:foo");
+     * final Path path6 = windowsFs.getPath("\\foo\\bar");
+     *
+     * // The following assertion succeeds:
+     * assertThat(path3).isAbsolute();
+     *
+     * // The following assertion fails...
+     * assertThat(path4).isAbsolute();
+     *
+     * // ... And these one also fail!
+     * assertThat(path5).isAbsolute();
+     * assertThat(path6).isAbsolute();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @see Path#isAbsolute()
+     * @see Path#toRealPath(LinkOption...)
+     */
+    public S isAbsolute()
+    {
+        paths.assertIsAbsolute(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -440,4 +440,45 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsNormalized(info, actual);
         return myself;
     }
+
+    /**
+     * Assert whether the tested path is canonical
+     *
+     * <p>For Windows users, this assertion is no different than {@link
+     * #isAbsolute()}. For Unix users, this assertion ensures that the tested
+     * path is the actual file system resource, that is, it is not a {@link
+     * Files#isSymbolicLink(Path) symbolic link} to the actual resource, even if
+     * the path is absolute.</p>
+     *
+     * <p>Example:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * // Create a directory
+     * final Path basedir = fs.getPath("/tmp/foo");
+     * Files.createDirectories(basedir);
+     * // Create a file in this directory
+     * final Path file = basedir.resolve("file");
+     * Files.createFile(file);
+     * // Create a symbolic link to that file
+     * final Path symlink = basedir.resolve("symlink");
+     * Files.createSymbolicLink(symlink, file);
+     *
+     * // The following assertion succeeds
+     * assertThat(file).isCanonical();
+     *
+     * // The following assertion fails
+     * assertThat(symlink).isCanonical();
+     * </code></pre>
+     *
+     * @throws PathsException an I/O error occurred while evaluating the path
+     *
+     * @see Path#toRealPath(LinkOption...)
+     * @see Files#isSameFile(Path, Path)
+     */
+    public S isCanonical()
+    {
+        paths.assertIsCanonical(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -250,4 +250,58 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsRegularFile(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given path is a directory
+     *
+     * <p><strong>Note that this method will follow symbolic links.</strong> If
+     * you are a Unix user and wish to assert that a path is a symbolic link
+     * instead, use {@link #isSymbolicLink()}.</p>
+     *
+     * <p>This assertion first asserts the existence of the path (using {@link
+     * #exists()}) then checks whether the path is a directory.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     *
+     * // Create a regular file, and a symbolic link to that regular file
+     * final Path regularFile = fs.getPath("regularFile");
+     * final Path symlink = fs.getPath("symlink");
+     * Files.createFile(regularFile);
+     * Files.createSymbolicLink(symlink, regularFile);
+     *
+     * // Create a directory, and a symbolic link to that directory
+     * final Path dir = fs.getPath("dir");
+     * final Path dirSymlink = fs.getPath("dirSymlink");
+     * Files.createDirectories(dir);
+     * Files.createSymbolicLink(dirSymlink, dir);
+     *
+     * // Create a nonexistent entry, and a symbolic link to that entry
+     * final Path nonExistent = fs.getPath("nonexistent");
+     * final Path dangling = fs.getPath("dangling");
+     * Files.createSymbolicLink(dangling, nonExistent);
+     *
+     * // the following assertions fail because paths do not exist:
+     * assertThat(nonExistent).isRegularFile();
+     * assertThat(dangling).isRegularFile();
+     *
+     * // the following assertions fail because paths exist but are not
+     * // directories:
+     * assertThat(regularFile).isRegularFile();
+     * assertThat(symlink).isRegularFile();
+     *
+     * // the following assertions succeed:
+     * assertThat(dir).isRegularFile();
+     * assertThat(dirSymlink).isRegularFile();
+     * </code></pre>
+     *
+     * @return self
+     */
+    public S isDirectory()
+    {
+        paths.assertIsDirectory(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -304,4 +304,54 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsDirectory(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given path is a symbolic link
+     *
+     * <p>This assertion first asserts the existence of the path (using {@link
+     * #existsNoFollow()}) then checks whether the path is a symbolic link.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     *
+     * // Create a regular file, and a symbolic link to that regular file
+     * final Path regularFile = fs.getPath("regularFile");
+     * final Path symlink = fs.getPath("symlink");
+     * Files.createFile(regularFile);
+     * Files.createSymbolicLink(symlink, regularFile);
+     *
+     * // Create a directory, and a symbolic link to that directory
+     * final Path dir = fs.getPath("dir");
+     * final Path dirSymlink = fs.getPath("dirSymlink");
+     * Files.createDirectories(dir);
+     * Files.createSymbolicLink(dirSymlink, dir);
+     *
+     * // Create a nonexistent entry, and a symbolic link to that entry
+     * final Path nonExistent = fs.getPath("nonexistent");
+     * final Path dangling = fs.getPath("dangling");
+     * Files.createSymbolicLink(dangling, nonExistent);
+     *
+     * // the following assertion fails because the path does not exist:
+     * assertThat(nonExistent).isSymbolicLink();
+     *
+     * // the following assertions fail because paths exist but are not symbolic
+     * // links
+     * assertThat(regularFile).isSymbolicLink();
+     * assertThat(dirSymlink).isSymbolicLink();
+     *
+     * // the following assertions succeed:
+     * assertThat(symlink).isSymbolicLink();
+     * assertThat(dangling).isSymbolicLink();
+     * assertThat(dir).isSymbolicLink();
+     * </code></pre>
+     *
+     * @return self
+     */
+    public S isSymbolicLink()
+    {
+        paths.assertIsSymbolicLink(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.Paths;
+import org.assertj.core.util.PathsException;
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
+import java.nio.file.spi.FileSystemProvider;
+
+/**
+ * Assertions for {@link Path} objects
+ *
+ * <p>Note that some assertions have two versions: a normal one and a "raw" one
+ * (for instance, {@code hasParent()} and {@code hasParentRaw()}. The difference
+ * is that normal assertions will {@link Path#toRealPath(LinkOption...)
+ * canonicalize} or {@link Path#normalize() normalize} the tested path and,
+ * where applicable, the path argument, before performing the actual test.
+ * Canonicalization includes normalization.</p>
+ *
+ * <p>Canonicalization may lead to an I/O error if a path does not exist, in
+ * which case the given assertions will fail with a {@link PathsException}. Also
+ * note that {@link Files#isSymbolicLink(Path) symbolic links} will be followed
+ * if the filesystem supports them. Finally, if a path is not {@link
+ * Path#isAbsolute()} absolute}, canonicalization will resolve the path against
+ * the process' current working directory.</p>
+ *
+ * <p>These assertions are filesystem independent. You may use them on {@code
+ * Path} instances issued from the default filesystem (ie, instances you get
+ * when using {@link java.nio.file.Paths#get(String, String...)}) or from other
+ * filesystems. For more information, see the {@link FileSystem javadoc for
+ * {@code FileSystem}}.</p>
+ *
+ * <p>Furthermore:</p>
+ *
+ * <ul>
+ *     <li>Unless otherwise noted, assertions which accept arguments will not
+ *     accept {@code null} arguments; if a null argument is passed, these
+ *     assertions will throw a {@link NullPointerException}.</li>
+ *     <li>It is the caller's responsibility to ensure that paths used in
+ *     assertions are issued from valid filesystems which are not {@link
+ *     FileSystem#close() closed}. If a filesystems is closed, assertions will
+ *     throw a {@link ClosedFileSystemException}.</li>
+ *     <li>Some assertions take another {@link Path} as an argument. If this
+ *     path is not issued from the same {@link FileSystemProvider provider} as
+ *     the tested path, assertions will throw a {@link
+ *     ProviderMismatchException}.</li>
+ *     <li>Some assertions may need to perform I/O on the path's underlying
+ *     filesystem; if an I/O error occurs when accessing the filesystem, these
+ *     assertions will throw a {@link PathsException}.</li>
+ * </ul>
+ *
+ * @param <S> self type
+ *
+ * @see Path
+ * @see java.nio.file.Paths#get(String, String...)
+ * @see FileSystem
+ * @see FileSystem#getPath(String, String...)
+ * @see FileSystems#getDefault()
+ * @see Files
+ */
+public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
+    extends AbstractAssert<S, Path>
+{
+    @VisibleForTesting
+    protected Paths paths = Paths.instance();
+
+    protected AbstractPathAssert(final Path actual, final Class<?> selfType)
+    {
+        super(actual, selfType);
+    }
+}

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -739,4 +739,83 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertStartsWithRaw(info, actual, other);
         return myself;
     }
+
+    /**
+     * Check whether this path ends with another path
+     *
+     * <p>This assertion will attempt to canonicalize the tested path and
+     * normalize the path given as an argument before performing the actual test.
+     * </p>
+     *
+     * <p>Note that the criterion to determine success is determined by the
+     * path's name elements; therefore, {@code /home/foobar/baz} does
+     * <em>not</em> end with {@code bar/baz}.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem; the current directory is supposed to be /home
+     * // tested will be canonicalized to /home/joe/myfile
+     * final Path tested = fs.getPath("/home/jane/../joe/myfile");
+     * final Path good = fs.getPath("joe/myfile");
+     * // this path will be normalized to joe/otherfile
+     * final Path bad = fs.getPath("joe/myfile/../otherfile");
+     *
+     * // the following assertion succeeds:
+     * assertThat(tested).endsWith(good);
+     *
+     * // the following assertion fails:
+     * assertThat(tested).endsWith(bad);
+     * </code></pre>
+     *
+     * @param other the other path
+     * @return self
+     *
+     * @throws PathsException failed to canonicalize the tested path (see class
+     * description)
+     */
+    public S endsWith(final Path other)
+    {
+        paths.assertEndsWith(info, actual, other);
+        return myself;
+    }
+
+    /**
+     * Check whether this path ends with another path
+     *
+     * <p><em>This assertion will not perform any canonicalization (on the
+     * tested path) or normalization (on the path given as an argument); see the
+     * class description for more details. If this is not what you want, use
+     * {@link #endsWith(Path)} instead.</em></p>
+     *
+     * <p>This may lead to some surprising results; for instance, path {@code
+     * /home/foo} does <em>not</em> end with {@code foo/.} since the last name
+     * element of the former ({@code foo}) is different from the last name
+     * element of the latter ({@code .}).</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path tested = fs.getPath("/home/joe/myfile");
+     * final Path good = fs.getPath("joe/myfile");
+     * // Even though the path below is the same as "good" when normalized,
+     * // this assertion will not normalize.
+     * final Path bad = fs.getPath("harry/../joe/myfile");
+     *
+     * // The following assertion succeeds:
+     * assertThat(tested).endsWithRaw(good);
+     *
+     * // But the following assertion fails:
+     * assertThat(tested).endsWithRaw(bad);
+     * </code></pre>
+     *
+     * @param other the other path
+     * @return self
+     */
+    public S endsWithRaw(final Path other)
+    {
+        paths.assertEndsWithRaw(info, actual, other);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -481,4 +481,93 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsCanonical(info, actual);
         return myself;
     }
+
+    /**
+     * Assert whether the tested path has the expected parent path
+     *
+     * <p><em>This assertion will perform canonicalization of the tested path
+     * and of the given argument before performing the test; see the class
+     * description for more details. If this is not what you want, use {@link
+     * #hasParentRaw(Path)} instead.</em></p>
+     *
+     * <p>Checks that the tested path has the given parent. This assertion will
+     * fail both if the tested path has no parent, or has a different parent
+     * than what is expected.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path actual = fs.getPath("/dir1/dir2/file");
+     * // this path will be normalized to "/dir1/dir2"
+     * final Path good = fs.getPath("/dir1/dir3/../dir2/.");
+     * final Path bad = fs.getPath("/dir1");
+     *
+     * // the following assertion succeeds
+     * assertThat(actual).hasParent(good);
+     *
+     * // the following assertion fails
+     * assertThat(actual).hasParent(bad);
+     * </code></pre>
+     *
+     * @param expected the expected parent path
+     * @return self
+     *
+     * @see Path#getParent()
+     */
+    public S hasParent(final Path expected)
+    {
+        paths.assertHasParent(info, actual, expected);
+        return myself;
+    }
+
+    /**
+     * Assert whether the tested path has the expected parent path
+     *
+     * <p><em>This assertion will not perform any canonicalization of either the
+     * tested path or the path given as an argument; see class description for
+     * more details. If this is not what you want, use {@link #hasParent(Path)}
+     * instead.</em></p>
+     *
+     * <p>This assertion uses {@link Path#getParent()} with no modification,
+     * which means the only criterion for this assertion's success is the path's
+     * components (its root and its name elements).</p>
+     *
+     * <p>This may lead to surprising results if the tested path and the path
+     * given as an argument are not normalized. For instance, if the tested
+     * path is {@code /home/foo/../bar} and the argument is {@code /home}, the
+     * assertion will <em>fail</em> since the parent of the tested path is not
+     * {@code /home} but... {@code /home/foo/..}.</p>
+     *
+     * <p>While this may seem counterintuitive, it has to be recalled here that
+     * it is not required for a {@link FileSystem} to consider that {@code .}
+     * and {@code ..} are name elements for respectively the current directory
+     * and the parent directory respectively. In fact, it is not even required
+     * that a {@link FileSystem} be hierarchical at all.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path actual = fs.getPath("/dir1/dir2/file");
+     * final Path good = fs.getPath("/dir1/dir2");
+     * final Path bad = fs.getPath("/dir1/dir3/../dir2");
+     *
+     * // the following assertion succeeds
+     * assertThat(actual).hasParentRaw(good);
+     *
+     * // the following assertion fails
+     * assertThat(actual).hasParentRaw(bad);
+     * </code></pre>
+     *
+     * @param expected the expected parent path
+     * @return self
+     *
+     * @see Path#getParent()
+     */
+    public S hasParentRaw(final Path expected)
+    {
+        paths.assertHasParentRaw(info, actual, expected);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -652,4 +652,91 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertHasNoParentRaw(info, actual);
         return myself;
     }
+
+    /**
+     * Check whether this path starts with another path
+     *
+     * <p><em>This assertion will perform canonicalization of both the tested
+     * path and the path given as an argument; see class description for more
+     * details. If this is not what you want, use {@link #startsWithRaw(Path)}
+     * instead.</em></p>
+     *
+     * <p>Checks whether the tested path starts with another path. Note that the
+     * name components matter, not the string representation; this means that,
+     * for example, {@code /home/foobar/baz} <em>does not</em> start with {@code
+     * /home/foo}.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path tested = fs.getPath("/home/joe/myfile");
+     * // this path will be canonicalized to "/home/joe"
+     * final Path good = fs.getPath("/home/jane/../joe/.");
+     * final Path bad = fs.getPath("/home/harry");
+     *
+     * // the following assertion succeeds:
+     * assertThat(tested).startsWith(good);
+     *
+     * // the following assertion fails:
+     * assertThat(tested).startsWith(bad);
+     * </code></pre>
+     *
+     * @param other the other path
+     * @return self
+     *
+     * @throws PathsException failed to canonicalize the tested path or the path
+     * given as an argument
+     *
+     * @see Path#startsWith(Path)
+     */
+    public S startsWith(final Path other)
+    {
+        paths.assertStartsWith(info, actual, other);
+        return myself;
+    }
+
+    /**
+     * Check whether this path starts with another path
+     *
+     * <p><em>This assertions does not perform canonicalization on either the
+     * tested path or the path given as an argument; see class description for
+     * more details. If this is not what you want, use {@link #startsWith(Path)}
+     * instead.</em></p>
+     *
+     * <p>Checks whether the tested path starts with another path, without
+     * performing canonicalization on its arguments. This means that the only
+     * criterion to determine whether a path starts with another is the tested
+     * path's, and the argument's, name elements.</p>
+     *
+     * <p>This may lead to some surprising results: for instance, path {@code
+     * /../home/foo} does <em>not</em> start with {@code /home} since the first
+     * name element of the former ({@code ..}) is different from the first name
+     * element of the latter ({@code home}).</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path tested = fs.getPath("/home/joe/myfile");
+     * final Path good = fs.getPath("/home/joe");
+     * final Path bad = fs.getPath("/home/../joe");
+     *
+     * // the following assertion succeeds:
+     * assertThat(tested).startsWithRaw(good);
+     *
+     * // the following assertion fails:
+     * assertThat(tested).startsWithRaw(bad);
+     * </code></pre>
+     *
+     * @param other the other path
+     * @return self
+     *
+     * @see Path#startsWith(Path)
+     */
+    public S startsWithRaw(final Path other)
+    {
+        paths.assertStartsWithRaw(info, actual, other);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -402,4 +402,42 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertIsAbsolute(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given {@link Path} is normalized
+     *
+     * <p>A path is normalized if it has no redundant components; typically, on
+     * both Unix and Windows, this means that the path has no "self" components
+     * ({@code .}) and that its only parent components ({@code ..}), if any, are
+     * at the beginning of the path.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * final Path normalized1 = fs.getPath("/usr/lib");
+     * final Path normalized2 = fs.getPath("/../../e");
+     * final Path normalized3 = fs.getPath("a/b/c");
+     * final Path normalized4 = fs.getPath("../d");
+     * final Path notNormalized1 = fs.getPath("/a/./b");
+     * final Path notNormalized2 = fs.getPath("c/..");
+     *
+     * // the following assertions succeed:
+     * assertThat(normalized1).isNormalized();
+     * assertThat(normalized2).isNormalized();
+     * assertThat(normalized3).isNormalized();
+     * assertThat(normalized4).isNormalized();
+     *
+     * // the following assertions fail:
+     * assertThat(notNormalized1).isNormalized();
+     * assertThat(notNormalized2).isNormalized();
+     * </code></pre>
+     *
+     * @return self
+     */
+    public S isNormalized()
+    {
+        paths.assertIsNormalized(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -20,6 +20,7 @@ import java.nio.file.ClosedFileSystemException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
 import java.nio.file.spi.FileSystemProvider;
@@ -157,6 +158,42 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
     public S existsNoFollow()
     {
         paths.assertExistsNoFollow(info, actual);
+        return myself;
+    }
+
+    /**
+     * Assert that a given path does not exist
+     *
+     * <p><strong>IMPORTANT NOTE:</strong> this method will NOT follow symbolic
+     * links (provided that the underlying {@link FileSystem} of this path
+     * supports symbolic links at all).</p>
+     *
+     * <p>This means that even if the path to test is a symbolic link whose
+     * target does not exist, this assertion will consider that the path exists
+     * (note that this is unlike the default behavior of {@link #exists()}).</p>
+     *
+     * <p>If you are a Windows user, the above does not apply to you; if you are
+     * a Unix user however, this is important. Consider the following:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a FileSystem
+     * // Create a symbolic link "foo" whose nonexistent target is "bar"
+     * final Path foo = fs.getPath("foo");
+     * final Path bar = fs.getPath("bar");
+     * Files.createSymbolicLink(foo, bar);
+     *
+     * // The following assertion fails:
+     * assertThat(foo).doesNotExist();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @see Files#notExists(Path, LinkOption...)
+     * @see LinkOption#NOFOLLOW_LINKS
+     */
+    public S doesNotExist()
+    {
+        paths.assertNotExists(info, actual);
         return myself;
     }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -128,4 +128,35 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertExists(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given path exists, not following symbolic links
+     *
+     * <p>This assertion behaves like {@link #exists()}, with the difference
+     * that it can be used to assert the existence of a symbolic link even if
+     * its target is invalid.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * // Create a symbolic link whose target does not exist
+     * final Path nonExistent = fs.getPath("nonexistent");
+     * final Path dangling = fs.getPath("dangling");
+     * Files.createSymbolicLink(dangling, nonExistent);
+     *
+     * // The following assertions succeed
+     * assertThat(symlink).existsNoFollow();
+     * assertThat(dangling).existsNoFollow();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @see Files#exists(Path, LinkOption...)
+     */
+    public S existsNoFollow()
+    {
+        paths.assertExistsNoFollow(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -196,4 +196,58 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertNotExists(info, actual);
         return myself;
     }
+
+    /**
+     * Assert that a given path is a regular file
+     *
+     * <p><strong>Note that this method will follow symbolic links.</strong> If
+     * you are a Unix user and wish to assert that a path is a symbolic link
+     * instead, use {@link #isSymbolicLink()}.</p>
+     *
+     * <p>This assertion first asserts the existence of the path (using {@link
+     * #exists()}) then checks whether the path is a regular file.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     *
+     * // Create a regular file, and a symbolic link to that regular file
+     * final Path regularFile = fs.getPath("regularFile");
+     * final Path symlink = fs.getPath("symlink");
+     * Files.createFile(regularFile);
+     * Files.createSymbolicLink(symlink, regularFile);
+     *
+     * // Create a directory, and a symbolic link to that directory
+     * final Path dir = fs.getPath("dir");
+     * final Path dirSymlink = fs.getPath("dirSymlink");
+     * Files.createDirectories(dir);
+     * Files.createSymbolicLink(dirSymlink, dir);
+     *
+     * // Create a nonexistent entry, and a symbolic link to that entry
+     * final Path nonExistent = fs.getPath("nonexistent");
+     * final Path dangling = fs.getPath("dangling");
+     * Files.createSymbolicLink(dangling, nonExistent);
+     *
+     * // the following assertions fail because paths do not exist:
+     * assertThat(nonExistent).isRegularFile();
+     * assertThat(dangling).isRegularFile();
+     *
+     * // the following assertions fail because paths exist but are not regular
+     * // files:
+     * assertThat(dir).isRegularFile();
+     * assertThat(dirSymlink).isRegularFile();
+     *
+     * // the following assertions succeed:
+     * assertThat(regularFile).isRegularFile();
+     * assertThat(symlink).isRegularFile();
+     * </code></pre>
+     *
+     * @return self
+     */
+    public S isRegularFile()
+    {
+        paths.assertIsRegularFile(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -570,4 +570,86 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
         paths.assertHasParentRaw(info, actual, expected);
         return myself;
     }
+
+    /**
+     * Assert whether the tested path has no parent
+     *
+     * <p><em>This assertion will first canonicalize the tested path before
+     * performing the test; if this is not what you want, use {@link
+     * #hasNoParentRaw()} instead.</em></p>
+     *
+     * <p>Check that the tested path, after canonicalization, has no parent. See
+     * the class description for more information about canonicalization.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // unixFs is a Unix filesystem
+     * final Path path1 = fs.getPath("/usr");
+     * // this path will be normalized to "/"
+     * final Path path2 = fs.getPath("/foo/..");
+     * final Path path3 = fs.getPath("/usr/lib");
+     *
+     * // the following assertions succeed
+     * assertThat(path1).hasNoParent();
+     * assertThat(path2).hasNoParent();
+     *
+     * // the following assertion fails
+     * assertThat(path3).hasNoParent();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @throws PathsException failed to canonicalize the tested path
+     *
+     * @see Path#getParent()
+     */
+    public S hasNoParent()
+    {
+        paths.assertHasNoParent(info, actual);
+        return myself;
+    }
+
+    /**
+     * Assert whether the tested path has no parent
+     *
+     * <p><em>This assertion will not canonicalize the tested path before
+     * performing the test; if this is not what you want, use {@link
+     * #hasNoParent()} instead.</em></p>
+     *
+     * <p>As canonicalization is not performed, this means the only criterion
+     * for this assertion's success is the path's components (its root and its
+     * name elements).</p>
+     *
+     * <p>This may lead to surprising results. For instance, path {@code
+     * /usr/..} <em>does</em> have a parent, and this parent is {@code /usr}.
+     * </p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // unixFs is a Unix filesystem
+     * final Path path1 = fs.getPath("/usr");
+     * final Path path2 = fs.getPath("/");
+     * final Path path3 = fs.getPath("foo");
+     * final Path path4 = fs.getPath("/usr/lib");
+     *
+     * // the following assertions succeed
+     * assertThat(path1).hasNoParentRaw();
+     * assertThat(path2).hasNoParentRaw();
+     * assertThat(path3).hasNoParentRaw();
+     *
+     * // the following assertion fails
+     * assertThat(path4).hasNoParentRaw();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @see Path#getParent()
+     */
+    public S hasNoParentRaw()
+    {
+        paths.assertHasNoParentRaw(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -85,4 +85,47 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>>
     {
         super(actual, selfType);
     }
+
+    /**
+     * Assert that a given path exists
+     *
+     * <p><strong>Note that this assertion will follow symbolic links before
+     * asserting the path's existence.</strong></p>
+     *
+     * <p>On Windows system, this has no influence. On Unix systems, this means
+     * the assertion result will fail if the path is a symbolic link whose
+     * target does not exist. If you want to assert the existence of the
+     * symbolic link itself, use {@link #existsNoFollow()} instead.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <pre><code class="java">
+     * // fs is a Unix filesystem
+     * // Create a symbolic link whose target does not exist
+     * final Path nonExistent = fs.getPath("nonexistent");
+     * final Path dangling = fs.getPath("dangling");
+     * Files.createSymbolicLink(dangling, nonExistent);
+     *
+     * // Create a regular file, and a symbolic link pointing to it
+     * final Path someFile = fs.getPath("somefile");
+     * Files.createFile(someFile);
+     * final Path symlink = fs.getPath("symlink");
+     * Files.createSymbolicLink(symlink, someFile);
+     *
+     * // The following assertion succeeds
+     * assertThat(symlink).exists();
+     *
+     * // The following assertion fails
+     * assertThat(dangling).exists();
+     * </code></pre>
+     *
+     * @return self
+     *
+     * @see Files#exists(Path, LinkOption...)
+     */
+    public S exists()
+    {
+        paths.assertExists(info, actual);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -17,6 +17,7 @@ import static org.assertj.core.util.Arrays.array;
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -215,6 +216,16 @@ public abstract class AbstractSoftAssertions {
    */
   public FileAssert assertThat(File actual) {
 	return proxy(FileAssert.class, File.class, actual);
+  }
+
+  /**
+   * Creates a new, proxied instance of a {@link PathAssert}
+   *
+   * @param actual the path
+   * @return the created assertion object
+   */
+  public PathAssert assertThat(Path actual) {
+    return proxy(PathAssert.class, Path.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Iterator;
@@ -250,6 +251,17 @@ public class Assertions {
    */
   public static AbstractFileAssert<?> assertThat(File actual) {
 	return new FileAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link PathAssert}
+   *
+   * @param actual the path to test
+   * @return the created assertion object
+   */
+  public static AbstractPathAssert<?> assertThat(Path actual)
+  {
+    return new PathAssert(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/PathAssert.java
+++ b/src/main/java/org/assertj/core/api/PathAssert.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.nio.file.Path;
+
+/**
+ * Assertion class for {@link Path}s
+ */
+public class PathAssert
+    extends AbstractPathAssert<PathAssert>
+{
+    /**
+     * Constructor
+     *
+     * @param actual the path to test
+     */
+    protected PathAssert(Path actual)
+    {
+        super(actual, PathAssert.class);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeAbsolutePath.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeAbsolutePath.java
@@ -12,15 +12,24 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
- * Creates an error message indicating that an assertion that verifies that a <code>{@link File}</code> is an absolute path
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link File} or {@link Path} is an absolute path
  * failed.
  * 
  * @author Yvonne Wang
+ * @author Francis Galiegue
  */
 public class ShouldBeAbsolutePath extends BasicErrorMessageFactory {
+
+  @VisibleForTesting
+  public static final String MESSAGE
+      = "%nExpecting:%n  <%s>%nto be an absolute path";
 
   /**
    * Creates a new <code>{@link ShouldBeAbsolutePath}</code>.
@@ -31,7 +40,17 @@ public class ShouldBeAbsolutePath extends BasicErrorMessageFactory {
     return new ShouldBeAbsolutePath(actual);
   }
 
+  public static ErrorMessageFactory shouldBeAbsolutePath(final Path actual)
+  {
+    return new ShouldBeAbsolutePath(actual);
+  }
+
   private ShouldBeAbsolutePath(File actual) {
-    super("\nExpecting:\n <%s>\nto be an absolute path", actual);
+    super(MESSAGE, actual);
+  }
+
+  private ShouldBeAbsolutePath(final Path actual)
+  {
+    super(MESSAGE, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeCanonicalPath.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeCanonicalPath.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link Path} is canonical has failed.
+ * 
+ */
+public class ShouldBeCanonicalPath
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String MESSAGE
+        = "%nExpecting:%n  <%s>%nto be a canonical path";
+
+    public static ErrorMessageFactory shouldBeCanonicalPath(final Path actual)
+    {
+        return new ShouldBeCanonicalPath(actual);
+    }
+
+    private ShouldBeCanonicalPath(final Path actual)
+    {
+        super(MESSAGE, actual);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeDirectory.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeDirectory.java
@@ -12,26 +12,46 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
- * Creates an error message indicating that an assertion that verifies that a <code>{@link File}</code> is an existing directory
- * failed.
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link File} or {@link Path} is an existing directory failed
  * 
  * @author Yvonne Wang
+ * @author Francis Galiegue
  */
-public class ShouldBeDirectory extends BasicErrorMessageFactory {
+public class ShouldBeDirectory
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String PATH_SHOULD_BE_DIRECTORY
+        = "%nExpecting path:%n  <%s>%nto be a directory";
 
-  /**
-   * Creates a new <code>{@link ShouldBeDirectory}</code>.
-   * @param actual the actual value in the failed assertion.
-   * @return the created {@code ErrorMessageFactory}.
-   */
-  public static ErrorMessageFactory shouldBeDirectory(File actual) {
-    return new ShouldBeDirectory(actual);
-  }
+    @VisibleForTesting
+    public static final String FILE_SHOULD_BE_DIRECTORY
+        = "%nExpecting file:%n  <%s>%n to be an existing directory";
 
-  private ShouldBeDirectory(File actual) {
-    super("\nExpecting:\n <%s>\nto be an existing directory", actual);
-  }
+    public static ErrorMessageFactory shouldBeDirectory(final Path actual)
+    {
+        return new ShouldBeDirectory(actual);
+    }
+
+    public static ErrorMessageFactory shouldBeDirectory(final File actual)
+    {
+        return new ShouldBeDirectory(actual);
+    }
+
+    private ShouldBeDirectory(final Path actual)
+    {
+        super(PATH_SHOULD_BE_DIRECTORY, actual);
+    }
+
+    private ShouldBeDirectory(final File actual)
+    {
+        super(FILE_SHOULD_BE_DIRECTORY, actual);
+    }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeNormalized.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeNormalized.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Assertion error message delivered when a {@link Path} is not normalized
+ *
+ * @see Path#normalize()
+ */
+public class ShouldBeNormalized
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String SHOULD_BE_NORMALIZED
+        = "Expected path:%n  <%s>%nto be normalized";
+
+    private ShouldBeNormalized(Path actual)
+    {
+        super(SHOULD_BE_NORMALIZED, actual);
+    }
+
+    public static ErrorMessageFactory shouldBeNormalized(Path actual)
+    {
+        return new ShouldBeNormalized(actual);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeRegularFile.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeRegularFile.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link Path} is a regular file has failed.
+ *
+ */
+public class ShouldBeRegularFile
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String SHOULD_BE_REGULAR_FILE
+        = "%nExpecting path:%n  <%s>%nto be a regular file";
+
+    public static ErrorMessageFactory shouldBeRegularFile(final Path actual)
+    {
+        return new ShouldBeRegularFile(actual);
+    }
+
+    private ShouldBeRegularFile(final Path actual)
+    {
+        super(SHOULD_BE_REGULAR_FILE, actual);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeSymbolicLink.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeSymbolicLink.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link Path} is a regular file has failed.
+ *
+ */
+public class ShouldBeSymbolicLink
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String SHOULD_BE_SYMBOLIC_LINK
+        = "%nExpecting path:%n  <%s>%nto be a symbolic link";
+
+    public static ErrorMessageFactory shouldBeSymbolicLink(final Path actual)
+    {
+        return new ShouldBeSymbolicLink(actual);
+    }
+
+    private ShouldBeSymbolicLink(final Path actual)
+    {
+        super(SHOULD_BE_SYMBOLIC_LINK, actual);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldEndWithPath.java
+++ b/src/main/java/org/assertj/core/error/ShouldEndWithPath.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+public class ShouldEndWithPath
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String PATH_SHOULD_END_WITH
+        = "Expected path:%n  <%s>%nto end with:%n  <%s>%nbut it does not";
+
+    public static ErrorMessageFactory shouldEndWith(final Path actual,
+        final Path other)
+    {
+        return new ShouldEndWithPath(actual, other);
+    }
+
+    private ShouldEndWithPath(final Path actual, final Path other)
+    {
+        super(PATH_SHOULD_END_WITH, actual, other);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldExist.java
+++ b/src/main/java/org/assertj/core/error/ShouldExist.java
@@ -12,15 +12,22 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
- * Creates an error message indicating that an assertion that verifies that a <code>{@link File}</code> exists failed.
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link File} or {@link Path} exists failed.
  * 
  * @author Yvonne Wang
  */
 public class ShouldExist extends BasicErrorMessageFactory {
 
+  @VisibleForTesting
+  public static final String PATH_SHOULD_EXIST
+      = "Expecting path:%n  <%s>%nto exist";
   /**
    * Creates a new <code>{@link ShouldExist}</code>.
    * @param actual the actual value in the failed assertion.
@@ -30,7 +37,17 @@ public class ShouldExist extends BasicErrorMessageFactory {
     return new ShouldExist(actual);
   }
 
+  public static ErrorMessageFactory shouldExist(final Path actual)
+  {
+    return new ShouldExist(actual);
+  }
+
   private ShouldExist(File actual) {
-    super("\nExpecting file:<%s> to exist", actual);
+    super("%nExpecting file:%n  <%s>%nto exist", actual);
+  }
+
+  private ShouldExist(final Path actual)
+  {
+    super(PATH_SHOULD_EXIST, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldExistNoFollow.java
+++ b/src/main/java/org/assertj/core/error/ShouldExistNoFollow.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link File} or {@link Path} exists failed.
+ * 
+ */
+public class ShouldExistNoFollow
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String PATH_SHOULD_EXIST_NOFOLLOW
+        = "Expecting path:%n  <%s>%nto exist (symbolic links not followed)";
+
+    public static ErrorMessageFactory shouldExistNoFollow(final Path actual)
+    {
+        return new ShouldExistNoFollow(actual);
+    }
+
+    private ShouldExistNoFollow(final Path actual)
+    {
+        super(PATH_SHOULD_EXIST_NOFOLLOW, actual);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveNoParent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveNoParent.java
@@ -12,7 +12,10 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Creates an error message when a {@code File} should not have a parent.
@@ -20,6 +23,14 @@ import java.io.File;
  * @author Jean-Christophe Gay
  */
 public class ShouldHaveNoParent extends BasicErrorMessageFactory {
+
+  @VisibleForTesting
+  public static final String PATH_HAS_PARENT
+      = "%nExpected actual path not to have a parent, but parent was:%n  <%s>";
+
+  @VisibleForTesting
+  public static final String FILE_HAS_PARENT
+      = "%nExpecting file (or directory) without parent, but parent was:%n  <%s>";
 
   /**
    * Creates a new </code>{@link ShouldHaveNoParent}</code>.
@@ -31,7 +42,16 @@ public class ShouldHaveNoParent extends BasicErrorMessageFactory {
     return new ShouldHaveNoParent(actual);
   }
 
+  public static ShouldHaveNoParent shouldHaveNoParent(Path actual) {
+    return new ShouldHaveNoParent(actual);
+  }
+
   private ShouldHaveNoParent(File actual) {
-    super("%nExpecting file (or directory) without parent, but parent was:%n  <%s>", actual.getParentFile());
+    super(FILE_HAS_PARENT, actual.getParentFile());
+  }
+
+  private ShouldHaveNoParent(Path actual)
+  {
+    super(PATH_HAS_PARENT, actual.getParent());
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveParent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveParent.java
@@ -12,7 +12,10 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Creates an error message indicating that a {@code File} should have a parent.
@@ -21,16 +24,52 @@ import java.io.File;
  */
 public class ShouldHaveParent extends BasicErrorMessageFactory {
 
+  @VisibleForTesting
+  public static final String PATH_NO_PARENT
+      = "%nExpecting path%n  <%s>%nto have parent:%n  <%s>%nbut did not have one.";
+
+  @VisibleForTesting
+  public static final String PATH_NOT_EXPECTED_PARENT
+      = "%nExpecting path%n  <%s>%nto have parent:%n  <%s>%nbut had:%n  <%s>.";
+
+  @VisibleForTesting
+  public static final String FILE_NO_PARENT
+      = "%nExpecting file%n  <%s>%nto have parent:%n  <%s>%nbut did not have one.";
+
+  @VisibleForTesting
+  public static final String FILE_NOT_EXPECTED_PARENT
+      = "%nExpecting file%n  <%s>%nto have parent:%n  <%s>%nbut had:%n  <%s>.";
+
   public static ShouldHaveParent shouldHaveParent(File actual, File expected) {
     return actual.getParentFile() == null ? new ShouldHaveParent(actual, expected) : new ShouldHaveParent(actual,
         actual.getParentFile(), expected);
   }
 
+  public static ShouldHaveParent shouldHaveParent(Path actual, Path expected) {
+    final Path actualParent = actual.getParent();
+    return actualParent == null
+        ? new ShouldHaveParent(actual, expected)
+        : new ShouldHaveParent(actual, actualParent, expected);
+  }
+
+  public static ShouldHaveParent shouldHaveParent(Path actual, Path actualParent, Path expected) {
+    return new ShouldHaveParent(actual, actualParent, expected);
+  }
+
+
   private ShouldHaveParent(File actual, File expected) {
-    super("%nExpecting file%n  <%s>%nto have parent:%n  <%s>%nbut did not have one.", actual, expected);
+    super(FILE_NO_PARENT, actual, expected);
   }
 
   private ShouldHaveParent(File actual, File actualParent, File expected) {
-    super("%nExpecting file%n  <%s>%nto have parent:%n  <%s>%nbut had:%n  <%s>.", actual, expected, actualParent);
+    super(FILE_NOT_EXPECTED_PARENT, actual, expected, actualParent);
+  }
+
+  private ShouldHaveParent(Path actual, Path expected) {
+    super(PATH_NO_PARENT, actual, expected);
+  }
+
+  private ShouldHaveParent(Path actual, Path actualParent, Path expected) {
+    super(PATH_NOT_EXPECTED_PARENT, actual, expected, actualParent);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldNotExist.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotExist.java
@@ -12,14 +12,27 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.VisibleForTesting;
+
 import java.io.File;
+import java.nio.file.Path;
 
 /**
- * Creates an error message indicating that an assertion that verifies that a <code>{@link File}</code> does not exist failed.
+ * Creates an error message indicating that an assertion that verifies that a
+ * {@link File} or {@link Path} does not exist failed.
  * 
  * @author Yvonne Wang
+ * @author Francis Galiegue
  */
 public class ShouldNotExist extends BasicErrorMessageFactory {
+
+  @VisibleForTesting
+  public static final String PATH_SHOULDNOTEXIST
+      = "%nExpecting path:%n  <%s>%nnot to exist";
+
+  @VisibleForTesting
+  public static final String FILE_SHOULDNOTEXIST
+      = "%nExpecting file:%n  <%s>%nnot to exist";
 
   /**
    * Creates a new <code>{@link ShouldNotExist}</code>.
@@ -30,7 +43,16 @@ public class ShouldNotExist extends BasicErrorMessageFactory {
     return new ShouldNotExist(actual);
   }
 
+  public static ErrorMessageFactory shouldNotExist(final Path actual)
+  {
+    return new ShouldNotExist(actual);
+  }
+
   private ShouldNotExist(File actual) {
-    super("\nExpecting file:<%s> not to exist", actual);
+    super(FILE_SHOULDNOTEXIST, actual);
+  }
+
+  private ShouldNotExist(final Path actual) {
+    super(PATH_SHOULDNOTEXIST, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldStartWithPath.java
+++ b/src/main/java/org/assertj/core/error/ShouldStartWithPath.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+public class ShouldStartWithPath
+    extends BasicErrorMessageFactory
+{
+    @VisibleForTesting
+    public static final String PATH_SHOULD_START_WITH
+        = "Expected path:%n  <%s>%nto start with:%n  <%s>%nbut it does not";
+
+    public static ErrorMessageFactory shouldStartWith(final Path actual,
+        final Path other)
+    {
+        return new ShouldStartWithPath(actual, other);
+    }
+
+    private ShouldStartWithPath(final Path actual, final Path other)
+    {
+        super(PATH_SHOULD_START_WITH, actual, other);
+    }
+}

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 
 import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldExist.shouldExist;
 
 /**
  * Core assertion class for {@link Path} assertions
@@ -33,5 +36,19 @@ public class Paths
     public static Paths instance()
     {
         return INSTANCE;
+    }
+
+    public void assertExists(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+
+        if (!java.nio.file.Files.exists(actual))
+            throw failures.failure(info, shouldExist(actual));
+    }
+
+    private static void assertNotNull(final AssertionInfo info,
+        final Path actual)
+    {
+        Objects.instance().assertNotNull(info, actual);
     }
 }

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -13,12 +13,15 @@
 package org.assertj.core.internal;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.PathsException;
 import org.assertj.core.util.VisibleForTesting;
 
+import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
 import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
+import static org.assertj.core.error.ShouldBeCanonicalPath.shouldBeCanonicalPath;
 
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeNormalized.shouldBeNormalized;
@@ -110,6 +113,22 @@ public class Paths
 
         if (!normalized.equals(actual))
             throw failures.failure(info, shouldBeNormalized(actual));
+    }
+
+    public void assertIsCanonical(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+
+        final Path realPath;
+
+        try {
+            realPath = actual.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException(String.format(IOERROR_FORMAT, actual), e);
+        }
+
+        if (!actual.equals(realPath))
+            throw failures.failure(info, shouldBeCanonicalPath(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -29,6 +29,7 @@ import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 
 /**
@@ -129,6 +130,58 @@ public class Paths
 
         if (!actual.equals(realPath))
             throw failures.failure(info, shouldBeCanonicalPath(actual));
+    }
+
+    public void assertHasParent(final AssertionInfo info, final Path actual,
+        final Path expected)
+    {
+        assertNotNull(info, actual);
+
+        if (expected == null)
+            throw new NullPointerException("parent should not be null");
+
+        final Path canonicalActual;
+
+        try {
+            canonicalActual = actual.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("failed to resolve actual", e);
+        }
+
+        final Path canonicalExpected;
+
+        try {
+            canonicalExpected = expected.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("failed to resolve path argument", e);
+        }
+
+        final Path actualParent = canonicalActual.getParent();
+
+        if (actualParent == null)
+            throw failures.failure(info, shouldHaveParent(actual, expected));
+
+        if (!actualParent.equals(canonicalExpected))
+            throw failures.failure(info,
+                shouldHaveParent(actual, actualParent, expected));
+    }
+
+    public void assertHasParentRaw(final AssertionInfo info, final Path actual,
+        final Path expected)
+    {
+        assertNotNull(info, actual);
+
+        if (expected == null)
+            throw new NullPointerException("parent should not be null");
+
+        final Path actualParent = actual.getParent();
+
+        if (actualParent == null)
+            throw failures.failure(info, shouldHaveParent(actual, expected));
+
+        if (!actualParent.equals(expected))
+            throw failures.failure(info,
+                shouldHaveParent(actual, actualParent, expected));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
 
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldBeNormalized.shouldBeNormalized;
 import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
 import static org.assertj.core.error.ShouldExist.shouldExist;
@@ -100,6 +101,15 @@ public class Paths
         assertNotNull(info, actual);
         if (!actual.isAbsolute())
             throw failures.failure(info, shouldBeAbsolutePath(actual));
+    }
+
+    public void assertIsNormalized(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+        final Path normalized = actual.normalize();
+
+        if (!normalized.equals(actual))
+            throw failures.failure(info, shouldBeNormalized(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -18,6 +18,7 @@ import org.assertj.core.util.VisibleForTesting;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
@@ -72,6 +73,14 @@ public class Paths
 
         if (!java.nio.file.Files.isRegularFile(actual))
             throw failures.failure(info, shouldBeRegularFile(actual));
+    }
+
+    public void assertIsDirectory(final AssertionInfo info, final Path actual)
+    {
+        assertExists(info, actual);
+
+        if (!java.nio.file.Files.isDirectory(actual))
+            throw failures.failure(info, shouldBeDirectory(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -18,6 +18,8 @@ import org.assertj.core.util.VisibleForTesting;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
+import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
+
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
@@ -91,6 +93,13 @@ public class Paths
 
         if (!java.nio.file.Files.isSymbolicLink(actual))
             throw failures.failure(info, shouldBeSymbolicLink(actual));
+    }
+
+    public void assertIsAbsolute(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+        if (!actual.isAbsolute())
+            throw failures.failure(info, shouldBeAbsolutePath(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -15,9 +15,11 @@ package org.assertj.core.internal;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
 import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
 
 /**
  * Core assertion class for {@link Path} assertions
@@ -44,6 +46,15 @@ public class Paths
 
         if (!java.nio.file.Files.exists(actual))
             throw failures.failure(info, shouldExist(actual));
+    }
+
+    public void assertExistsNoFollow(final AssertionInfo info,
+        final Path actual)
+    {
+        assertNotNull(info, actual);
+
+        if (!java.nio.file.Files.exists(actual, LinkOption.NOFOLLOW_LINKS))
+            throw failures.failure(info, shouldExistNoFollow(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -27,6 +27,7 @@ import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeNormalized.shouldBeNormalized;
 import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
+import static org.assertj.core.error.ShouldEndWithPath.shouldEndWith;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
@@ -249,6 +250,40 @@ public class Paths
 
         if (!actual.startsWith(other))
             throw failures.failure(info, shouldStartWith(actual, other));
+    }
+
+    public void assertEndsWith(final AssertionInfo info, final Path actual,
+        final Path other)
+    {
+        assertNotNull(info, actual);
+
+        if (other == null)
+            throw new NullPointerException("other should not be null");
+
+        final Path canonicalActual;
+
+        try {
+            canonicalActual = actual.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("cannot resolve actual path", e);
+        }
+
+        final Path normalizedOther = other.normalize();
+
+        if (!canonicalActual.endsWith(normalizedOther))
+            throw failures.failure(info, shouldEndWith(actual, other));
+    }
+
+    public void assertEndsWithRaw(final AssertionInfo info, final Path actual,
+        final Path other)
+    {
+        assertNotNull(info, actual);
+
+        if (other == null)
+            throw new NullPointerException("other should not be null");
+
+        if (!actual.endsWith(other))
+            throw failures.failure(info, shouldEndWith(actual, other));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Core assertion class for {@link Path} assertions
+ */
+public class Paths
+{
+    @VisibleForTesting
+    public static final String IOERROR_FORMAT
+        = "I/O error attempting to process assertion for path: <%s>";
+
+    private static final Paths INSTANCE = new Paths();
+
+    @VisibleForTesting
+    Failures failures = Failures.instance();
+
+    public static Paths instance()
+    {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 
 /**
  * Core assertion class for {@link Path} assertions
@@ -55,6 +56,13 @@ public class Paths
 
         if (!java.nio.file.Files.exists(actual, LinkOption.NOFOLLOW_LINKS))
             throw failures.failure(info, shouldExistNoFollow(actual));
+    }
+
+    public void assertNotExists(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+        if (!java.nio.file.Files.notExists(actual, LinkOption.NOFOLLOW_LINKS))
+            throw failures.failure(info, shouldNotExist(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -18,6 +18,7 @@ import org.assertj.core.util.VisibleForTesting;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
@@ -63,6 +64,14 @@ public class Paths
         assertNotNull(info, actual);
         if (!java.nio.file.Files.notExists(actual, LinkOption.NOFOLLOW_LINKS))
             throw failures.failure(info, shouldNotExist(actual));
+    }
+
+    public void assertIsRegularFile(final AssertionInfo info, final Path actual)
+    {
+        assertExists(info, actual);
+
+        if (!java.nio.file.Files.isRegularFile(actual))
+            throw failures.failure(info, shouldBeRegularFile(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -32,6 +32,7 @@ import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
+import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
 
 /**
  * Core assertion class for {@link Path} assertions
@@ -208,6 +209,46 @@ public class Paths
 
         if (actual.getParent() != null)
             throw failures.failure(info, shouldHaveNoParent(actual));
+    }
+
+    public void assertStartsWith(final AssertionInfo info, final Path actual,
+        final Path other)
+    {
+        assertNotNull(info, actual);
+
+        if (other == null)
+            throw new NullPointerException("other should not be null");
+
+        final Path canonicalActual;
+
+        try {
+            canonicalActual = actual.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("failed to resolve actual", e);
+        }
+
+        final Path canonicalOther;
+
+        try {
+            canonicalOther = other.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("failed to resolve path argument", e);
+        }
+
+        if (!canonicalActual.startsWith(canonicalOther))
+            throw failures.failure(info, shouldStartWith(actual, other));
+    }
+
+    public void assertStartsWithRaw(final AssertionInfo info, final Path actual,
+        final Path other)
+    {
+        assertNotNull(info, actual);
+
+        if (other == null)
+            throw new NullPointerException("other should not be null");
+
+        if (!actual.startsWith(other))
+            throw failures.failure(info, shouldStartWith(actual, other));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
+import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
@@ -81,6 +82,15 @@ public class Paths
 
         if (!java.nio.file.Files.isDirectory(actual))
             throw failures.failure(info, shouldBeDirectory(actual));
+    }
+
+    public void assertIsSymbolicLink(final AssertionInfo info,
+        final Path actual)
+    {
+        assertExistsNoFollow(info, actual);
+
+        if (!java.nio.file.Files.isSymbolicLink(actual))
+            throw failures.failure(info, shouldBeSymbolicLink(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -29,6 +29,7 @@ import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 
@@ -182,6 +183,31 @@ public class Paths
         if (!actualParent.equals(expected))
             throw failures.failure(info,
                 shouldHaveParent(actual, actualParent, expected));
+    }
+
+    public void assertHasNoParent(final AssertionInfo info, final Path actual)
+    {
+        assertNotNull(info, actual);
+
+        final Path canonicalActual;
+
+        try {
+            canonicalActual = actual.toRealPath();
+        } catch (IOException e) {
+            throw new PathsException("cannot resolve actual path", e);
+        }
+
+        if (canonicalActual.getParent() != null)
+            throw failures.failure(info, shouldHaveNoParent(actual));
+    }
+
+    public void assertHasNoParentRaw(final AssertionInfo info,
+        final Path actual)
+    {
+        assertNotNull(info, actual);
+
+        if (actual.getParent() != null)
+            throw failures.failure(info, shouldHaveNoParent(actual));
     }
 
     private static void assertNotNull(final AssertionInfo info,

--- a/src/main/java/org/assertj/core/util/PathsException.java
+++ b/src/main/java/org/assertj/core/util/PathsException.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.util;
+
+public final class PathsException
+    extends RuntimeException
+{
+    // TODO: serialUID or not?
+
+    public PathsException(final String message, final Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/test/java/org/assertj/core/api/PathAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/PathAssertBaseTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.Paths;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Base class for {@link PathAssert} tests.
+ */
+public abstract class PathAssertBaseTest
+    extends BaseTestTemplate<PathAssert, Path>
+{
+  protected Paths paths;
+
+  @Override
+  protected PathAssert create_assertions() {
+    return new PathAssert(mock(Path.class));
+  }
+
+  @Override
+  protected void inject_internal_objects() {
+    super.inject_internal_objects();
+    paths = mock(Paths.class);
+    assertions.paths = paths;
+  }
+
+  protected Paths getPaths(PathAssert someAssertions) {
+    return someAssertions.paths;
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_doesNotExist_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_doesNotExist_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_doesNotExist_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.doesNotExist();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertNotExists(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_endsWithRaw_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_endsWithRaw_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_endsWithRaw_Test
+    extends PathAssertBaseTest
+{
+    private final Path other = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.endsWithRaw(other);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertEndsWithRaw(getInfo(assertions),
+            getActual(assertions), other);
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_endsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_endsWith_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_endsWith_Test
+    extends PathAssertBaseTest
+{
+    private final Path other = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.endsWith(other);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertEndsWith(getInfo(assertions),
+            getActual(assertions), other);
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_existsNoFollow_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_existsNoFollow_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_existsNoFollow_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.existsNoFollow();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertExistsNoFollow(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_exists_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_exists_Test.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_exists_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.exists();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertExists(getInfo(assertions), getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasNoParentRaw_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasNoParentRaw_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_hasNoParentRaw_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.hasNoParentRaw();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertHasNoParentRaw(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasNoParent_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasNoParent_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_hasNoParent_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.hasNoParent();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertHasNoParent(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasParentRaw_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasParentRaw_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_hasParentRaw_Test
+    extends PathAssertBaseTest
+{
+    private final Path expected = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.hasParentRaw(expected);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertHasParentRaw(getInfo(assertions), getActual(
+            assertions), expected);
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasParent_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasParent_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_hasParent_Test
+    extends PathAssertBaseTest
+{
+    private final Path expected = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.hasParent(expected);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertHasParent(getInfo(assertions), getActual(
+            assertions), expected);
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isAbsolute_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isAbsolute_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isAbsolute_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isAbsolute();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsAbsolute(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isCanonical_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isCanonical_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isCanonical_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isCanonical();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsCanonical(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectory_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectory_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isDirectory_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isDirectory();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsDirectory(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isNormalized_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isNormalized_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isNormalized_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isNormalized();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsNormalized(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isRegularFile_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isRegularFile_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isRegularFile_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isRegularFile();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsRegularFile(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isSymbolicLink_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isSymbolicLink_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_isSymbolicLink_Test
+    extends PathAssertBaseTest
+{
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.isSymbolicLink();
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertIsSymbolicLink(getInfo(assertions),
+            getActual(assertions));
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_startsWithRaw_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_startsWithRaw_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_startsWithRaw_Test
+    extends PathAssertBaseTest
+{
+    private final Path other = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.startsWithRaw(other);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertStartsWithRaw(getInfo(assertions),
+            getActual(assertions), other);
+    }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_startsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_startsWith_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PathAssert_startsWith_Test
+    extends PathAssertBaseTest
+{
+    private final Path other = mock(Path.class);
+
+    @Override
+    protected PathAssert invoke_api_method()
+    {
+        return assertions.startsWith(other);
+    }
+
+    @Override
+    protected void verify_internal_effects()
+    {
+        verify(paths).assertStartsWith(getInfo(assertions),
+            getActual(assertions), other);
+    }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeAbsolutePath_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeAbsolutePath_create_Test.java
@@ -12,14 +12,18 @@
  */
 package org.assertj.core.error;
 
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
-
-
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeAbsolutePath.MESSAGE;
+import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for <code>{@link ShouldBeAbsolutePath#create(Description, org.assertj.core.presentation.Representation)}</code>.
@@ -28,16 +32,40 @@ import org.junit.*;
  */
 public class ShouldBeAbsolutePath_create_Test {
 
+  private TestDescription description;
+  private StandardRepresentation representation;
+
   private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
 
   @Before
   public void setUp() {
-    factory = shouldBeAbsolutePath(new FakeFile("xyz"));
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
   }
 
   @Test
-  public void should_create_error_message() {
-    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertEquals("[Test] \nExpecting:\n <xyz>\nto be an absolute path", message);
+  public void should_create_error_message_for_File_Object() {
+    final FakeFile file = new FakeFile("xyz");
+
+    factory = shouldBeAbsolutePath(file);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + MESSAGE, file);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void should_create_error_message_for_Path_object() {
+    final Path actual = mock(Path.class);
+
+    factory = shouldBeAbsolutePath(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + MESSAGE, actual);
+
+    assertEquals(expectedMessage, actualMessage);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeCanonicalPath_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeCanonicalPath_create_Test.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeCanonicalPath.MESSAGE;
+import static org.assertj.core.error.ShouldBeCanonicalPath.shouldBeCanonicalPath;
+import static org.mockito.Mockito.mock;
+
+public class ShouldBeCanonicalPath_create_Test
+{
+  private TestDescription description;
+  private StandardRepresentation representation;
+
+  private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
+
+  @Before
+  public void setUp()
+  {
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
+  }
+
+  @Test
+  public void should_create_error_message()
+  {
+    final Path actual = mock(Path.class);
+
+    factory = shouldBeCanonicalPath(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + MESSAGE, actual);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeDirectory_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeDirectory_create_Test.java
@@ -12,32 +12,62 @@
  */
 package org.assertj.core.error;
 
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
-
-
-import org.assertj.core.description.Description;
 import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
-/**
- * Tests for <code>{@link ShouldBeDirectory#create(Description, org.assertj.core.presentation.Representation)}</code>.
- * 
- * @author Yvonne Wang
- */
-public class ShouldBeDirectory_create_Test {
+import java.io.File;
+import java.nio.file.Path;
 
-  private ErrorMessageFactory factory;
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeDirectory.FILE_SHOULD_BE_DIRECTORY;
+import static org.assertj.core.error.ShouldBeDirectory.PATH_SHOULD_BE_DIRECTORY;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.mockito.Mockito.mock;
 
-  @Before
-  public void setUp() {
-    factory = shouldBeDirectory(new FakeFile("xyz"));
-  }
+public class ShouldBeDirectory_create_Test
+{
+    private TestDescription description;
+    private Representation representation;
 
-  @Test
-  public void should_create_error_message() {
-    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertEquals("[Test] \nExpecting:\n <xyz>\nto be an existing directory", message);
-  }
+    private ErrorMessageFactory factory;
+    private String message;
+    private String expectedMessage;
+
+    @Before
+    public void setup()
+    {
+        description = new TestDescription("Test");
+        representation = new StandardRepresentation();
+    }
+
+    @Test
+    public void should_create_error_message_for_Path()
+    {
+        final Path path = mock(Path.class);
+
+        factory = shouldBeDirectory(path);
+        message = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + PATH_SHOULD_BE_DIRECTORY,
+            path);
+
+        assertEquals(expectedMessage, message);
+    }
+
+    @Test
+    public void should_create_error_message_for_File()
+    {
+        final File file = new FakeFile("xyz");
+
+        factory = shouldBeDirectory(file);
+        message = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + FILE_SHOULD_BE_DIRECTORY,
+            file);
+
+        assertEquals(expectedMessage, message);
+    }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeNormalized_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeNormalized_create_Test.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeNormalized.SHOULD_BE_NORMALIZED;
+import static org.assertj.core.error.ShouldBeNormalized.shouldBeNormalized;
+import static org.mockito.Mockito.mock;
+
+public class ShouldBeNormalized_create_Test
+{
+    private TestDescription description;
+    private Representation representation;
+
+    private ErrorMessageFactory factory;
+    private String actualMessage;
+    private String expectedMessage;
+
+    @Before
+    public void setup()
+    {
+        description = new TestDescription("Test");
+        representation = new StandardRepresentation();
+    }
+
+    @Test
+    public void should_create_error_message()
+    {
+        final Path actual = mock(Path.class);
+
+        factory = shouldBeNormalized(actual);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + SHOULD_BE_NORMALIZED, actual);
+
+        assertEquals(expectedMessage, actualMessage);
+    }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeRegularFile_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeRegularFile_create_Test.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeRegularFile.SHOULD_BE_REGULAR_FILE;
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
+import static org.mockito.Mockito.mock;
+
+public class ShouldBeRegularFile_create_Test
+{
+  private TestDescription description;
+  private StandardRepresentation representation;
+
+  private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
+
+  @Before
+  public void setUp()
+  {
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
+  }
+
+  @Test
+  public void should_create_error_message()
+  {
+    final Path actual = mock(Path.class);
+
+    factory = shouldBeRegularFile(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + SHOULD_BE_REGULAR_FILE, actual);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeSymbolicLink_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeSymbolicLink_create_Test.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeSymbolicLink.SHOULD_BE_SYMBOLIC_LINK;
+import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
+import static org.mockito.Mockito.mock;
+
+public class ShouldBeSymbolicLink_create_Test
+{
+  private TestDescription description;
+  private StandardRepresentation representation;
+
+  private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
+
+  @Before
+  public void setUp()
+  {
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
+  }
+
+  @Test
+  public void should_create_error_message()
+  {
+    final Path actual = mock(Path.class);
+
+    factory = shouldBeSymbolicLink(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + SHOULD_BE_SYMBOLIC_LINK,
+        actual);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldEndWithPath_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldEndWithPath_create_Test.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldEndWithPath.PATH_SHOULD_END_WITH;
+import static org.assertj.core.error.ShouldEndWithPath.shouldEndWith;
+import static org.mockito.Mockito.mock;
+
+public final class ShouldEndWithPath_create_Test
+{
+    private TestDescription description;
+    private Representation representation;
+
+    private ErrorMessageFactory factory;
+    private String actualMessage;
+    private String expectedMessage;
+
+    @Before
+    public void setup()
+    {
+        description = new TestDescription("Test");
+        representation = new StandardRepresentation();
+    }
+
+    @Test
+    public void should_create_error_message()
+    {
+        final Path actual = mock(Path.class);
+        final Path other = mock(Path.class);
+
+        factory = shouldEndWith(actual, other);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + PATH_SHOULD_END_WITH,
+            actual, other);
+
+        assertEquals(expectedMessage, actualMessage);
+    }
+}

--- a/src/test/java/org/assertj/core/error/ShouldExistNoFollow_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldExistNoFollow_create_Test.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldExistNoFollow.PATH_SHOULD_EXIST_NOFOLLOW;
+import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.mockito.Mockito.mock;
+
+public class ShouldExistNoFollow_create_Test
+{
+  private TestDescription description;
+  private StandardRepresentation representation;
+
+  private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
+
+  @Before
+  public void setUp()
+  {
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
+  }
+
+  @Test
+  public void should_create_error_message()
+  {
+    final Path actual = mock(Path.class);
+
+    factory = shouldExistNoFollow(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + PATH_SHOULD_EXIST_NOFOLLOW,
+        actual);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldExist_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldExist_create_Test.java
@@ -12,31 +12,59 @@
  */
 package org.assertj.core.error;
 
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.error.ShouldExist.shouldExist;
-
-
+import org.assertj.core.description.Description;
 import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldExist.PATH_SHOULD_EXIST;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.mockito.Mockito.mock;
 
 /**
- * Tests for <code>{@link ShouldExist#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ * Tests for {@link ShouldExist#create(Description, Representation)}
  * 
  * @author Yvonne Wang
  */
 public class ShouldExist_create_Test {
 
+  private TestDescription description;
+  private Representation representation;
+
   private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
 
   @Before
   public void setUp() {
-    factory = shouldExist(new FakeFile("xyz"));
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
   }
 
   @Test
-  public void should_create_error_message() {
-    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertEquals("[Test] \nExpecting file:<xyz> to exist", message);
+  public void should_create_error_message_for_File() {
+    factory = shouldExist(new FakeFile("xyz"));
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = "[Test] \nExpecting file:\n  <xyz>\nto exist";
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void should_create_error_message_for_Path() {
+    final Path actual = mock(Path.class);
+
+    factory = shouldExist(actual);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + PATH_SHOULD_EXIST, actual);
+
+    assertEquals(expectedMessage, actualMessage);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveNoParent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveNoParent_create_Test.java
@@ -13,41 +13,72 @@
 package org.assertj.core.error;
 
 import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveNoParent.FILE_HAS_PARENT;
+import static org.assertj.core.error.ShouldHaveNoParent.PATH_HAS_PARENT;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for <code>{@link org.assertj.core.error.ShouldHaveNoParent#shouldHaveNoParent(java.io.File)}</code>
+ * Tests for {@link ShouldHaveNoParent#shouldHaveNoParent(File)} and {@link
+ * ShouldHaveNoParent#shouldHaveNoParent(Path)}
  * 
  * @author Jean-Christophe Gay
+ * @author Francis Galiegue
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ShouldHaveNoParent_create_Test {
+public class ShouldHaveNoParent_create_Test
+{
 
-  @Mock
-  private File actual;
+  private TestDescription description;
+  private Representation representation;
 
-  @Test
-  public void should_create_error_message_when_actual_does_not_have_a_parent() {
+  private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
 
-    when(actual.getParentFile()).thenReturn(new FakeFile("unexpected.parent"));
-
-    assertThat(createMessage()).isEqualTo(String.format(
-      "[TEST] %n" +
-      "Expecting file (or directory) without parent, but parent was:%n" +
-      "  <" + actual.getParentFile() + ">"));
+  @Before
+  public void setup()
+  {
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
   }
 
-  private String createMessage() {
-    return shouldHaveNoParent(actual).create(new TestDescription("TEST"), new StandardRepresentation());
+  @Test
+  public void should_create_error_message_when_file_has_a_parent()
+  {
+    final File file = mock(File.class);
+    final FakeFile parent = new FakeFile("unexpected.parent");
+    when(file.getParentFile()).thenReturn(parent);
+
+    factory = shouldHaveNoParent(file);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + FILE_HAS_PARENT, parent);
+
+    assertThat(actualMessage).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  public void should_create_error_message_when_path_has_a_parent()
+  {
+    final Path path = mock(Path.class);
+    final Path parent = mock(Path.class);
+    when(path.getParent()).thenReturn(parent);
+
+    factory = shouldHaveNoParent(path);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + PATH_HAS_PARENT, parent);
+
+    assertThat(actualMessage).isEqualTo(expectedMessage);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveParent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveParent_create_Test.java
@@ -13,60 +13,107 @@
 package org.assertj.core.error;
 
 import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
-
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveParent.FILE_NOT_EXPECTED_PARENT;
+import static org.assertj.core.error.ShouldHaveParent.FILE_NO_PARENT;
+import static org.assertj.core.error.ShouldHaveParent.PATH_NOT_EXPECTED_PARENT;
+import static org.assertj.core.error.ShouldHaveParent.PATH_NO_PARENT;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for <code>{@link ShouldHaveParent#shouldHaveParent(java.io.File, java.io.File)}</code>
+ * Tests for {@link ShouldHaveParent#shouldHaveParent(File, File)} and {@link
+ * ShouldHaveParent#shouldHaveParent(Path, Path)}
  *
  * @author Jean-Christophe Gay
+ * @author Francis Galiegue
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ShouldHaveParent_create_Test {
+public class ShouldHaveParent_create_Test
+{
+    private final File expectedFileParent = new FakeFile("expected.parent");
+    private final Path expectedPathParent = mock(Path.class);
 
-  @Spy
-  private File actual = new FakeFile("actual");
+    private TestDescription description;
+    private Representation representation;
 
-  private File expectedParent = new FakeFile("expected.parent");
+    private ErrorMessageFactory factory;
+    private String actualMessage;
+    private String expectedMessage;
 
-  @Test
-  public void should_create_error_message_when_actual_does_not_have_a_parent() {
+    @Before
+    public void setup()
+    {
+        description = new TestDescription("Test");
+        representation = new StandardRepresentation();
+    }
 
-    when(actual.getParentFile()).thenReturn(null);
+    @Test
+    public void should_create_error_message_when_file_has_no_parent()
+    {
+        final File actual = spy(new FakeFile("actual"));
+        when(actual.getParentFile()).thenReturn(null);
 
-    assertThat(createMessage()).isEqualTo(String.format("[TEST] %n" +
-                                                        "Expecting file%n" +
-                                                        "  <" + actual + ">%n" +
-                                                        "to have parent:%n" +
-                                                        "  <" + expectedParent + ">%n" +
-                                                        "but did not have one."));
-  }
+        factory = shouldHaveParent(actual, expectedFileParent);
+        actualMessage = factory.create(description, representation);
 
-  @Test
-  public void should_create_error_message_when_actual_does_not_have_expected_parent() throws Exception {
+        expectedMessage = String.format("[Test] " + FILE_NO_PARENT,
+            actual, expectedFileParent);
 
-    when(actual.getParentFile()).thenReturn(new FakeFile("not.expected.parent"));
+        assertThat(expectedMessage).isEqualTo(actualMessage);
+    }
 
-    assertThat(createMessage()).isEqualTo(String.format("[TEST] %n" +
-                                                        "Expecting file%n" +
-                                                        "  <" + actual + ">%n" +
-                                                        "to have parent:%n" +
-                                                        "  <" + expectedParent + ">%n" +
-                                                        "but had:%n" +
-                                                        "  <" + actual.getParentFile() + ">."));
-  }
+    @Test
+    public void should_create_error_message_when_file_does_not_have_expected_parent()
+    {
+        final File actual = spy(new FakeFile("actual"));
+        final FakeFile actualParent = new FakeFile("not.expected.parent");
+        when(actual.getParentFile()).thenReturn(actualParent);
 
-  private String createMessage() {
-    return shouldHaveParent(actual, expectedParent).create(new TestDescription("TEST"), new StandardRepresentation());
-  }
+        factory = shouldHaveParent(actual, expectedFileParent);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + FILE_NOT_EXPECTED_PARENT,
+            actual, expectedFileParent, actualParent);
+
+        assertThat(actualMessage).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void should_create_error_message_when_path_has_no_parent()
+    {
+        final Path actual = mock(Path.class);
+
+        factory = shouldHaveParent(actual, expectedPathParent);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + PATH_NO_PARENT,
+            actual, expectedPathParent);
+
+        assertThat(actualMessage).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void should_create_error_message_when_path_does_not_have_expected_parent()
+    {
+        final Path actual = mock(Path.class);
+        final Path actualParent = mock(Path.class);
+
+        factory = shouldHaveParent(actual, actualParent, expectedPathParent);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + PATH_NOT_EXPECTED_PARENT,
+            actual, expectedPathParent, actualParent);
+
+        assertThat(actualMessage).isEqualTo(expectedMessage);
+    }
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotExist_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotExist_create_Test.java
@@ -12,13 +12,18 @@
  */
 package org.assertj.core.error;
 
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
-
-
 import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldNotExist.FILE_SHOULDNOTEXIST;
+import static org.assertj.core.error.ShouldNotExist.PATH_SHOULDNOTEXIST;
+import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for <code>{@link ShouldNotExist#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
@@ -27,16 +32,40 @@ import org.junit.*;
  */
 public class ShouldNotExist_create_Test {
 
+  private TestDescription description;
+  private StandardRepresentation representation;
+
   private ErrorMessageFactory factory;
+  private String actualMessage;
+  private String expectedMessage;
 
   @Before
   public void setUp() {
-    factory = shouldNotExist(new FakeFile("xyz"));
+    description = new TestDescription("Test");
+    representation = new StandardRepresentation();
   }
 
   @Test
-  public void should_create_error_message() {
-    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertEquals("[Test] \nExpecting file:<xyz> not to exist", message);
+  public void should_create_error_message_for_File_object() {
+    final FakeFile file = new FakeFile("xyz");
+
+    factory = shouldNotExist(file);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + FILE_SHOULDNOTEXIST, file);
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void should_create_error_message_for_Path_object() {
+    final Path path = mock(Path.class);
+
+    factory = shouldNotExist(path);
+    actualMessage = factory.create(description, representation);
+
+    expectedMessage = String.format("[Test] " + PATH_SHOULDNOTEXIST, path);
+
+    assertEquals(expectedMessage, actualMessage);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldStartWithPath_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldStartWithPath_create_Test.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldStartWithPath.PATH_SHOULD_START_WITH;
+import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
+import static org.mockito.Mockito.mock;
+
+public final class ShouldStartWithPath_create_Test
+{
+    private TestDescription description;
+    private Representation representation;
+
+    private ErrorMessageFactory factory;
+    private String actualMessage;
+    private String expectedMessage;
+
+    @Before
+    public void setup()
+    {
+        description = new TestDescription("Test");
+        representation = new StandardRepresentation();
+    }
+
+    @Test
+    public void should_create_error_message()
+    {
+        final Path actual = mock(Path.class);
+        final Path other = mock(Path.class);
+
+        factory = shouldStartWith(actual, other);
+        actualMessage = factory.create(description, representation);
+
+        expectedMessage = String.format("[Test] " + PATH_SHOULD_START_WITH,
+            actual, other);
+
+        assertEquals(expectedMessage, actualMessage);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/PathsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/PathsBaseTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ExternalResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+
+import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.spy;
+
+
+/**
+ * Base test class for {@link Path} instances
+ *
+ * <p>Assertion on {@link Path} objects are of two categories:</p>
+ *
+ * <ul>
+ *     <li>assertions on the {@link Path} object themselves: those do not
+ *     require a {@link FileSystem};</li>
+ *     <li>assertions inducing filesystem I/O: those <em>do</em> require a
+ *     {@link FileSystem}.</li>
+ * </ul>
+ *
+ * <p>An advantage when compared with {@link File} is that we do not need to
+ * pollute the developer's machine with temporary files/directories/etc for I/O
+ * bound tests; all that is required is a filesystem implementation.</p>
+ *
+ * <p><a
+ * href="https://github.com/marschall/memoryfilesystem">memoryfilesystem</a> is
+ * chosen for its great support of getting/setting file attributes etc, and for
+ * its emulation of both Unix and Windows filesystems.</p>
+ *
+ * @see Path
+ * @see FileSystem
+ * @see Files
+ */
+public abstract class PathsBaseTest
+{
+  @Rule
+  public ExpectedException thrown = none();
+  protected Failures failures;
+  protected Paths paths;
+  protected AssertionInfo info;
+  // TODO! uncomment when needed
+  //protected Diff diff;
+  //protected BinaryDiff binaryDiff;
+
+  @Before
+  public void setUp()
+      throws IOException
+  {
+    failures = spy(new Failures());
+    paths = new Paths();
+    paths.failures = failures;
+    info = someInfo();
+    //diff = mock(Diff.class);
+    //files.diff = diff;
+    //binaryDiff = mock(BinaryDiff.class);
+    //files.binaryDiff = binaryDiff;
+  }
+
+  /**
+   * A {@link FileSystem} for test classes which need them
+   *
+   * <p>For tets classes which do need a filesystem to test assertions and not
+   * only paths, declare a {@code static} instance field of this class as a
+   * {@link ClassRule} and initialize it in {@link BeforeClass}.</p>
+   */
+  public static class FileSystemResource
+    extends ExternalResource
+  {
+    private final FileSystem fs;
+
+    public FileSystemResource()
+        throws IOException
+    {
+      fs = MemoryFileSystemBuilder.newLinux().build("PathsTest");
+    }
+
+    public FileSystem getFileSystem()
+    {
+      return fs;
+    }
+
+    @Override
+    protected void after()
+    {
+      try {
+        fs.close();
+      } catch (IOException e) {
+        throw new RuntimeException("failed to close filesystem", e);
+      }
+    }
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.error.ShouldEndWithPath.shouldEndWith;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertEndsWithRaw_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+    private Path other;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+        other = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertEndsWithRaw(info, null, other);
+    }
+
+    @Test
+    public void should_fail_if_other_is_null()
+    {
+        try {
+            paths.assertEndsWithRaw(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "other should not be null");
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_does_not_end_with_other()
+    {
+        // This is the default, but let's make this explicit
+        when(actual.endsWith(other)).thenReturn(false);
+
+        try {
+            paths.assertEndsWithRaw(info, actual, other);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldEndWith(actual, other));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_ends_with_other()
+    {
+        when(actual.endsWith(other)).thenReturn(true);
+
+        paths.assertEndsWithRaw(info, actual, other);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.PathsException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertSame;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.error.ShouldEndWithPath.shouldEndWith;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertEndsWith_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path nonExistingActual;
+    public static Path nonExistingParent;
+    public static Path existingActual;
+    public static Path existingGoodParent;
+    public static Path existingBadParent;
+
+    @BeforeClass
+    public static void initPaths()
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        nonExistingActual = fs.getPath("/noActual");
+        nonExistingParent = fs.getPath("/noParent");
+    }
+
+    private Path actual;
+    private Path other;
+
+    @Before
+    public void initMocks()
+    {
+        actual = mock(Path.class);
+        other = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertEndsWith(info, null, other);
+    }
+
+    @Test
+    public void should_fail_if_other_is_null()
+    {
+        try {
+            paths.assertEndsWith(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "other should not be null");
+        }
+    }
+
+    @Test
+    public void should_fail_with_PathsException_if_actual_cannot_resolve()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+        when(actual.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertEndsWith(info, actual, other);
+            fail("expected a PathsException here");
+        } catch (PathsException e) {
+            assertEquals("cannot resolve actual path", e.getMessage());
+            assertSame(exception, e.getCause());
+        }
+    }
+
+    @Test
+    public void should_fail_if_canonical_actual_does_not_end_with_normalized_other()
+        throws IOException
+    {
+        final Path canonicalActual = mock(Path.class);
+        final Path normalizedOther = mock(Path.class);
+
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(other.normalize()).thenReturn(normalizedOther);
+
+        // This is the default, but...
+        when(canonicalActual.endsWith(normalizedOther)).thenReturn(false);
+
+        try {
+            paths.assertEndsWith(info, actual, other);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldEndWith(actual, other));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_canonical_actual_ends_with_normalized_other()
+        throws IOException
+    {
+        final Path canonicalActual = mock(Path.class);
+        final Path normalizedOther = mock(Path.class);
+
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(other.normalize()).thenReturn(normalizedOther);
+
+        // We want the canonical versions to be compared, not the arguments
+        when(canonicalActual.endsWith(normalizedOther)).thenReturn(true);
+
+        paths.assertEndsWith(info, actual, other);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollow_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollow_Test.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertExistsNoFollow_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path existing;
+    public static Path nonExisting;
+    public static Path symlink;
+    public static Path dangling;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        existing = fs.getPath("/existing");
+        Files.createFile(existing);
+
+        symlink = fs.getPath("/symlink");
+        Files.createSymbolicLink(symlink, existing);
+
+        nonExisting = fs.getPath("/nonExisting");
+        dangling = fs.getPath("/dangling");
+        Files.createSymbolicLink(dangling, nonExisting);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertExistsNoFollow(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_does_not_exist()
+    {
+        try {
+            paths.assertExistsNoFollow(info, nonExisting);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExistNoFollow(nonExisting));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_is_dangling_symlink()
+    {
+        paths.assertExistsNoFollow(info, dangling);
+    }
+
+    @Test
+    public void should_pass_if_actual_exists()
+    {
+        paths.assertExistsNoFollow(info, existing);
+    }
+
+    @Test
+    public void should_pass_if_actual_is_non_dangling_symlink()
+    {
+        paths.assertExistsNoFollow(info, symlink);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertExists_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path existing;
+    public static Path nonExisting;
+    public static Path symlink;
+    public static Path dangling;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        existing = fs.getPath("/existing");
+        Files.createFile(existing);
+
+        symlink = fs.getPath("/symlink");
+        Files.createSymbolicLink(symlink, existing);
+
+        nonExisting = fs.getPath("/nonExisting");
+        dangling = fs.getPath("/dangling");
+        Files.createSymbolicLink(dangling, nonExisting);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertExists(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_does_not_exist()
+    {
+        try {
+            paths.assertExists(info, nonExisting);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(nonExisting));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_is_dangling_symlink()
+    {
+        try {
+            paths.assertExists(info, dangling);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(dangling));
+        }
+    }
+
+    @Test
+    public void should_pass_if_actual_exists()
+    {
+        paths.assertExists(info, existing);
+    }
+
+    @Test
+    public void should_pass_if_actual_is_non_dangling_symlink()
+    {
+        paths.assertExists(info, symlink);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Paths_assertHasNoParentRaw_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertHasNoParentRaw(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_has_parent()
+        throws IOException
+    {
+        final Path parent = mock(Path.class);
+        when(actual.getParent()).thenReturn(parent);
+
+        try {
+            paths.assertHasNoParentRaw(info, actual);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldHaveNoParent(actual));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_has_no_parent()
+        throws IOException
+    {
+        // This is the default, but let's make that clear
+        when(actual.getParent()).thenReturn(null);
+
+        paths.assertHasNoParentRaw(info, actual);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.PathsException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertSame;
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Paths_assertHasNoParent_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertHasNoParent(info, null);
+    }
+
+    @Test
+    public void should_throw_PathsException_if_actual_cannot_be_canonicalized()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+        when(actual.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertHasNoParent(info, actual);
+            fail("was expecting a PathsException");
+        } catch (PathsException e) {
+            assertEquals("cannot resolve actual path", e.getMessage());
+            assertSame(exception, e.getCause());
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_has_parent()
+        throws IOException
+    {
+        final Path canonicalActual = mock(Path.class);
+        final Path parent = mock(Path.class);
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(canonicalActual.getParent()).thenReturn(parent);
+
+        try {
+            paths.assertHasNoParent(info, actual);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldHaveNoParent(actual));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_has_no_parent()
+        throws IOException
+    {
+        final Path canonicalActual = mock(Path.class);
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        // This is the default, but let's make that clear
+        when(canonicalActual.getParent()).thenReturn(null);
+
+        paths.assertHasNoParent(info, actual);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Paths_assertHasParentRaw_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+    private Path expectedParent;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+        expectedParent = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertHasParentRaw(info, null, expectedParent);
+    }
+
+    @Test
+    public void should_fail_if_provided_parent_is_null()
+    {
+        try {
+            paths.assertHasParentRaw(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "parent should not be null");
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_has_no_parent()
+        throws IOException
+    {
+        // This is the default, but...
+        when(actual.getParent()).thenReturn(null);
+
+        try {
+            paths.assertHasParentRaw(info, actual, expectedParent);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info,
+                shouldHaveParent(actual, expectedParent));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_parent_is_not_expected_parent()
+        throws IOException
+    {
+        final Path actualParent = mock(Path.class);
+
+        when(actual.getParent()).thenReturn(actualParent);
+
+        try {
+            paths.assertHasParentRaw(info, actual, expectedParent);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info,
+                shouldHaveParent(actual, actualParent, expectedParent));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_parent_is_expected_parent()
+    {
+        when(actual.getParent()).thenReturn(expectedParent);
+
+        paths.assertHasParentRaw(info, actual, expectedParent);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.PathsException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertSame;
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Paths_assertHasParent_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+    private Path canonicalActual;
+    private Path expected;
+    private Path canonicalExpected;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+        canonicalActual = mock(Path.class);
+        expected = mock(Path.class);
+        canonicalExpected = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertHasParent(info, null, expected);
+    }
+
+    @Test
+    public void should_fail_if_provided_parent_is_null()
+    {
+        try {
+            paths.assertHasParent(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "parent should not be null");
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_cannot_be_canonicalized()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+        when(actual.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertHasParent(info, actual, expected);
+            fail("expected a PathsException here");
+        } catch (PathsException e) {
+            assertSame(exception, e.getCause());
+            assertEquals("failed to resolve actual", e.getMessage());
+        }
+    }
+
+    @Test
+    public void should_fail_if_expected_parent_cannot_be_canonicalized()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(expected.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertHasParent(info, actual, expected);
+            fail("expected a PathsException here");
+        } catch (PathsException e) {
+            assertSame(exception, e.getCause());
+            assertEquals("failed to resolve path argument", e.getMessage());
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_has_no_parent()
+        throws IOException
+    {
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(expected.toRealPath()).thenReturn(canonicalExpected);
+
+        // This is the default, but...
+        when(canonicalActual.getParent()).thenReturn(null);
+
+        try {
+            paths.assertHasParent(info, actual, expected);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info,
+                shouldHaveParent(actual, expected));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_parent_is_not_expected_parent()
+        throws IOException
+    {
+        final Path actualParent = mock(Path.class);
+
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(expected.toRealPath()).thenReturn(canonicalExpected);
+
+        when(canonicalActual.getParent()).thenReturn(actualParent);
+
+        try {
+            paths.assertHasParent(info, actual, expected);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info,
+                shouldHaveParent(actual, actualParent, expected));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_canonical_actual_has_expected_parent()
+        throws IOException
+    {
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(expected.toRealPath()).thenReturn(canonicalExpected);
+
+        when(canonicalActual.getParent()).thenReturn(canonicalExpected);
+
+        paths.assertHasParent(info, actual, expected);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsAbsolute_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsAbsolute_Test.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertIsAbsolute_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsAbsolute(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_absolute()
+    {
+        // This is the default, but make it explicit
+        when(actual.isAbsolute()).thenReturn(false);
+
+        try {
+            paths.assertIsAbsolute(info, actual);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeAbsolutePath(actual));
+        }
+    }
+
+    @Test
+    public void should_pass_if_actual_is_absolute()
+    {
+        when(actual.isAbsolute()).thenReturn(true);
+        paths.assertIsAbsolute(info, actual);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.PathsException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.error.ShouldBeCanonicalPath.shouldBeCanonicalPath;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Paths_assertIsCanonical_Test
+    extends PathsBaseTest
+{
+    private Path path;
+
+
+    @Before
+    public void init()
+    {
+        path = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsCanonical(info, null);
+    }
+
+    @Test
+    public void should_throw_pathsexception_on_io_error()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+        when(path.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertIsCanonical(info, path);
+            fail("Expected a PathsException here");
+        } catch (PathsException e) {
+            assertEquals(String.format(Paths.IOERROR_FORMAT, path),
+                e.getMessage());
+            assertSame(e.getCause(), exception);
+        }
+    }
+
+    @Test
+    public void should_fail_if_real_path_differs_from_actual()
+        throws IOException
+    {
+        final Path other = mock(Path.class);
+        when(path.toRealPath()).thenReturn(other);
+
+        try {
+            paths.assertIsCanonical(info, path);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeCanonicalPath(path));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_real_path_is_same_as_actual()
+        throws IOException
+    {
+        when(path.toRealPath()).thenReturn(path);
+        paths.assertIsCanonical(info, path);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectory_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectory_Test.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertIsDirectory_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path regularFile;
+    public static Path symlink;
+
+    public static Path nonExisting;
+    public static Path dangling;
+
+    public static Path directory;
+    public static Path dirSymlink;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        regularFile = fs.getPath("/existing");
+        symlink = fs.getPath("/symlink");
+        Files.createFile(regularFile);
+        Files.createSymbolicLink(symlink, regularFile);
+
+
+        nonExisting = fs.getPath("/nonExisting");
+        dangling = fs.getPath("/dangling");
+        Files.createSymbolicLink(dangling, nonExisting);
+
+        directory = fs.getPath("/dir");
+        dirSymlink = fs.getPath("/dirsymlink");
+        Files.createDirectory(directory);
+        Files.createSymbolicLink(dirSymlink, directory);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsDirectory(info, null);
+    }
+
+    @Test
+    public void should_fail_with_notexists_if_actual_does_not_exist()
+    {
+        try {
+            paths.assertIsDirectory(info, nonExisting);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(nonExisting));
+        }
+    }
+
+    @Test
+    public void should_fail_with_notexists_if_actual_is_dangling_symlink()
+    {
+        try {
+            paths.assertIsDirectory(info, dangling);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(dangling));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_is_regular_file()
+    {
+        try {
+            paths.assertIsDirectory(info, regularFile);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeDirectory(regularFile));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_is_symlink_pointing_to_regular_file()
+    {
+        try {
+            paths.assertIsDirectory(info, symlink);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeDirectory(symlink));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_target_is_directory()
+    {
+        paths.assertIsDirectory(info, directory);
+    }
+
+    @Test
+    public void should_succeed_if_target_is_symlink_pointing_to_directory()
+    {
+        paths.assertIsDirectory(info, dirSymlink);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNormalized_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNormalized_Test.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldBeNormalized.shouldBeNormalized;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertIsNormalized_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsNormalized(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_normalized()
+    {
+        when(actual.normalize()).thenReturn(mock(Path.class));
+
+        try {
+            paths.assertIsNormalized(info, actual);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeNormalized(actual));
+        }
+    }
+
+    @Test
+    public void should_pass_if_actual_is_normalized()
+    {
+        when(actual.normalize()).thenReturn(actual);
+
+        paths.assertIsNormalized(info, actual);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRegularFile_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRegularFile_Test.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertIsRegularFile_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path regularFile;
+    public static Path symlink;
+
+    public static Path nonExisting;
+    public static Path dangling;
+
+    public static Path directory;
+    public static Path dirSymlink;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        regularFile = fs.getPath("/existing");
+        symlink = fs.getPath("/symlink");
+        Files.createFile(regularFile);
+        Files.createSymbolicLink(symlink, regularFile);
+
+
+        nonExisting = fs.getPath("/nonExisting");
+        dangling = fs.getPath("/dangling");
+        Files.createSymbolicLink(dangling, nonExisting);
+
+        directory = fs.getPath("/dir");
+        dirSymlink = fs.getPath("/dirsymlink");
+        Files.createDirectory(directory);
+        Files.createSymbolicLink(dirSymlink, directory);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsRegularFile(info, null);
+    }
+
+    @Test
+    public void should_fail_with_notexists_if_actual_does_not_exist()
+    {
+        try {
+            paths.assertIsRegularFile(info, nonExisting);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(nonExisting));
+        }
+    }
+
+    @Test
+    public void should_fail_with_notexists_if_actual_is_dangling_symlink()
+    {
+        try {
+            paths.assertIsRegularFile(info, dangling);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExist(dangling));
+        }
+    }
+
+    @Test
+    public void should_fail_if_target_is_directory()
+    {
+        try {
+            paths.assertIsRegularFile(info, directory);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeRegularFile(directory));
+        }
+    }
+
+    @Test
+    public void should_fail_if_target_is_symlink_pointing_to_directory()
+    {
+        try {
+            paths.assertIsRegularFile(info, dirSymlink);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeRegularFile(dirSymlink));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_is_symlink_pointing_to_regular_file()
+    {
+        paths.assertIsRegularFile(info, symlink);
+    }
+
+    @Test
+    public void should_succeed_if_actual_is_regular_file()
+    {
+        paths.assertIsRegularFile(info, regularFile);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldBeSymbolicLink.shouldBeSymbolicLink;
+import static org.assertj.core.error.ShouldExistNoFollow.shouldExistNoFollow;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertIsSymbolicLink_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path regularFile;
+    public static Path symlink;
+
+    public static Path nonExisting;
+    public static Path dangling;
+
+    public static Path directory;
+    public static Path dirSymlink;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        regularFile = fs.getPath("/existing");
+        symlink = fs.getPath("/symlink");
+        Files.createFile(regularFile);
+        Files.createSymbolicLink(symlink, regularFile);
+
+
+        nonExisting = fs.getPath("/nonExisting");
+        dangling = fs.getPath("/dangling");
+        Files.createSymbolicLink(dangling, nonExisting);
+
+        directory = fs.getPath("/dir");
+        dirSymlink = fs.getPath("/dirsymlink");
+        Files.createDirectory(directory);
+        Files.createSymbolicLink(dirSymlink, directory);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertIsSymbolicLink(info, null);
+    }
+
+    @Test
+    public void should_fail_with_notexists_nofollow_if_actual_does_not_exist()
+    {
+        try {
+            paths.assertIsSymbolicLink(info, nonExisting);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldExistNoFollow(nonExisting));
+        }
+    }
+
+    @Test
+    public void should_fail_if_target_is_directory()
+    {
+        try {
+            paths.assertIsSymbolicLink(info, directory);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeSymbolicLink(directory));
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_is_regular_file()
+    {
+        try {
+            paths.assertIsSymbolicLink(info, regularFile);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeSymbolicLink(regularFile));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_target_is_symlink_pointing_to_directory()
+    {
+        paths.assertIsSymbolicLink(info, dirSymlink);
+    }
+
+    @Test
+    public void should_succeed_if_actual_is_symlink_pointing_to_regular_file()
+    {
+        paths.assertIsSymbolicLink(info, symlink);
+    }
+
+    @Test
+    public void should_succeed_if_actual_is_dangling_symlink()
+    {
+        paths.assertIsSymbolicLink(info, dangling);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Paths_assertNotExists_Test
+    extends PathsBaseTest
+{
+    @ClassRule
+    public static FileSystemResource resource;
+
+    static {
+        try {
+            resource = new FileSystemResource();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+
+        }
+    }
+
+    public static Path existing;
+    public static Path symlink;
+    public static Path nonExisting;
+
+    @BeforeClass
+    public static void initPaths()
+        throws IOException
+    {
+        final FileSystem fs = resource.getFileSystem();
+
+        existing = fs.getPath("/existing");
+        Files.createFile(existing);
+
+        nonExisting = fs.getPath("/nonExisting");
+
+        symlink = fs.getPath("/symlink");
+        Files.createSymbolicLink(symlink, nonExisting);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertNotExists(info, null);
+    }
+
+    @Test
+    public void should_fail_if_actual_exists()
+    {
+        try {
+            paths.assertNotExists(info, existing);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldNotExist(existing));
+        }
+    }
+
+    @Test
+    public void should_fail_even_if_actual_is_dangling_symlink()
+    {
+        try {
+            paths.assertNotExists(info, symlink);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldNotExist(symlink));
+        }
+    }
+
+    @Test
+    public void should_pass_if_actual_does_not_exist()
+    {
+        paths.assertNotExists(info, nonExisting);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertStartsWithRaw_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+    private Path other;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+        other = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertStartsWithRaw(info, null, other);
+    }
+
+    @Test
+    public void should_fail_if_other_is_null()
+    {
+        try {
+            paths.assertStartsWithRaw(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "other should not be null");
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_does_not_start_with_other()
+    {
+        // This is the default, but let's make this explicit
+        when(actual.startsWith(other)).thenReturn(false);
+
+        try {
+            paths.assertStartsWithRaw(info, actual, other);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldStartWith(actual, other));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_starts_with_other()
+    {
+        when(actual.startsWith(other)).thenReturn(true);
+
+        paths.assertStartsWithRaw(info, actual, other);
+    }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.PathsException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertSame;
+import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("AutoBoxing")
+public class Paths_assertStartsWith_Test
+    extends PathsBaseTest
+{
+    private Path actual;
+    private Path canonicalActual;
+    private Path other;
+    private Path canonicalOther;
+
+    @Before
+    public void init()
+    {
+        actual = mock(Path.class);
+        canonicalActual = mock(Path.class);
+        other = mock(Path.class);
+        canonicalOther = mock(Path.class);
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null()
+    {
+        thrown.expectAssertionError(actualIsNull());
+        paths.assertStartsWith(info, null, other);
+    }
+
+    @Test
+    public void should_fail_if_other_is_null()
+    {
+        try {
+            paths.assertStartsWith(info, actual, null);
+            fail("expected a NullPointerException here");
+        } catch (NullPointerException e) {
+            assertEquals(e.getMessage(), "other should not be null");
+        }
+    }
+
+    @Test
+    public void should_throw_PathsException_if_actual_cannot_be_resolved()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+        when(actual.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertStartsWith(info, actual, other);
+            fail("was expecting a PathsException here");
+        } catch (PathsException e) {
+            assertEquals("failed to resolve actual", e.getMessage());
+            assertSame(exception, e.getCause());
+        }
+    }
+
+    @Test
+    public void should_throw_PathsException_if_other_cannot_be_resolved()
+        throws IOException
+    {
+        final IOException exception = new IOException();
+
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(other.toRealPath()).thenThrow(exception);
+
+        try {
+            paths.assertStartsWith(info, actual, other);
+            fail("was expecting a PathsException here");
+        } catch (PathsException e) {
+            assertEquals("failed to resolve path argument", e.getMessage());
+            assertSame(exception, e.getCause());
+        }
+    }
+
+    @Test
+    public void should_fail_if_actual_does_not_start_with_other()
+        throws IOException
+    {
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(other.toRealPath()).thenReturn(canonicalOther);
+        // This is the default, but let's make this explicit
+        when(canonicalActual.startsWith(canonicalOther)).thenReturn(false);
+
+        try {
+            paths.assertStartsWith(info, actual, other);
+            wasExpectingAssertionError();
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldStartWith(actual, other));
+        }
+    }
+
+    @Test
+    public void should_succeed_if_actual_starts_with_other()
+        throws IOException
+    {
+        when(actual.toRealPath()).thenReturn(canonicalActual);
+        when(other.toRealPath()).thenReturn(canonicalOther);
+
+        when(canonicalActual.startsWith(canonicalOther)).thenReturn(true);
+
+        paths.assertStartsWith(info, actual, other);
+    }
+
+}

--- a/src/test/java/org/assertj/core/test/AssertionErrorExpectedException.java
+++ b/src/test/java/org/assertj/core/test/AssertionErrorExpectedException.java
@@ -12,21 +12,11 @@
  */
 package org.assertj.core.test;
 
-import org.junit.Assert;
-
-/**
- * @author Yvonne Wang
- * @author Francis Galiegue
- */
-public final class TestFailures {
-
-  public static void failBecauseExpectedAssertionErrorWasNotThrown() {
-    Assert.fail("Assertion error expected");
-  }
-
-  public static void wasExpectingAssertionError() {
-    throw new AssertionErrorExpectedException();
-  }
-
-  private TestFailures() {}
+public final class AssertionErrorExpectedException
+    extends RuntimeException
+{
+    public AssertionErrorExpectedException()
+    {
+        super("was expecting an AssertionError");
+    }
 }


### PR DESCRIPTION
Skeleton based on existing code. I modeled it on FileAssert. In fact I saw nothing related to anything java.nio.file in the code, so I created it from scratch...

Preview only. I know the coding style does not fit; knowing that I use IDEA, do you happen to have a style file available?

Also, about error messages: there seem to be a lot of factories; FileAssert seems to basically use one per message! Is that on purpose? Can I create a single factory for Path-specific operations (including exists, non exists and absolute)?

Please comment! I'll add more test when the base is good enough for you.