### PR TITLE
implemented issue #257

### DIFF
--- a/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.groups.Properties.extractProperty;
+
+import java.util.List;
+
+/**
+ * <p>
+ * BDD style variation of {@link SoftAssertions}.
+ * </p>
+ *
+ * <p>
+ * Example usage compared to SoftAssertions:
+ * </p>
+ *
+ * SoftAssertions:
+ *
+ * <pre><code class='java'>
+ *     SoftAssertions softly = new SoftAssertions();
+ *     softly.assertThat(mansion.guests()).as(&quot;Living Guests&quot;).isEqualTo(7);
+ *     softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
+ *     softly.assertThat(mansion.library()).as(&quot;Library&quot;).isEqualTo(&quot;clean&quot;);
+ *     softly.assertThat(mansion.revolverAmmo()).as(&quot;Revolver Ammo&quot;).isEqualTo(6);
+ *     softly.assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
+ *     softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
+ *     softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
+ *     softly.assertAll();
+ * </code></pre>
+ *
+ * translated to BDDSoftAssertions:
+ *
+ * <pre><code class='java'>
+ *     BDDSoftAssertions.then(new BDDSoftAssertionsConsumer() {
+ *
+ *         &#064Override
+ *         public void accept(BDDSoftAssertions softly) {
+ *
+ *             softly.assertThat(mansion.guests()).as(&quot;Living Guests&quot;).isEqualTo(7);
+ *             softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
+ *             softly.assertThat(mansion.library()).as(&quot;Library&quot;).isEqualTo(&quot;clean&quot;);
+ *             softly.assertThat(mansion.revolverAmmo()).as(&quot;Revolver Ammo&quot;).isEqualTo(6);
+ *             softly.assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
+ *             softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
+ *             softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
+ *         }
+ *     });
+ * </code></pre>
+ *
+ * simplified with Java 8 lambdas:
+ *
+ * <pre><code class='java'>
+ *     BDDSoftAssertions.then(softly -> {
+ *
+ *             softly.assertThat(mansion.guests()).as(&quot;Living Guests&quot;).isEqualTo(7);
+ *             softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
+ *             softly.assertThat(mansion.library()).as(&quot;Library&quot;).isEqualTo(&quot;clean&quot;);
+ *             softly.assertThat(mansion.revolverAmmo()).as(&quot;Revolver Ammo&quot;).isEqualTo(6);
+ *             softly.assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
+ *             softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
+ *             softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
+ *     });
+ * </code></pre>
+ *
+ * Note that {@link #assertAll()} is called in {@link #then} for the user and therefore it is private.
+ *
+ * @author Lovro Pandzic
+ * @see org.assertj.core.api.SoftAssertions
+ */
+public final class BDDSoftAssertions extends AbstractSoftAssertions {
+
+	/**
+	 * Entry point for constructing {@link BDDSoftAssertions}.
+	 *
+	 * @param consumer that performs multiple assertions on the provided {@link BDDSoftAssertions}
+	 */
+	public static void then(BDDSoftAssertionsConsumer consumer) {
+
+		BDDSoftAssertions softAssertions = new BDDSoftAssertions();
+		consumer.accept(softAssertions);
+		softAssertions.assertAll();
+	}
+
+	private BDDSoftAssertions() {
+
+	}
+
+	/**
+	 * Verifies that no proxied assertion methods have failed.
+	 *
+	 * <p><strong> This method is marked private since {@link #then} calls this method after execution of {@link
+	 * BDDSoftAssertionsConsumer#accept(BDDSoftAssertions)}. </strong> </p>
+	 *
+	 * @throws SoftAssertionError if any proxied assertion objects threw
+	 * @see SoftAssertions#assertAll()
+	 */
+	private void assertAll() {
+
+		List<Throwable> errors = collector.errors();
+		if (!errors.isEmpty()) {
+			throw new SoftAssertionError(extractProperty("message", String.class).from(errors));
+		}
+	}
+
+}

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertionsConsumer.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertionsConsumer.java
@@ -1,0 +1,13 @@
+package org.assertj.core.api;
+
+/**
+ * Specialized operation similar to Java 8 java.util.function.Consumer that accepts a single {@link BDDSoftAssertions}
+ * input argument and and returns no result.
+ *
+ * @author Lovro Pandzic
+ * @see BDDSoftAssertions
+ */
+interface BDDSoftAssertionsConsumer {
+
+	void accept(BDDSoftAssertions softly);
+}

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Dates.parseDatetime;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+/**
+ * Tests the {@link org.assertj.core.api.BDDSoftAssertions} in the same way {@link
+ * org.assertj.core.api.SoftAssertionsTest} tests {@link org.assertj.core.api.SoftAssertions}.
+ *
+ * @author Lovro Pandzic
+ */
+public class BDDSoftAssertionsTest {
+
+	@Test
+	public void all_assertions_should_pass() {
+
+		BDDSoftAssertions.then(new BDDSoftAssertionsConsumer() {
+			@Override
+			public void accept(BDDSoftAssertions softly) {
+
+				softly.assertThat(1).isEqualTo(1);
+				softly.assertThat(Lists.newArrayList(1, 2)).containsOnly(1, 2);
+			}
+		});
+	}
+
+	@Test
+	public void should_be_able_to_catch_exceptions_thrown_by_all_proxied_methods() {
+
+		try {
+			BDDSoftAssertions.then(new BDDSoftAssertionsConsumer() {
+				@Override
+				public void accept(BDDSoftAssertions softly) {
+
+					softly.assertThat(BigDecimal.ZERO).isEqualTo(BigDecimal.ONE);
+
+					softly.assertThat(Boolean.FALSE).isTrue();
+					softly.assertThat(false).isTrue();
+					softly.assertThat(new boolean[]{false}).isEqualTo(new boolean[]{true});
+
+					softly.assertThat(new Byte((byte) 0)).isEqualTo((byte) 1);
+					softly.assertThat((byte) 2).inHexadecimal().isEqualTo((byte) 3);
+					softly.assertThat(new byte[]{4}).isEqualTo(new byte[]{5});
+
+					softly.assertThat(new Character((char) 65)).isEqualTo(new Character((char) 66));
+					softly.assertThat((char) 67).isEqualTo((char) 68);
+					softly.assertThat(new char[]{69}).isEqualTo(new char[]{70});
+
+					softly.assertThat(new StringBuilder("a")).isEqualTo(new StringBuilder("b"));
+
+					softly.assertThat(Object.class).isEqualTo(String.class);
+
+					softly.assertThat(parseDatetime("1999-12-31T23:59:59"))
+					      .isEqualTo(parseDatetime("2000-01-01T00:00:01"));
+
+					softly.assertThat(new Double(6.0d)).isEqualTo(new Double(7.0d));
+					softly.assertThat(8.0d).isEqualTo(9.0d);
+					softly.assertThat(new double[]{10.0d}).isEqualTo(new double[]{11.0d});
+
+					softly.assertThat(new File("a"))
+					      .overridingErrorMessage("expected:<File(b)> but was:<File(a)>")
+					      .isEqualTo(new File("b"));
+
+					softly.assertThat(new Float(12f)).isEqualTo(new Float(13f));
+					softly.assertThat(14f).isEqualTo(15f);
+					softly.assertThat(new float[]{16f}).isEqualTo(new float[]{17f});
+
+					softly.assertThat(new ByteArrayInputStream(new byte[]{(byte) 65}))
+					      .hasContentEqualTo(new ByteArrayInputStream(new byte[]{(byte) 66}));
+
+					softly.assertThat(new Integer(20)).isEqualTo(new Integer(21));
+					softly.assertThat(22).isEqualTo(23);
+					softly.assertThat(new int[]{24}).isEqualTo(new int[]{25});
+
+					softly.assertThat((Iterable<String>) Lists.newArrayList("26")).isEqualTo(Lists.newArrayList("27"));
+					softly.assertThat(Lists.newArrayList("28").iterator()).contains("29");
+					softly.assertThat(Lists.newArrayList("30")).isEqualTo(Lists.newArrayList("31"));
+
+					softly.assertThat(new Long(32L)).isEqualTo(new Long(33L));
+					softly.assertThat(34L).isEqualTo(35L);
+					softly.assertThat(new long[]{36L}).isEqualTo(new long[]{37L});
+
+					softly.assertThat(Maps.mapOf(MapEntry.entry("38", "39")))
+					      .isEqualTo(Maps.mapOf(MapEntry.entry("40", "41")));
+
+					softly.assertThat(new Short((short) 42)).isEqualTo(new Short((short) 43));
+					softly.assertThat((short) 44).isEqualTo((short) 45);
+					softly.assertThat(new short[]{(short) 46}).isEqualTo(new short[]{(short) 47});
+
+					softly.assertThat("48").isEqualTo("49");
+
+					softly.assertThat(new Object() {
+						@Override
+						public String toString() {
+
+							return "50";
+						}
+					}).isEqualTo(new Object() {
+						@Override
+						public String toString() {
+
+							return "51";
+						}
+					});
+
+					softly.assertThat(new Object[]{new Object() {
+						@Override
+						public String toString() {
+
+							return "52";
+						}
+					}}).isEqualTo(new Object[]{new Object() {
+						@Override
+						public String toString() {
+
+							return "53";
+						}
+					}});
+
+					final IllegalArgumentException illegalArgumentException = new IllegalArgumentException
+							("IllegalArgumentException message");
+					softly.assertThat(illegalArgumentException).hasMessage("NullPointerException message");
+					softly.assertThatExceptionThrownBy(new Callable<Void>() {
+						@Override
+						public Void call() throws Exception {
+
+							throw new Exception("something was wrong");
+						}
+
+					}).hasMessage("something was good");
+				}
+			});
+			fail("Should not reach here");
+		} catch (SoftAssertionError e) {
+			List<String> errors = e.getErrors();
+			assertThat(errors).hasSize(39);
+			assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
+
+			assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
+			assertThat(errors.get(2)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
+			assertThat(errors.get(3)).isEqualTo("expected:<[[tru]e]> but was:<[[fals]e]>");
+
+			assertThat(errors.get(4)).isEqualTo("expected:<[1]> but was:<[0]>");
+			assertThat(errors.get(5)).isEqualTo("expected:<0x0[3]> but was:<0x0[2]>");
+			assertThat(errors.get(6)).isEqualTo("expected:<[[5]]> but was:<[[4]]>");
+
+			assertThat(errors.get(7)).isEqualTo("expected:<'[B]'> but was:<'[A]'>");
+			assertThat(errors.get(8)).isEqualTo("expected:<'[D]'> but was:<'[C]'>");
+			assertThat(errors.get(9)).isEqualTo("expected:<['[F]']> but was:<['[E]']>");
+
+			assertThat(errors.get(10)).isEqualTo("expected:<[b]> but was:<[a]>");
+
+			assertThat(errors.get(11)).isEqualTo("expected:<java.lang.[String]> but was:<java.lang.[Object]>");
+
+			assertThat(errors.get(12)).isEqualTo("expected:<[2000-01-01T00:00:01]> but was:<[1999-12-31T23:59:59]>");
+
+			assertThat(errors.get(13)).isEqualTo("expected:<[7].0> but was:<[6].0>");
+			assertThat(errors.get(14)).isEqualTo("expected:<[9].0> but was:<[8].0>");
+			assertThat(errors.get(15)).isEqualTo("expected:<[1[1].0]> but was:<[1[0].0]>");
+
+			assertThat(errors.get(16)).isEqualTo("expected:<File(b)> but was:<File(a)>");
+
+			assertThat(errors.get(17)).isEqualTo("expected:<1[3].0f> but was:<1[2].0f>");
+			assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
+			assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
+
+			assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
+					                                     + System.getProperty("line.separator")
+					                                     + "line:<1>, expected:<B> but was:<A>");
+
+			assertThat(errors.get(21)).isEqualTo("expected:<2[1]> but was:<2[0]>");
+			assertThat(errors.get(22)).isEqualTo("expected:<2[3]> but was:<2[2]>");
+			assertThat(errors.get(23)).isEqualTo("expected:<[2[5]]> but was:<[2[4]]>");
+
+			assertThat(errors.get(24)).isEqualTo("expected:<[\"2[7]\"]> but was:<[\"2[6]\"]>");
+			assertThat(errors.get(25)).isEqualTo("\nExpecting:\n" +
+					                                     " <[\"28\"]>\n" +
+					                                     "to contain:\n" +
+					                                     " <[\"29\"]>\n" +
+					                                     "but could not find:\n" +
+					                                     " <[\"29\"]>\n");
+			assertThat(errors.get(26)).isEqualTo("expected:<[\"3[1]\"]> but was:<[\"3[0]\"]>");
+
+			assertThat(errors.get(27)).isEqualTo("expected:<3[3]L> but was:<3[2]L>");
+			assertThat(errors.get(28)).isEqualTo("expected:<3[5]L> but was:<3[4]L>");
+			assertThat(errors.get(29)).isEqualTo("expected:<[3[7]L]> but was:<[3[6]L]>");
+
+			assertThat(errors.get(30)).isEqualTo("expected:<{\"[40\"=\"41]\"}> but was:<{\"[38\"=\"39]\"}>");
+
+			assertThat(errors.get(31)).isEqualTo("expected:<4[3]> but was:<4[2]>");
+			assertThat(errors.get(32)).isEqualTo("expected:<4[5]> but was:<4[4]>");
+			assertThat(errors.get(33)).isEqualTo("expected:<[4[7]]> but was:<[4[6]]>");
+
+			assertThat(errors.get(34)).isEqualTo("expected:<\"4[9]\"> but was:<\"4[8]\">");
+
+			assertThat(errors.get(35)).isEqualTo("expected:<5[1]> but was:<5[0]>");
+			assertThat(errors.get(36)).isEqualTo("expected:<[5[3]]> but was:<[5[2]]>");
+			assertThat(errors.get(37)).isEqualTo("\nExpecting message:\n"
+					                                     + " <\"NullPointerException message\">\n"
+					                                     + "but was:\n"
+					                                     + " <\"IllegalArgumentException message\">");
+			assertThat(errors.get(38)).isEqualTo("\nExpecting message:\n"
+					                                     + " <\"something was good\">\n"
+					                                     + "but was:\n"
+					                                     + " <\"something was wrong\">");
+		}
+	}
+
+}


### PR DESCRIPTION
BDDSoftAssertions for issue 257.

Example usage (using lambdas):

```java
BDDSoftAssertions.then(softly -> {
    softly.assertThat(mansion.guests()).as("Living Guests").isEqualTo(7)
    softly.assertThat(mansion.kitchen()).as("Kitchen").isEqualTo("clean");
});
```

Note that assertAll is called for users in the then method and hence there is some duplication involved regarding assertAll mainly to mark it private and prevent users from using it (since it is redundant). Javadoc is marked with comment why it is private.
