### PR TITLE
Fixes #398

### DIFF
--- a/src/main/java/org/assertj/core/util/Iterables.java
+++ b/src/main/java/org/assertj/core/util/Iterables.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -88,6 +89,8 @@ public final class Iterables {
 
   /**
    * Create an array from an {@link Iterable}.
+   * <p/>
+   * Note: this method will return Object[]. If you require a typed array please use {@link #toArray(Iterable, Class)}.
    * 
    * @param iterable an {@link Iterable} to translate in an array.
    * @param <T> the type of elements of the {@code Iterable}.
@@ -102,5 +105,37 @@ public final class Iterables {
     return (T[]) newArrayList(iterable).toArray();
   }
 
+  /**
+   * Create an typed array from an {@link Iterable}.
+   *
+   * @param iterable an {@link Iterable} to translate in an array.
+   * @param type the type of the resulting array.
+   * @param <T> the type of elements of the {@code Iterable}.
+   * @return all the elements from the given {@link Iterable} in an array. {@code null} if given {@link Iterable} is
+   *         null.
+   */
+  public static <T> T[] toArray(Iterable<? extends T> iterable, Class<T> type) {
+    if (iterable == null) {
+      return null;
+    }
+
+    Collection<? extends T> collection = toCollection(iterable);
+    T[] array = newArray(type, collection.size());
+    return collection.toArray(array);
+  }
+
+  private static <T> Collection<T> toCollection(Iterable<T> iterable) {
+    if (iterable instanceof Collection) {
+      return (Collection<T>) iterable;
+    } else {
+      return Lists.newArrayList(iterable);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T[] newArray(Class<T> type, int length) {
+    return (T[]) Array.newInstance(type, length);
+  }
+  
   private Iterables() {}
 }

--- a/src/test/java/org/assertj/core/util/Iterables_toArray_Test.java
+++ b/src/test/java/org/assertj/core/util/Iterables_toArray_Test.java
@@ -16,7 +16,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import java.util.ArrayList;
+import java.util.*;
 
 import org.junit.Test;
 
@@ -32,15 +32,25 @@ public class Iterables_toArray_Test {
   @Test
   public void should_return_null_when_given_iterable_is_null() throws Exception {
     assertThat(Iterables.toArray(null)).isNull();
+    assertThat(Iterables.toArray(null, Object.class)).isNull();
   }
 
   @Test
   public void should_return_array_of_given_iterable_elements() throws Exception {
     assertThat(Iterables.toArray(values)).containsExactly("one", "two");
+    assertThat(Iterables.toArray(values, String.class)).containsExactly("one", "two");
   }
 
   @Test
   public void should_return_empty_array_when_given_iterable_is_empty() throws Exception {
     assertThat(Iterables.toArray(emptyList())).isEmpty();
+    assertThat(Iterables.toArray(emptyList(), Object.class)).isEmpty();
+  }
+
+  @Test
+  public void should_return_array_of_given_iterable_type() throws Exception {
+    CharSequence[] result = Iterables.toArray(values, CharSequence.class);
+    
+    assertThat(result).containsExactly("one", "two");
   }
 }


### PR DESCRIPTION
Extended current Iterables utils in order to implement feature #393.

My idea is to just convert the iterable to an array to be able to reuse the current implementation.

**AbstractCharSequenceAssert.java**
```java
/* omitted javadoc for clarity */
  public S contains(Iterable<CharSequence> values) {
    strings.assertContains(info, actual, Iterables.toArray(values, CharSequence.class));
    return myself;
  }
```

and

```java
/* omitted javadoc for clarity */
  public S containsSequence(Iterable<CharSequence> values) {
    strings.assertContainsSequence(info, actual, Iterables.toArray(values, CharSequence.class));
    return myself;
  }
```