### PR TITLE
Java 8 friendly throwable capture (and assert) API

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -1,19 +1,20 @@
 /*
  * Created on Jan 28, 2011
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this Throwable except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * Copyright @2011 the original author or authors.
  */
 package org.assertj.core.api;
 
+import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Throwables;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -37,6 +38,13 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
 
 	protected AbstractThrowableAssert(A actual, Class<?> selfType) {
 		super(actual, selfType);
+	}
+
+	protected S hasBeenThrown() {
+		if(actual == null) {
+			throw Failures.instance().failure("Expected a throwable to have been raised");
+		}
+		return myself;
 	}
 
 	/**

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1,15 +1,15 @@
 /*
  * Created on Sep 30, 2010
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * Copyright @2010-2011 the original author or authors.
  */
 package org.assertj.core.api;
@@ -24,7 +24,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.AllOf;
 import org.assertj.core.condition.AnyOf;
@@ -45,7 +45,7 @@ import org.assertj.core.util.introspection.FieldSupport;
  * <p>
  * For example:
  * <p/>
- * 
+ *
  * <pre><code class='java'>
  * int removed = employees.removeFired();
  * {@link Assertions#assertThat(int) assertThat}(removed).{@link IntegerAssert#isZero isZero}();
@@ -426,7 +426,7 @@ public class Assertions {
    *   assertThat(buttonAssert).isBlinking(); // same as : buttonAssert.isBlinking();
    * }
    * </pre>
-   * 
+   *
    * @param <T> the generic type of the user-defined assert.
    * @param assertion the assertion to return.
    * @return the given assertion.
@@ -523,6 +523,54 @@ public class Assertions {
    */
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
+  }
+
+  /**
+   * Allows to capture and then assert on a Throwable more easily when used with Java 8 lambdas.
+   *
+   * <pre><code class='java'>
+   *     &#64;Test
+   *     public void testException() {
+   *         assertThatThrownBy(() -> { throw new Exception("boom!") })
+   *                 .isInstanceOf(...)
+   *                 .hasMessageContaining("...")
+   *                 .hasRootCauseInstanceOf(...)
+   *                 ;
+   *     }
+   * </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+    return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to catch an Exception more easily when used with Java 8 lambdas.
+   *
+   * <p>This exception can then be asserted.</p>
+   * <pre><code class='java'>
+   *     &#64;Test
+   *     public void testException() {
+   *         // ...
+   *
+   *         Throwable actual = ThrowableCatcher.catchThrowable(() -> { throw new Exception("boom!") });
+   *
+   *         // assert
+   *         assertThat(actual)
+   *                 .isInstanceOf(...)
+   *                 .hasMessageContaining("...")
+   *                 .hasRootCauseInstanceOf(...)
+   *                 ;
+   *     }
+   * </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
+    return ThrowableAssert.catchThrowable(shouldRaiseThrowable);
   }
 
   // -------------------------------------------------------------------------------------------------
@@ -726,7 +774,7 @@ public class Assertions {
   public static Offset<Float> within(Float value) {
     return Offset.offset(value);
   }
-  
+
   /**
    * Assertions entry point for BigDecimal {@link Offset} to use with isCloseTo assertions.
    * <p/>

--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -1,15 +1,15 @@
 /*
  * Created on Jan 28, 2011
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this Throwable except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * Copyright @2011 the original author or authors.
  */
 package org.assertj.core.api;
@@ -19,7 +19,7 @@ package org.assertj.core.api;
  * <p>
  * To create a new instance of this class, invoke <code>{@link Assertions#assertThat(Throwable)}</code>.
  * </p>
- * 
+ *
  * @author David DIDIER
  * @author Alex Ruiz
  * @author Joel Costigliola
@@ -27,7 +27,20 @@ package org.assertj.core.api;
  */
 public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Throwable> {
 
+  public interface ThrowingCallable {
+    void call() throws Throwable;
+  }
+
   protected ThrowableAssert(Throwable actual) {
     super(actual, ThrowableAssert.class);
+  }
+
+  public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
+    try {
+      shouldRaiseThrowable.call();
+    } catch (Throwable throwable) {
+      return throwable;
+    }
+    return null;
   }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -1,0 +1,85 @@
+/*
+ * Created on Feb 8, 2011
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.math.BigDecimal;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(BigDecimal)}</code>.
+ */
+public class Assertions_assertThat_with_Throwable_Test {
+
+  @Test
+  public void can_capture_exception_and_then_assert_following_AAA_or_BDD_style() throws Exception {
+    // given
+    // some preconditions
+
+    // when
+    Throwable boom = Assertions.catchThrowable(raisingException("boom!!!!"));
+
+    // then
+    assertThat(boom)
+            .isInstanceOf(Exception.class)
+            .hasMessageContaining("boom");
+  }
+
+  @Test
+  public void can_capture_and_assert_with_AssertJ() throws Exception {
+    Assertions.assertThatThrownBy(raisingException("boom!!!!"))
+            .isInstanceOf(Exception.class)
+            .hasMessageContaining("boom");
+  }
+
+  @Test
+  public void fail_with_good_message_when_nothing_was_captured() throws Exception {
+    try {
+      Assertions.assertThatThrownBy(notRaisingException())
+              .hasMessage("yo");
+    } catch (AssertionError ae) {
+      Assertions.assertThat(ae).hasMessageContaining("Expected a throwable to have been raised");
+    }
+  }
+
+  @Test
+  public void fail_with_good_message_when_assertion_is_failing() throws Exception {
+    try {
+      Assertions.assertThatThrownBy(raisingException("boom"))
+              .hasMessage("yo");
+    } catch (AssertionError ae) {
+      Assertions.assertThat(ae)
+              .hasMessageContaining("Expecting message:")
+              .hasMessageContaining("<\"yo\">")
+              .hasMessageContaining("but was:")
+              .hasMessageContaining("<\"boom\">");
+    }
+  }
+
+  private ThrowingCallable notRaisingException() {
+    return new ThrowingCallable() {
+      @Override public void call() throws Throwable { }
+    };
+  }
+
+  private ThrowingCallable raisingException(final String reason) {
+    return new ThrowingCallable() {
+      @Override public void call() throws Throwable {
+        throw new Exception(reason);
+      }
+    };
+  }
+}


### PR DESCRIPTION
This PR proposes an API that allows a better integration with Java 8 on the 1.7.x branch.

The proposed code covers more need than the one introduced in AssertJ 2.0.0-SNAPSHOT on master in eb0cddd02de8415efa4276de6533f2d403e68576 for issue #255.

1. Users won't have to wait for AssertJ 2.0.0 ...if AssertJ 1.7.2 is released ;)
2. The API don't use the `java.util.concurrent.Callable`
  a. This is cleaner package wise as such test are not about concurrent stuff
  b. `Callable` is limited to raise `Exception`, this PR custom callable allows `Throwable`
3. The API is split in two composable methods.

  The change introduced in eb0cddd02de8415efa4276de6533f2d403e68576 forces the user to _assert_ at the same place he want to _act_. 

  ```java
  assertThatExceptionThrownBy(() -> service.sendMail()).isInstanceOf(...);
  ```

  This is uncomfortable when one wants to follow BDD or AAA styles, hence this PR proposes a `capturing` API

  ```java
  // given
  /* setup fixture */

  // when
  Throwable thrown = capture(() -> service.sendMail());

  // then
  assertThat(thrown).isInstanceOf(...);
  ```

4. The API was also designed for brevity.

The idea comes from my own [StackOverflow answer](http://stackoverflow.com/questions/17426313/how-to-verify-that-an-exception-was-not-thrown/17428439#17428439) and we are users of this code since we are running Java 8 already.

As a heavy github user, I'm open for comment, review, change