### PR TITLE
Added OffsetTime assertion (#363)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -557,5 +557,14 @@ public abstract class AbstractBDDSoftAssertions extends AbstractSoftAssertions {
   public OffsetTimeAssert then(OffsetTime actual) {
         return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
     }
-  
+
+  /**
+   * Creates a new instance of <code>{@link OffsetTimeAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public OffsetDateTimeAssert then(OffsetDateTime actual) {
+      return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -12,19 +12,16 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public abstract class AbstractBDDSoftAssertions extends AbstractSoftAssertions {
 
@@ -550,5 +547,15 @@ public abstract class AbstractBDDSoftAssertions extends AbstractSoftAssertions {
   public LocalTimeAssert then(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
+
+  /**
+   * Creates a new instance of <code>{@link OffsetTimeAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public OffsetTimeAssert then(OffsetTime actual) {
+        return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
+    }
   
 }

--- a/src/main/java/org/assertj/core/api/AbstractOffsetDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOffsetDateTimeAssert.java
@@ -1,0 +1,682 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.Objects;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
+import static org.assertj.core.error.ShouldBeAfterOrEqualsTo.shouldBeAfterOrEqualsTo;
+import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
+import static org.assertj.core.error.ShouldBeBeforeOrEqualsTo.shouldBeBeforeOrEqualsTo;
+import static org.assertj.core.error.ShouldBeEqualIgnoringHours.shouldBeEqualIgnoringHours;
+import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualIgnoringMinutes;
+import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
+import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
+import static org.assertj.core.error.ShouldBeEqualIgnoringTimezone.shouldBeEqualIgnoringTimezone;
+
+/**
+ * Assertions for {@link java.time.OffsetDateTime} type from new Date &amp; Time API introduced in Java 8.
+ *
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+public abstract class AbstractOffsetDateTimeAssert<S extends AbstractOffsetDateTimeAssert<S>> extends
+    AbstractAssert<S, OffsetDateTime> {
+
+    public static final String NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE = "The OffsetDateTime to compare actual with should not be null";
+
+    /**
+     * Creates a new <code>{@link org.assertj.core.api.AbstractOffsetDateTimeAssert}</code>.
+     *
+     * @param selfType the "self type"
+     * @param actual   the actual value to verify
+     */
+    protected AbstractOffsetDateTimeAssert(OffsetDateTime actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    // visible for test
+    protected OffsetDateTime getActual() {
+        return actual;
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetDateTime} is <b>strictly</b> before the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("2000-01-01T23:59:59Z")).isBefore(parse("2000-01-02T00:00:00Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not strictly before the given one.
+     */
+    public S isBefore(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!actual.isBefore(other)) {
+            throw Failures.instance().failure(info, shouldBeBefore(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isBefore(java.time.OffsetDateTime)} but the {@link java.time.OffsetDateTime} is built from given String, which
+     * must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use directly String in comparison to avoid writing the code to perform the conversion
+     * assertThat(parse("2000-01-01T23:59:59Z")).isBefore("2000-01-02T00:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetDateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not strictly before the {@link java.time.OffsetDateTime} built
+     *                                  from given String.
+     */
+    public S isBefore(String offsetDateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(offsetDateTimeAsString);
+        return isBefore(OffsetDateTime.parse(offsetDateTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetDateTime} is before or equals to the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("2000-01-01T23:59:59Z")).isBeforeOrEqualTo(parse("2000-01-01T23:59:59Z"))
+     *                                         .isBeforeOrEqualTo(parse("2000-01-02T00:00:00Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not before or equals to the given one.
+     */
+    public S isBeforeOrEqualTo(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (actual.isAfter(other)) {
+            throw Failures.instance().failure(info, shouldBeBeforeOrEqualsTo(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isBeforeOrEqualTo(java.time.OffsetDateTime)} but the {@link java.time.OffsetDateTime} is built from given
+     * String, which must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use String in comparison to avoid conversion
+     * assertThat(parse("2000-01-01T23:59:59Z")).isBeforeOrEqualTo("2000-01-01T23:59:59Z")
+     *                                         .isBeforeOrEqualTo("2000-01-02T00:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetDateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not before or equals to the {@link java.time.OffsetDateTime}
+     *                                  built from given String.
+     */
+    public S isBeforeOrEqualTo(String offsetDateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(offsetDateTimeAsString);
+        return isBeforeOrEqualTo(OffsetDateTime.parse(offsetDateTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetDateTime} is after or equals to the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("2000-01-01T00:00:00Z")).isAfterOrEqualTo(parse("2000-01-01T00:00:00Z"))
+     *                                         .isAfterOrEqualTo(parse("1999-12-31T23:59:59Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not after or equals to the given one.
+     */
+    public S isAfterOrEqualTo(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (actual.isBefore(other)) {
+            throw Failures.instance().failure(info, shouldBeAfterOrEqualsTo(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isAfterOrEqualTo(java.time.OffsetDateTime)} but the {@link java.time.OffsetDateTime} is built from given
+     * String, which must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use String in comparison to avoid conversion
+     * assertThat(parse("2000-01-01T00:00:00Z")).isAfterOrEqualTo("2000-01-01T00:00:00Z")
+     *                                         .isAfterOrEqualTo("1999-12-31T23:59:59Z");
+     * </code></pre>
+     *
+     * @param offsetDateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not after or equals to the {@link java.time.OffsetDateTime}
+     *                                  built from given String.
+     */
+    public S isAfterOrEqualTo(String offsetDateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(offsetDateTimeAsString);
+        return isAfterOrEqualTo(OffsetDateTime.parse(offsetDateTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetDateTime} is <b>strictly</b> after the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("2000-01-01T00:00:00Z")).isAfter(parse("1999-12-31T23:59:59Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not strictly after the given one.
+     */
+    public S isAfter(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!actual.isAfter(other)) {
+            throw Failures.instance().failure(info, shouldBeAfter(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isAfter(java.time.OffsetDateTime)} but the {@link java.time.OffsetDateTime} is built from given a String that
+     * must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use String in comparison to avoid conversion
+     * assertThat(parse("2000-01-01T00:00:00Z")).isAfter("1999-12-31T23:59:59Z");
+     * </code></pre>
+     *
+     * @param offsetDateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not strictly after the {@link java.time.OffsetDateTime} built
+     *                                  from given String.
+     */
+    public S isAfter(String offsetDateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(offsetDateTimeAsString);
+        return isAfter(OffsetDateTime.parse(offsetDateTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isEqualTo(Object)} (where Object is expected to be {@link java.time.OffsetDateTime}) but here you
+     * pass {@link java.time.OffsetDateTime} String representation that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use directly String in comparison to avoid writing the code to perform the conversion
+     * assertThat(parse("2000-01-01T00:00:00Z")).isEqualTo("2000-01-01T00:00:00Z");
+     * </code></pre>
+     *
+     * @param dateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not equal to the {@link java.time.OffsetDateTime} built from
+     *                                  given String.
+     */
+    public S isEqualTo(String dateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(dateTimeAsString);
+        return isEqualTo(OffsetDateTime.parse(dateTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isNotEqualTo(Object)} (where Object is expected to be {@link java.time.OffsetDateTime}) but here you
+     * pass {@link java.time.OffsetDateTime} String representation that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use directly String in comparison to avoid writing the code to perform the conversion
+     * assertThat(parse("2000-01-01T00:00:00Z")).isNotEqualTo("2000-01-15T00:00:00Z");
+     * </code></pre>
+     *
+     * @param dateTimeAsString String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is equal to the {@link java.time.OffsetDateTime} built from given
+     *                                  String.
+     */
+    public S isNotEqualTo(String dateTimeAsString) {
+        assertOffsetDateTimeAsStringParameterIsNotNull(dateTimeAsString);
+        return isNotEqualTo(OffsetDateTime.parse(dateTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isIn(Object...)} (where Objects are expected to be {@link java.time.OffsetDateTime}) but here you
+     * pass {@link java.time.OffsetDateTime} String representations that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use String based representation of OffsetDateTime
+     * assertThat(parse("2000-01-01T00:00:00Z")).isIn("1999-12-31T00:00:00Z", "2000-01-01T00:00:00Z");
+     * </code></pre>
+     *
+     * @param dateTimesAsString String array representing {@link java.time.OffsetDateTime}s.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is not in the {@link java.time.OffsetDateTime}s built from given
+     *                                  Strings.
+     */
+    public S isIn(String... dateTimesAsString) {
+        checkIsNotNullAndNotEmpty(dateTimesAsString);
+        return isIn(convertToOffsetDateTimeArray(dateTimesAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isNotIn(Object...)} (where Objects are expected to be {@link java.time.OffsetDateTime}) but here you
+     * pass {@link java.time.OffsetDateTime} String representations that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_DATE_TIME"
+     * >ISO OffsetDateTime format</a> to allow calling {@link java.time.OffsetDateTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // use String based representation of OffsetDateTime
+     * assertThat(parse("2000-01-01T00:00:00Z")).isNotIn("1999-12-31T00:00:00Z", "2000-01-02T00:00:00Z");
+     * </code></pre>
+     *
+     * @param dateTimesAsString Array of String representing a {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetDateTime}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is in the {@link java.time.OffsetDateTime}s built from given
+     *                                  Strings.
+     */
+    public S isNotIn(String... dateTimesAsString) {
+        checkIsNotNullAndNotEmpty(dateTimesAsString);
+        return isNotIn(convertToOffsetDateTimeArray(dateTimesAsString));
+    }
+
+    private static Object[] convertToOffsetDateTimeArray(String... dateTimesAsString) {
+        OffsetDateTime[] dates = new OffsetDateTime[dateTimesAsString.length];
+        for (int i = 0; i < dateTimesAsString.length; i++) {
+            dates[i] = OffsetDateTime.parse(dateTimesAsString[i]);
+        }
+        return dates;
+    }
+
+    private void checkIsNotNullAndNotEmpty(Object[] values) {
+        if (values == null) {
+            throw new IllegalArgumentException("The given OffsetDateTime array should not be null");
+        }
+        if (values.length == 0) {
+            throw new IllegalArgumentException("The given OffsetDateTime array should not be empty");
+        }
+    }
+
+    /**
+     * Check that the {@link java.time.OffsetDateTime} string representation to compare actual {@link java.time.OffsetDateTime} to is not null,
+     * otherwise throws a {@link IllegalArgumentException} with an explicit message
+     *
+     * @param offsetDateTimeAsString String representing the {@link java.time.OffsetDateTime} to compare actual with
+     * @throws IllegalArgumentException with an explicit message if the given {@link String} is null
+     */
+    private static void assertOffsetDateTimeAsStringParameterIsNotNull(String offsetDateTimeAsString) {
+        if (offsetDateTimeAsString == null) {
+            throw new IllegalArgumentException(
+                "The String representing the OffsetDateTime to compare actual with should not be null");
+        }
+    }
+
+    /**
+     * Check that the {@link java.time.OffsetDateTime} to compare actual {@link java.time.OffsetDateTime} to is not null, in that case throws a
+     * {@link IllegalArgumentException} with an explicit message
+     *
+     * @param other the {@link java.time.OffsetDateTime} to check
+     * @throws IllegalArgumentException with an explicit message if the given {@link java.time.OffsetDateTime} is null
+     */
+    private static void assertOffsetDateTimeParameterIsNotNull(OffsetDateTime other) {
+        if (other == null) {
+            throw new IllegalArgumentException("The OffsetDateTime to compare actual with should not be null");
+        }
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetDateTime} have same year, month, day, hour, minute and second fields,
+     * (nanosecond fields are ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetDateTimes in same chronological nanosecond time window, e.g :
+     * <p>
+     * 2000-01-01T00:00:<b>01.000000000</b> and 2000-01-01T00:00:<b>00.999999999</b>.
+     * <p>
+     * Assertion fails as second fields differ even if time difference is only 1ns.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetDateTime OffsetDateTime1 = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTime2 = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 456, ZoneOffset.UTC);
+     * assertThat(OffsetDateTime1).isEqualToIgnoringNanos(OffsetDateTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetDateTime OffsetDateTimeA = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTimeB = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 999999999, ZoneOffset.UTC);
+     * assertThat(OffsetDateTimeA).isEqualToIgnoringNanos(OffsetDateTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is are not equal with nanoseconds ignored.
+     */
+    public S isEqualToIgnoringNanos(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringNanos(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringNanos(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetDateTime} have same year, month, day, hour, minute, second and nanosecond fields,
+     * (timezone fields are ignored in comparison).
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetDateTime OffsetDateTime1 = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTime2 = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 0, ZoneOffset.MAX);
+     * assertThat(OffsetDateTime1).isEqualToIgnoringTimezone(OffsetDateTime2);
+     * <p>
+     * // failing assertions
+     * OffsetDateTime OffsetDateTimeA = OffsetDateTime.of(2000, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTimeB = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 999999999, ZoneOffset.UTC);
+     * assertThat(OffsetDateTimeA).isEqualToIgnoringTimezone(OffsetDateTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is are not equal with timezone ignored.
+     */
+    public S isEqualToIgnoringTimezone(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringTimezone(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringTimezone(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@link java.time.OffsetDateTime} have same year, month, day, hour and minute fields (second and
+     * nanosecond fields are ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetDateTimes in same chronological second time window, e.g :
+     * <p>
+     * 2000-01-01T00:<b>01:00</b>.000 and 2000-01-01T00:<b>00:59</b>.000.
+     * <p>
+     * Assertion fails as minute fields differ even if time difference is only 1s.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetDateTime OffsetDateTime1 = OffsetDateTime.of(2000, 1, 1, 23, 50, 0, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTime2 = OffsetDateTime.of(2000, 1, 1, 23, 50, 10, 456, ZoneOffset.UTC);
+     * assertThat(OffsetDateTime1).isEqualToIgnoringSeconds(OffsetDateTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetDateTime OffsetDateTimeA = OffsetDateTime.of(2000, 1, 1, 23, 50, 00, 000, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTimeB = OffsetDateTime.of(2000, 1, 1, 23, 49, 59, 999, ZoneOffset.UTC);
+     * assertThat(OffsetDateTimeA).isEqualToIgnoringSeconds(OffsetDateTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is are not equal with second and nanosecond fields
+     *                                  ignored.
+     */
+    public S isEqualToIgnoringSeconds(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringSeconds(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringSeconds(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetDateTime} have same year, month, day and hour fields (minute, second and
+     * nanosecond fields are ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetDateTimes in same chronological second time window, e.g :
+     * <p>
+     * 2000-01-01T<b>01:00</b>:00.000 and 2000-01-01T<b>00:59:59</b>.000.
+     * <p>
+     * Time difference is only 1s but hour fields differ.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetDateTime OffsetDateTime1 = OffsetDateTime.of(2000, 1, 1, 23, 50, 0, 0, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTime2 = OffsetDateTime.of(2000, 1, 1, 23, 00, 2, 7, ZoneOffset.UTC);
+     * assertThat(OffsetDateTime1).isEqualToIgnoringMinutes(OffsetDateTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetDateTime OffsetDateTimeA = OffsetDateTime.of(2000, 1, 1, 01, 00, 00, 000, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTimeB = OffsetDateTime.of(2000, 1, 1, 00, 59, 59, 999, ZoneOffset.UTC);
+     * assertThat(OffsetDateTimeA).isEqualToIgnoringMinutes(OffsetDateTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is are not equal ignoring minute, second and nanosecond
+     *                                  fields.
+     */
+    public S isEqualToIgnoringMinutes(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringMinutes(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringMinutes(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetDateTime} have same year, month and day fields (hour, minute, second and
+     * nanosecond fields are ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetDateTimes in same chronological minute time window, e.g :
+     * <p>
+     * 2000-01-<b>01T23:59</b>:00.000 and 2000-01-02T<b>00:00</b>:00.000.
+     * <p>
+     * Time difference is only 1min but day fields differ.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetDateTime OffsetDateTime1 = OffsetDateTime.of(2000, 1, 1, 23, 59, 59, 999, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTime2 = OffsetDateTime.of(2000, 1, 1, 00, 00, 00, 000, ZoneOffset.UTC);
+     * assertThat(OffsetDateTime1).isEqualToIgnoringHours(OffsetDateTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetDateTime OffsetDateTimeA = OffsetDateTime.of(2000, 1, 2, 00, 00, 00, 000, ZoneOffset.UTC);
+     * OffsetDateTime OffsetDateTimeB = OffsetDateTime.of(2000, 1, 1, 23, 59, 59, 999, ZoneOffset.UTC);
+     * assertThat(OffsetDateTimeA).isEqualToIgnoringHours(OffsetDateTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetDateTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetDateTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetDateTime} is are not equal with second and nanosecond fields
+     *                                  ignored.
+     */
+    public S isEqualToIgnoringHours(OffsetDateTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetDateTimeParameterIsNotNull(other);
+        if (!haveSameYearMonthAndDayOfMonth(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringHours(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year, month and day of month, hour, minute and second, false
+     * otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, month and day of month, hour, minute and second, false
+     * otherwise.
+     */
+    private static boolean areEqualIgnoringNanos(OffsetDateTime actual, OffsetDateTime other) {
+        return areEqualIgnoringSeconds(actual, other) && actual.getSecond() == other.getSecond();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year, month, day of month, hour and minute, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, month, day of month, hour and minute, false otherwise.
+     */
+    private static boolean areEqualIgnoringSeconds(OffsetDateTime actual, OffsetDateTime other) {
+        return areEqualIgnoringMinutes(actual, other) && actual.getMinute() == other.getMinute();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year, month, day of month and hour, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, month, day of month and hour, false otherwise.
+     */
+    private static boolean areEqualIgnoringMinutes(OffsetDateTime actual, OffsetDateTime other) {
+        return haveSameYearMonthAndDayOfMonth(actual, other) && actual.getHour() == other.getHour();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year, month and day of month, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, month and day of month, false otherwise
+     */
+    private static boolean haveSameYearMonthAndDayOfMonth(OffsetDateTime actual, OffsetDateTime other) {
+        return haveSameYearAndMonth(actual, other) && actual.getDayOfMonth() == other.getDayOfMonth();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year and month, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year and month, false otherwise
+     */
+    private static boolean haveSameYearAndMonth(OffsetDateTime actual, OffsetDateTime other) {
+        return haveSameYear(actual, other) && actual.getMonth() == other.getMonth();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same year, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, false otherwise
+     */
+    private static boolean haveSameYear(OffsetDateTime actual, OffsetDateTime other) {
+        return actual.getYear() == other.getYear();
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same hour, minute, second and nanosecond false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same hour, minute, second and nanosecond false otherwise.
+     */
+    private static boolean areEqualIgnoringTimezone(OffsetDateTime actual, OffsetDateTime other) {
+        return areEqualIgnoringNanos(actual, other) && haveSameNano(actual, other);
+    }
+
+    /**
+     * Returns true if both OffsetDateTime are in the same nanosecond, false otherwise.
+     *
+     * @param actual the actual OffsetDateTime. expected not be null
+     * @param other  the other OffsetDateTime. expected not be null
+     * @return true if both OffsetDateTime are in the same year, false otherwise
+     */
+    private static boolean haveSameNano(OffsetDateTime actual, OffsetDateTime other) {
+        return actual.getNano() == other.getNano();
+    }
+}

--- a/src/main/java/org/assertj/core/api/AbstractOffsetTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOffsetTimeAssert.java
@@ -1,0 +1,596 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.Objects;
+
+import java.time.OffsetTime;
+
+import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
+import static org.assertj.core.error.ShouldBeAfterOrEqualsTo.shouldBeAfterOrEqualsTo;
+import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
+import static org.assertj.core.error.ShouldBeBeforeOrEqualsTo.shouldBeBeforeOrEqualsTo;
+import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
+import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
+import static org.assertj.core.error.ShouldBeEqualIgnoringTimezone.shouldBeEqualIgnoringTimezone;
+import static org.assertj.core.error.ShouldHaveSameHourAs.shouldHaveSameHourAs;
+
+/**
+ * Assertions for {@link java.time.OffsetTime} type from new Date &amp; Time API introduced in Java 8.
+ *
+ * @author Alexander Bischof
+ */
+public abstract class AbstractOffsetTimeAssert<S extends AbstractOffsetTimeAssert<S>>
+    extends AbstractAssert<S, OffsetTime> {
+
+    public static final String NULL_OFFSET_TIME_PARAMETER_MESSAGE = "The OffsetTime to compare actual with should not be null";
+
+    /**
+     * Creates a new <code>{@link org.assertj.core.api.AbstractOffsetTimeAssert}</code>.
+     *
+     * @param selfType the "self type"
+     * @param actual   the actual value to verify
+     */
+    protected AbstractOffsetTimeAssert(OffsetTime actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    // visible for test
+    protected OffsetTime getActual() {
+        return actual;
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetTime} is <b>strictly</b> before the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("12:00:00Z")).isBefore(parse("13:00:00Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not strictly before the given one.
+     */
+    public S isBefore(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!actual.isBefore(other)) {
+            throw Failures.instance().failure(info, shouldBeBefore(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isBefore(java.time.OffsetTime)} but the {@link java.time.OffsetTime} is built from given String, which
+     * must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("12:59Z")).isBefore("13:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not strictly before the {@link java.time.OffsetTime} built
+     *                                  from given String.
+     */
+    public S isBefore(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isBefore(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetTime} is before or equals to the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("12:00:00Z")).isBeforeOrEqualTo(parse("12:00:00Z"))
+     *                                        .isBeforeOrEqualTo(parse("12:00:01Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not before or equals to the given one.
+     */
+    public S isBeforeOrEqualTo(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (actual.isAfter(other)) {
+            throw Failures.instance().failure(info, shouldBeBeforeOrEqualsTo(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isBeforeOrEqualTo(java.time.OffsetTime)} but the {@link java.time.OffsetTime} is built from given
+     * String, which must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("12:00:00Z")).isBeforeOrEqualTo("12:00:00Z")
+     *                              .isBeforeOrEqualTo("13:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not before or equals to the {@link java.time.OffsetTime} built from
+     *                                  given String.
+     */
+    public S isBeforeOrEqualTo(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isBeforeOrEqualTo(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetTime} is after or equals to the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("13:00:00Z")).isAfterOrEqualTo(parse("13:00:00Z"))
+     *                              .isAfterOrEqualTo(parse("12:00:00Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not after or equals to the given one.
+     */
+    public S isAfterOrEqualTo(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (actual.isBefore(other)) {
+            throw Failures.instance().failure(info, shouldBeAfterOrEqualsTo(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isAfterOrEqualTo(java.time.OffsetTime)} but the {@link java.time.OffsetTime} is built from given
+     * String, which must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isAfterOrEqualTo("13:00:00Z")
+     *                              .isAfterOrEqualTo("12:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not after or equals to the {@link java.time.OffsetTime} built from
+     *                                  given String.
+     */
+    public S isAfterOrEqualTo(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isAfterOrEqualTo(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Verifies that the actual {@code OffsetTime} is <b>strictly</b> after the given one.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * assertThat(parse("13:00:00Z")).isAfter(parse("12:00:00Z"));
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not strictly after the given one.
+     */
+    public S isAfter(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!actual.isAfter(other)) {
+            throw Failures.instance().failure(info, shouldBeAfter(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Same assertion as {@link #isAfter(java.time.OffsetTime)} but the {@link java.time.OffsetTime} is built from given a String that
+     * must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isAfter("12:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not strictly after the {@link java.time.OffsetTime} built
+     *                                  from given String.
+     */
+    public S isAfter(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isAfter(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isEqualTo(Object)} (where Object is expected to be {@link java.time.OffsetTime}) but here you
+     * pass {@link java.time.OffsetTime} String representation that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isEqualTo("13:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not equal to the {@link java.time.OffsetTime} built from
+     *                                  given String.
+     */
+    public S isEqualTo(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isEqualTo(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isNotEqualTo(Object)} (where Object is expected to be {@link java.time.OffsetTime}) but here you
+     * pass {@link java.time.OffsetTime} String representation that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTime as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isNotEqualTo("12:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimeAsString String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is equal to the {@link java.time.OffsetTime} built from given
+     *                                  String.
+     */
+    public S isNotEqualTo(String offsetTimeAsString) {
+        assertOffsetTimeAsStringParameterIsNotNull(offsetTimeAsString);
+        return isNotEqualTo(OffsetTime.parse(offsetTimeAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isIn(Object...)} (where Objects are expected to be {@link java.time.OffsetTime}) but here you
+     * pass {@link java.time.OffsetTime} String representations that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTimes as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isIn("12:00:00Z", "13:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimesAsString String array representing {@link java.time.OffsetTime}s.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not in the {@link java.time.OffsetTime}s built from given
+     *                                  Strings.
+     */
+    public S isIn(String... offsetTimesAsString) {
+        checkIsNotNullAndNotEmpty(offsetTimesAsString);
+        return isIn(convertToOffsetTimeArray(offsetTimesAsString));
+    }
+
+    /**
+     * Same assertion as {@link #isNotIn(Object...)} (where Objects are expected to be {@link java.time.OffsetTime}) but here you
+     * pass {@link java.time.OffsetTime} String representations that must follow <a href=
+     * "http://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_OFFSET_TIME"
+     * >ISO OffsetTime format</a> to allow calling {@link java.time.OffsetTime#parse(CharSequence)} method.
+     * <p>
+     * Example :
+     * <p>
+     * <pre><code class='java'>
+     * // you can express expected OffsetTimes as String (AssertJ taking care of the conversion)
+     * assertThat(parse("13:00:00Z")).isNotIn("12:00:00Z", "14:00:00Z");
+     * </code></pre>
+     *
+     * @param offsetTimesAsString Array of String representing a {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if given String is null or can't be converted to a {@link java.time.OffsetTime}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is in the {@link java.time.OffsetTime}s built from given
+     *                                  Strings.
+     */
+    public S isNotIn(String... offsetTimesAsString) {
+        checkIsNotNullAndNotEmpty(offsetTimesAsString);
+        return isNotIn(convertToOffsetTimeArray(offsetTimesAsString));
+    }
+
+    private static Object[] convertToOffsetTimeArray(String... offsetTimesAsString) {
+        OffsetTime[] dates = new OffsetTime[offsetTimesAsString.length];
+        for (int i = 0; i < offsetTimesAsString.length; i++) {
+            dates[i] = OffsetTime.parse(offsetTimesAsString[i]);
+        }
+        return dates;
+    }
+
+    private void checkIsNotNullAndNotEmpty(Object[] values) {
+        if (values == null) throw new IllegalArgumentException("The given OffsetTime array should not be null");
+        if (values.length == 0) throw new IllegalArgumentException("The given OffsetTime array should not be empty");
+    }
+
+    /**
+     * Check that the {@link java.time.OffsetTime} string representation to compare actual {@link java.time.OffsetTime} to is not null,
+     * otherwise throws a {@link IllegalArgumentException} with an explicit message
+     *
+     * @param OffsetTimeAsString String representing the {@link java.time.OffsetTime} to compare actual with
+     * @throws IllegalArgumentException with an explicit message if the given {@link String} is null
+     */
+    private static void assertOffsetTimeAsStringParameterIsNotNull(String OffsetTimeAsString) {
+        // @format:off
+	if (OffsetTimeAsString == null) throw new IllegalArgumentException("The String representing the OffsetTime to compare actual with should not be null");
+	// @format:on
+    }
+
+    /**
+     * Check that the {@link java.time.OffsetTime} to compare actual {@link java.time.OffsetTime} to is not null, in that case throws a
+     * {@link IllegalArgumentException} with an explicit message
+     *
+     * @param other the {@link java.time.OffsetTime} to check
+     * @throws IllegalArgumentException with an explicit message if the given {@link java.time.OffsetTime} is null
+     */
+    private static void assertOffsetTimeParameterIsNotNull(OffsetTime other) {
+        if (other == null)
+            throw new IllegalArgumentException("The OffsetTime to compare actual with should not be null");
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetTime} have same hour, minute and second fields (nanosecond fields are
+     * ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetTimes in same chronological nanosecond time window, e.g :
+     * <p>
+     * 23:00:<b>01.000000000</b> and 23:00:<b>00.999999999</b>.
+     * <p>
+     * Assertion fails as second fields differ even if time difference is only 1ns.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetTime OffsetTime1 = OffsetTime.of(12, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetTime OffsetTime2 = OffsetTime.of(12, 0, 1, 456, ZoneOffset.UTC);
+     * assertThat(OffsetTime1).isEqualToIgnoringNanos(OffsetTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ns)
+     * OffsetTime OffsetTimeA = OffsetTime.of(12, 0, 1, 0, ZoneOffset.UTC);
+     * OffsetTime OffsetTimeB = OffsetTime.of(12, 0, 0, 999999999, ZoneOffset.UTC);
+     * assertThat(OffsetTimeA).isEqualToIgnoringNanos(OffsetTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not equal with nanoseconds ignored.
+     */
+    public S isEqualToIgnoringNanos(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringNanos(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringNanos(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@link java.time.OffsetTime} have same hour and minute fields (second and nanosecond fields are
+     * ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetTimes in same chronological second time window, e.g :
+     * <p>
+     * 23:<b>01:00</b>.000 and 23:<b>00:59</b>.000.
+     * <p>
+     * Assertion fails as minute fields differ even if time difference is only 1s.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetTime OffsetTime1 = OffsetTime.of(23, 50, 0, 0, ZoneOffset.UTC);
+     * OffsetTime OffsetTime2 = OffsetTime.of(23, 50, 10, 456, ZoneOffset.UTC);
+     * assertThat(OffsetTime1).isEqualToIgnoringSeconds(OffsetTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetTime OffsetTimeA = OffsetTime.of(23, 50, 00, 000, ZoneOffset.UTC);
+     * OffsetTime OffsetTimeB = OffsetTime.of(23, 49, 59, 999, ZoneOffset.UTC);
+     * assertThat(OffsetTimeA).isEqualToIgnoringSeconds(OffsetTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not equal with second and nanosecond fields
+     *                                  ignored.
+     */
+    public S isEqualToIgnoringSeconds(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringSeconds(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringSeconds(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@link java.time.OffsetTime} have same hour, minute, second and nanosecond fields).
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetTime offsetTime = OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC);
+     * OffsetTime offsetTime2 = OffsetTime.of(12, 0, 0, 0, ZoneOffset.MAX);
+     * assertThat(offsetTime).isEqualToIgnoringTimezone(offsetTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetTime offsetTime = OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC);
+     * OffsetTime offsetTime2 = OffsetTime.of(12, 1, 0, 0, ZoneOffset.UTC);
+     * assertThat(offsetTime).isEqualToIgnoringTimezone(null);
+     * assertThat((OffsetTime)null).isEqualToIgnoringTimezone(null);
+     * assertThat(offsetTime).isEqualToIgnoringTimezone(offsetTime2);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not equal with timezone ignored.
+     */
+    public S isEqualToIgnoringTimezone(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!areEqualIgnoringTimezone(actual, other)) {
+            throw Failures.instance().failure(info, shouldBeEqualIgnoringTimezone(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Verifies that actual and given {@code OffsetTime} have same hour fields (minute, second and nanosecond fields are
+     * ignored in comparison).
+     * <p>
+     * Assertion can fail with OffsetTimes in same chronological second time window, e.g :
+     * <p>
+     * <b>01:00</b>:00.000 and <b>00:59:59</b>.000.
+     * <p>
+     * Time difference is only 1s but hour fields differ.
+     * <p>
+     * Code example :
+     * <p>
+     * <pre><code class='java'>
+     * // successful assertions
+     * OffsetTime OffsetTime1 = OffsetTime.of(23, 50, 0, 0, ZoneOffset.UTC);
+     * OffsetTime OffsetTime2 = OffsetTime.of(23, 00, 2, 7, ZoneOffset.UTC);
+     * assertThat(OffsetTime1).hasSameHourAs(OffsetTime2);
+     * <p>
+     * // failing assertions (even if time difference is only 1ms)
+     * OffsetTime OffsetTimeA = OffsetTime.of(01, 00, 00, 000, ZoneOffset.UTC);
+     * OffsetTime OffsetTimeB = OffsetTime.of(00, 59, 59, 999, ZoneOffset.UTC);
+     * assertThat(OffsetTimeA).hasSameHourAs(OffsetTimeB);
+     * </code></pre>
+     *
+     * @param other the given {@link java.time.OffsetTime}.
+     * @return this assertion object.
+     * @throws AssertionError           if the actual {@code OffsetTime} is {@code null}.
+     * @throws IllegalArgumentException if other {@code OffsetTime} is {@code null}.
+     * @throws AssertionError           if the actual {@code OffsetTime} is not equal ignoring minute, second and nanosecond
+     *                                  fields.
+     */
+    public S hasSameHourAs(OffsetTime other) {
+        Objects.instance().assertNotNull(info, actual);
+        assertOffsetTimeParameterIsNotNull(other);
+        if (!haveSameHourField(actual, other)) {
+            throw Failures.instance().failure(info, shouldHaveSameHourAs(actual, other));
+        }
+        return myself;
+    }
+
+    /**
+     * Returns true if both OffsetTime are in the same hour, minute and second, false
+     * otherwise.
+     *
+     * @param actual the actual OffsetTime. expected not be null
+     * @param other  the other OffsetTime. expected not be null
+     * @return true if both OffsetTime are in the same year, month and day of month, hour, minute and second, false
+     * otherwise.
+     */
+    private static boolean areEqualIgnoringNanos(OffsetTime actual, OffsetTime other) {
+        return areEqualIgnoringSeconds(actual, other) && haveSameSecond(actual, other);
+    }
+
+    /**
+     * Returns true if both OffsetTime are in the same hour and minute, false otherwise.
+     *
+     * @param actual the actual OffsetTime. expected not be null
+     * @param other  the other OffsetTime. expected not be null
+     * @return true if both OffsetTime are in the same hour and minute, false otherwise.
+     */
+    private static boolean areEqualIgnoringSeconds(OffsetTime actual, OffsetTime other) {
+        return haveSameHourField(actual, other) && haveSameMinute(actual, other);
+    }
+
+    /**
+     * Returns true if both OffsetTime are in the same hour, minute, second and nanosecond false otherwise.
+     *
+     * @param actual the actual OffsetTime. expected not be null
+     * @param other  the other OffsetTime. expected not be null
+     * @return true if both OffsetTime are in the same hour, minute, second and nanosecond false otherwise.
+     */
+    private static boolean areEqualIgnoringTimezone(OffsetTime actual, OffsetTime other) {
+        return areEqualIgnoringNanos(actual, other) && haveSameNano(actual, other);
+    }
+
+    private static boolean haveSameNano(OffsetTime actual, OffsetTime other) {
+        return actual.getNano() == other.getNano();
+    }
+
+    private static boolean haveSameSecond(OffsetTime actual, OffsetTime other) {
+        return actual.getSecond() == other.getSecond();
+    }
+
+    private static boolean haveSameMinute(OffsetTime actual, OffsetTime other) {
+        return actual.getMinute() == other.getMinute();
+    }
+
+    private static boolean haveSameHourField(OffsetTime actual, OffsetTime other) {
+        return actual.getHour() == other.getHour();
+    }
+
+}

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -12,19 +12,16 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public abstract class AbstractStandardSoftAssertions extends AbstractSoftAssertions {
 
@@ -550,5 +547,15 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
   public LocalTimeAssert assertThat(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
-  
+
+
+  /**
+   * Creates a new instance of <code>{@link OffsetTimeAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public OffsetTimeAssert assertThat(OffsetTime actual) {
+      return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
+  }
 }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -12,18 +12,6 @@
  */
 package org.assertj.core.api;
 
-import java.io.File;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.text.DateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
-import java.util.*;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.AllOf;
@@ -38,6 +26,15 @@ import org.assertj.core.groups.Tuple;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.FilesException;
 import org.assertj.core.util.introspection.FieldSupport;
+
+import java.io.File;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.text.DateFormat;
+import java.time.*;
+import java.util.*;
 
 /**
  * Entry point for assertion methods for different data types. Each method in this class is a static factory for the
@@ -115,7 +112,18 @@ public class Assertions {
         return new OptionalLongAssert(optionalLong);
     }
 
-    /**
+  /**
+   * Create assertion for {@link java.time.OffsetTime}.
+   *
+   * @param offsetTime the actual value.
+   *
+   * @return the created assertion object.
+   */
+  public static OffsetTimeAssert assertThat(OffsetTime offsetTime) {
+      return new OffsetTimeAssert(offsetTime);
+  }
+
+  /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
    *
    * @param actual the actual value.
@@ -592,7 +600,7 @@ public class Assertions {
   /**
    * Creates a new instance of <code>{@link ZonedDateTimeAssert}</code>.
    *
-   * @param actual the actual value.
+   * @param date the actual value.
    * @return the created assertion object.
    */
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime date) {
@@ -602,7 +610,7 @@ public class Assertions {
   /**
    * Creates a new instance of <code>{@link LocalDateTimeAssert}</code>.
    *
-   * @param actual the actual value.
+   * @param localDateTime the actual value.
    * @return the created assertion object.
    */
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime localDateTime) {
@@ -622,7 +630,7 @@ public class Assertions {
   /**
    * Creates a new instance of <code>{@link LocalDateAssert}</code>.
    *
-   * @param actual the actual value.
+   * @param localDate the actual value.
    * @return the created assertion object.
    */
   public static AbstractLocalDateAssert<?> assertThat(LocalDate localDate) {

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -616,6 +616,16 @@ public class Assertions {
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime localDateTime) {
     return new LocalDateTimeAssert(localDateTime);
   }
+
+  /**
+   * Creates a new instance of <code>{@link java.time.OffsetDateTime}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
+      return new OffsetDateTimeAssert(actual);
+  }
   
   /**
    * Creates a new instance of <code>{@link LocalTimeAssert}</code>.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -12,16 +12,13 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
-
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
 /**
  * BDD style entry point for assertion methods for different data types. Each method in this class is a static factory
@@ -577,6 +574,16 @@ public class BDDAssertions extends Assertions {
   public static AbstractLocalTimeAssert<?> then(LocalTime actual) {
 	return assertThat(actual);
   }
+
+  /**
+   * Creates a new instance of <code>{@link OffsetTimeAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractOffsetTimeAssert<?> then(OffsetTime actual) {
+        return assertThat(actual);
+    }
   
 
   /**

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -584,7 +584,16 @@ public class BDDAssertions extends Assertions {
   public static AbstractOffsetTimeAssert<?> then(OffsetTime actual) {
         return assertThat(actual);
     }
-  
+
+  /**
+   * Creates a new instance of <code>{@link OffsetTimeAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractOffsetDateTimeAssert<?> then(OffsetDateTime actual) {
+        return assertThat(actual);
+    }
 
   /**
    * Creates a new </code>{@link org.assertj.core.api.BDDAssertions}</code>.

--- a/src/main/java/org/assertj/core/api/OffsetDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/OffsetDateTimeAssert.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.OffsetDateTime;
+
+public class OffsetDateTimeAssert extends AbstractOffsetDateTimeAssert<OffsetDateTimeAssert> {
+
+  /**
+   * Creates a new <code>{@link org.assertj.core.api.OffsetDateTimeAssert}</code>.
+   *
+   * @param actual the actual value to verify
+   */
+  protected OffsetDateTimeAssert(OffsetDateTime actual) {
+    super(actual, OffsetDateTimeAssert.class);
+  }
+}

--- a/src/main/java/org/assertj/core/api/OffsetTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/OffsetTimeAssert.java
@@ -12,16 +12,16 @@
  */
 package org.assertj.core.api;
 
-import java.time.LocalTime;
+import java.time.OffsetTime;
 
-public class LocalTimeAssert extends AbstractLocalTimeAssert<LocalTimeAssert> {
+public class OffsetTimeAssert extends AbstractOffsetTimeAssert<OffsetTimeAssert> {
 
   /**
-   * Creates a new <code>{@link LocalTimeAssert}</code>.
+   * Creates a new <code>{@link org.assertj.core.api.OffsetTimeAssert}</code>.
    *
    * @param actual the actual value to verify
    */
-  protected LocalTimeAssert(LocalTime actual) {
-    super(actual, LocalTimeAssert.class);
+  protected OffsetTimeAssert(OffsetTime actual) {
+    super(actual, OffsetTimeAssert.class);
   }
 }

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -12,21 +12,6 @@
  */
 package org.assertj.core.api;
 
-import java.io.File;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.nio.charset.Charset;
-import java.text.DateFormat;
-import java.time.*;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.DoesNotHave;
 import org.assertj.core.condition.Not;
@@ -35,6 +20,14 @@ import org.assertj.core.data.MapEntry;
 import org.assertj.core.data.Offset;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
+
+import java.io.File;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.Charset;
+import java.text.DateFormat;
+import java.time.*;
+import java.util.*;
 
 /**
  *
@@ -592,6 +585,13 @@ public interface WithAssertions {
    */
   default public AbstractLocalDateAssert<?> assertThat(final LocalDate localDate) {
     return Assertions.assertThat(localDate);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(OffsetDateTime)}
+   */
+  default public AbstractOffsetDateTimeAssert<?> assertThat(final OffsetDateTime offsetDateTime) {
+      return Assertions.assertThat(offsetDateTime);
   }
 
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -17,9 +17,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -612,5 +610,19 @@ public interface WithAssertions {
    */
   default public <E> Filters<E> filter(final Iterable<E> iterableToFilter) {
     return Assertions.filter(iterableToFilter);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(LocalTime)}
+   */
+  default public AbstractLocalTimeAssert<?> assertThat(final LocalTime localTime) {
+      return Assertions.assertThat(localTime);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(OffsetTime)}
+   */
+  default public AbstractOffsetTimeAssert<?> assertThat(final OffsetTime offsetTime) {
+      return Assertions.assertThat(offsetTime);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes.java
@@ -12,15 +12,21 @@
  */
 package org.assertj.core.error;
 
-import org.assertj.core.error.BasicErrorMessageFactory;
-import org.assertj.core.error.ErrorMessageFactory;
-
+import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 
 /**
  * Creates an error message indicating that an assertion that verifies that two {@link ZonedDateTime} have same year,
  * month, day and hour fields failed.
- * 
+ *
+ * Creates an error message indicating that an assertion that verifies that :
+ * <ul>
+ * <li>two {@link ZonedDateTime}, {@link java.time.LocalDateTime} have same year, month, day, hour fields failed.</li>
+ * <li>two {@link LocalTime} have same hour failed.</li>
+ * <li>two {@link java.time.OffsetTime} have same hour failed.</li>
+ * </ul>
+ *
  * @author Joel Costigliola
  */
 public class ShouldBeEqualIgnoringMinutes extends BasicErrorMessageFactory {
@@ -36,7 +42,37 @@ public class ShouldBeEqualIgnoringMinutes extends BasicErrorMessageFactory {
     return new ShouldBeEqualIgnoringMinutes(actual, other);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringSeconds}</code>.
+   *
+   * @param actual the actual LocalTime in the failed assertion.
+   * @param other the LocalTime used in the failed assertion to compare the actual LocalTime to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringMinutes(LocalTime actual, LocalTime other) {
+      return new ShouldBeEqualIgnoringMinutes(actual, other);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringSeconds}</code>.
+   *
+   * @param actual the actual OffsetTime in the failed assertion.
+   * @param other the OffsetTime used in the failed assertion to compare the actual OffsetTime to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringMinutes(OffsetTime actual, OffsetTime other) {
+      return new ShouldBeEqualIgnoringMinutes(actual, other);
+  }
+
   private ShouldBeEqualIgnoringMinutes(Object actual, Object other) {
     super("\nExpecting:\n  <%s>\nto have same year, month, day and hour as:\n  <%s>\nbut had not.", actual, other);
+  }
+
+  private ShouldBeEqualIgnoringMinutes(LocalTime actual, LocalTime other) {
+      super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
+  }
+
+  private ShouldBeEqualIgnoringMinutes(OffsetTime actual, OffsetTime other) {
+      super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos.java
@@ -17,13 +17,15 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 
 /**
  * Creates an error message indicating that an assertion that verifies that :
  * <ul>
  * <li>two {@link ZonedDateTime}, {@link LocalDateTime} have same year, month, day, hour, minute and second failed.</li>
- * <li>two {@link LocalTime} have hour, minute and second failed.</li>
+ * <li>two {@link LocalTime} have same hour, minute and second failed.</li>
+ * <li>two {@link java.time.OffsetTime} have same hour, minute and second failed.</li>
  * </ul>
  * 
  * @author Joel Costigliola
@@ -52,6 +54,17 @@ public class ShouldBeEqualIgnoringNanos extends BasicErrorMessageFactory {
 	return new ShouldBeEqualIgnoringNanos(actual, other);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringNanos}</code>.
+   *
+   * @param actual the actual OffsetTime in the failed assertion.
+   * @param other the OffsetTime used in the failed assertion to compare the actual OffsetTime to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringNanos(OffsetTime actual, OffsetTime other) {
+      return new ShouldBeEqualIgnoringNanos(actual, other);
+  }
+
   private ShouldBeEqualIgnoringNanos(Object actual, Object other) {
 	super("\nExpecting:\n  <%s>\nto have same year, month, day, hour, minute and second as:\n  <%s>\nbut had not.",
 	      actual, other);
@@ -59,5 +72,9 @@ public class ShouldBeEqualIgnoringNanos extends BasicErrorMessageFactory {
 
   private ShouldBeEqualIgnoringNanos(LocalTime actual, LocalTime other) {
 	super("\nExpecting:\n  <%s>\nto have same hour, minute and second as:\n  <%s>\nbut had not.", actual, other);
+  }
+
+  private ShouldBeEqualIgnoringNanos(OffsetTime actual, OffsetTime other) {
+      super("\nExpecting:\n  <%s>\nto have same hour, minute and second as:\n  <%s>\nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds.java
@@ -13,12 +13,20 @@
 package org.assertj.core.error;
 
 import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 
 /**
  * Creates an error message indicating that an assertion that verifies that two {@link ZonedDateTime} have same year,
  * month, day, hour and minute failed.
- * 
+ *
+ * Creates an error message indicating that an assertion that verifies that :
+ * <ul>
+ * <li>two {@link ZonedDateTime}, {@link java.time.LocalDateTime} have same year, month, day, hour and minute failed.</li>
+ * <li>two {@link LocalTime} have same hour and minute failed.</li>
+ * <li>two {@link java.time.OffsetTime} have same hour and minute failed.</li>
+ * </ul>
+ *
  * @author Joel Costigliola
  */
 public class ShouldBeEqualIgnoringSeconds extends BasicErrorMessageFactory {
@@ -50,7 +58,22 @@ public class ShouldBeEqualIgnoringSeconds extends BasicErrorMessageFactory {
 	return new ShouldBeEqualIgnoringSeconds(actual, other);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringSeconds}</code>.
+   *
+   * @param actual the actual OffsetTime in the failed assertion.
+   * @param other the OffsetTime used in the failed assertion to compare the actual OffsetTime to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringSeconds(OffsetTime actual, OffsetTime other) {
+      return new ShouldBeEqualIgnoringSeconds(actual, other);
+  }
+
   private ShouldBeEqualIgnoringSeconds(LocalTime actual, LocalTime other) {
 	super("\nExpecting:\n  <%s>\nto have same hour and minute as:\n  <%s>\nbut had not.", actual, other);
+  }
+
+  private ShouldBeEqualIgnoringSeconds(OffsetTime actual, OffsetTime other) {
+      super("\nExpecting:\n  <%s>\nto have same hour and minute as:\n  <%s>\nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 
 /**
@@ -31,6 +32,17 @@ public class ShouldBeEqualIgnoringTimezone extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldBeEqualIgnoringTimezone(OffsetTime actual, OffsetTime other) {
     return new ShouldBeEqualIgnoringTimezone(actual, other);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringTimezone}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param other the value used in the failed assertion to compare the actual value to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringTimezone(OffsetDateTime actual, OffsetDateTime other) {
+      return new ShouldBeEqualIgnoringTimezone(actual, other);
   }
 
   private ShouldBeEqualIgnoringTimezone(Object actual, Object other) {

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.time.OffsetTime;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that two {@link java.time.OffsetTime} have same
+ * time fields except the timezone.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringTimezone extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeEqualIgnoringTimezone}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param other the value used in the failed assertion to compare the actual value to.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEqualIgnoringTimezone(OffsetTime actual, OffsetTime other) {
+    return new ShouldBeEqualIgnoringTimezone(actual, other);
+  }
+
+  private ShouldBeEqualIgnoringTimezone(Object actual, Object other) {
+    super("\nExpecting:\n  <%s>\nto have same time fields except timezone as:\n  <%s>\nbut had not.", actual, other);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveSameHourAs.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSameHourAs.java
@@ -16,28 +16,30 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
 import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 
 /**
  * Creates an error message indicating that an assertion that verifies that two {@link ZonedDateTime} have same year,
  * month, day and hour fields failed.
- * 
+ *
  * @author Joel Costigliola
  */
 public class ShouldHaveSameHourAs extends BasicErrorMessageFactory {
 
-  /**
-   * Creates a new <code>{@link ShouldHaveSameHourAs}</code>.
-   * 
-   * @param actual the actual value in the failed assertion.
-   * @param other the value used in the failed assertion to compare the actual value to.
-   * @return the created {@code ErrorMessageFactory}.
-   */
-  public static ErrorMessageFactory shouldHaveSameHourAs(LocalTime actual, LocalTime other) {
-    return new ShouldHaveSameHourAs(actual, other);
-  }
+    /**
+     * Creates a new <code>{@link ShouldHaveSameHourAs}</code>.
+     *
+     * @param actual the actual value in the failed assertion.
+     * @param other  the value used in the failed assertion to compare the actual value to.
+     * @return the created {@code ErrorMessageFactory}.
+     */
+    public static ErrorMessageFactory shouldHaveSameHourAs(Temporal actual, Temporal other) {
+        return new ShouldHaveSameHourAs(actual, other);
+    }
 
-  private ShouldHaveSameHourAs(LocalTime actual, LocalTime other) {
-	super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
-  }
+    private ShouldHaveSameHourAs(Temporal actual, Temporal other) {
+        super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
+    }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_OffsetDateTime_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_OffsetDateTime_Test.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.Assertions#assertThat(java.time.OffsetDateTime)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class Assertions_assertThat_with_OffsetDateTime_Test {
+
+    private OffsetDateTime actual;
+
+    @Before
+    public void before() {
+        actual = OffsetDateTime.now();
+    }
+
+    @Test
+    public void should_create_Assert() {
+        AbstractOffsetDateTimeAssert<?> assertions = assertThat(actual);
+        assertThat(assertions).isNotNull();
+    }
+
+    @Test
+    public void should_pass_actual() {
+        AbstractOffsetDateTimeAssert<?> assertions = assertThat(actual);
+        assertThat(assertions.getActual()).isSameAs(actual);
+    }
+}

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_OffsetTime_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_OffsetTime_Test.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.util.Optional;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(OffsetTime)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class Assertions_assertThat_with_OffsetTime_Test {
+
+    private OffsetTime actual;
+
+    @Before
+    public void before(){
+        actual = OffsetTime.now();
+    }
+
+    @Test
+    public void should_create_Assert() {
+        OffsetTimeAssert assertions = Assertions.assertThat(actual);
+        assertNotNull(assertions);
+    }
+
+    @Test
+    public void should_pass_actual() {
+        OffsetTimeAssert assertions = Assertions.assertThat(actual);
+        assertSame(actual, assertions.actual);
+    }
+}

--- a/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.math.BigDecimal;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -133,10 +134,11 @@ public class AutoCloseableBDDSoftAssertionsTest {
 
     softly.then(LocalTime.of(12, 00)).isEqualTo(LocalTime.of(13, 00));
     softly.then(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+    softly.then(OffsetDateTime.MIN).isEqualTo(OffsetDateTime.MAX);
 
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(44);
+	  assertThat(errors).hasSize(45);
 
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
@@ -211,7 +213,7 @@ public class AutoCloseableBDDSoftAssertionsTest {
 
     assertThat(errors.get(42)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
     assertThat(errors.get(43)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
-
+    assertThat(errors.get(44)).isEqualTo("expected:<[+999999999-12-31T23:59:59.999999999-]18:00> but was:<[-999999999-01-01T00:00+]18:00>");
 	  return;
 	}
 	fail("Should not reach here");

--- a/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
@@ -12,19 +12,22 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Dates.parseDatetime;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.math.BigDecimal;
-import java.util.*;
-
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.test.Maps;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Dates.parseDatetime;
+import static org.junit.Assert.fail;
 
 public class AutoCloseableBDDSoftAssertionsTest {
 
@@ -127,9 +130,14 @@ public class AutoCloseableBDDSoftAssertionsTest {
     softly.then(OptionalInt.of(0)).isEqualTo(1);
     softly.then(OptionalDouble.of(0.0)).isEqualTo(1.0);
     softly.then(OptionalLong.of(0L)).isEqualTo(1L);
+
+    softly.then(LocalTime.of(12, 00)).isEqualTo(LocalTime.of(13, 00));
+    softly.then(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(42);
+	  assertThat(errors).hasSize(44);
+
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
 	  assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
@@ -200,6 +208,9 @@ public class AutoCloseableBDDSoftAssertionsTest {
     assertThat(errors.get(39)).isEqualTo("expected:<[1]> but was:<[OptionalInt[0]]>");
     assertThat(errors.get(40)).isEqualTo("expected:<[1.0]> but was:<[OptionalDouble[0.0]]>");
     assertThat(errors.get(41)).isEqualTo("expected:<[1L]> but was:<[OptionalLong[0]]>");
+
+    assertThat(errors.get(42)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
+    assertThat(errors.get(43)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
 
 	  return;
 	}

--- a/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -143,10 +143,11 @@ public class AutoCloseableSoftAssertionsTest {
 
     softly.assertThat(LocalTime.of(12, 0)).isEqualTo(LocalTime.of(13,0));
     softly.assertThat(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+    softly.assertThat(OffsetDateTime.MIN).isEqualTo(OffsetDateTime.MAX);
 
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(48);
+	  assertThat(errors).hasSize(49);
 
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
@@ -229,6 +230,7 @@ public class AutoCloseableSoftAssertionsTest {
     assertThat(errors.get(46)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
     assertThat(errors.get(47)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
 
+    assertThat(errors.get(48)).isEqualTo("expected:<[+999999999-12-31T23:59:59.999999999-]18:00> but was:<[-999999999-01-01T00:00+]18:00>");
 	  return;
 	}
 	fail("Should not reach here");

--- a/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -12,24 +12,22 @@
  */
 package org.assertj.core.api;
 
-import static java.time.ZoneOffset.UTC;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Dates.parseDatetime;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.util.*;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.test.Maps;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.*;
+import java.util.*;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Dates.parseDatetime;
+import static org.junit.Assert.fail;
 
 public class AutoCloseableSoftAssertionsTest {
 
@@ -139,14 +137,17 @@ public class AutoCloseableSoftAssertionsTest {
 	  softly.assertThat(LocalDateTime.of(2015, 1, 1, 23, 59, 59)).isEqualTo(LocalDateTime.of(2015, 1, 1, 23, 59, 0));
 	  softly.assertThat(ZonedDateTime.of(2015, 1, 1, 23, 59, 59, 0, UTC)).isEqualTo(ZonedDateTime.of(2015, 1, 1, 23,
 		                                                                                             59, 0, 0, UTC));
-
     softly.assertThat(OptionalInt.of(0)).isEqualTo(1);
     softly.assertThat(OptionalDouble.of(0.0)).isEqualTo(1.0);
     softly.assertThat(OptionalLong.of(0L)).isEqualTo(1L);
 
+    softly.assertThat(LocalTime.of(12, 0)).isEqualTo(LocalTime.of(13,0));
+    softly.assertThat(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(46);
+	  assertThat(errors).hasSize(48);
+
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
 	  assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
@@ -224,6 +225,9 @@ public class AutoCloseableSoftAssertionsTest {
     assertThat(errors.get(43)).isEqualTo("expected:<[1]> but was:<[OptionalInt[0]]>");
     assertThat(errors.get(44)).isEqualTo("expected:<[1.0]> but was:<[OptionalDouble[0.0]]>");
     assertThat(errors.get(45)).isEqualTo("expected:<[1L]> but was:<[OptionalLong[0]]>");
+
+    assertThat(errors.get(46)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
+    assertThat(errors.get(47)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
 
 	  return;
 	}

--- a/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -542,13 +542,23 @@ public class BDDAssertions_then_Test {
 
   @Test
   public void then_of_OffsetTime_should_delegate_to_assertThat() {
-  // GIVEN
-  OffsetTime actual = OffsetTime.of(23, 59, 59,0, ZoneOffset.UTC);
-  // WHEN
-  then(actual);
-  // THEN
-  verifyStatic();
-  assertThat(actual);
+      // GIVEN
+      OffsetTime actual = OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC);
+      // WHEN
+      then(actual);
+      // THEN
+      verifyStatic();
+      assertThat(actual);
+  }
+
+  public void then_of_OffsetDateTime_should_delegate_to_assertThat() {
+      // GIVEN
+      OffsetDateTime actual = OffsetDateTime.of(LocalDateTime.now(), ZoneOffset.UTC);
+      // WHEN
+      then(actual);
+      // THEN
+      verifyStatic();
+      assertThat(actual);
   }
 
   public void should_build_ThrowableAssert_with_throwable_thrown() {

--- a/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -12,6 +12,17 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.util.*;
+
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,20 +30,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
-import java.util.*;
-
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.BDDAssertions#then(String)}</code>.
@@ -541,6 +538,17 @@ public class BDDAssertions_then_Test {
 	// THEN
 	verifyStatic();
 	assertThat(actual);
+  }
+
+  @Test
+  public void then_of_OffsetTime_should_delegate_to_assertThat() {
+  // GIVEN
+  OffsetTime actual = OffsetTime.of(23, 59, 59,0, ZoneOffset.UTC);
+  // WHEN
+  then(actual);
+  // THEN
+  verifyStatic();
+  assertThat(actual);
   }
 
   public void should_build_ThrowableAssert_with_throwable_thrown() {

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -19,6 +19,9 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -142,12 +145,15 @@ public class BDDSoftAssertionsTest {
     softly.then(OptionalDouble.of(0.0)).isEqualTo(1.0);
     softly.then(OptionalLong.of(0L)).isEqualTo(1L);
 
+    softly.then(LocalTime.of(12,0)).isEqualTo(LocalTime.of(13,0));
+    softly.then(OffsetTime.of(12, 0,0,0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0,0,0, ZoneOffset.UTC));
+
 	  softly.assertAll();
 	  fail("Should not reach here");
 
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(43);
+	  assertThat(errors).hasSize(45);
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
 	  assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
@@ -222,6 +228,9 @@ public class BDDSoftAssertionsTest {
     assertThat(errors.get(40)).isEqualTo("expected:<[1]> but was:<[OptionalInt[0]]>");
     assertThat(errors.get(41)).isEqualTo("expected:<[1.0]> but was:<[OptionalDouble[0.0]]>");
     assertThat(errors.get(42)).isEqualTo("expected:<[1L]> but was:<[OptionalLong[0]]>");
+
+    assertThat(errors.get(43)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
+    assertThat(errors.get(44)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
 	}
   }
 

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -12,24 +12,22 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Dates.parseDatetime;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.time.OffsetTime;
-import java.time.ZoneOffset;
-import java.util.*;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.test.Maps;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Dates.parseDatetime;
+import static org.junit.Assert.fail;
 
 public class BDDSoftAssertionsTest {
 
@@ -147,13 +145,16 @@ public class BDDSoftAssertionsTest {
 
     softly.then(LocalTime.of(12,0)).isEqualTo(LocalTime.of(13,0));
     softly.then(OffsetTime.of(12, 0,0,0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0,0,0, ZoneOffset.UTC));
+    softly.then(OffsetDateTime.MIN).isEqualTo(LocalDateTime.MAX);
 
 	  softly.assertAll();
+
 	  fail("Should not reach here");
 
 	} catch (SoftAssertionError e) {
 	  List<String> errors = e.getErrors();
-	  assertThat(errors).hasSize(45);
+	  assertThat(errors).hasSize(46);
+
 	  assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
 	  assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
@@ -231,6 +232,7 @@ public class BDDSoftAssertionsTest {
 
     assertThat(errors.get(43)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
     assertThat(errors.get(44)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
+    assertThat(errors.get(45)).isEqualTo("expected:<[+999999999-12-31T23:59:59.999999999]> but was:<[-999999999-01-01T00:00+18:00]>");
 	}
   }
 

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -187,11 +190,15 @@ public class SoftAssertionsTest {
 
       }).hasMessage("something was good");
       softly.assertThat(Maps.mapOf(MapEntry.entry("54", "55"))).contains(MapEntry.entry("1", "2"));
+
+      softly.assertThat(LocalTime.of(12, 00)).isEqualTo(LocalTime.of(13,00));
+      softly.assertThat(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)).isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+
       softly.assertAll();
       fail("Should not reach here");
     } catch (SoftAssertionError e) {
       List<String> errors = e.getErrors();
-      assertThat(errors).hasSize(40);
+      assertThat(errors).hasSize(42);
       assertThat(errors.get(0)).isEqualTo("expected:<[1]> but was:<[0]>");
 
       assertThat(errors.get(1)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
@@ -267,6 +274,9 @@ public class SoftAssertionsTest {
                                            + " <[MapEntry[key='1', value='2']]>\n"
                                            + "but could not find:\n"
                                            + " <[MapEntry[key='1', value='2']]>\n");
+
+      assertThat(errors.get(40)).isEqualTo("expected:<1[3]:00> but was:<1[2]:00>");
+      assertThat(errors.get(41)).isEqualTo("expected:<1[3]:00Z> but was:<1[2]:00Z>");
     }
   }  
 

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -669,4 +670,11 @@ public class WithAssertions_delegation_Test implements WithAssertions {
     assertThat(LocalDate.now()).isNotNull();
   }
 
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThat_offset_date_time_Test() {
+        assertThat(OffsetDateTime.now()).isNotNull();
+    }
 }

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssertBaseTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.experimental.theories.DataPoint;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Base test class for {@link org.assertj.core.api.AbstractOffsetDateTimeAssert} tests.
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+public class OffsetDateTimeAssertBaseTest extends BaseTest {
+
+    @DataPoint
+    public static OffsetDateTime offsetDateTime1 = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetDateTime offsetDateTime2 = OffsetDateTime.of(2000, 12, 13, 23, 59, 59, 999, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetDateTime offsetDateTime3 = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetDateTime offsetDateTime4 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 875, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetDateTime offsetDateTime5 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 874, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetDateTime offsetDateTime6 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 876, ZoneOffset.UTC);
+
+    protected static void testAssumptions(OffsetDateTime reference, OffsetDateTime dateBefore,
+                                          OffsetDateTime dateAfter) {
+        assumeTrue(dateBefore.isBefore(reference));
+        assumeTrue(dateAfter.isAfter(reference));
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isAfterOrEqualTo_Test extends OffsetDateTimeAssertBaseTest {
+
+    @Theory
+    public void test_isAfterOrEqual_assertion(OffsetDateTime referenceDate, OffsetDateTime dateBefore,
+                                              OffsetDateTime dateAfter) {
+        // GIVEN
+        testAssumptions(referenceDate, dateBefore, dateAfter);
+        // WHEN
+        assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
+        assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
+        // THEN
+        verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    }
+
+    @Test
+    public void test_isAfterOrEqual_assertion_error_message() {
+        try {
+            assertThat(of(2000, 1, 5, 3, 0, 5, 0, UTC)).isAfterOrEqualTo(of(2012, 1, 1, 3, 3, 3, 0, UTC));
+        } catch (AssertionError e) {
+            assertThat(e).hasMessage("\n" +
+                                     "Expecting:\n" +
+                                     "  <2000-01-05T03:00:05Z>\n" +
+                                     "to be after or equals to:\n" +
+                                     "  <2012-01-01T03:03:03Z>");
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        expectException(AssertionError.class, actualIsNull());
+        OffsetDateTime actual = null;
+        assertThat(actual).isAfterOrEqualTo(OffsetDateTime.now());
+    }
+
+    @Test
+    public void should_fail_if_dateTime_parameter_is_null() {
+        expectException(IllegalArgumentException.class, "The OffsetDateTime to compare actual with should not be null");
+        assertThat(OffsetDateTime.now()).isAfterOrEqualTo((OffsetDateTime) null);
+    }
+
+    @Test
+    public void should_fail_if_dateTime_as_string_parameter_is_null() {
+        expectException(IllegalArgumentException.class,
+                        "The String representing the OffsetDateTime to compare actual with should not be null");
+        assertThat(OffsetDateTime.now()).isAfterOrEqualTo((String) null);
+    }
+
+    private static void verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(OffsetDateTime dateToCheck,
+                                                                                             OffsetDateTime reference) {
+        try {
+            assertThat(dateToCheck).isAfterOrEqualTo(reference);
+        } catch (AssertionError e) {
+            // AssertionError was expected, test same assertion with String based parameter
+            try {
+                assertThat(dateToCheck).isAfterOrEqualTo(reference.toString());
+            } catch (AssertionError e2) {
+                // AssertionError was expected (again)
+                return;
+            }
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfter_Test.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isAfter_Test extends OffsetDateTimeAssertBaseTest {
+
+  @Theory
+  public void test_isAfter_assertion(OffsetDateTime referenceDate, OffsetDateTime dateBefore, OffsetDateTime dateAfter) {
+	// GIVEN
+	testAssumptions(referenceDate, dateBefore, dateAfter);
+	// WHEN
+	assertThat(dateAfter).isAfter(referenceDate);
+	assertThat(dateAfter).isAfter(referenceDate.toString());
+	// THEN
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+  }
+
+  @Test
+  public void test_isAfter_assertion_error_message() {
+	try {
+	  assertThat(parse("2000-01-01T03:00:05.123Z")).isAfter(parse("2000-01-01T03:00:05.123456789Z"));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <2000-01-01T03:00:05.123Z>\n" +
+		                       "to be strictly after:\n" +
+		                       "  <2000-01-01T03:00:05.123456789Z>");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetDateTime actual = null;
+	assertThat(actual).isAfter(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_fail_if_dateTime_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The OffsetDateTime to compare actual with should not be null");
+	assertThat(OffsetDateTime.now()).isAfter((OffsetDateTime) null);
+  }
+
+  @Test
+  public void should_fail_if_dateTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetDateTime to compare actual with should not be null");
+	assertThat(OffsetDateTime.now()).isAfter((String) null);
+  }
+
+  private static void verify_that_isAfter_assertion_fails_and_throws_AssertionError(OffsetDateTime dateToCheck,
+	                                                                                OffsetDateTime reference) {
+	try {
+	  assertThat(dateToCheck).isAfter(reference);
+	} catch (AssertionError e) {
+	  // AssertionError was expected, test same assertion with String based parameter
+	  try {
+		assertThat(dateToCheck).isAfter(reference.toString());
+	  } catch (AssertionError e2) {
+		// AssertionError was expected (again)
+		return;
+	  }
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isBeforeOrEqualTo_Test extends OffsetDateTimeAssertBaseTest {
+
+    @Theory
+    public void test_isBeforeOrEqual_assertion(OffsetDateTime referenceDate, OffsetDateTime dateBefore,
+                                               OffsetDateTime dateAfter) {
+        // GIVEN
+        testAssumptions(referenceDate, dateBefore, dateAfter);
+        // WHEN
+        assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
+        assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
+        // THEN
+        verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    }
+
+    @Test
+    public void test_isBeforeOrEqual_assertion_error_message() {
+        try {
+            assertThat(of(2000, 1, 5, 3, 0, 5, 0, UTC)).isBeforeOrEqualTo(of(1998, 1, 1, 3, 3, 3, 0, UTC));
+        } catch (AssertionError e) {
+            assertThat(e).hasMessage(
+                "\nExpecting:\n  <2000-01-05T03:00:05Z>\nto be before or equals to:\n  <1998-01-01T03:03:03Z>");
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        expectException(AssertionError.class, actualIsNull());
+        OffsetDateTime actual = null;
+        assertThat(actual).isBeforeOrEqualTo(OffsetDateTime.now());
+    }
+
+    @Test
+    public void should_fail_if_dateTime_parameter_is_null() {
+        expectException(IllegalArgumentException.class, "The OffsetDateTime to compare actual with should not be null");
+        assertThat(OffsetDateTime.now()).isBeforeOrEqualTo((OffsetDateTime) null);
+    }
+
+    @Test
+    public void should_fail_if_dateTime_as_string_parameter_is_null() {
+        expectException(IllegalArgumentException.class,
+                        "The String representing the OffsetDateTime to compare actual with should not be null");
+        assertThat(OffsetDateTime.now()).isBeforeOrEqualTo((String) null);
+    }
+
+    private static void verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(
+        OffsetDateTime dateToCheck,
+        OffsetDateTime reference) {
+        try {
+            assertThat(dateToCheck).isBeforeOrEqualTo(reference);
+        } catch (AssertionError e) {
+            // AssertionError was expected, test same assertion with String based parameter
+            try {
+                assertThat(dateToCheck).isBeforeOrEqualTo(reference.toString());
+            } catch (AssertionError e2) {
+                // AssertionError was expected (again)
+                return;
+            }
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBefore_Test.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isBefore_Test extends OffsetDateTimeAssertBaseTest {
+
+  @Theory
+  public void test_isBefore_assertion(OffsetDateTime referenceDate, OffsetDateTime dateBefore, OffsetDateTime dateAfter) {
+    // GIVEN
+    testAssumptions(referenceDate, dateBefore, dateAfter);
+    // WHEN
+    assertThat(dateBefore).isBefore(referenceDate);
+    // THEN
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+  }
+
+  @Test
+  public void test_isBefore_assertion_error_message() {
+    try {
+      assertThat(of(2000, 1, 5, 3, 0, 5, 0, UTC)).isBefore(of(1998, 1, 1, 3, 3, 3, 0, UTC));
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05Z>\nto be strictly before:\n  <1998-01-01T03:03:03Z>");
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    expectException(AssertionError.class, actualIsNull());
+    OffsetDateTime actual = null;
+    assertThat(actual).isBefore(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_fail_if_dateTime_parameter_is_null() {
+    expectException(IllegalArgumentException.class, "The OffsetDateTime to compare actual with should not be null");
+    assertThat(OffsetDateTime.now()).isBefore((OffsetDateTime) null);
+  }
+
+  @Test
+  public void should_fail_if_dateTime_as_string_parameter_is_null() {
+    expectException(IllegalArgumentException.class,
+        "The String representing the OffsetDateTime to compare actual with should not be null");
+    assertThat(OffsetDateTime.now()).isBefore((String) null);
+  }
+
+  private static void verify_that_isBefore_assertion_fails_and_throws_AssertionError(OffsetDateTime dateToTest,
+      OffsetDateTime reference) {
+    try {
+      assertThat(dateToTest).isBefore(reference);
+    } catch (AssertionError e) {
+      // AssertionError was expected, test same assertion with String based parameter
+      try {
+        assertThat(dateToTest).isBefore(reference.toString());
+      } catch (AssertionError e2) {
+        // AssertionError was expected (again)
+        return;
+      }
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AbstractOffsetDateTimeAssert.NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
+
+    private final OffsetDateTime refOffsetDateTime = of(2000, 1, 2, 0, 0, 0, 0, UTC);
+
+    @Test
+    public void should_pass_if_actual_is_equal_to_other_ignoring_hour_fields() {
+        assertThat(refOffsetDateTime).isEqualToIgnoringHours(refOffsetDateTime.plusHours(1));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_equal_to_given_offsetdatetime_with_hour_ignored() {
+        try {
+            assertThat(refOffsetDateTime).isEqualToIgnoringHours(refOffsetDateTime.minusHours(1));
+        } catch (AssertionError e) {
+            assertThat(e.getMessage())
+                .isEqualTo(
+                    "\nExpecting:\n  <2000-01-02T00:00Z>\nto have same year, month and day as:\n  <2000-01-01T23:00Z>\nbut had not.");
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+
+    @Test
+    public void should_fail_as_hours_fields_are_different_even_if_time_difference_is_less_than_a_hour() {
+        try {
+            assertThat(refOffsetDateTime).isEqualToIgnoringHours(refOffsetDateTime.minusNanos(1));
+        } catch (AssertionError e) {
+            assertThat(e.getMessage())
+                .isEqualTo(
+                    "\nExpecting:\n  <2000-01-02T00:00Z>\nto have same year, month and day as:\n  <2000-01-01T23:59:59.999999999Z>\nbut had not.");
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        expectException(AssertionError.class, actualIsNull());
+        OffsetDateTime actual = null;
+        assertThat(actual).isEqualToIgnoringHours(OffsetDateTime.now());
+    }
+
+    @Test
+    public void should_throw_error_if_given_offsetdatetime_is_null() {
+        expectIllegalArgumentException(NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE);
+        assertThat(refOffsetDateTime).isEqualToIgnoringHours(null);
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringMinutes_Test.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AbstractOffsetDateTimeAssert.NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetDateTimeAssert_isEqualToIgnoringMinutes_Test extends BaseTest {
+
+  private final OffsetDateTime refOffsetDateTime = of(2000, 1, 1, 23, 0, 0, 0, UTC);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_minute_fields() {
+    assertThat(refOffsetDateTime).isEqualToIgnoringMinutes(refOffsetDateTime.plusMinutes(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_offsetdatetime_with_minute_ignored() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringMinutes(refOffsetDateTime.minusMinutes(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T23:00Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_minutes_fields_are_different_even_if_time_difference_is_less_than_a_minute() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringMinutes(refOffsetDateTime.minusNanos(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T23:00Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:59.999999999Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    expectException(AssertionError.class, actualIsNull());
+    OffsetDateTime actual = null;
+    assertThat(actual).isEqualToIgnoringMinutes(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_offsetdatetime_is_null() {
+    expectIllegalArgumentException(NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE);
+    assertThat(refOffsetDateTime).isEqualToIgnoringMinutes(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AbstractOffsetDateTimeAssert.NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetDateTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseTest {
+
+  private final OffsetDateTime refOffsetDateTime = of(2000, 1, 1, 0, 0, 1, 0, UTC);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_nanosecond_fields() {
+    assertThat(refOffsetDateTime).isEqualToIgnoringNanos(refOffsetDateTime.withNano(55));
+    assertThat(refOffsetDateTime).isEqualToIgnoringNanos(refOffsetDateTime.plusNanos(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_offsetdatetime_with_nanoseconds_ignored() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringNanos(refOffsetDateTime.plusSeconds(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T00:00:01Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:02Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_seconds_fields_are_different_even_if_time_difference_is_less_than_a_second() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringNanos(refOffsetDateTime.minusNanos(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T00:00:01Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:00.999999999Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    expectException(AssertionError.class, actualIsNull());
+    OffsetDateTime actual = null;
+    assertThat(actual).isEqualToIgnoringNanos(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_offsetdatetime_is_null() {
+    expectIllegalArgumentException(NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE);
+    assertThat(refOffsetDateTime).isEqualToIgnoringNanos(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AbstractOffsetDateTimeAssert.NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetDateTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest {
+
+  private final OffsetDateTime refOffsetDateTime = OffsetDateTime.of(2000, 1, 1, 23, 51, 0, 0, UTC);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_second_fields() {
+    assertThat(refOffsetDateTime).isEqualToIgnoringSeconds(refOffsetDateTime.plusSeconds(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_offsetdatetime_with_second_ignored() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringSeconds(refOffsetDateTime.plusMinutes(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T23:51Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:52Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_seconds_fields_are_different_even_if_time_difference_is_less_than_a_second() {
+    try {
+      assertThat(refOffsetDateTime).isEqualToIgnoringSeconds(refOffsetDateTime.minusNanos(1));
+    } catch (AssertionError e) {
+      assertThat(e.getMessage())
+          .isEqualTo(
+              "\nExpecting:\n  <2000-01-01T23:51Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:50:59.999999999Z>\nbut had not.");
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    expectException(AssertionError.class, actualIsNull());
+    OffsetDateTime actual = null;
+    assertThat(actual).isEqualToIgnoringSeconds(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_offsetdatetime_is_null() {
+    expectIllegalArgumentException(NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE);
+    assertThat(refOffsetDateTime).isEqualToIgnoringSeconds(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringTimezone_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualToIgnoringTimezone_Test.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.assertj.core.api.AbstractOffsetDateTimeAssert;
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.MAX;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AbstractOffsetDateTimeAssert.NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetDateTimeAssert_isEqualToIgnoringTimezone_Test extends BaseTest {
+  private final OffsetDateTime actual = of(2000, 1, 5, 12, 0, 0, 0, MAX);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_timezone_fields() {
+	assertThat(actual).isEqualToIgnoringTimezone(of(2000, 1, 5,12, 0, 0, 0, UTC));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_OffsetDateTime_with_timezone_ignored() {
+	try {
+	  assertThat(actual).isEqualToIgnoringTimezone(of(2000, 1, 5,12, 1, 0, 0, UTC));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n  " +
+		                       "<2000-01-05T12:00+18:00>\n" +
+		                       "to have same time fields except timezone as:\n" +
+		                       "  <2000-01-05T12:01Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetDateTime actual = null;
+	assertThat(actual).isEqualToIgnoringTimezone(OffsetDateTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_OffsetDateTimetime_is_null() {
+	expectIllegalArgumentException(NULL_OFFSET_DATE_TIME_PARAMETER_MESSAGE);
+	assertThat(actual).isEqualToIgnoringTimezone(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualTo_Test.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
+ * 
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isEqualTo_Test extends OffsetDateTimeAssertBaseTest {
+
+  @Theory
+  public void test_isEqualTo_assertion(OffsetDateTime referenceDate) {
+    // WHEN
+    assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    // THEN
+    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
+  }
+
+  @Test
+  public void test_isEqualTo_assertion_error_message() {
+    try {
+      assertThat(of(2000, 1, 5, 3, 0, 5, 0, UTC)).isEqualTo(of(2012, 1, 1, 3, 3, 3, 0, UTC).toString());
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("expected:<20[12-01-01T03:03:03]Z> but was:<20[00-01-05T03:00:05]Z>");
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_dateTime_as_string_parameter_is_null() {
+    expectException(IllegalArgumentException.class,
+        "The String representing the OffsetDateTime to compare actual with should not be null");
+    assertThat(OffsetDateTime.now()).isEqualTo((String) null);
+  }
+
+  private static void verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(OffsetDateTime reference) {
+    try {
+      assertThat(reference).isEqualTo(reference.plusDays(1).toString());
+    } catch (AssertionError e) {
+      // AssertionError was expected
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isIn_Test.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.OffsetDateTime.of;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isIn_Test extends OffsetDateTimeAssertBaseTest {
+
+  @Theory
+  public void test_isIn_assertion(OffsetDateTime referenceDate) {
+    // WHEN
+    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusDays(1).toString());
+    // THEN
+    verify_that_isIn_assertion_fails_and_throws_AssertionError(referenceDate);
+  }
+
+  @Test
+  public void test_isIn_assertion_error_message() {
+    try {
+      assertThat(of(2000, 1, 5, 3, 0, 5, 0, UTC)).isIn(of(2012, 1, 1, 3, 3, 3, 0, UTC).toString());
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05Z>\nto be in:\n <[2012-01-01T03:03:03Z]>\n");
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_dateTimes_as_string_array_parameter_is_null() {
+    expectException(IllegalArgumentException.class, "The given OffsetDateTime array should not be null");
+    assertThat(OffsetDateTime.now()).isIn((String[]) null);
+  }
+
+  @Test
+  public void should_fail_if_dateTimes_as_string_array_parameter_is_empty() {
+    expectException(IllegalArgumentException.class, "The given OffsetDateTime array should not be empty");
+    assertThat(OffsetDateTime.now()).isIn(new String[0]);
+  }
+
+  private static void verify_that_isIn_assertion_fails_and_throws_AssertionError(OffsetDateTime reference) {
+    try {
+      assertThat(reference).isIn(reference.plusDays(1).toString(), reference.plusDays(2).toString());
+    } catch (AssertionError e) {
+      // AssertionError was expected
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotEqualTo_Test.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isNotEqualTo_Test extends OffsetDateTimeAssertBaseTest {
+
+    @Theory
+    public void test_isNotEqualTo_assertion(OffsetDateTime referenceDate) {
+        // WHEN
+        assertThat(referenceDate).isNotEqualTo(referenceDate.plusDays(1).toString());
+        // THEN
+        verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
+    }
+
+    @Test
+    public void test_isNotEqualTo_assertion_error_message() {
+        try {
+            assertThat(OffsetDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC))
+                .isNotEqualTo(OffsetDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC).toString());
+        } catch (AssertionError e) {
+            assertThat(e)
+                .hasMessage("\nExpecting:\n <2000-01-05T03:00:05Z>\nnot to be equal to:\n <2000-01-05T03:00:05Z>\n");
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+    @Test
+    public void should_fail_if_dateTime_as_string_parameter_is_null() {
+        expectException(IllegalArgumentException.class,
+                        "The String representing the OffsetDateTime to compare actual with should not be null");
+        assertThat(OffsetDateTime.now()).isNotEqualTo((String) null);
+    }
+
+    private static void verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(OffsetDateTime reference) {
+        try {
+            assertThat(reference).isNotEqualTo(reference.toString());
+        } catch (AssertionError e) {
+            // AssertionError was expected
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotIn_Test.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetDateTime;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetDateTimeAssert_isNotIn_Test extends OffsetDateTimeAssertBaseTest {
+
+    @Theory
+    public void test_isNotIn_assertion(OffsetDateTime referenceDate) {
+        // WHEN
+        assertThat(referenceDate).isNotIn(referenceDate.plusDays(1).toString(), referenceDate.plusDays(2).toString());
+        // THEN
+        verify_that_isNotIn_assertion_fails_and_throws_AssertionError(referenceDate);
+    }
+
+    @Test
+    public void test_isNotIn_assertion_error_message() {
+        try {
+            assertThat(OffsetDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC))
+                .isNotIn(OffsetDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC).toString(),
+                         OffsetDateTime.of(2012, 1, 1, 3, 3, 3, 0, UTC).toString());
+        } catch (AssertionError e) {
+            assertThat(e)
+                .hasMessage(
+                    "\nExpecting:\n <2000-01-05T03:00:05Z>\nnot to be in:\n <[2000-01-05T03:00:05Z, 2012-01-01T03:03:03Z]>\n");
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+    @Test
+    public void should_fail_if_dateTimes_as_string_array_parameter_is_null() {
+        expectException(IllegalArgumentException.class, "The given OffsetDateTime array should not be null");
+        assertThat(OffsetDateTime.now()).isNotIn((String[]) null);
+    }
+
+    @Test
+    public void should_fail_if_dateTimes_as_string_array_parameter_is_empty() {
+        expectException(IllegalArgumentException.class, "The given OffsetDateTime array should not be empty");
+        assertThat(OffsetDateTime.now()).isNotIn(new String[0]);
+    }
+
+    private static void verify_that_isNotIn_assertion_fails_and_throws_AssertionError(OffsetDateTime reference) {
+        try {
+            assertThat(reference).isNotIn(reference.toString(), reference.plusDays(1).toString());
+        } catch (AssertionError e) {
+            // AssertionError was expected
+            return;
+        }
+        fail("Should have thrown AssertionError");
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssertBaseTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.experimental.theories.DataPoint;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Base test class for {@link org.assertj.core.api.AbstractOffsetTimeAssert} tests.
+ */
+public class OffsetTimeAssertBaseTest extends BaseTest {
+
+    @DataPoint
+    public static OffsetTime OffsetTime1 = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetTime OffsetTime2 = OffsetTime.of(23, 59, 59, 999, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetTime OffsetTime3 = OffsetTime.of(0, 0, 0, 1, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetTime OffsetTime4 = OffsetTime.of(22, 15, 15, 875, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetTime OffsetTime5 = OffsetTime.of(22, 15, 15, 874, ZoneOffset.UTC);
+    @DataPoint
+    public static OffsetTime OffsetTime6 = OffsetTime.of(22, 15, 15, 876, ZoneOffset.UTC);
+
+    protected static void testAssumptions(OffsetTime reference, OffsetTime timeBefore, OffsetTime timeAfter) {
+        assumeTrue(timeBefore.isBefore(reference));
+        assumeTrue(timeAfter.isAfter(reference));
+    }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_hasSameHourAs_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_hasSameHourAs_Test.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.AbstractOffsetTimeAssert.NULL_OFFSET_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetTimeAssert_hasSameHourAs_Test extends BaseTest {
+
+  private final OffsetTime refOffsetTime = OffsetTime.of(23, 0, 0, 0, ZoneOffset.UTC);
+
+  @Test
+  public void should_pass_if_actual_andexpected_have_same_hour() {
+	assertThat(refOffsetTime).hasSameHourAs(refOffsetTime.plusMinutes(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_OffsetTimetime_with_minute_ignored() {
+	try {
+	  assertThat(refOffsetTime).hasSameHourAs(refOffsetTime.minusMinutes(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <23:00Z>\n" +
+		                       "to have same hour as:\n" +
+		                       "  <22:59Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_minutes_fields_are_different_even_if_time_difference_is_less_than_a_minute() {
+	try {
+	  assertThat(refOffsetTime).hasSameHourAs(refOffsetTime.minusNanos(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <23:00Z>\n" +
+		                       "to have same hour as:\n" +
+		                       "  <22:59:59.999999999Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).hasSameHourAs(OffsetTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_OffsetTimetime_is_null() {
+	expectIllegalArgumentException(NULL_OFFSET_TIME_PARAMETER_MESSAGE);
+	assertThat(refOffsetTime).hasSameHourAs(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfterOrEqualTo_Test.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isAfterOrEqualTo_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isAfterOrEqual_assertion(OffsetTime referenceTime, OffsetTime timeBefore,
+	                                        OffsetTime timeAfter) {
+	// GIVEN
+	testAssumptions(referenceTime, timeBefore, timeAfter);
+	// WHEN
+	assertThat(timeAfter).isAfterOrEqualTo(referenceTime);
+	assertThat(referenceTime).isAfterOrEqualTo(referenceTime);
+	// THEN
+	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+  }
+
+  @Test
+  public void test_isAfterOrEqual_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isAfterOrEqualTo(OffsetTime.of(3, 3, 3, 0, ZoneOffset.UTC));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <03:00:05Z>\n" +
+		                       "to be after or equals to:\n" +
+		                       "  <03:03:03Z>");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isAfterOrEqualTo(OffsetTime.now());
+  }
+
+  @Test
+  public void should_fail_if_timeTime_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isAfterOrEqualTo((OffsetTime) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isAfterOrEqualTo((String) null);
+  }
+
+  private static void verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(OffsetTime timeToCheck,
+	                                                                                       OffsetTime reference) {
+	try {
+	  assertThat(timeToCheck).isAfterOrEqualTo(reference);
+	} catch (AssertionError e) {
+	  // AssertionError was expected, test same assertion with String based parameter
+	  try {
+		assertThat(timeToCheck).isAfterOrEqualTo(reference.toString());
+	  } catch (AssertionError e2) {
+		// AssertionError was expected (again)
+		return;
+	  }
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfter_Test.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+
+import static java.time.OffsetTime.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isAfter_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isAfter_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeAfter) {
+	// GIVEN
+	testAssumptions(referenceTime, timeBefore, timeAfter);
+	// WHEN
+	assertThat(timeAfter).isAfter(referenceTime);
+	assertThat(timeAfter).isAfter(referenceTime.toString());
+	// THEN
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+  }
+
+  @Test
+  public void test_isAfter_assertion_error_message() {
+	try {
+	  assertThat(parse("03:00:05.123Z")).isAfter(parse("03:00:05.123456789Z"));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <03:00:05.123Z>\n" +
+		                       "to be strictly after:\n" +
+		                       "  <03:00:05.123456789Z>");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isAfter(OffsetTime.now());
+  }
+
+  @Test
+  public void should_fail_if_timeTime_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isAfter((OffsetTime) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isAfter((String) null);
+  }
+
+  private static void verify_that_isAfter_assertion_fails_and_throws_AssertionError(OffsetTime timeToCheck,
+	                                                                                OffsetTime reference) {
+	try {
+	  assertThat(timeToCheck).isAfter(reference);
+	} catch (AssertionError e) {
+	  // AssertionError was expected, test same assertion with String based parameter
+	  try {
+		assertThat(timeToCheck).isAfter(reference.toString());
+	  } catch (AssertionError e2) {
+		// AssertionError was expected (again)
+		return;
+	  }
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBeforeOrEqualTo_Test.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isBeforeOrEqualTo_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isBeforeOrEqual_assertion(OffsetTime referenceTime, OffsetTime timeBefore,
+	                                         OffsetTime timeAfter) {
+	// GIVEN
+	testAssumptions(referenceTime, timeBefore, timeAfter);
+	// WHEN
+	assertThat(timeBefore).isBeforeOrEqualTo(referenceTime);
+	assertThat(referenceTime).isBeforeOrEqualTo(referenceTime);
+	// THEN
+	verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+  }
+
+  @Test
+  public void test_isBeforeOrEqual_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isBeforeOrEqualTo(OffsetTime.of(3, 0, 4, 0, ZoneOffset.UTC));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <03:00:05Z>\n" +
+		                       "to be before or equals to:\n" +
+		                       "  <03:00:04Z>");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isBeforeOrEqualTo(OffsetTime.now());
+  }
+
+  @Test
+  public void should_fail_if_timeTime_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isBeforeOrEqualTo((OffsetTime) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isBeforeOrEqualTo((String) null);
+  }
+
+  private static void verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(OffsetTime timeToCheck,
+	                                                                                        OffsetTime reference) {
+	try {
+	  assertThat(timeToCheck).isBeforeOrEqualTo(reference);
+	} catch (AssertionError e) {
+	  // AssertionError was expected, test same assertion with String based parameter
+	  try {
+		assertThat(timeToCheck).isBeforeOrEqualTo(reference.toString());
+	  } catch (AssertionError e2) {
+		// AssertionError was expected (again)
+		return;
+	  }
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBefore_Test.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * @author Paweł Stawicki
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isBefore_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isBefore_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeAfter) {
+	// GIVEN
+	testAssumptions(referenceTime, timeBefore, timeAfter);
+	// WHEN
+	assertThat(timeBefore).isBefore(referenceTime);
+	// THEN
+	verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
+	verify_that_isBefore_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+  }
+
+  @Test
+  public void test_isBefore_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isBefore(OffsetTime.of(3, 0, 4, 0, ZoneOffset.UTC));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       "  <03:00:05Z>\n" +
+		                       "to be strictly before:\n" +
+		                       "  <03:00:04Z>");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isBefore(OffsetTime.now());
+  }
+
+  @Test
+  public void should_fail_if_timeTime_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isBefore((OffsetTime) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isBefore((String) null);
+  }
+
+  private static void verify_that_isBefore_assertion_fails_and_throws_AssertionError(OffsetTime timeToTest,
+	                                                                                 OffsetTime reference) {
+	try {
+	  assertThat(timeToTest).isBefore(reference);
+	} catch (AssertionError e) {
+	  // AssertionError was expected, test same assertion with String based parameter
+	  try {
+		assertThat(timeToTest).isBefore(reference.toString());
+	  } catch (AssertionError e2) {
+		// AssertionError was expected (again)
+		return;
+	  }
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringNanoseconds_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringNanoseconds_Test.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.AbstractOffsetTimeAssert.NULL_OFFSET_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseTest {
+
+  private final OffsetTime refOffsetTime = OffsetTime.of(0, 0, 1, 0, ZoneOffset.UTC);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_nanosecond_fields() {
+	assertThat(refOffsetTime).isEqualToIgnoringNanos(refOffsetTime.withNano(55));
+	assertThat(refOffsetTime).isEqualToIgnoringNanos(refOffsetTime.plusNanos(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_OffsetTime_with_nanoseconds_ignored() {
+	try {
+	  assertThat(refOffsetTime).isEqualToIgnoringNanos(refOffsetTime.plusSeconds(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n  " +
+		                       "<00:00:01Z>\n" +
+		                       "to have same hour, minute and second as:\n" +
+		                       "  <00:00:02Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_seconds_fields_are_different_even_if_time_difference_is_less_than_a_second() {
+	try {
+	  assertThat(refOffsetTime).isEqualToIgnoringNanos(refOffsetTime.minusNanos(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n" +
+		                       "  <00:00:01Z>\n" +
+		                       "to have same hour, minute and second as:\n" +
+		                       "  <00:00:00.999999999Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isEqualToIgnoringNanos(OffsetTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_OffsetTimetime_is_null() {
+	expectIllegalArgumentException(NULL_OFFSET_TIME_PARAMETER_MESSAGE);
+	assertThat(refOffsetTime).isEqualToIgnoringNanos(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.AbstractOffsetTimeAssert.NULL_OFFSET_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest {
+
+  private final OffsetTime refOffsetTime = OffsetTime.of(23, 51, 0, 0, ZoneOffset.UTC);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_second_fields() {
+	assertThat(refOffsetTime).isEqualToIgnoringSeconds(refOffsetTime.plusSeconds(1));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_offsettime_with_second_ignored() {
+	try {
+	  assertThat(refOffsetTime).isEqualToIgnoringSeconds(refOffsetTime.plusMinutes(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n" +
+		                       "  <23:51Z>\n" +
+		                       "to have same hour and minute as:\n" +
+		                       "  <23:52Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_as_seconds_fields_are_different_even_if_time_difference_is_less_than_a_second() {
+	try {
+	  assertThat(refOffsetTime).isEqualToIgnoringSeconds(refOffsetTime.minusNanos(1));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n" +
+		                       "  <23:51Z>\n" +
+		                       "to have same hour and minute as:\n" +
+		                       "  <23:50:59.999999999Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isEqualToIgnoringSeconds(OffsetTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_offsettime_is_null() {
+	expectIllegalArgumentException(NULL_OFFSET_TIME_PARAMETER_MESSAGE);
+	assertThat(refOffsetTime).isEqualToIgnoringSeconds(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringTimezone_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualToIgnoringTimezone_Test.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.AbstractOffsetTimeAssert.NULL_OFFSET_TIME_PARAMETER_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OffsetTimeAssert_isEqualToIgnoringTimezone_Test extends BaseTest {
+
+  private final OffsetTime actual = OffsetTime.of(12, 0, 0, 0, ZoneOffset.MAX);
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_other_ignoring_timezone_fields() {
+	assertThat(actual).isEqualToIgnoringTimezone(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_equal_to_given_OffsetTime_with_timezone_ignored() {
+	try {
+	  assertThat(actual).isEqualToIgnoringTimezone(OffsetTime.of(12, 1, 0, 0, ZoneOffset.UTC));
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\nExpecting:\n  " +
+		                       "<12:00+18:00>\n" +
+		                       "to have same time fields except timezone as:\n" +
+		                       "  <12:01Z>\n" +
+		                       "but had not.");
+	  return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+	expectException(AssertionError.class, actualIsNull());
+	OffsetTime actual = null;
+	assertThat(actual).isEqualToIgnoringTimezone(OffsetTime.now());
+  }
+
+  @Test
+  public void should_throw_error_if_given_OffsetTimetime_is_null() {
+	expectIllegalArgumentException(NULL_OFFSET_TIME_PARAMETER_MESSAGE);
+	assertThat(actual).isEqualToIgnoringTimezone(null);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualTo_Test.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isEqualTo_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isEqualTo_assertion(OffsetTime referenceTime) {
+    // WHEN
+    assertThat(referenceTime).isEqualTo(referenceTime.toString());
+    // THEN
+    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(referenceTime);
+  }
+
+  @Test
+  public void test_isEqualTo_assertion_error_message() {
+    try {
+      assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isEqualTo("03:03:03Z");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("expected:<03:0[3:03]Z> but was:<03:0[0:05]Z>");
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+    expectException(IllegalArgumentException.class,
+        "The String representing the OffsetTime to compare actual with should not be null");
+    assertThat(OffsetTime.now()).isEqualTo((String) null);
+  }
+
+  private static void verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(OffsetTime reference) {
+    try {
+      assertThat(reference).isEqualTo(reference.plusHours(1).toString());
+    } catch (AssertionError e) {
+      // AssertionError was expected
+      return;
+    }
+    fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isIn_Test.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isIn_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isIn_assertion(OffsetTime referenceTime) {
+	// WHEN
+	assertThat(referenceTime).isIn(referenceTime.toString(), referenceTime.plusHours(1).toString());
+	// THEN
+	verify_that_isIn_assertion_fails_and_throws_AssertionError(referenceTime);
+  }
+
+  @Test
+  public void test_isIn_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isIn("03:03:03Z");
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       " <03:00:05Z>\n" +
+		                       "to be in:\n" +
+		                       " <[03:03:03Z]>\n");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_timeTimes_as_string_array_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The given OffsetTime array should not be null");
+	assertThat(OffsetTime.now()).isIn((String[]) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTimes_as_string_array_parameter_is_empty() {
+	expectException(IllegalArgumentException.class, "The given OffsetTime array should not be empty");
+	assertThat(OffsetTime.now()).isIn(new String[0]);
+  }
+
+  private static void verify_that_isIn_assertion_fails_and_throws_AssertionError(OffsetTime reference) {
+	try {
+	  assertThat(reference).isIn(reference.plusHours(1).toString(), reference.plusHours(2).toString());
+	} catch (AssertionError e) {
+	  // AssertionError was expected
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotEqualTo_Test.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
+ * 
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isNotEqualTo_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isNotEqualTo_assertion(OffsetTime referenceTime) {
+	// WHEN
+	assertThat(referenceTime).isNotEqualTo(referenceTime.plusHours(1).toString());
+	// THEN
+	verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceTime);
+  }
+
+  @Test
+  public void test_isNotEqualTo_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isNotEqualTo("03:00:05Z");
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       " <03:00:05Z>\n" +
+		                       "not to be equal to:\n" +
+		                       " <03:00:05Z>\n");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_timeTime_as_string_parameter_is_null() {
+	expectException(IllegalArgumentException.class,
+	                "The String representing the OffsetTime to compare actual with should not be null");
+	assertThat(OffsetTime.now()).isNotEqualTo((String) null);
+  }
+
+  private static void verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(OffsetTime reference) {
+	try {
+	  assertThat(reference).isNotEqualTo(reference.toString());
+	} catch (AssertionError e) {
+	  // AssertionError was expected
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotIn_Test.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.offsettime;
+
+import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
+ *
+ * @author Joel Costigliola
+ * @author Marcin Zajączkowski
+ */
+@RunWith(Theories.class)
+public class OffsetTimeAssert_isNotIn_Test extends OffsetTimeAssertBaseTest {
+
+  @Theory
+  public void test_isNotIn_assertion(OffsetTime referenceTime) {
+	// WHEN
+	assertThat(referenceTime).isNotIn(referenceTime.plusHours(1).toString(), referenceTime.plusHours(2).toString());
+	// THEN
+	verify_that_isNotIn_assertion_fails_and_throws_AssertionError(referenceTime);
+  }
+
+  @Test
+  public void test_isNotIn_assertion_error_message() {
+	try {
+	  assertThat(OffsetTime.of(3, 0, 5, 0, ZoneOffset.UTC)).isNotIn("03:00:05Z", "03:03:03Z");
+	} catch (AssertionError e) {
+	  assertThat(e).hasMessage("\n" +
+		                       "Expecting:\n" +
+		                       " <03:00:05Z>\n" +
+		                       "not to be in:\n" +
+		                       " <[03:00:05Z, 03:03:03Z]>\n");
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+  @Test
+  public void should_fail_if_timeTimes_as_string_array_parameter_is_null() {
+	expectException(IllegalArgumentException.class, "The given OffsetTime array should not be null");
+	assertThat(OffsetTime.now()).isNotIn((String[]) null);
+  }
+
+  @Test
+  public void should_fail_if_timeTimes_as_string_array_parameter_is_empty() {
+	expectException(IllegalArgumentException.class, "The given OffsetTime array should not be empty");
+	assertThat(OffsetTime.now()).isNotIn(new String[0]);
+  }
+
+  private static void verify_that_isNotIn_assertion_fails_and_throws_AssertionError(OffsetTime reference) {
+	try {
+	  assertThat(reference).isNotIn(reference.toString(), reference.plusHours(1).toString());
+	} catch (AssertionError e) {
+	  // AssertionError was expected
+	  return;
+	}
+	fail("Should have thrown AssertionError");
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes_create_Test.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualIgnoringMinutes;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldBeEqualIgnoringMinutes#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringMinutes_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Test
+  public void should_create_error_message_for_LocalTime() {
+
+      factory = shouldBeEqualIgnoringMinutes(LocalTime.of(12, 0), LocalTime.of(12, 1));
+
+      String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+      assertThat(message).isEqualTo("[Test] \n" +
+                                    "Expecting:\n" +
+                                    "  <12:00>\n" +
+                                    "to have same hour as:\n" +
+                                    "  <12:01>\n" +
+                                    "but had not.");
+  }
+
+  @Test
+  public void should_create_error_message_for_OffsetTime() {
+
+    factory = shouldBeEqualIgnoringMinutes(OffsetTime.of(12,0,0,0, ZoneOffset.UTC),OffsetTime.of(12,1,0,0, ZoneOffset.UTC));
+
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo("[Test] \n" +
+                                  "Expecting:\n" +
+                                  "  <12:00Z>\n" +
+                                  "to have same hour as:\n" +
+                                  "  <12:01Z>\n" +
+                                  "but had not.");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos_create_Test.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldBeEqualIgnoringNanos#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringNanos_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Test
+  public void should_create_error_message_for_LocalTime() {
+
+      factory = shouldBeEqualIgnoringNanos(LocalTime.of(12, 0),LocalTime.of(13,0));
+
+      String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+      assertThat(message).isEqualTo("[Test] \n" +
+                                    "Expecting:\n" +
+                                    "  <12:00>\n" +
+                                    "to have same hour, minute and second as:\n" +
+                                    "  <13:00>\n" +
+                                    "but had not.");
+  }
+
+  @Test
+  public void should_create_error_message_for_OffsetTime() {
+
+    factory = shouldBeEqualIgnoringNanos(OffsetTime.of(12,0,0,0, ZoneOffset.UTC),OffsetTime.of(13,0,0,0, ZoneOffset.UTC));
+
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo("[Test] \n" +
+                                  "Expecting:\n" +
+                                  "  <12:00Z>\n" +
+                                  "to have same hour, minute and second as:\n" +
+                                  "  <13:00Z>\n" +
+                                  "but had not.");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds_create_Test.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
+
+/**
+ * Tests for <code>{@link ShouldBeEqualIgnoringSeconds#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringSeconds_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Test
+  public void should_create_error_message_for_LocalTime() {
+
+      factory = shouldBeEqualIgnoringSeconds(LocalTime.of(12, 0, 1),LocalTime.of(12, 0, 2));
+
+      String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+      assertThat(message).isEqualTo("[Test] \n" +
+                                    "Expecting:\n" +
+                                    "  <12:00:01>\n" +
+                                    "to have same hour and minute as:\n" +
+                                    "  <12:00:02>\n" +
+                                    "but had not.");
+  }
+
+  @Test
+  public void should_create_error_message_for_OffsetTime() {
+
+    factory = shouldBeEqualIgnoringSeconds(OffsetTime.of(12,0,1,0, ZoneOffset.UTC),OffsetTime.of(12,0,2,0, ZoneOffset.UTC));
+
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo("[Test] \n" +
+                                  "Expecting:\n" +
+                                  "  <12:00:01Z>\n" +
+                                  "to have same hour and minute as:\n" +
+                                  "  <12:00:02Z>\n" +
+                                  "but had not.");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
@@ -16,9 +16,12 @@ import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
 
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import static java.time.ZoneOffset.*;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqualIgnoringTimezone.shouldBeEqualIgnoringTimezone;
 
@@ -34,8 +37,8 @@ public class ShouldBeEqualIgnoringTimezone_create_Test {
   @Test
   public void should_create_error_message_for_OffsetTime() {
 
-    factory = shouldBeEqualIgnoringTimezone(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC),
-                                            OffsetTime.of(12, 0, 0, 0, ZoneOffset.MIN));
+    factory = shouldBeEqualIgnoringTimezone(OffsetTime.of(12, 0, 0, 0, UTC),
+                                            OffsetTime.of(12, 0, 0, 0, MIN));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
     assertThat(message).isEqualTo("[Test] \n" +
@@ -45,4 +48,19 @@ public class ShouldBeEqualIgnoringTimezone_create_Test {
                                   "  <12:00-18:00>\n" +
                                   "but had not.");
   }
+
+    @Test
+    public void should_create_error_message_for_OffsetDateTime() {
+
+        factory = shouldBeEqualIgnoringTimezone(OffsetDateTime.of(2000, 5, 13, 12, 0, 0, 0, UTC),
+                                                OffsetDateTime.of(2000, 5, 13, 12, 0, 0, 0, MIN));
+
+        String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+        assertThat(message).isEqualTo("[Test] \n" +
+                                      "Expecting:\n" +
+                                      "  <2000-05-13T12:00Z>\n" +
+                                      "to have same time fields except timezone as:\n" +
+                                      "  <2000-05-13T12:00-18:00>\n" +
+                                      "but had not.");
+    }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqualIgnoringTimezone.shouldBeEqualIgnoringTimezone;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldBeEqualIgnoringTimezone#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualIgnoringTimezone_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Test
+  public void should_create_error_message_for_OffsetTime() {
+
+    factory = shouldBeEqualIgnoringTimezone(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC),
+                                            OffsetTime.of(12, 0, 0, 0, ZoneOffset.MIN));
+
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo("[Test] \n" +
+                                  "Expecting:\n" +
+                                  "  <12:00Z>\n" +
+                                  "to have same time fields except timezone as:\n" +
+                                  "  <12:00-18:00>\n" +
+                                  "but had not.");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveSameHourAs_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSameHourAs_create_Test.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveSameHourAs.shouldHaveSameHourAs;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldHaveSameHourAs}</code>
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldHaveSameHourAs_create_Test {
+
+    private ErrorMessageFactory factory;
+
+    @Test
+    public void should_create_error_message_localtime() {
+        factory = shouldHaveSameHourAs(LocalTime.of(12, 0), LocalTime.of(13, 0));
+        assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation()))
+            .isEqualTo("[Test] \nExpecting:\n  <12:00>\nto have same hour as:\n  <13:00>\nbut had not.");
+    }
+
+    @Test
+    public void should_create_error_message_offset() {
+        factory = shouldHaveSameHourAs(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC),
+                                       OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
+        assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation()))
+            .isEqualTo("[Test] \nExpecting:\n  <12:00Z>\nto have same hour as:\n  <13:00Z>\nbut had not.");
+    }
+}


### PR DESCRIPTION
This PR contains the OffsetTime assertion integration which is kind of similar to LocalTime assertion. Until now it differs only in the assertion isEqualsToIgnoringTimezone. 
I have tried to create tests accordingly and added also some missing tests for LocalTime (e.g. SoftAssertions).

