### PR TITLE
#355 isEqualToIgnoringWhitespace assertion on String

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -708,6 +708,25 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
     return myself;
   }
 
+   /**
+   * Verifies that the actual {@code CharSequence} is equal to the given one, ignoring whitespace differences (mostly).
+   * <p>
+   * Example :
+   *
+   * <pre><code class='java'>
+   * // assertion will pass
+   * assertThat(&quot; my\tfoo bar &quot;).isEqualToIgnoringWhitespace(&quot; my foo bar&quot;);
+   *
+   * // assertion will fail
+   * assertThat(&quot; my\tfoo bar &quot;).isEqualToIgnoringWhitespace(&quot; my foobar&quot;);
+   * </code></pre>
+   *
+   * </p>
+   *
+   * @param expected the given {@code CharSequence} to compare the actual {@code CharSequence} to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not equal ignoring whitespace differences to the given one.
+   */
   public S isEqualToIgnoringWhitespace(CharSequence expected) {
     strings.assertEqualsIgnoringWhitespace(info, actual, expected);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -708,4 +708,8 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
     return myself;
   }
 
+  public S isEqualToIgnoringWhitespaces(CharSequence expected) {
+    strings.assertEqualsIgnoringWhitespaces(info, actual, expected);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -708,8 +708,8 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
     return myself;
   }
 
-  public S isEqualToIgnoringWhitespaces(CharSequence expected) {
-    strings.assertEqualsIgnoringWhitespaces(info, actual, expected);
+  public S isEqualToIgnoringWhitespace(CharSequence expected) {
+    strings.assertEqualsIgnoringWhitespace(info, actual, expected);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringWhitespace.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringWhitespace.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that two {@code CharSequence}s are equal, ignoring whitespace
+ * differences, failed.
+ * 
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringWhitespace extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link org.assertj.core.error.ShouldBeEqualIgnoringWhitespace}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param expected the expected value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringWhitespace(CharSequence actual, CharSequence expected) {
+    return new ShouldBeEqualIgnoringWhitespace(actual, expected);
+  }
+
+  private ShouldBeEqualIgnoringWhitespace(CharSequence actual, CharSequence expected) {
+    super("%nExpecting:%n <%s>%nto be equal to:%n <%s>%nignoring whitespace differences", actual, expected);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -17,6 +17,7 @@ import static java.lang.String.format;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualIgnoringWhitespace.shouldBeEqualIgnoringWhitespace;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContainIgnoringCase;
@@ -340,7 +341,7 @@ public class Strings {
    */
   public void assertEqualsIgnoringWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
       if (!areEqualIgnoringWhitespace(actual, expected)) {
-        throw failures.failure(info, shouldBeEqual(actual, expected));
+        throw failures.failure(info, shouldBeEqualIgnoringWhitespace(actual, expected));
       }
   }
 

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -337,14 +337,14 @@ public class Strings {
    * @param expected the expected {@code CharSequence}.
    * @throws AssertionError if the given {@code CharSequence}s are not equal.
    */
-  public void assertEqualsIgnoringWhitespaces(AssertionInfo info, CharSequence actual, CharSequence expected) {
-      if (areEqualIgnoringWhitespaces(actual, expected)) {
+  public void assertEqualsIgnoringWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
+      if (areEqualIgnoringWhitespace(actual, expected)) {
           return;
       }
       throw failures.failure(info, shouldBeEqual(actual, expected));
   }
 
-  private boolean areEqualIgnoringWhitespaces(CharSequence actual, CharSequence expected) {
+  private boolean areEqualIgnoringWhitespace(CharSequence actual, CharSequence expected) {
       if (actual == null) {
           return expected == null;
       }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -330,6 +330,44 @@ public class Strings {
   }
 
   /**
+   * Verifies that two {@code CharSequence}s are equal, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param expected the expected {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence}s are not equal.
+   */
+  public void assertEqualsIgnoringWhitespaces(AssertionInfo info, CharSequence actual, CharSequence expected) {
+      if (areEqualIgnoringWhitespaces(actual, expected)) {
+          return;
+      }
+      throw failures.failure(info, shouldBeEqual(actual, expected));
+  }
+
+  private boolean areEqualIgnoringWhitespaces(CharSequence actual, CharSequence expected) {
+      if (actual == null) {
+          return expected == null;
+      }
+
+      StringBuilder result = new StringBuilder();
+      boolean lastWasSpace = true;
+      for (int i = 0; i < actual.length(); i++) {
+        char c = actual.charAt(i);
+        if (Character.isWhitespace(c)) {
+            if (!lastWasSpace) {
+                result.append(' ');
+            }
+            lastWasSpace = true;
+        } else {
+            result.append(c);
+            lastWasSpace = false;
+        }
+      }
+
+      return result.toString().trim().equals(expected.toString());
+  }
+
+  /**
    * Verifies that actual {@code CharSequence}s contains only once the given sequence.
    * 
    * @param info contains information about the assertion.

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal;
 
+import static java.lang.Character.isWhitespace;
 import static java.lang.String.format;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
@@ -348,22 +349,26 @@ public class Strings {
           return expected == null;
       }
 
-      StringBuilder result = new StringBuilder();
-      boolean lastWasSpace = true;
-      for (int i = 0; i < actual.length(); i++) {
-        char c = actual.charAt(i);
-        if (Character.isWhitespace(c)) {
-            if (!lastWasSpace) {
-                result.append(' ');
-            }
-            lastWasSpace = true;
-        } else {
-            result.append(c);
-            lastWasSpace = false;
-        }
-      }
 
-      return result.toString().trim().equals(expected.toString());
+      return stripSpace(actual).equals(stripSpace(expected));
+  }
+
+  private String stripSpace(CharSequence toBeStripped) {
+      final StringBuilder result = new StringBuilder();
+      boolean lastWasSpace = true;
+      for (int i = 0; i < toBeStripped.length(); i++) {
+          char c = toBeStripped.charAt(i);
+          if (isWhitespace(c)) {
+              if (!lastWasSpace) {
+                  result.append(' ');
+              }
+              lastWasSpace = true;
+          } else {
+              result.append(c);
+              lastWasSpace = false;
+          }
+      }
+      return result.toString().trim();
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -348,8 +348,7 @@ public class Strings {
       if (actual == null) {
           return expected == null;
       }
-
-
+      checkCharSequenceIsNotNull(expected);
       return stripSpace(actual).equals(stripSpace(expected));
   }
 

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -338,10 +338,9 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are not equal.
    */
   public void assertEqualsIgnoringWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
-      if (areEqualIgnoringWhitespace(actual, expected)) {
-          return;
+      if (!areEqualIgnoringWhitespace(actual, expected)) {
+        throw failures.failure(info, shouldBeEqual(actual, expected));
       }
-      throw failures.failure(info, shouldBeEqual(actual, expected));
   }
 
   private boolean areEqualIgnoringWhitespace(CharSequence actual, CharSequence expected) {

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -349,10 +349,10 @@ public class Strings {
           return expected == null;
       }
       checkCharSequenceIsNotNull(expected);
-      return stripSpace(actual).equals(stripSpace(expected));
+      return removeAllWhitespaces(actual).equals(removeAllWhitespaces(expected));
   }
 
-  private String stripSpace(CharSequence toBeStripped) {
+  private String removeAllWhitespaces(CharSequence toBeStripped) {
       final StringBuilder result = new StringBuilder();
       boolean lastWasSpace = true;
       for (int i = 0; i < toBeStripped.length(); i++) {

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -330,7 +330,7 @@ public class Strings {
   }
 
   /**
-   * Verifies that two {@code CharSequence}s are equal, ignoring case considerations.
+   * Verifies that two {@code CharSequence}s are equal, ignoring any changes in whitespace.
    *
    * @param info contains information about the assertion.
    * @param actual the actual {@code CharSequence}.

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespace_Test.java
@@ -18,19 +18,19 @@ import org.assertj.core.api.CharSequenceAssertBaseTest;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link org.assertj.core.api.CharSequenceAssert#isEqualToIgnoringWhitespaces(CharSequence)}</code>.
+ * Tests for <code>{@link org.assertj.core.api.CharSequenceAssert#isEqualToIgnoringWhitespace(CharSequence)}</code>.
  *
  * @author Alexander Bischof
  */
-public class CharSequenceAssert_isEqualToIgnoringWhitespaces_Test extends CharSequenceAssertBaseTest {
+public class CharSequenceAssert_isEqualToIgnoringWhitespace_Test extends CharSequenceAssertBaseTest {
 
     @Override
     protected CharSequenceAssert invoke_api_method() {
-        return assertions.isEqualToIgnoringWhitespaces(" my\tfoo bar ");
+        return assertions.isEqualToIgnoringWhitespace(" my\tfoo bar ");
     }
 
     @Override
     protected void verify_internal_effects() {
-        verify(strings).assertEqualsIgnoringWhitespaces(getInfo(assertions), getActual(assertions), " my foo bar ");
+        verify(strings).assertEqualsIgnoringWhitespace(getInfo(assertions), getActual(assertions), " my foo bar ");
     }
 }

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespace_Test.java
@@ -26,7 +26,7 @@ public class CharSequenceAssert_isEqualToIgnoringWhitespace_Test extends CharSeq
 
     @Override
     protected CharSequenceAssert invoke_api_method() {
-        return assertions.isEqualToIgnoringWhitespace(" my\tfoo bar ");
+        return assertions.isEqualToIgnoringWhitespace(" my foo bar ");
     }
 
     @Override

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespaces_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringWhitespaces_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.CharSequenceAssert#isEqualToIgnoringWhitespaces(CharSequence)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class CharSequenceAssert_isEqualToIgnoringWhitespaces_Test extends CharSequenceAssertBaseTest {
+
+    @Override
+    protected CharSequenceAssert invoke_api_method() {
+        return assertions.isEqualToIgnoringWhitespaces(" my\tfoo bar ");
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(strings).assertEqualsIgnoringWhitespaces(getInfo(assertions), getActual(assertions), " my foo bar ");
+    }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringWhitespace_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringWhitespace_create_Test.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualIgnoringWhitespace.shouldBeEqualIgnoringWhitespace;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldBeEqualIgnoringWhitespace#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alex Ruiz
+ * @author Joel Costigliola
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringWhitespace_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldBeEqualIgnoringWhitespace(" my\tfoo bar ", " myfoo bar ");
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertEquals("[Test] \nExpecting:\n <\" my\tfoo bar \">\nto be equal to:\n <\" myfoo bar \">\nignoring whitespace differences", message);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Successful_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Successful_Test.java
@@ -15,11 +15,17 @@ package org.assertj.core.internal.strings;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.StringsBaseTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
 
 import static org.assertj.core.error.ShouldBeEqualIgnoringWhitespace.shouldBeEqualIgnoringWhitespace;
+import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.ErrorMessages.charSequenceToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -29,40 +35,30 @@ import static org.mockito.Mockito.verify;
  * @author Joel Costigliola
  * @author Alexander Bischof
  */
-public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest {
+@RunWith(Parameterized.class)
+public class Strings_assertEqualsIgnoringWhitespace_Successful_Test extends StringsBaseTest {
 
-  @Test
-  public void should_fail_if_actual_is_null_and_expected_is_not() {
-    AssertionInfo info = someInfo();
-    try {
-      strings.assertEqualsIgnoringWhitespace(info, null, "Luke");
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, null, "Luke");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+  @Parameterized.Parameters
+  public static List<Object[]> parameters() {
+      return newArrayList(new Object[][] { { " my\tfoo bar ", " my foo bar" },
+            { " my\tfoo bar ", new String(arrayOf(' ', 'm', 'y', ' ', 'f', 'o', 'o', ' ', 'b', 'a', 'r'))},
+            { " my\tfoo bar ", " my\tfoo bar "},         //same
+            { null, null},         //null
+            { " \t \t", " "},
+            { " abc", "abc "}
+      });
+  }
+
+  private final String actual;
+  private final String expected;
+
+  public Strings_assertEqualsIgnoringWhitespace_Successful_Test(String actual, String expected) {
+    this.actual = actual;
+    this.expected = expected;
   }
 
   @Test
-  public void should_fail_if_actual_is_not_null_and_expected_is_null() {
-    thrown.expectNullPointerException(charSequenceToLookForIsNull());
-    strings.assertEqualsIgnoringWhitespace(someInfo(), "Luke", null);
-  }
-
-  @Test
-  public void should_fail_if_both_Strings_are_not_equal_regardless_of_case() {
-    AssertionInfo info = someInfo();
-    try {
-      strings.assertEqualsIgnoringWhitespace(info, "Yoda", "Luke");
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, "Yoda", "Luke");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
-  }
-
-  private void verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(AssertionInfo info, String actual,
-                                                                           String expected) {
-    verify(failures).failure(info, shouldBeEqualIgnoringWhitespace(actual, expected));
+  public void should_pass_if_both_Strings_are_equal_ignoring_whitespace() {
+    strings.assertEqualsIgnoringWhitespace(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
+import static org.assertj.core.test.CharArrays.arrayOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.Strings#assertEqualsIgnoringWhitespace(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
+ *
+ * @author Alex Ruiz
+ * @author Joel Costigliola
+ * @author Alexander Bischof
+ */
+public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null_and_expected_is_not() {
+    AssertionInfo info = someInfo();
+    try {
+      strings.assertEqualsIgnoringWhitespace(info, null, "Luke");
+    } catch (AssertionError e) {
+      verifyFailureThrownWhenStringsAreNotEqual(info, null, "Luke");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_both_Strings_are_not_equal_regardless_of_case() {
+    AssertionInfo info = someInfo();
+    try {
+      strings.assertEqualsIgnoringWhitespace(info, "Yoda", "Luke");
+    } catch (AssertionError e) {
+      verifyFailureThrownWhenStringsAreNotEqual(info, "Yoda", "Luke");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  private void verifyFailureThrownWhenStringsAreNotEqual(AssertionInfo info, String actual, String expected) {
+    verify(failures).failure(info, shouldBeEqual(actual, expected));
+  }
+
+  @Test
+  public void should_pass_if_both_Strings_are_null() {
+    strings.assertEqualsIgnoringWhitespace(someInfo(), null, null);
+  }
+
+  @Test
+  public void should_pass_if_both_Strings_are_the_same() {
+    String s = "Yoda";
+    strings.assertEqualsIgnoringWhitespace(someInfo(), s, s);
+  }
+
+  @Test
+  public void should_pass_if_both_Strings_are_equal_but_not_same() {
+    strings.assertEqualsIgnoringWhitespace(someInfo(), " my\tfoo bar ", new String(arrayOf(' ', 'm', 'y', ' ', 'f', 'o', 'o', ' ', 'b', 'a', 'r')));
+  }
+
+  @Test
+  public void should_pass_if_both_Strings_are_equal_ignoring_whitespace() {
+    strings.assertEqualsIgnoringWhitespace(someInfo(), " my\tfoo bar ", " my foo bar");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
 import static org.assertj.core.test.CharArrays.arrayOf;
+import static org.assertj.core.test.ErrorMessages.charSequenceToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
@@ -41,6 +42,12 @@ public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_null_and_expected_is_null() {
+    thrown.expectNullPointerException(charSequenceToLookForIsNull());
+    strings.assertEqualsIgnoringWhitespace(someInfo(), "Luke", null);
   }
 
   @Test


### PR DESCRIPTION
added assertEqualIgnoringWhitespaces to AbstractCharSequenceAssert which is using the logic of the corresponding hamcrest matcher.

The related test CharSequenceAssert_isEqualToIgnoringWhitespaces_Test still fails because something goes wrong with the CharSequenceAssertBaseTest design which i couldn't figure out yet.

Examples still missing...