### PR TITLE
Fixes #374 : Use strict instead of lenient date parsing by default

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -2345,6 +2345,45 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
   }
 
   /**
+   * Instead of using default strict date/time parsing it is possible to enforce mode when for default date formats
+   * parser uses heuristics to interpret inputs that do not precisely match supported date formats (lenient parsing).
+   *
+   * With strict parsing, inputs must match exactly date/time format.
+   *
+   * Example:
+   *
+   * <pre><code class='java'>
+   * final Date date = Dates.parse("2001-02-03");
+   * final Date dateTime = parseDatetime("2001-02-03T04:05:06");
+   * final Date dateTimeWithMs = parseDatetimeWithMs("2001-02-03T04:05:06.700");
+   *
+   * AbstractDateAssert.setLenientDateParsing(true);
+   *
+   * // assertions will pass
+   * assertThat(date).isEqualTo("2001-01-34");
+   * assertThat(date).isEqualTo("2001-02-02T24:00:00");
+   * assertThat(date).isEqualTo("2001-02-04T-24:00:00.000");
+   * assertThat(dateTime).isEqualTo("2001-02-03T04:05:05.1000");
+   * assertThat(dateTime).isEqualTo("2001-02-03T04:04:66");
+   * assertThat(dateTimeWithMs).isEqualTo("2001-02-03T04:05:07.-300");
+   *
+   * // assertions will fail
+   * assertThat(date).hasSameTimeAs("2001-02-04"); // different date
+   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here
+   * </code></pre>
+   *
+   * To revert to default strict date parsing, call {@code setLenientDateParsing(false)}.
+   *
+   * @param value whether lenient parsing mode should be enabled or not
+   * @author Michal Kordas
+   */
+  public static void setLenientDateParsing(boolean value) {
+    for (DateFormat defaultDateFormat : DEFAULT_DATE_FORMATS) {
+      defaultDateFormat.setLenient(value);
+    }
+  }
+
+  /**
    * Add the given date format to the ones used to parse date String in String based Date assertions like
    * {@link #isEqualTo(String)}.
    * <p/>

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1193,6 +1193,43 @@ public class Assertions {
   // --------------------------------------------------------------------------------------------------
 
   /**
+   * Instead of using default strict date/time parsing it is possible to enforce mode when for default date formats
+   * parser uses heuristics to interpret inputs that do not precisely match supported date formats (lenient parsing).
+   *
+   * With strict parsing, inputs must match exactly date/time format.
+   *
+   * Example:
+   *
+   * <pre><code class='java'>
+   * final Date date = Dates.parse("2001-02-03");
+   * final Date dateTime = parseDatetime("2001-02-03T04:05:06");
+   * final Date dateTimeWithMs = parseDatetimeWithMs("2001-02-03T04:05:06.700");
+   *
+   * Assertions.setLenientDateParsing(true);
+   *
+   * // assertions will pass
+   * assertThat(date).isEqualTo("2001-01-34");
+   * assertThat(date).isEqualTo("2001-02-02T24:00:00");
+   * assertThat(date).isEqualTo("2001-02-04T-24:00:00.000");
+   * assertThat(dateTime).isEqualTo("2001-02-03T04:05:05.1000");
+   * assertThat(dateTime).isEqualTo("2001-02-03T04:04:66");
+   * assertThat(dateTimeWithMs).isEqualTo("2001-02-03T04:05:07.-300");
+   *
+   * // assertions will fail
+   * assertThat(date).hasSameTimeAs("2001-02-04"); // different date
+   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here
+   * </code></pre>
+   *
+   * To revert to default strict date parsing, call {@code setLenientDateParsing(false)}.
+   *
+   * @param value whether lenient parsing mode should be enabled or not
+   * @author Michal Kordas
+   */
+  public static void setLenientDateParsing(boolean value) {
+    AbstractDateAssert.setLenientDateParsing(value);
+  }
+
+  /**
    * Add the given date format to the ones used to parse date String in String based Date assertions like
    * {@link org.assertj.core.api.AbstractDateAssert#isEqualTo(String)}.
    * <p/>
@@ -1213,7 +1250,7 @@ public class Assertions {
    * {@link org.assertj.core.api.AbstractDateAssert#withDefaultDateFormatsOnly()}.
    * <p/>
    * Code examples:
-   * 
+   *
    * <pre><code class='java'>
    * Date date = ... // set to 2003 April the 26th
    * assertThat(date).isEqualTo("2003-04-26");

--- a/src/main/java/org/assertj/core/util/Dates.java
+++ b/src/main/java/org/assertj/core/util/Dates.java
@@ -51,14 +51,14 @@ public class Dates {
    * ISO 8601 date format (yyyy-MM-dd), example : <code>2003-04-23</code>
    */
   public static DateFormat newIsoDateFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd");
+    return strictDateFormatForPattern("yyyy-MM-dd");
   }
 
   /**
    * ISO 8601 date-time format (yyyy-MM-dd'T'HH:mm:ss), example : <code>2003-04-26T13:01:02</code>
    */
   public static DateFormat newIsoDateTimeFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    return strictDateFormatForPattern("yyyy-MM-dd'T'HH:mm:ss");
   }
 
   /**
@@ -66,7 +66,7 @@ public class Dates {
    * <code>2003-04-26T03:01:02.999</code>
    */
   public static DateFormat newIsoDateTimeWithMsFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    return strictDateFormatForPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
   }
 
   /**
@@ -74,7 +74,13 @@ public class Dates {
    * <code>2003-04-26 03:01:02.999</code>
    */
   public static DateFormat newTimestampDateFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    return strictDateFormatForPattern("yyyy-MM-dd HH:mm:ss.SSS");
+  }
+
+  private static DateFormat strictDateFormatForPattern(String pattern) {
+    DateFormat dateFormat = new SimpleDateFormat(pattern);
+    dateFormat.setLenient(false);
+    return dateFormat;
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p/>
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.util.Dates.parseDatetime;
+import static org.assertj.core.util.Dates.parseDatetimeWithMs;
+
+import java.util.Date;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.DateAssertBaseTest;
+import org.assertj.core.test.ExpectedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests the lenient mode of date parsing used in date assertions with date represented as {@link String}.
+ *
+ * @author Michal Kordas
+ */
+public class DateAssert_setLenientDateParsing extends DateAssertBaseTest {
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Override @Before
+  public void setUp() {
+    super.setUp();
+    Assertions.setLenientDateParsing(true);
+  }
+
+  @Test
+  public void should_parse_date_leniently() {
+    final Date date = parse("2001-02-03");
+    assertThat(date).isEqualTo("2001-01-34");
+    assertThat(date).isEqualTo("2001-02-02T24:00:00");
+    assertThat(date).isEqualTo("2001-02-04T-24:00:00.000");
+  }
+
+  @Test
+  public void should_parse_date_time_leniently() {
+    final Date dateTime = parseDatetime("2001-02-03T04:05:06");
+    assertThat(dateTime).isEqualTo("2001-02-03T04:05:05.1000");
+    assertThat(dateTime).isEqualTo("2001-02-03T04:04:66");
+  }
+
+  @Test
+  public void should_parse_date_time_with_milliseconds_leniently() {
+    final Date dateTimeWithMs = parseDatetimeWithMs("2001-02-03T04:05:06.700");
+    assertThat(dateTimeWithMs).isEqualTo("2001-02-03T04:05:07.-300");
+  }
+
+  @Test
+  public void should_parse_date_time_leniently_using_custom_date_string_representation() {
+    final Date date = parse("2001-02-03");
+    assertThat(date).withDateFormat("yyyy/MM/dd").isEqualTo("2001/01/34");
+  }
+
+  @Test
+  public void should_fail_if_given_date_string_representation_cant_be_parsed() {
+    final String dateAsString = "2001/02/03";
+    thrown.expect(AssertionError.class);
+    assertThat(new Date()).isEqualTo(dateAsString);
+  }
+
+  @Test
+  public void should_fail_if_date_can_be_parsed_leniently_but_lenient_mode_is_disabled() {
+    final Date date = parse("2001-02-03");
+
+    Assertions.setLenientDateParsing(false);
+    try {
+      assertThat(date).isEqualTo("2001-01-34");
+      failBecauseExceptionWasNotThrown(AssertionError.class);
+    } catch (AssertionError error) {
+      assertThat(error).hasMessageContaining("Failed to parse");
+    } finally {
+      Assertions.setLenientDateParsing(true);
+    }
+  }
+
+  @Override @After
+  public void tearDown() {
+    super.tearDown();
+    Assertions.setLenientDateParsing(false);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBetween_Test.java
@@ -161,7 +161,7 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_equals_to_start_of_given_period_and_start_is_not_included_in_given_period_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = parseDate("2011-09-01");
-    Date start = parseDate("2011-09-31"); // = 2011-09-01 according to comparison strategy
+    Date start = parseDate("2011-09-01"); // = 2011-09-01 according to comparison strategy
     Date end = parseDate("2011-10-30");
     boolean inclusiveStart = false;
     boolean inclusiveEnd = true;


### PR DESCRIPTION
This change breaks backward compatibility.