### PR TITLE
#240 rename file/stream assertion hasContentEqualTo to hasSameContentAs

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -134,7 +134,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    */
   @Deprecated
   public S hasContentEqualTo(File expected) {
-    files.assertEqualContent(info, actual, expected);
+    files.assertSameContentAs(info, actual, expected);
     return myself;
   }
 
@@ -151,7 +151,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
    */
   public S hasSameContentAs(File expected) {
-      files.assertEqualContent(info, actual, expected);
+      files.assertSameContentAs(info, actual, expected);
       return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -129,10 +129,30 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * @throws AssertionError if the actual {@code File} is not an existing file.
    * @throws FilesException if an I/O error occurs.
    * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
+   *
+   * @deprecated use hasSameContentAs
    */
+  @Deprecated
   public S hasContentEqualTo(File expected) {
     files.assertEqualContent(info, actual, expected);
     return myself;
+  }
+
+  /**
+   * Verifies that the content of the actual {@code File} is equal to the content of the given one.
+   *
+   * @param expected the given {@code File} to compare the actual {@code File} to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code File} is {@code null}.
+   * @throws IllegalArgumentException if the given {@code File} is not an existing file.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws FilesException if an I/O error occurs.
+   * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
+   */
+  public S hasSameContentAs(File expected) {
+      files.assertEqualContent(info, actual, expected);
+      return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -47,9 +47,27 @@ public abstract class AbstractInputStreamAssert<S extends AbstractInputStreamAss
 	 * @throws AssertionError if the actual {@code InputStream} is {@code null}.
 	 * @throws AssertionError if the content of the actual {@code InputStream} is not equal to the content of the given one.
 	 * @throws InputStreamsException if an I/O error occurs.
+   *
+   * @deprecated use hasSameContentAs
 	 */
+  @Deprecated
 	public S hasContentEqualTo(InputStream expected) {
 		inputStreams.assertEqualContent(info, actual, expected);
 		return myself;
 	}
+
+  /**
+   * Verifies that the content of the actual {@code InputStream} is equal to the content of the given one.
+   *
+   * @param expected the given {@code InputStream} to compare the actual {@code InputStream} to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code InputStream} is {@code null}.
+   * @throws AssertionError if the actual {@code InputStream} is {@code null}.
+   * @throws AssertionError if the content of the actual {@code InputStream} is not equal to the content of the given one.
+   * @throws InputStreamsException if an I/O error occurs.
+   */
+  public S hasSameContentAs(InputStream expected) {
+      inputStreams.assertEqualContent(info, actual, expected);
+      return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -52,7 +52,7 @@ public abstract class AbstractInputStreamAssert<S extends AbstractInputStreamAss
 	 */
   @Deprecated
 	public S hasContentEqualTo(InputStream expected) {
-		inputStreams.assertEqualContent(info, actual, expected);
+		inputStreams.assertSameContentAs(info, actual, expected);
 		return myself;
 	}
 
@@ -67,7 +67,7 @@ public abstract class AbstractInputStreamAssert<S extends AbstractInputStreamAss
    * @throws InputStreamsException if an I/O error occurs.
    */
   public S hasSameContentAs(InputStream expected) {
-      inputStreams.assertEqualContent(info, actual, expected);
+      inputStreams.assertSameContentAs(info, actual, expected);
       return myself;
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
@@ -18,43 +18,43 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * Creates an error message indicating that an assertion that verifies that two files/inputStreams have equal content failed.
+ * Creates an error message indicating that an assertion that verifies that two files/inputStreams have same content failed.
  * 
  * @author Yvonne Wang
  * @author Matthieu Baechler
  * @author Joel Costigliola
  */
-public class ShouldHaveEqualContent extends AbstractShouldHaveTextContent {
+public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
 
   /**
-   * Creates a new <code>{@link ShouldHaveEqualContent}</code>.
+   * Creates a new <code>{@link ShouldHaveSameContent}</code>.
    * @param actual the actual file in the failed assertion.
    * @param expected the expected file in the failed assertion.
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveEqualContent(File actual, File expected, List<String> diffs) {
-    return new ShouldHaveEqualContent(actual, expected, diffsAsString(diffs));
+  public static ErrorMessageFactory shouldHaveSameContent(File actual, File expected, List<String> diffs) {
+    return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 
   /**
-   * Creates a new <code>{@link ShouldHaveEqualContent}</code>.
+   * Creates a new <code>{@link ShouldHaveSameContent}</code>.
    * @param actual the actual InputStream in the failed assertion.
    * @param expected the expected Stream in the failed assertion.
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveEqualContent(InputStream actual, InputStream expected, List<String> diffs) {
-    return new ShouldHaveEqualContent(actual, expected, diffsAsString(diffs));
+  public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, InputStream expected, List<String> diffs) {
+    return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 
-  private ShouldHaveEqualContent(File actual, File expected, String diffs) {
-    super("%nFile:%n  <%s>%nand file:%n  <%s>%ndo not have equal content:", actual, expected);
+  private ShouldHaveSameContent(File actual, File expected, String diffs) {
+    super("%nFile:%n  <%s>%nand file:%n  <%s>%ndo not have same content:", actual, expected);
     this.diffs = diffs;
   }
 
-  private ShouldHaveEqualContent(InputStream actual, InputStream expected, String diffs) {
-    super("%nInputStreams do not have equal content:", actual, expected);
+  private ShouldHaveSameContent(InputStream actual, InputStream expected, String diffs) {
+    super("%nInputStreams do not have same content:", actual, expected);
     this.diffs = diffs;
   }
 }

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -35,6 +35,7 @@ import static org.assertj.core.error.ShouldHaveExtension.shouldHaveExtension;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.util.Objects.areEqual;
 
@@ -89,7 +90,7 @@ public class Files {
     try {
       List<String> diffs = diff.diff(actual, expected);
       if (diffs.isEmpty()) return;
-      throw failures.failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
+      throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {
       String msg = String.format("Unable to compare contents of files:<%s> and:<%s>", actual, expected);
       throw new FilesException(msg, e);

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.error.ShouldHaveSameContent;
 import org.assertj.core.util.FilesException;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -30,7 +31,6 @@ import static org.assertj.core.error.ShouldBeWritable.shouldBeWritable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
 import static org.assertj.core.error.ShouldHaveExtension.shouldHaveExtension;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
@@ -70,7 +70,7 @@ public class Files {
   Files() {}
 
   /**
-   * Asserts that the given files have equal content. Adapted from <a
+   * Asserts that the given files have same content. Adapted from <a
    * href="http://junit-addons.sourceforge.net/junitx/framework/FileAssert.html" target="_blank">FileAssert</a> (from <a
    * href="http://sourceforge.net/projects/junit-addons">JUnit-addons</a>.)
    * @param info contains information about the assertion.
@@ -81,15 +81,15 @@ public class Files {
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if {@code actual} is not an existing file.
    * @throws FilesException if an I/O error occurs.
-   * @throws AssertionError if the given files do not have equal content.
+   * @throws AssertionError if the given files do not have same content.
    */
-  public void assertEqualContent(AssertionInfo info, File actual, File expected) {
+  public void assertSameContentAs(AssertionInfo info, File actual, File expected) {
     verifyIsFile(expected);
     assertIsFile(info, actual);
     try {
       List<String> diffs = diff.diff(actual, expected);
       if (diffs.isEmpty()) return;
-      throw failures.failure(info, shouldHaveEqualContent(actual, expected, diffs));
+      throw failures.failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {
       String msg = String.format("Unable to compare contents of files:<%s> and:<%s>", actual, expected);
       throw new FilesException(msg, e);

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -14,7 +14,7 @@ package org.assertj.core.internal;
 
 import static java.lang.String.format;
 
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,23 +50,23 @@ public class InputStreams {
   InputStreams() {}
 
   /**
-   * Asserts that the given InputStreams have equal content.
+   * Asserts that the given InputStreams have same content.
    * 
    * @param info contains information about the assertion.
    * @param actual the "actual" InputStream.
    * @param expected the "expected" InputStream.
    * @throws NullPointerException if {@code expected} is {@code null}.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the given InputStreams do not have equal content.
+   * @throws AssertionError if the given InputStreams do not have same content.
    * @throws InputStreamsException if an I/O error occurs.
    */
-  public void assertEqualContent(AssertionInfo info, InputStream actual, InputStream expected) {
+  public void assertSameContentAs(AssertionInfo info, InputStream actual, InputStream expected) {
     if (expected == null) throw new NullPointerException("The InputStream to compare to should not be null");
     assertNotNull(info, actual);
     try {
       List<String> diffs = diff.diff(actual, expected);
       if (diffs.isEmpty()) return;
-      throw failures.failure(info, shouldHaveEqualContent(actual, expected, diffs));
+      throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {
       String msg = format("Unable to compare contents of InputStreams:%n  <%s>%nand:%n  <%s>", actual, expected);
       throw new InputStreamsException(msg, e);

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -31,6 +31,7 @@ import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
 
@@ -309,7 +310,7 @@ public class Paths {
 	try {
 	  List<String> diffs = diff.diff(actualFile, expectedFile);
 	  if (diffs.isEmpty()) return;
-	  throw failures.failure(info, ShouldHaveSameContent.shouldHaveSameContent(actualFile, expectedFile, diffs));
+	  throw failures.failure(info, shouldHaveSameContent(actualFile, expectedFile, diffs));
 	} catch (IOException e) {
 	  throw new FilesException(format("Unable to compare contents of files:<%s> and:<%s>", actualFile, expectedFile), e);
 	}

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -28,7 +28,6 @@ import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExist.shouldExistNoFollowLinks;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
@@ -43,6 +42,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.error.ShouldHaveSameContent;
 import org.assertj.core.util.FilesException;
 import org.assertj.core.util.PathsException;
 import org.assertj.core.util.VisibleForTesting;
@@ -309,7 +309,7 @@ public class Paths {
 	try {
 	  List<String> diffs = diff.diff(actualFile, expectedFile);
 	  if (diffs.isEmpty()) return;
-	  throw failures.failure(info, shouldHaveEqualContent(actualFile, expectedFile, diffs));
+	  throw failures.failure(info, ShouldHaveSameContent.shouldHaveSameContent(actualFile, expectedFile, diffs));
 	} catch (IOException e) {
 	  throw new FilesException(format("Unable to compare contents of files:<%s> and:<%s>", actualFile, expectedFile), e);
 	}

--- a/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
@@ -73,7 +73,7 @@ public class AutoCloseableBDDSoftAssertionsTest {
 	  softly.then(new float[] { 16f }).isEqualTo(new float[] { 17f });
 
 	  softly.then(new ByteArrayInputStream(new byte[] { (byte) 65 }))
-		    .hasContentEqualTo(new ByteArrayInputStream(new byte[] { (byte) 66 }));
+		    .hasSameContentAs(new ByteArrayInputStream(new byte[] { (byte) 66 }));
 
 	  softly.then(new Integer(20)).isEqualTo(new Integer(21));
 	  softly.then(22).isEqualTo(23);

--- a/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
@@ -155,7 +155,7 @@ public class AutoCloseableBDDSoftAssertionsTest {
 	  assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
 	  assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
 
-	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
+	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have same content:"
 		                                   + System.getProperty("line.separator")
 		                                   + "line:<1>, expected:<B> but was:<A>");
 

--- a/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -73,7 +73,7 @@ public class AutoCloseableSoftAssertionsTest {
 	  softly.assertThat(new float[] { 16f }).isEqualTo(new float[] { 17f });
 
 	  softly.assertThat(new ByteArrayInputStream(new byte[] { (byte) 65 }))
-		    .hasContentEqualTo(new ByteArrayInputStream(new byte[] { (byte) 66 }));
+		    .hasSameContentAs(new ByteArrayInputStream(new byte[] { (byte) 66 }));
 
 	  softly.assertThat(new Integer(20)).isEqualTo(new Integer(21));
 	  softly.assertThat(22).isEqualTo(23);

--- a/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -155,7 +155,7 @@ public class AutoCloseableSoftAssertionsTest {
 	  assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
 	  assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
 
-	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
+	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have same content:"
 		                                   + System.getProperty("line.separator")
 		                                   + "line:<1>, expected:<B> but was:<A>");
 

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -80,7 +80,7 @@ public class BDDSoftAssertionsTest {
 	  softly.then(new float[] { 16f }).isEqualTo(new float[] { 17f });
 
 	  softly.then(new ByteArrayInputStream(new byte[] { (byte) 65 }))
-		    .hasContentEqualTo(new ByteArrayInputStream(new byte[] { (byte) 66 }));
+		    .hasSameContentAs(new ByteArrayInputStream(new byte[] { (byte) 66 }));
 
 	  softly.then(new Integer(20)).isEqualTo(new Integer(21));
 	  softly.then(22).isEqualTo(23);

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -171,7 +171,7 @@ public class BDDSoftAssertionsTest {
 	  assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
 	  assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
 
-	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
+	  assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have same content:"
 		                                   + System.getProperty("line.separator")
 		                                   + "line:<1>, expected:<B> but was:<A>");
 

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -129,7 +129,7 @@ public class SoftAssertionsTest {
       softly.assertThat(new float[] { 16f }).isEqualTo(new float[] { 17f });
 
       softly.assertThat(new ByteArrayInputStream(new byte[] { (byte) 65 }))
-            .hasContentEqualTo(new ByteArrayInputStream(new byte[] { (byte) 66 }));
+            .hasSameContentAs(new ByteArrayInputStream(new byte[] { (byte) 66 }));
 
       softly.assertThat(new Integer(20)).isEqualTo(new Integer(21));
       softly.assertThat(22).isEqualTo(23);

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -222,7 +222,7 @@ public class SoftAssertionsTest {
       assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
       assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
 
-      assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
+      assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have same content:"
                                            + System.getProperty("line.separator")
                                            + "line:<1>, expected:<B> but was:<A>");
 

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
@@ -22,11 +22,11 @@ import org.assertj.core.api.FileAssertBaseTest;
 import org.junit.BeforeClass;
 
 /**
- * Tests for <code>{@link FileAssert#hasContentEqualTo(File)}</code>.
+ * Tests for <code>{@link FileAssert#hasSameContentAs(java.io.File)}</code>.
  * 
  * @author Yvonne Wang
  */
-public class FileAssert_hasContentEqualTo_Test extends FileAssertBaseTest {
+public class FileAssert_hasSameContentAs_Test extends FileAssertBaseTest {
 
   private static File expected;
 
@@ -37,7 +37,7 @@ public class FileAssert_hasContentEqualTo_Test extends FileAssertBaseTest {
 
   @Override
   protected FileAssert invoke_api_method() {
-    return assertions.hasContentEqualTo(expected);
+    return assertions.hasSameContentAs(expected);
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
@@ -42,6 +42,6 @@ public class FileAssert_hasSameContentAs_Test extends FileAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(files).assertEqualContent(getInfo(assertions), getActual(assertions), expected);
+    verify(files).assertSameContentAs(getInfo(assertions), getActual(assertions), expected);
   }
 }

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
@@ -44,7 +44,7 @@ public class InputStreamAssert_hasSameContentAs_Test extends InputStreamAssertBa
 
   @Override
   protected void verify_internal_effects() {
-    verify(inputStreams).assertEqualContent(getInfo(assertions), getActual(assertions), expected);
+    verify(inputStreams).assertSameContentAs(getInfo(assertions), getActual(assertions), expected);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
@@ -23,12 +23,12 @@ import org.junit.BeforeClass;
 
 
 /**
- * Tests for <code>{@link InputStreamAssert#hasContentEqualTo(InputStream)}</code>.
+ * Tests for <code>{@link InputStreamAssert#hasSameContentAs(java.io.InputStream)}</code>.
  * 
  * @author Matthieu Baechler
  * @author Joel Costigliola
  */
-public class InputStreamAssert_hasContentEqualTo_Test extends InputStreamAssertBaseTest {
+public class InputStreamAssert_hasSameContentAs_Test extends InputStreamAssertBaseTest {
 
   private static InputStream expected;
 
@@ -39,7 +39,7 @@ public class InputStreamAssert_hasContentEqualTo_Test extends InputStreamAssertB
 
   @Override
   protected InputStreamAssert invoke_api_method() {
-    return assertions.hasContentEqualTo(expected);
+    return assertions.hasSameContentAs(expected);
   }
 
   @Override

--- a/src/test/java/org/assertj/core/error/ShouldHaveSameContent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSameContent_create_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.SystemProperties.LINE_SEPARATOR;
 
@@ -27,13 +27,13 @@ import org.junit.Test;
 
 /**
  * Tests for
- * <code>{@link ShouldHaveEqualContent#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
+ * <code>{@link ShouldHaveSameContent#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
  * .
  * 
  * @author Yvonne Wang
  * @author Matthieu Baechler
  */
-public class ShouldHaveEqualContent_create_Test {
+public class ShouldHaveSameContent_create_Test {
 
   private List<String> diffs;
 
@@ -46,8 +46,9 @@ public class ShouldHaveEqualContent_create_Test {
 
   @Test
   public void should_create_error_message_file_even_if_content_contains_format_specifier() {
-	ErrorMessageFactory factory = shouldHaveEqualContent(new FakeFile("abc"), new FakeFile("xyz"), diffs);
-	StringBuilder b = new StringBuilder("[Test] \nFile:\n  <abc>\nand file:\n  <xyz>\ndo not have equal content:");
+	ErrorMessageFactory factory = ShouldHaveSameContent
+      .shouldHaveSameContent(new FakeFile("abc"), new FakeFile("xyz"), diffs);
+	StringBuilder b = new StringBuilder("[Test] \nFile:\n  <abc>\nand file:\n  <xyz>\ndo not have same content:");
 	for (String diff : diffs)
 	  b.append(LINE_SEPARATOR).append(diff);
 	assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation())).isEqualTo(b.toString());
@@ -55,10 +56,10 @@ public class ShouldHaveEqualContent_create_Test {
 
   @Test
   public void should_create_error_message_inputstream_even_if_content_contains_format_specifier() {
-	ErrorMessageFactory factory = shouldHaveEqualContent(new ByteArrayInputStream(new byte[] { 'a' }),
-	                                                     new ByteArrayInputStream(new byte[] { 'b' }),
-	                                                     diffs);
-	StringBuilder b = new StringBuilder("[Test] \nInputStreams do not have equal content:");
+	ErrorMessageFactory factory = shouldHaveSameContent(new ByteArrayInputStream(new byte[] { 'a' }),
+                                                      new ByteArrayInputStream(new byte[] { 'b' }),
+                                                      diffs);
+	StringBuilder b = new StringBuilder("[Test] \nInputStreams do not have same content:");
 	for (String diff : diffs)
 	  b.append(LINE_SEPARATOR).append(diff);
 	assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation())).isEqualTo(b.toString());

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -12,40 +12,35 @@
  */
 package org.assertj.core.internal.files;
 
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.fail;
-
-import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Lists.newArrayList;
-
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.error.ShouldHaveSameContent;
+import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.FilesException;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.error.ShouldHaveSameContent;
-import org.assertj.core.internal.Files;
-import org.assertj.core.internal.FilesBaseTest;
-import org.assertj.core.util.FilesException;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.fail;
+import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests for <code>{@link Files#assertSameContentAs(AssertionInfo, File, File)}</code>.
- * 
+ * Tests for <code>{@link org.assertj.core.internal.Files#assertSameContentAs(org.assertj.core.api.AssertionInfo, java.io.File, java.io.File)}</code>.
+ *
  * @author Yvonne Wang
  * @author Joel Costigliola
  */
-public class Files_assertEqualContent_Test extends FilesBaseTest {
+public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   private static File actual;
   private static File expected;

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
@@ -15,7 +15,7 @@ package org.assertj.core.internal.inputstreams;
 import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.fail;
 
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -38,28 +38,28 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link InputStreams#assertEqualContent(AssertionInfo, InputStream, InputStream)}</code>.
+ * Tests for <code>{@link InputStreams#assertSameContentAs(AssertionInfo, InputStream, InputStream)}</code>.
  * 
  * @author Matthieu Baechler
  */
-public class InputStreams_assertEqualContent_Test extends InputStreamsBaseTest {
+public class InputStreams_assertSameContentAs_Test extends InputStreamsBaseTest {
 
   @Test
   public void should_throw_error_if_expected_is_null() {
     thrown.expectNullPointerException("The InputStream to compare to should not be null");
-    inputStreams.assertEqualContent(someInfo(), actual, null);
+    inputStreams.assertSameContentAs(someInfo(), actual, null);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    inputStreams.assertEqualContent(someInfo(), null, expected);
+    inputStreams.assertSameContentAs(someInfo(), null, expected);
   }
 
   @Test
   public void should_pass_if_inputstreams_have_equal_content() throws IOException {
     when(diff.diff(actual, expected)).thenReturn(new ArrayList<String>());
-    inputStreams.assertEqualContent(someInfo(), actual, expected);
+    inputStreams.assertSameContentAs(someInfo(), actual, expected);
   }
 
   @Test
@@ -67,7 +67,7 @@ public class InputStreams_assertEqualContent_Test extends InputStreamsBaseTest {
     IOException cause = new IOException();
     when(diff.diff(actual, expected)).thenThrow(cause);
     try {
-      inputStreams.assertEqualContent(someInfo(), actual, expected);
+      inputStreams.assertSameContentAs(someInfo(), actual, expected);
       fail("Expected a InputStreamsException to be thrown");
     } catch (InputStreamsException e) {
       assertSame(cause, e.getCause());
@@ -80,9 +80,9 @@ public class InputStreams_assertEqualContent_Test extends InputStreamsBaseTest {
     when(diff.diff(actual, expected)).thenReturn(diffs);
     AssertionInfo info = someInfo();
     try {
-      inputStreams.assertEqualContent(info, actual, expected);
+      inputStreams.assertSameContentAs(info, actual, expected);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveEqualContent(actual, expected, diffs));
+      verify(failures).failure(info, shouldHaveSameContent(actual, expected, diffs));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -129,7 +130,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	try {
 	  paths.assertHasSameContentAs(info, actual, other);
 	} catch (AssertionError e) {
-	  verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual.toFile(), other.toFile(), diffs));
+	  verify(failures).failure(info, shouldHaveSameContent(actual.toFile(), other.toFile(), diffs));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
-import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -31,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.error.ShouldHaveSameContent;
 import org.assertj.core.internal.Paths;
 import org.assertj.core.util.FilesException;
 import org.junit.Test;
@@ -129,7 +129,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	try {
 	  paths.assertHasSameContentAs(info, actual, other);
 	} catch (AssertionError e) {
-	  verify(failures).failure(info, shouldHaveEqualContent(actual.toFile(), other.toFile(), diffs));
+	  verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual.toFile(), other.toFile(), diffs));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION
Simple refactoring as described in the issue #240. hasContentEqualTo is marked as deprecated and uses internally hasSameContentAs