### PR TITLE
Fixes #399: usingFieldByFieldElementComparator - polymorphic collection - org.assertj.core.util.introspection.IntrospectionError

### DIFF
--- a/src/main/java/org/assertj/core/internal/FieldByFieldComparator.java
+++ b/src/main/java/org/assertj/core/internal/FieldByFieldComparator.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import java.util.Comparator;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.introspection.IntrospectionError;
 
 /**
  * Compare Object field by field including private fields unless
@@ -33,7 +34,11 @@ public class FieldByFieldComparator implements Comparator<Object> {
   }
 
   protected boolean areEqual(Object actual, Object other) {
-	return Objects.instance().areEqualToIgnoringGivenFields(actual, other);
+    try {
+      return Objects.instance().areEqualToIgnoringGivenFields(actual, other);
+    } catch (IntrospectionError e) {
+      return false;
+    }
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal;
 
 import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.introspection.IntrospectionError;
 
 public class IgnoringFieldsComparator extends FieldByFieldComparator {
 
@@ -31,7 +32,11 @@ public class IgnoringFieldsComparator extends FieldByFieldComparator {
   
   @Override
   protected boolean areEqual(Object actualElement, Object otherElement) {
-    return Objects.instance().areEqualToIgnoringGivenFields(actualElement, otherElement, fields);
+    try {
+      return Objects.instance().areEqualToIgnoringGivenFields(actualElement, otherElement, fields);
+    } catch (IntrospectionError e) {
+      return false;
+    }
   }
   
   @Override

--- a/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
@@ -17,6 +17,7 @@ import static org.assertj.core.util.Strings.isNullOrEmpty;
 
 import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.introspection.IntrospectionError;
 
 public class OnFieldsComparator extends FieldByFieldComparator {
 
@@ -41,7 +42,11 @@ public class OnFieldsComparator extends FieldByFieldComparator {
 
   @Override
   protected boolean areEqual(Object actualElement, Object otherElement) {
-	return Objects.instance().areEqualToComparingOnlyGivenFields(actualElement, otherElement, fields);
+    try {
+      return Objects.instance().areEqualToComparingOnlyGivenFields(actualElement, otherElement, fields);
+    } catch (IntrospectionError e) {
+      return false;
+    }
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
@@ -49,14 +49,14 @@ public class IterableAssert_usingFieldByFieldElementComparator_Test extends Iter
   }
 
   @Test
-  public void succesful_isEqualTo_assertion_using_field_by_field_element_comparator() {
+  public void successful_isEqualTo_assertion_using_field_by_field_element_comparator() {
 	List<Foo> list1 = singletonList(new Foo("id", 1));
 	List<Foo> list2 = singletonList(new Foo("id", 1));
 	assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
   }
 
   @Test
-  public void succesful_isIn_assertion_using_field_by_field_element_comparator() {
+  public void successful_isIn_assertion_using_field_by_field_element_comparator() {
 	List<Foo> list1 = singletonList(new Foo("id", 1));
 	List<Foo> list2 = singletonList(new Foo("id", 1));
 	System.out.println(new FieldByFieldComparator());

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
@@ -1,13 +1,13 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
+ * <p>
  * Copyright 2012-2015 the original author or authors.
  */
 package org.assertj.core.api.iterable;
@@ -15,6 +15,7 @@ package org.assertj.core.api.iterable;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
 
 import java.util.List;
 
@@ -33,83 +34,143 @@ public class IterableAssert_usingFieldByFieldElementComparator_Test extends Iter
 
   @Before
   public void before() {
-	iterablesBefore = getIterables(assertions);
+    iterablesBefore = getIterables(assertions);
   }
 
   @Override
   protected ConcreteIterableAssert<Object> invoke_api_method() {
-	return assertions.usingFieldByFieldElementComparator();
+    return assertions.usingFieldByFieldElementComparator();
   }
 
   @Override
   protected void verify_internal_effects() {
-	assertThat(iterablesBefore).isNotSameAs(getIterables(assertions));
-	assertThat(getIterables(assertions).getComparisonStrategy() instanceof ComparatorBasedComparisonStrategy).isTrue();
-	assertThat(getObjects(assertions).getComparisonStrategy() instanceof IterableElementComparisonStrategy).isTrue();
+    assertThat(iterablesBefore).isNotSameAs(getIterables(assertions));
+    assertThat(getIterables(assertions).getComparisonStrategy() instanceof ComparatorBasedComparisonStrategy).isTrue();
+    assertThat(getObjects(assertions).getComparisonStrategy() instanceof IterableElementComparisonStrategy).isTrue();
   }
 
   @Test
   public void successful_isEqualTo_assertion_using_field_by_field_element_comparator() {
-	List<Foo> list1 = singletonList(new Foo("id", 1));
-	List<Foo> list2 = singletonList(new Foo("id", 1));
-	assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
+    List<Foo> list1 = singletonList(new Foo("id", 1));
+    List<Foo> list2 = singletonList(new Foo("id", 1));
+    assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
   }
 
   @Test
   public void successful_isIn_assertion_using_field_by_field_element_comparator() {
-	List<Foo> list1 = singletonList(new Foo("id", 1));
-	List<Foo> list2 = singletonList(new Foo("id", 1));
-	System.out.println(new FieldByFieldComparator());
-	assertThat(list1).usingFieldByFieldElementComparator().isIn(singletonList(list2));
+    List<Foo> list1 = singletonList(new Foo("id", 1));
+    List<Foo> list2 = singletonList(new Foo("id", 1));
+    System.out.println(new FieldByFieldComparator());
+    assertThat(list1).usingFieldByFieldElementComparator().isIn(singletonList(list2));
+  }
+
+  @Test
+  public void successful_isEqualTo_assertion_using_field_by_field_element_comparator_with_heterogeneous_list() {
+    List<Animal> list1 = newArrayList(new Bird("White"), new Snake(15));
+    List<Animal> list2 = newArrayList(new Bird("White"), new Snake(15));
+    assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
+  }
+
+  @Test
+  public void successful_isIn_assertion_using_field_by_field_element_comparator_with_heterogeneous_list() {
+    List<Animal> list1 = newArrayList(new Bird("White"), new Snake(15));
+    List<Animal> list2 = newArrayList(new Bird("White"), new Snake(15));
+    System.out.println(new FieldByFieldComparator());
+    assertThat(list1).usingFieldByFieldElementComparator().isIn(singletonList(list2));
+  }
+
+  @Test
+  public void successful_containsExactly_assertion_using_field_by_field_element_comparator_with_heterogeneous_list() {
+    List<Animal> list1 = newArrayList(new Bird("White"), new Snake(15));
+    System.out.println(new FieldByFieldComparator());
+    assertThat(list1).usingFieldByFieldElementComparator().containsExactly(new Bird("White"), new Snake(15));
   }
 
   @Test
   public void failed_isEqualTo_assertion_using_field_by_field_element_comparator() {
-	List<Foo> list1 = singletonList(new Foo("id", 1));
-	List<Foo> list2 = singletonList(new Foo("id", 2));
-	try {
-	  assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
-	} catch (AssertionError e) {
-	  assertThat(e).hasMessage(String.format("%nExpecting:%n" +
-		                       " <[Foo(id=id, bar=1)]>%n" +
-		                       "to be equal to:%n" +
-		                       " <[Foo(id=id, bar=2)]>%n" +
-		                       "when comparing elements using 'field by field comparator on all fields' but was not."));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
+    List<Foo> list1 = singletonList(new Foo("id", 1));
+    List<Foo> list2 = singletonList(new Foo("id", 2));
+    try {
+      assertThat(list1).usingFieldByFieldElementComparator().isEqualTo(list2);
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage(String.format("%nExpecting:%n" +
+          " <[Foo(id=id, bar=1)]>%n" +
+          "to be equal to:%n" +
+          " <[Foo(id=id, bar=2)]>%n" +
+          "when comparing elements using 'field by field comparator on all fields' but was not."));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
   public void failed_isIn_assertion_using_field_by_field_element_comparator() {
-	List<Foo> list1 = singletonList(new Foo("id", 1));
-	List<Foo> list2 = singletonList(new Foo("id", 2));
-	try {
-	  assertThat(list1).usingFieldByFieldElementComparator().isIn(singletonList(list2));
-	} catch (AssertionError e) {
-	  assertThat(e).hasMessage(String.format("%nExpecting:%n" +
-		                       " <[Foo(id=id, bar=1)]>%n" +
-		                       "to be in:%n" +
-		                       " <[[Foo(id=id, bar=2)]]>%n" +
-		                       "when comparing elements using 'field by field comparator on all fields'"));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
+    List<Foo> list1 = singletonList(new Foo("id", 1));
+    List<Foo> list2 = singletonList(new Foo("id", 2));
+    try {
+      assertThat(list1).usingFieldByFieldElementComparator().isIn(singletonList(list2));
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage(String.format("%nExpecting:%n" +
+          " <[Foo(id=id, bar=1)]>%n" +
+          "to be in:%n" +
+          " <[[Foo(id=id, bar=2)]]>%n" +
+          "when comparing elements using 'field by field comparator on all fields'"));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   public static class Foo {
-	public final String id;
-	public final int bar;
+    public final String id;
+    public final int bar;
 
-	public Foo(final String id, final int bar) {
-	  this.id = id;
-	  this.bar = bar;
-	}
+    public Foo(final String id, final int bar) {
+      this.id = id;
+      this.bar = bar;
+    }
 
-	@Override
-	public String toString() {
-	  return "Foo(id=" + id + ", bar=" + bar + ")";
-	}
+    @Override
+    public String toString() {
+      return "Foo(id=" + id + ", bar=" + bar + ")";
+    }
 
+  }
+
+  private static class Animal {
+    private final String name;
+
+    private Animal(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+
+  private static class Bird extends Animal {
+    private final String color;
+
+    private Bird(String color) {
+      super("Bird");
+      this.color = color;
+    }
+
+    public String getColor() {
+      return color;
+    }
+  }
+
+  private static class Snake extends Animal {
+    private final int length;
+
+    private Snake(int length) {
+      super("Snake");
+      this.length = length;
+    }
+
+    public int getLength() {
+      return length;
+    }
   }
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingFieldByFieldElementComparator_Test.java
@@ -1,13 +1,13 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
+ *
  * Copyright 2012-2015 the original author or authors.
  */
 package org.assertj.core.api.iterable;

--- a/src/test/java/org/assertj/core/internal/FieldByFieldComparator_compareTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/FieldByFieldComparator_compareTo_Test.java
@@ -13,18 +13,11 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
 
-import org.assertj.core.test.ExpectedException;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class FieldByFieldComparator_compareTo_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   private FieldByFieldComparator fieldByFieldComparator;
 
@@ -59,8 +52,7 @@ public class FieldByFieldComparator_compareTo_Test {
   }
 
   @Test
-  public void should_throw_exception_if_Objects_have_not_the_same_properties() {
-	thrown.expect(IntrospectionError.class);
+  public void should_return_are_not_equal_if_Objects_do_not_have_the_same_properties() {
 	assertThat(fieldByFieldComparator.compare(new JarJar("Yoda"), 2)).isNotZero();
   }
 

--- a/src/test/java/org/assertj/core/internal/IgnoringFieldsComparator_compareTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/IgnoringFieldsComparator_compareTo_Test.java
@@ -13,18 +13,11 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
 
-import org.assertj.core.test.ExpectedException;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class IgnoringFieldsComparator_compareTo_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   private IgnoringFieldsComparator ignoringFieldsComparator;
 
@@ -61,9 +54,8 @@ public class IgnoringFieldsComparator_compareTo_Test {
   }
 
   @Test
-  public void should_throw_exception_if_Objects_have_not_the_same_properties() {
-	thrown.expect(IntrospectionError.class);
-	assertThat(ignoringFieldsComparator.compare(new DarthVader("I like you", "I'll kill you"), 2)).isNotZero();
+  public void should_return_false_if_Objects_do_not_have_the_same_properties() {
+    assertThat(ignoringFieldsComparator.compare(new DarthVader("I like you", "I'll kill you"), 2)).isNotZero();
   }
 
   public static class DarthVader {

--- a/src/test/java/org/assertj/core/internal/OnFieldsComparator_compare_Test.java
+++ b/src/test/java/org/assertj/core/internal/OnFieldsComparator_compare_Test.java
@@ -13,18 +13,11 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
 
-import org.assertj.core.test.ExpectedException;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class OnFieldsComparator_compare_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   private OnFieldsComparator onFieldsComparator;
 
@@ -63,10 +56,8 @@ public class OnFieldsComparator_compare_Test {
   }
 
   @Test
-  public void should_throw_exception_if_Objects_have_not_the_same_properties() {
-	thrown.expect(IntrospectionError.class,
-	              "Unable to obtain the value of <'telling'> field/property from <2>, expecting a public field or getter");
-	assertThat(onFieldsComparator.compare(new DarthVader("I like you", "I'll kill you"), 2)).isNotZero();
+  public void should_return_false_if_Objects_do_not_have_the_same_properties() {
+    assertThat(onFieldsComparator.compare(new DarthVader("I like you", "I'll kill you"), 2)).isNotZero();
   }
 
   public static class DarthVader {


### PR DESCRIPTION
The implementations of `FieldByFieldComparator.areEqual`, `IgnoringFieldsComparator.areEqual` and `OnFieldsComparator.areEqual` all catch the `IntrospectionError` and return `false`.

The test case reported in Issue #399 has been added to `IterableAssert_usingFieldByFieldElementComparator_Test`.