### PR TITLE
introduce CheckStyle/ImportControl for restricting layer dependencies

### DIFF
--- a/etc/check-layering-src.xml
+++ b/etc/check-layering-src.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+	<module name="TreeWalker">
+		<module name="ImportControl">
+			<property name="severity" value="error"/>
+			<property name="file" value="layering-rules-src.xml"/>
+		</module>
+	</module>
+</module>

--- a/etc/check-layering-test.xml
+++ b/etc/check-layering-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+	<module name="TreeWalker">
+		<module name="ImportControl">
+			<property name="file" value="layering-rules-test.xml"/>
+		</module>
+	</module>
+</module>

--- a/etc/check-layering.bat
+++ b/etc/check-layering.bat
@@ -1,0 +1,2 @@
+@java -jar checkstyle-6.3-all.jar -c check-layering-src.xml ../src/main/java
+@java -jar checkstyle-6.3-all.jar -c check-layering-test.xml ../src/test/java

--- a/etc/layering-rules-src.xml
+++ b/etc/layering-rules-src.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.1//EN"
+    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+
+<import-control pkg="org.assertj.core">
+
+	<allow pkg="java.io"/>
+	<allow pkg="java.nio"/>
+	<allow pkg="java.util"/>
+	<allow pkg="java.security"/>
+	<allow pkg="java.text"/>
+	<allow pkg="java.lang"/>
+	<allow pkg="java.math"/>
+	<allow pkg="java.sql"/>
+	<allow pkg="java.beans"/>
+	<allow pkg="javax.xml"/>
+	<allow pkg="org.xml.sax"/>
+	<allow pkg="org.w3c"/>
+	<allow pkg="org.junit"/>
+	<allow pkg="net.sf.cglib"/>
+
+	<subpackage name="api">
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.condition" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.extractor" />
+		<allow pkg="org.assertj.core.error" />
+	</subpackage>
+	<subpackage name="condition">
+		<allow pkg="org.assertj.core.condition" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="data">
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="description">
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="error">
+		<allow pkg="org.assertj.core.error" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.presentation" />
+	</subpackage>
+	<subpackage name="extractor">
+		<allow pkg="org.assertj.core.extractor" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.internal" />
+	</subpackage>
+	<subpackage name="groups">
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.internal" />
+	</subpackage>
+	<subpackage name="internal">
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.error" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.presentation" />
+	</subpackage>
+	<subpackage name="presentation">
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.internal" />
+	</subpackage>
+	<subpackage name="util">
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.presentation" />
+	</subpackage>
+
+</import-control>

--- a/etc/layering-rules-src.xml
+++ b/etc/layering-rules-src.xml
@@ -34,7 +34,6 @@
 	</subpackage>
 	<subpackage name="condition">
 		<allow pkg="org.assertj.core.condition" />
-		<allow pkg="org.assertj.core.api" />
 		<allow pkg="org.assertj.core.util" />
 	</subpackage>
 	<subpackage name="data">
@@ -47,7 +46,6 @@
 	</subpackage>
 	<subpackage name="error">
 		<allow pkg="org.assertj.core.error" />
-		<allow pkg="org.assertj.core.api" />
 		<allow pkg="org.assertj.core.internal" />
 		<allow pkg="org.assertj.core.util" />
 		<allow pkg="org.assertj.core.data" />
@@ -56,25 +54,20 @@
 	</subpackage>
 	<subpackage name="extractor">
 		<allow pkg="org.assertj.core.extractor" />
-		<allow pkg="org.assertj.core.api" />
 		<allow pkg="org.assertj.core.util" />
 		<allow pkg="org.assertj.core.groups" />
 		<allow pkg="org.assertj.core.internal" />
 	</subpackage>
 	<subpackage name="groups">
 		<allow pkg="org.assertj.core.groups" />
-		<allow pkg="org.assertj.core.api" />
 		<allow pkg="org.assertj.core.util" />
 		<allow pkg="org.assertj.core.internal" />
 	</subpackage>
 	<subpackage name="internal">
 		<allow pkg="org.assertj.core.internal" />
-		<allow pkg="org.assertj.core.api" />
 		<allow pkg="org.assertj.core.data" />
-		<allow pkg="org.assertj.core.error" />
 		<allow pkg="org.assertj.core.util" />
 		<allow pkg="org.assertj.core.description" />
-		<allow pkg="org.assertj.core.presentation" />
 	</subpackage>
 	<subpackage name="presentation">
 		<allow pkg="org.assertj.core.presentation" />
@@ -84,7 +77,6 @@
 	</subpackage>
 	<subpackage name="util">
 		<allow pkg="org.assertj.core.util" />
-		<allow pkg="org.assertj.core.presentation" />
 	</subpackage>
 
 </import-control>

--- a/etc/layering-rules-test.xml
+++ b/etc/layering-rules-test.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.1//EN"
+    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+
+<import-control pkg="org.assertj.core">
+
+	<allow pkg="java.io"/>
+	<allow pkg="java.nio"/>
+	<allow pkg="java.util"/>
+	<allow pkg="java.security"/>
+	<allow pkg="java.text"/>
+	<allow pkg="java.lang"/>
+	<allow pkg="java.math"/>
+	<allow pkg="java.sql"/>
+	<allow pkg="java.beans"/>
+	<allow pkg="javax.xml"/>
+	<allow pkg="org.xml.sax"/>
+	<allow pkg="org.w3c"/>
+	<allow pkg="org.junit"/>
+	<allow pkg="net.sf.cglib"/>
+
+	<allow pkg="junit.framework"/>
+	<allow pkg="org.hamcrest"/>
+	<allow pkg="org.mockito"/>
+
+	<allow pkg="org.assertj.core.test" />
+
+	<subpackage name="api">
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.error" />
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="condition">
+		<allow pkg="org.assertj.core.condition" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="data">
+		<allow pkg="org.assertj.core.data" />
+	</subpackage>
+	<subpackage name="description">
+		<allow pkg="org.assertj.core.description" />
+	</subpackage>
+	<subpackage name="error">
+		<allow pkg="org.assertj.core.error" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="extractor">
+		<allow pkg="org.assertj.core.extractor" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="groups">
+		<allow pkg="org.assertj.core.groups" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.extractor" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.util" />
+	</subpackage>
+	<subpackage name="internal">
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.condition" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.description" />
+		<allow pkg="org.assertj.core.error" />
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.util" />
+		<allow class="java.awt.Rectangle"/>
+	</subpackage>
+	<subpackage name="presentation">
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.api" />
+	</subpackage>
+	<subpackage name="util">
+		<allow pkg="org.assertj.core.util" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.presentation" />
+		<allow pkg="org.assertj.core.internal" />
+		<allow pkg="org.assertj.core.data" />
+	</subpackage>
+	<subpackage name="test">
+		<allow pkg="org.assertj.core.test" />
+		<allow pkg="org.assertj.core.api" />
+		<allow pkg="org.assertj.core.data" />
+		<allow pkg="org.assertj.core.description" />
+	</subpackage>
+
+</import-control>


### PR DESCRIPTION
The first commit covers the existing package dependency graph; it compiles without warning.

The second commit is a possible solution to break the existing cycles; I just analyzed the dependency graph, not the actual code so maybe you would do the breaking on an other way; anyhow this shows how to remove an edge so you can remove the choice of yours.

Feel free to contact me if you needs more information on this topic.