### PR TITLE
Fix 381

### DIFF
--- a/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_test.java
+++ b/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_test.java
@@ -134,6 +134,12 @@ public class FieldsOrPropertiesExtractor_extract_test {
     extract(employees, byName("adult"));
   }
 
+  @Test
+  public void should_extract_property_field_combinations() throws Exception {
+    List<Object> extractedValues = extract(employees, byName("surname.name"));
+    assertThat(extractedValues).containsOnly("Master Jedi");
+  }
+
   // --
   
   private Employee employeeWithBrokenName(String name) {

--- a/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_test.java
+++ b/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_test.java
@@ -136,7 +136,11 @@ public class FieldsOrPropertiesExtractor_extract_test {
 
   @Test
   public void should_extract_property_field_combinations() throws Exception {
-    List<Object> extractedValues = extract(employees, byName("surname.name"));
+    Employee darth = new Employee(1L, new Name("Darth", "Vader"), 100);
+    darth.field = luke;
+    luke.field = yoda;
+    employees = newArrayList(darth);
+    List<Object> extractedValues = extract(employees, byName("method.field.method.field.method.surname.name"));
     assertThat(extractedValues).containsOnly("Master Jedi");
   }
 

--- a/src/test/java/org/assertj/core/test/Employee.java
+++ b/src/test/java/org/assertj/core/test/Employee.java
@@ -57,6 +57,12 @@ public class Employee {
   public boolean isAdult() {
     return age > 18;
   }
+  
+  // testing nested combinations of field/property
+  public Employee field;
+  public Employee getMethod(){
+    return this;
+  }
 
   @Override
   public String toString() {

--- a/src/test/java/org/assertj/core/test/Name.java
+++ b/src/test/java/org/assertj/core/test/Name.java
@@ -51,6 +51,11 @@ public class Name {
   public void setLast(String last) {
     this.last = last;
   }
+  
+  // property without field in order to test field/property combinations
+  public String getName(){
+    return String.format("%s %s", getFirst(), getLast());
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION
Fixes #381.

I tried to keep changes to a minimum. I only needed to extend some of the test fixtures in order to test "altering nested property/field combinations".

Furthermore I decided to copy some stuff into ByNameSingleExtractor.java to avoid a variety of changes when for instance moving PropertySupport to the Introspection package.

I used the code style mentioned in CONTRIBUTING.md ... however I noticed that ByNameSingleExtractor.java seems to be not formatted conforming to that style. However I DID NOT reformat the code in order to avoid "unrelated changes".