### PR TITLE
Fixes #405: DateAssert_with_string_based_date_representation_Test#date_assertion_should_support_timestamp_string_representation - flakey

### DIFF
--- a/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.util.Dates.parseDatetime;
 import static org.assertj.core.util.Dates.parseDatetimeWithMs;
 
 import java.sql.Timestamp;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -68,6 +69,16 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     Timestamp timestamp = new Timestamp(date.getTime());
     // 2015-04-12 21:25:12.293
     String timestampAsString = Dates.newTimestampDateFormat().format(timestamp); // 2015-04-12 21:25:12.293
+
+    assertThat(date).isEqualTo(timestampAsString);
+  }
+
+  @Test
+  public void date_assertion_should_support_timestamp_string_representation_in_ms() throws ParseException {
+    Date date = Dates.newTimestampDateFormat().parse("2015-05-08 11:30:00.56");
+    Timestamp timestamp = new Timestamp(date.getTime());
+
+    String timestampAsString = Dates.newTimestampDateFormat().format(timestamp);
 
     assertThat(date).isEqualTo(timestampAsString);
   }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
@@ -67,7 +67,7 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     Date date = new Date();
     Timestamp timestamp = new Timestamp(date.getTime());
     // 2015-04-12 21:25:12.293
-    String timestampAsString = timestamp.toString(); // 2015-04-12 21:25:12.293
+    String timestampAsString = Dates.newTimestampDateFormat().format(timestamp); // 2015-04-12 21:25:12.293
 
     assertThat(date).isEqualTo(timestampAsString);
   }


### PR DESCRIPTION
Fixes #405 - based on comments made.

I've also added an explicit test around timestamps formatted as `2015-05-08 11:30:00.56`