### PR TITLE
#415 Added isCloseToPercentage to numbers

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -302,7 +302,30 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with BigDecimal:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(20d)));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(10d)));
+     *
+     * // assertion will fail
+     * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(5d)));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
     public S isCloseTo(BigDecimal expected, Percentage<BigDecimal> percentage) {
         bigDecimals.assertIsCloseToPercentage(info, actual, expected, percentage);

--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.BigDecimals;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.util.VisibleForTesting;
@@ -300,4 +301,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
     bigDecimals.assertIsCloseTo(info, actual, other, offset);
     return myself;
   }
+
+    /** {@inheritDoc} */
+    @Override
+    public S isCloseTo(BigDecimal expected, Percentage<BigDecimal> percentage) {
+        bigDecimals.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
 }

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import java.util.Comparator;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.Bytes;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.util.VisibleForTesting;
@@ -375,7 +376,43 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
     bytes.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
-  
+
+  /** {@inheritDoc} */
+  @Override
+  public S isCloseTo(Byte expected, Percentage<Byte> percentage) {
+    bytes.assertIsCloseToPercentage(info, actual, expected, percentage);
+    return myself;
+  }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+  public S isCloseTo(byte expected, Percentage<Byte> percentage) {
+      bytes.assertIsCloseToPercentage(info, actual, expected, percentage);
+      return myself;
+  }
+
   @Override
   public S usingComparator(Comparator<? super Byte> customComparator) {
     super.usingComparator(customComparator);

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -377,7 +377,30 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
     return myself;
   }
 
-  /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with byte:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)20));
+     *
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)10));
+     *
+     * // assertion will fail
+     * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)5));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
   @Override
   public S isCloseTo(Byte expected, Percentage<Byte> percentage) {
     bytes.assertIsCloseToPercentage(info, actual, expected, percentage);
@@ -388,17 +411,17 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
      * Verifies that the actual number is close to the given one within the given percentage.<br>
      * If difference is equal to the percentage value, assertion is considered valid.
      * <p>
-     * Example with double:
+     * Example with byte:
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)20));
      *
-     * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)10));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)5));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -132,14 +132,63 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
     return myself;
   }
 
-  /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given offset.<br>
+     * If difference is equal to offset value, assertion is considered valid.
+     * <p>
+     * Example:
+     *
+     * <pre><code class='java'>
+     * // assertion will pass
+     * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.2));
+     *
+     * // you can use offset if you prefer
+     * assertThat(8.1).isCloseTo(Double.valueOf(8.0), offset(0.2));
+     *
+     * // if difference is exactly equals to 0.1, it's ok
+     * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.1));
+     *
+     * // assertion will fail
+     * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.01));
+     * </code></pre>
+     *
+     * @param other the given number to compare the actual value to.
+     * @param offset the given positive offset.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
   @Override
   public S isCloseTo(Double other, Offset<Double> offset) {
     doubles.assertIsCloseTo(info, actual, other, offset);
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
     public S isCloseTo(Double expected, Percentage<Double> percentage) {
         doubles.assertIsCloseToPercentage(info, actual, expected, percentage);
@@ -154,13 +203,13 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat(11.0).isCloseTo(10.0, withinPercentage(20d));
      *
      * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * assertThat(11.0).isCloseTo(10.0, withinPercentage(10d));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat(11.0).isCloseTo(10.0, withinPercentage(5d));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import java.util.Comparator;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.*;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -137,6 +138,42 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
     doubles.assertIsCloseTo(info, actual, other, offset);
     return myself;
   }
+
+    /** {@inheritDoc} */
+    @Override
+    public S isCloseTo(Double expected, Percentage<Double> percentage) {
+        doubles.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+    public S isCloseTo(double expected, Percentage<Double> percentage) {
+        doubles.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
 
   /**
 	 * Verifies that the actual value is equal to the given one.

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -185,7 +185,30 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with float:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(20f));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(10f));
+     *
+     * // assertion will fail
+     * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(5f));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
     public S isCloseTo(Float expected, Percentage<Float> percentage) {
         floats.assertIsCloseToPercentage(info, actual, expected, percentage);
@@ -196,17 +219,17 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
      * Verifies that the actual number is close to the given one within the given percentage.<br>
      * If difference is equal to the percentage value, assertion is considered valid.
      * <p>
-     * Example with double:
+     * Example with float:
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(20f));
      *
      * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(10f));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(5f));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.api;
 
-import java.util.Comparator;
-
 import org.assertj.core.data.Offset;
-import org.assertj.core.internal.*;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.Floats;
 import org.assertj.core.util.VisibleForTesting;
+
+import java.util.Comparator;
 
 
 /**
@@ -183,38 +185,43 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
     return myself;
   }
 
-  /**
-   * Verifies that the actual value is close to the given one by less than the given offset.<br>
-   * If difference is equal to offset value, assertion is considered valid.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
-   * assertThat(8.1f).isEqualTo(new Float(8.2f), offset(0.2f));
-   *
-   * // if difference is exactly equals to the offset (0.1f), it's ok
-   * assertThat(8.1f).isEqualTo(new Float(8.2f), offset(0.1f));
-   *
-   * // within is an alias of offset
-   * assertThat(8.1f).isEqualTo(new Float(8.2f), within(0.1f));
-   *
-   * // assertion will fail
-   * assertThat(8.1f).isEqualTo(new Float(8.2f), offset(0.01f));
-   * </code></pre>
-   * Beware that java floating point number precision might have some unexpected behavior, e.g. the assertion below fails:
-   * <pre><code class='java'>
-   *  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
-   * assertThat(8.1f).isEqualTo(new Float(8.0f), offset(0.1f));
-   * </code></pre>
-   *
-   * @param expected the given value to compare the actual value to.
-   * @param offset the given positive offset.
-   * @return {@code this} assertion object.
-   * @throws NullPointerException if the given offset is {@code null}.
-   * @throws NullPointerException if the expected number is {@code null}.
-   * @throws AssertionError if the actual value is not equal to the given one.
-   */
+    /** {@inheritDoc} */
+    @Override
+    public S isCloseTo(Float expected, Percentage<Float> percentage) {
+        floats.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+    public S isCloseTo(float expected, Percentage<Float> percentage) {
+        floats.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+  /** {@inheritDoc} */
 	@Override
 	public S isEqualTo(Float expected, Offset<Float> offset) {
 		floats.assertEqual(info, actual, expected, offset);

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -211,14 +211,59 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual int is close to the given one within the given offset.<br>
+     * If difference is equal to offset value, assertion is considered valid.
+     * <p>
+     * Example:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(5).isCloseTo(Integer.valueOf(7), within(3));
+     *
+     * // if difference is exactly equals to the offset, it's ok
+     * assertThat(5).isCloseTo(Integer.valueOf(7), within(2));
+     *
+     * // assertion will fail
+     * assertThat(5).isCloseTo(Integer.valueOf(7), within(1));
+     * </code></pre>
+     *
+     * @param expected the given int to compare the actual value to.
+     * @param offset the given positive offset.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
   public S isCloseTo(Integer expected, Offset<Integer> offset) {
     integers.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with integer:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(20));
+     *
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(10));
+     *
+     * // assertion will fail
+     * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(5));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
     public S isCloseTo(Integer expected, Percentage<Integer> percentage) {
         integers.assertIsCloseToPercentage(info, actual, expected, percentage);
@@ -229,17 +274,17 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
      * Verifies that the actual number is close to the given one within the given percentage.<br>
      * If difference is equal to the percentage value, assertion is considered valid.
      * <p>
-     * Example with double:
+     * Example with integer:
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat(11).isCloseTo(10, withinPercentage(20));
      *
-     * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat(11).isCloseTo(10, withinPercentage(10));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat(11).isCloseTo(10, withinPercentage(5));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import java.util.Comparator;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Integers;
 import org.assertj.core.util.VisibleForTesting;
@@ -210,35 +211,48 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
     return myself;
   }
 
-  /**
-   * Verifies that the actual Integer is close to the given one within the given offset.<br>
-   * If difference is equal to offset value, assertion is considered valid.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
-   * assertThat(5).isCloseTo(new Integer(7), within(3));
-   *
-   * // if difference is exactly equals to the offset (0.1), it's ok
-   * assertThat(5).isCloseTo(new Integer(7), within(2));
-   *
-   * // assertion will fail
-   * assertThat(5).isCloseTo(new Integer(7), within(1));
-   * </code></pre>
-   *
-   * @param expected the given Integer to compare the actual value to.
-   * @param offset the given positive offset.
-   * @return {@code this} assertion object.
-   * @throws NullPointerException if the given offset is {@code null}.
-   * @throws NullPointerException if the expected Integer is {@code null}.
-   * @throws AssertionError if the actual value is not equal to the given one.
-   */
+    /** {@inheritDoc} */
+    @Override
   public S isCloseTo(Integer expected, Offset<Integer> offset) {
     integers.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
-  
+
+    /** {@inheritDoc} */
+    @Override
+    public S isCloseTo(Integer expected, Percentage<Integer> percentage) {
+        integers.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+    public S isCloseTo(int expected, Percentage<Integer> percentage) {
+        integers.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
   
   @Override
   public S usingComparator(Comparator<? super Integer> customComparator) {

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -206,13 +206,59 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
     return myself;
   }
 
-  /** {@inheritDoc} */
+    /**
+     * Verifies that the actual long is close to the given one within the given offset.<br>
+     * If difference is equal to offset value, assertion is considered valid.
+     * <p>
+     * Example:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(5l).isCloseTo(Long.valueOf(7l), within(3l));
+     *
+     * // if difference is exactly equals to the offset, it's ok
+     * assertThat(5l).isCloseTo(Long.valueOf(7l), within(2l));
+     *
+     * // assertion will fail
+     * assertThat(5l).isCloseTo(Long.valueOf(7l), within(1l));
+     * </code></pre>
+     *
+     * @param expected the given long to compare the actual value to.
+     * @param offset the given positive offset.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
   @Override
   public S isCloseTo(Long expected, Offset<Long> offset) {
     longs.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
 
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with long:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(20L));
+     *
+     * // if difference is exactly equals to the computed offset (1L), it's ok
+     * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(10L));
+     *
+     * // assertion will fail
+     * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(5L));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     public S isCloseTo(Long expected, Percentage<Long> percentage) {
         longs.assertIsCloseToPercentage(info, actual, expected, percentage);
         return myself;
@@ -222,17 +268,17 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
      * Verifies that the actual number is close to the given one within the given percentage.<br>
      * If difference is equal to the percentage value, assertion is considered valid.
      * <p>
-     * Example with double:
+     * Example with long:
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat(11L).isCloseTo(10L, withinPercentage(20L));
      *
-     * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * // if difference is exactly equals to the computed offset (1L), it's ok
+     * assertThat(11L).isCloseTo(10L, withinPercentage(10L));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat(11L).isCloseTo(10L, withinPercentage(5L));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import java.util.Comparator;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.*;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -205,35 +206,46 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
     return myself;
   }
 
-  /**
-   * Verifies that the actual Long is close to the given one within the given offset.<br>
-   * If difference is equal to offset value, assertion is considered valid.
-   * <p>
-   * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
-   * assertThat(5l).isCloseTo(new Long(7), within(3l));
-   *
-   * // if difference is exactly equals to the offset (0.1), it's ok
-   * assertThat(5l).isCloseTo(new Long(7), within(2l));
-   *
-   * // assertion will fail
-   * assertThat(5l).isCloseTo(new Long(7), within(1l));
-   * </code></pre>
-   *
-   * @param expected the given Long to compare the actual value to.
-   * @param offset the given positive offset.
-   * @return {@code this} assertion object.
-   * @throws NullPointerException if the given offset is {@code null}.
-   * @throws NullPointerException if the expected Long is {@code null}.
-   * @throws AssertionError if the actual value is not equal to the given one.
-   */
+  /** {@inheritDoc} */
   @Override
   public S isCloseTo(Long expected, Offset<Long> offset) {
     longs.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
+
+    public S isCloseTo(Long expected, Percentage<Long> percentage) {
+        longs.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+    public S isCloseTo(long expected, Percentage<Long> percentage) {
+        longs.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
 
   @Override
   public S usingComparator(Comparator<? super Long> customComparator) {

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -274,14 +274,59 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
     return myself;
   }
 
-  /** {@inheritDoc} */
+    /**
+     * Verifies that the actual short is close to the given one within the given offset.<br>
+     * If difference is equal to offset value, assertion is considered valid.
+     * <p>
+     * Example:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)3));
+     *
+     * // if difference is exactly equals to the offset, it's ok
+     * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)2));
+     *
+     * // assertion will fail
+     * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)1));
+     * </code></pre>
+     *
+     * @param expected the given short to compare the actual value to.
+     * @param offset the given positive offset.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
   @Override
   public S isCloseTo(Short expected, Offset<Short> offset) {
     shorts.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
 
-    /** {@inheritDoc} */
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with short:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)20));
+     *
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)10));
+     *
+     * // assertion will fail
+     * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)5));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
     @Override
     public S isCloseTo(Short expected, Percentage<Short> percentage) {
         shorts.assertIsCloseToPercentage(info, actual, expected, percentage);
@@ -292,17 +337,17 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
      * Verifies that the actual number is close to the given one within the given percentage.<br>
      * If difference is equal to the percentage value, assertion is considered valid.
      * <p>
-     * Example with double:
+     * Example with short:
      *
      * <pre><code class='java'>
      * // assertions will pass:
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)20));
      *
-     * // if difference is exactly equals to the computed offset (1.0), it's ok
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     * // if difference is exactly equals to the computed offset (1), it's ok
+     * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)10));
      *
      * // assertion will fail
-     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)5));
      * </code></pre>
      *
      * @param expected the given number to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.api;
 
-import java.util.Comparator;
-
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Shorts;
 import org.assertj.core.util.VisibleForTesting;
+
+import java.util.Comparator;
 
 /**
  * Base class for all implementations of assertions for {@link Short}s.
@@ -273,35 +274,48 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
     return myself;
   }
 
-  /**
-   * Verifies that the actual Short is close to the given one within the given offset.<br>
-   * If difference is equal to offset value, assertion is considered valid.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
-   * assertThat((short)5).isCloseTo(new Short("7"), within((short)3));
-   *
-   * // if difference is exactly equals to the offset, it's ok
-   * assertThat((short)5).isCloseTo(new Short("7"), within((short)2));
-   *
-   * // assertion will fail
-   * assertThat((short)5).isCloseTo(new Short("7"), within((short)1));
-   * </code></pre>
-   *
-   * @param expected the given Short to compare the actual value to.
-   * @param offset the given positive offset.
-   * @return {@code this} assertion object.
-   * @throws NullPointerException if the given offset is {@code null}.
-   * @throws NullPointerException if the expected Short is {@code null}.
-   * @throws AssertionError if the actual value is not equal to the given one.
-   */
+  /** {@inheritDoc} */
   @Override
   public S isCloseTo(Short expected, Offset<Short> offset) {
     shorts.assertIsCloseTo(info, actual, expected, offset);
     return myself;
   }
+
+    /** {@inheritDoc} */
+    @Override
+    public S isCloseTo(Short expected, Percentage<Short> percentage) {
+        shorts.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+    public S isCloseTo(short expected, Percentage<Short> percentage) {
+        shorts.assertIsCloseToPercentage(info, actual, expected, percentage);
+        return myself;
+    }
 
   @Override
   public S usingComparator(Comparator<? super Short> customComparator) {

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -39,12 +39,15 @@ import org.assertj.core.condition.Not;
 import org.assertj.core.data.Index;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.RuntimeIOException;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
+
+import static org.assertj.core.data.Percentage.withPercentage;
 
 /**
  * Entry point for assertion methods for different data types. Each method in this class is a static factory for the
@@ -984,6 +987,104 @@ public class Assertions {
   public static Offset<Long> within(Long value) {
     return Offset.offset(value);
   }
+
+    /**
+     * Assertions entry point for BigDecimal {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat(BigDecimal.TEN).isCloseTo(new BigDecimal("10.5"), withinPercentage(BigDecimal.ONE));
+     * </code></pre>
+     */
+    public static Percentage<BigDecimal> withinPercentage(BigDecimal value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Double {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat(11.0).isCloseTo(10.0, withinPercentage(10.0));
+     * </code></pre>
+     */
+    public static Percentage<Double> withinPercentage(Double value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Float {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(10.0f));
+     * </code></pre>
+     */
+    public static Percentage<Float> withinPercentage(Float value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Integer {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat(11).isCloseTo(10, withinPercentage(10));
+     * </code></pre>
+     */
+    public static Percentage<Integer> withinPercentage(Integer value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Long {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat(11L).isCloseTo(10L, withinPercentage(10L));
+     * </code></pre>
+     */
+    public static Percentage<Long> withinPercentage(Long value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Short {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)10));
+     * </code></pre>
+     */
+    public static Percentage<Short> withinPercentage(Short value) {
+        return withPercentage(value);
+    }
+
+    /**
+     * Assertions entry point for Byte {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
+     * <p/>
+     * Typical usage :
+     * <p/>
+     *
+     * <pre><code class='java'>
+     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)10));
+     * </code></pre>
+     */
+    public static Percentage<Byte> withinPercentage(Byte value) {
+        return withPercentage(value);
+    }
 
   // ------------------------------------------------------------------------------------------------------
   // Condition methods : not assertions but here to have a single entry point to all AssertJ features.

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -851,8 +851,7 @@ public class Assertions {
    * features (but you can use {@link Index} if you prefer).
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * List&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * assertThat(elvesRings).contains(vilya, atIndex(0)).contains(nenya, atIndex(1)).contains(narya, atIndex(2));
@@ -866,8 +865,7 @@ public class Assertions {
    * Assertions entry point for double {@link Offset}.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(8.1).isEqualTo(8.0, offset(0.1));
    * </code></pre>
@@ -880,8 +878,7 @@ public class Assertions {
    * Assertions entry point for float {@link Offset}.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(8.2f).isCloseTo(8.0f, offset(0.2f));
    * </code></pre>
@@ -894,8 +891,7 @@ public class Assertions {
    * Alias for {@link #offset(Double)} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(8.1).isCloseTo(8.0, within(0.1));
    * </code></pre>
@@ -908,8 +904,7 @@ public class Assertions {
    * Alias for {@link #offset(Float)} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(8.2f).isCloseTo(8.0f, within(0.2f));
    * </code></pre>
@@ -922,8 +917,7 @@ public class Assertions {
    * Assertions entry point for BigDecimal {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(BigDecimal.TEN).isCloseTo(new BigDecimal("10.5"), within(BigDecimal.ONE));
    * </code></pre>
@@ -936,8 +930,7 @@ public class Assertions {
    * Assertions entry point for Byte {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat((byte)10).isCloseTo((byte)11, within((byte)1));
    * </code></pre>
@@ -950,8 +943,7 @@ public class Assertions {
    * Assertions entry point for Integer {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(10).isCloseTo(11, within(1));
    * </code></pre>
@@ -964,8 +956,7 @@ public class Assertions {
    * Assertions entry point for Short {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(10).isCloseTo(11, within(1));
    * </code></pre>
@@ -978,8 +969,7 @@ public class Assertions {
    * Assertions entry point for Long {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   * <p/>
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(5l).isCloseTo(7l, within(2l));
    * </code></pre>
@@ -992,7 +982,6 @@ public class Assertions {
      * Assertions entry point for BigDecimal {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat(BigDecimal.TEN).isCloseTo(new BigDecimal("10.5"), withinPercentage(BigDecimal.ONE));
@@ -1006,7 +995,6 @@ public class Assertions {
      * Assertions entry point for Double {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat(11.0).isCloseTo(10.0, withinPercentage(10.0));
@@ -1020,7 +1008,6 @@ public class Assertions {
      * Assertions entry point for Float {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(10.0f));
@@ -1034,7 +1021,6 @@ public class Assertions {
      * Assertions entry point for Integer {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat(11).isCloseTo(10, withinPercentage(10));
@@ -1048,7 +1034,6 @@ public class Assertions {
      * Assertions entry point for Long {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat(11L).isCloseTo(10L, withinPercentage(10L));
@@ -1062,7 +1047,6 @@ public class Assertions {
      * Assertions entry point for Short {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)10));
@@ -1076,7 +1060,6 @@ public class Assertions {
      * Assertions entry point for Byte {@link org.assertj.core.data.Percentage} to use with isCloseTo assertions for percentages.
      * <p/>
      * Typical usage :
-     * <p/>
      *
      * <pre><code class='java'>
      * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)10));

--- a/src/main/java/org/assertj/core/api/NumberAssert.java
+++ b/src/main/java/org/assertj/core/api/NumberAssert.java
@@ -13,6 +13,9 @@
 package org.assertj.core.api;
 
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+
+import java.math.BigDecimal;
 
 /**
  * Assertion methods applicable to <code>{@link Number}</code>s.
@@ -147,4 +150,29 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
    */
   S isCloseTo(A expected, Offset<A> offset);
 
+    /**
+     * Verifies that the actual number is close to the given one within the given percentage.<br>
+     * If difference is equal to the percentage value, assertion is considered valid.
+     * <p>
+     * Example with double:
+     *
+     * <pre><code class='java'>
+     * // assertions will pass:
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
+     *
+     * // if difference is exactly equals to the computed offset (1.0), it's ok
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
+     *
+     * // assertion will fail
+     * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
+     * </code></pre>
+     *
+     * @param expected the given number to compare the actual value to.
+     * @param percentage the given positive percentage between 0 and 100.
+     * @return {@code this} assertion object.
+     * @throws NullPointerException if the given offset is {@code null}.
+     * @throws NullPointerException if the expected number is {@code null}.
+     * @throws AssertionError if the actual value is not equal to the given one.
+     */
+  S isCloseTo(A expected, Percentage<A> percentage);
 }

--- a/src/main/java/org/assertj/core/data/Offset.java
+++ b/src/main/java/org/assertj/core/data/Offset.java
@@ -15,8 +15,6 @@ package org.assertj.core.data;
 import static org.assertj.core.util.Objects.*;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
-import java.math.BigDecimal;
-
 /**
  * A positive offset.
  *
@@ -36,106 +34,14 @@ public class Offset<T extends Number> {
    * @throws NullPointerException if the given value is {@code null}.
    * @throws IllegalArgumentException if the given value is negative.
    */
-  public static Offset<Double> offset(Double value) {
+  public static <T extends Number> Offset<T> offset(T value) {
     checkNotNull(value);
-    if (value < 0d) {
+    if (value.doubleValue() < 0d) {
       throw valueNotPositive();
     }
     return new Offset<>(value);
   }
 
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<Float> offset(Float value) {
-    checkNotNull(value);
-    if (value < 0f) {
-      throw valueNotPositive();
-    }
-    return new Offset<>(value);
-  }
-
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<Integer> offset(Integer value) {
-    checkNotNull(value);
-    if (value < 0) {
-      throw valueNotPositive();
-    }
-    return new Offset<>(value);
-  }
-
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<Short> offset(Short value) {
-    checkNotNull(value);
-    if (value < 0) {
-      throw valueNotPositive();
-    }
-    return new Offset<>(value);
-  }
-  
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<Long> offset(Long value) {
-    checkNotNull(value);
-    if (value < 0) {
-      throw valueNotPositive();
-    }
-    return new Offset<>(value);
-  }
-  
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<BigDecimal> offset(final BigDecimal value) {
-    checkNotNull(value);
-    if (value.compareTo(BigDecimal.ZERO) < 0) throw valueNotPositive();
-    return new Offset<>(value);
-  }
-
-  /**
-   * Creates a new {@link Offset}.
-   *
-   * @param value the value of the offset.
-   * @return the created {@code Offset}.
-   * @throws NullPointerException if the given value is {@code null}.
-   * @throws IllegalArgumentException if the given value is negative.
-   */
-  public static Offset<Byte> offset(final Byte value) {
-    checkNotNull(value);
-    if (value.compareTo((byte) 0) < 0) throw valueNotPositive();
-    return new Offset<>(value);
-  }
-  
   private static IllegalArgumentException valueNotPositive() {
     return new IllegalArgumentException("The value of the offset should be greater than zero");
   }

--- a/src/main/java/org/assertj/core/data/Percentage.java
+++ b/src/main/java/org/assertj/core/data/Percentage.java
@@ -43,7 +43,7 @@ public class Percentage<T extends Number> {
     private static void checkBoundaries(double value) {
         if (value < 0 || value > 100)
             throw new IllegalArgumentException(
-                String.format("The percentage value <%s> should be between zero and hundred.", value));
+                String.format("The percentage value <%s> should be between 0 and 100.", value));
     }
 
     private Percentage(T value) {

--- a/src/main/java/org/assertj/core/data/Percentage.java
+++ b/src/main/java/org/assertj/core/data/Percentage.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.util.Objects.*;
+import static org.assertj.core.util.Preconditions.checkNotNull;
+
+/**
+ * A percentage value between zero and hundred.
+ *
+ * @param <T> the type of the percentage value.
+ * @author Alexander Bishcof
+ */
+public class Percentage<T extends Number> {
+    public final T value;
+
+    /**
+     * Creates a new {@link org.assertj.core.data.Percentage}.
+     *
+     * @param value the value of the percentage.
+     * @return the created {@code Percentage}.
+     * @throws NullPointerException     if the given value is {@code null}.
+     * @throws IllegalArgumentException if the given value is negative or greater hundred.
+     */
+    public static <T extends Number> Percentage<T> withPercentage(T value) {
+        checkNotNull(value);
+        checkBoundaries(value.doubleValue());
+        return new Percentage<>(value);
+    }
+
+    private static void checkBoundaries(double value) {
+        if (value < 0 || value > 100)
+            throw new IllegalArgumentException(
+                String.format("The percentage value <%s> should be between zero and hundred.", value));
+    }
+
+    private Percentage(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Percentage<?> other = (Percentage<?>) obj;
+        return areEqual(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = HASH_CODE_PRIME * result + hashCodeFor(value);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[value=%s]", getClass().getSimpleName(), value);
+    }
+
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualWithinPercentage.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualWithinPercentage.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.data.Percentage;
+
+/**
+ * Creates an error message indicating that an assertion that
+ * verifies that two numbers are equal within a positive percentage failed.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualWithinPercentage extends BasicErrorMessageFactory {
+
+    /**
+     * Creates a new <code>{@link org.assertj.core.error.ShouldBeEqualWithinPercentage}</code>.
+     *
+     * @param actual     the actual value in the failed assertion.
+     * @param expected   the expected value in the failed assertion.
+     * @param percentage the given percentage between 0 and 100.
+     * @param difference the effective difference between actual and expected.
+     * @return the created {@code ErrorMessageFactory}.
+     */
+    public static <T extends Number> ErrorMessageFactory shouldBeEqualWithinPercentage(T actual, T expected,
+                                                                                       Percentage<T> percentage,
+                                                                                       T difference) {
+        double expectedPercentage = difference.doubleValue() / expected.doubleValue() * 100d;
+        return new ShouldBeEqualWithinPercentage(actual, expected, percentage, expectedPercentage);
+    }
+
+    private <T extends Number> ShouldBeEqualWithinPercentage(Number actual, Number expected, Percentage<T> percentage,
+                                                             double expectedPercentage) {
+        super("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%n" +
+              "by less than <%s> percent but difference was <%s> percent.%n" +
+              "(a difference of exactly <%s> being considered valid)",
+              actual, expected, percentage.value, expectedPercentage, percentage.value);
+    }
+}

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualWithinPercentage.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualWithinPercentage.java
@@ -41,7 +41,7 @@ public class ShouldBeEqualWithinPercentage extends BasicErrorMessageFactory {
     private <T extends Number> ShouldBeEqualWithinPercentage(Number actual, Number expected, Percentage<T> percentage,
                                                              double expectedPercentage) {
         super("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%n" +
-              "by less than <%s> percent but difference was <%s> percent.%n" +
+              "by less than <%s>%% but difference was <%s>%%.%n" +
               "(a difference of exactly <%s> being considered valid)",
               actual, expected, percentage.value, expectedPercentage, percentage.value);
     }

--- a/src/main/java/org/assertj/core/internal/BigDecimals.java
+++ b/src/main/java/org/assertj/core/internal/BigDecimals.java
@@ -24,6 +24,7 @@ import static java.math.BigDecimal.ZERO;
 import static java.math.BigDecimal.valueOf;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
@@ -62,11 +63,11 @@ public class BigDecimals extends Numbers<BigDecimal> {
 
   public void assertIsCloseTo(final AssertionInfo info, final BigDecimal actual, final BigDecimal other, final Offset<BigDecimal> offset) {
     assertNotNull(info, actual);
-    if (areNotEqual(actual, other, offset))
+    if (areNotCloseEnough(actual, other, offset))
         throw failures.failure(info, shouldBeEqual(actual, other, offset, actual.subtract(other).abs()));
   }
 
-    private boolean areNotEqual(BigDecimal actual, BigDecimal other,Offset<BigDecimal> offset) {
+    private boolean areNotCloseEnough(BigDecimal actual, BigDecimal other, Offset<BigDecimal> offset) {
         return actual.subtract(other).abs().subtract(offset.value).compareTo(ZERO) > 0;
     }
 
@@ -76,12 +77,11 @@ public class BigDecimals extends Numbers<BigDecimal> {
         checkPercentageIsNotNull(percentage);
         checkNumberIsNotNull(other);
 
-        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
-
         Offset<BigDecimal> calculatedOffset = offset(percentage.value.multiply(other).divide(valueOf(100d)));
 
-        if (areNotEqual(actual, other, calculatedOffset))
-            throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, other, percentage, actual.subtract(other).abs()));
+        if (areNotCloseEnough(actual, other, calculatedOffset))
+            throw failures.failure(info,
+                                   shouldBeEqualWithinPercentage(actual, other, percentage,
+                                                                 actual.subtract(other).abs()));
     }
 }

--- a/src/main/java/org/assertj/core/internal/BigDecimals.java
+++ b/src/main/java/org/assertj/core/internal/BigDecimals.java
@@ -12,18 +12,25 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
+import org.assertj.core.util.*;
 
 import java.math.BigDecimal;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.data.Offset;
-import org.assertj.core.util.*;
+import static java.math.BigDecimal.ZERO;
+import static java.math.BigDecimal.valueOf;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
+import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
 
 /**
  * Reusable assertions for <code>{@link BigDecimal}</code>s.
- * 
+ *
  * @author Yvonne Wang
  * @author Joel Costigliola
  */
@@ -50,20 +57,31 @@ public class BigDecimals extends Numbers<BigDecimal> {
 
   @Override
   protected BigDecimal zero() {
-    return BigDecimal.ZERO;
+    return ZERO;
   }
 
   public void assertIsCloseTo(final AssertionInfo info, final BigDecimal actual, final BigDecimal other, final Offset<BigDecimal> offset) {
     assertNotNull(info, actual);
-    final BigDecimal differenceAbsoluteValue = abs(actual.subtract(other));
-    if (differenceAbsoluteValue.subtract(offset.value).compareTo(BigDecimal.ZERO) <= 0) return;
-    throw failures.failure(info, shouldBeEqual(actual, other, offset, differenceAbsoluteValue));
+    if (areNotEqual(actual, other, offset))
+        throw failures.failure(info, shouldBeEqual(actual, other, offset, actual.subtract(other).abs()));
   }
 
-  // borrowed from java 7 API ... to remove when we will be using Java 7 instead of java 6.
-  private BigDecimal abs(final BigDecimal bigDecimal) {
-    return (bigDecimal.signum() < 0 ? bigDecimal.negate() : bigDecimal);
-  }
+    private boolean areNotEqual(BigDecimal actual, BigDecimal other,Offset<BigDecimal> offset) {
+        return actual.subtract(other).abs().subtract(offset.value).compareTo(ZERO) > 0;
+    }
 
+    public void assertIsCloseToPercentage(AssertionInfo info, BigDecimal actual, BigDecimal other,
+                                Percentage<BigDecimal> percentage) {
+        assertNotNull(info, actual);
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(other);
 
+        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
+
+        Offset<BigDecimal> calculatedOffset = offset(percentage.value.multiply(other).divide(valueOf(100d)));
+
+        if (areNotEqual(actual, other, calculatedOffset))
+            throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, other, percentage, actual.subtract(other).abs()));
+    }
 }

--- a/src/main/java/org/assertj/core/internal/Bytes.java
+++ b/src/main/java/org/assertj/core/internal/Bytes.java
@@ -12,55 +12,70 @@
  */
 package org.assertj.core.internal;
 
-import static java.lang.Math.abs;
-import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
-import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
-import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
-
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.*;
+
+import static java.lang.Math.abs;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.internal.CommonValidations.*;
 
 /**
  * Reusable assertions for <code>{@link Byte}</code>s.
- * 
+ *
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
 public class Bytes extends Numbers<Byte> {
 
-  private static final Bytes INSTANCE = new Bytes();
+    private static final Bytes INSTANCE = new Bytes();
 
-  /**
-   * Returns the singleton instance of this class.
-   * 
-   * @return the singleton instance of this class.
-   */
-  public static Bytes instance() {
-    return INSTANCE;
-  }
-
-  @VisibleForTesting
-  Bytes() {
-    super();
-  }
-
-  public Bytes(ComparisonStrategy comparisonStrategy) {
-    super(comparisonStrategy);
-  }
-
-  @Override
-  protected Byte zero() {
-    return 0;
-  }
-
-  public void assertIsCloseTo(AssertionInfo info, Byte actual, Byte expected, Offset<Byte> offset) {
-      assertNotNull(info, actual);
-      checkOffsetIsNotNull(offset);
-      checkNumberIsNotNull(expected);
-      byte absDiff = (byte) abs(expected - actual);
-      if (absDiff > offset.value) throw failures.failure(info, shouldBeEqual(actual, expected, offset, absDiff));
+    /**
+     * Returns the singleton instance of this class.
+     *
+     * @return the singleton instance of this class.
+     */
+    public static Bytes instance() {
+        return INSTANCE;
     }
 
+    @VisibleForTesting Bytes() {
+        super();
+    }
 
+    public Bytes(ComparisonStrategy comparisonStrategy) {
+        super(comparisonStrategy);
+    }
+
+    @Override
+    protected Byte zero() {
+        return 0;
+    }
+
+    @Override
+    public void assertIsCloseTo(AssertionInfo info, Byte actual, Byte expected, Offset<Byte> offset) {
+        assertNotNull(info, actual);
+        checkOffsetIsNotNull(offset);
+        checkNumberIsNotNull(expected);
+        byte absDiff = (byte) abs(expected - actual);
+        if (absDiff > offset.value) throw failures.failure(info, shouldBeEqual(actual, expected, offset, absDiff));
+    }
+
+    public void assertIsCloseToPercentage(AssertionInfo info, Byte actual, Byte other,
+                                Percentage<Byte> percentage) {
+        assertNotNull(info, actual);
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(other);
+
+        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
+
+        Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
+
+        byte absDiff = (byte) abs(other - actual);
+        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+    }
 }

--- a/src/main/java/org/assertj/core/internal/Bytes.java
+++ b/src/main/java/org/assertj/core/internal/Bytes.java
@@ -21,6 +21,7 @@ import org.assertj.core.util.*;
 import static java.lang.Math.abs;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.*;
 
 /**
@@ -70,12 +71,11 @@ public class Bytes extends Numbers<Byte> {
         checkPercentageIsNotNull(percentage);
         checkNumberIsNotNull(other);
 
-        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
-
         Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
 
         byte absDiff = (byte) abs(other - actual);
-        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+        if (absDiff > calculatedOffset.value) throw failures.failure(info,
+                                                                     shouldBeEqualWithinPercentage(actual, other,
+                                                                                                   percentage, absDiff));
     }
 }

--- a/src/main/java/org/assertj/core/internal/CommonValidations.java
+++ b/src/main/java/org/assertj/core/internal/CommonValidations.java
@@ -25,6 +25,7 @@ import static org.assertj.core.util.Iterables.sizeOf;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 
 import java.lang.reflect.Array;
 import java.util.Map;
@@ -49,6 +50,10 @@ final class CommonValidations {
   static void checkOffsetIsNotNull(Offset<?> offset) {
     if (offset == null) throw new NullPointerException("The given offset should not be null");
   }
+
+    static void checkPercentageIsNotNull(Percentage<?> percentage) {
+        if (percentage == null) throw new NullPointerException("The given percentage should not be null");
+    }
 
   static void checkNumberIsNotNull(Number number) {
     if (number == null) throw new NullPointerException("The given number should not be null");

--- a/src/main/java/org/assertj/core/internal/Doubles.java
+++ b/src/main/java/org/assertj/core/internal/Doubles.java
@@ -16,6 +16,7 @@ import static java.lang.Math.abs;
 
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.*;
 
 import org.assertj.core.api.AssertionInfo;
@@ -106,14 +107,11 @@ public class Doubles extends RealNumbers<Double> {
       checkNumberIsNotNull(expected);
       assertNotNull(info, actual);
 
-      // doesn't use areEqual method relying on comparisonStrategy attribute
-      if (Objects.areEqual(actual, expected)) return;
-
       Offset<Double> calculatedOffset = offset(percentage.value * expected / 100d);
 
       if (isEqualTo(actual, expected, calculatedOffset)) return;
-      throw failures.failure(info, ShouldBeEqualWithinPercentage
-          .shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
+      throw failures.failure(info,
+                             shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
     }
 
 }

--- a/src/main/java/org/assertj/core/internal/Doubles.java
+++ b/src/main/java/org/assertj/core/internal/Doubles.java
@@ -14,11 +14,14 @@ package org.assertj.core.internal;
 
 import static java.lang.Math.abs;
 
+import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.CommonValidations.*;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.Objects;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -91,8 +94,26 @@ public class Doubles extends RealNumbers<Double> {
     return abs(expected - actual) <= offset.value.doubleValue();
   }
 
+  @Override
   public void assertIsCloseTo(final AssertionInfo info, final Double actual, final Double other,
                               final Offset<Double> offset) {
     assertEqual(info, actual, other, offset);
   }
+
+  public void assertIsCloseToPercentage(final AssertionInfo info, final Double actual, final Double expected,
+                              final Percentage<Double> percentage) {
+      checkPercentageIsNotNull(percentage);
+      checkNumberIsNotNull(expected);
+      assertNotNull(info, actual);
+
+      // doesn't use areEqual method relying on comparisonStrategy attribute
+      if (Objects.areEqual(actual, expected)) return;
+
+      Offset<Double> calculatedOffset = offset(percentage.value * expected / 100d);
+
+      if (isEqualTo(actual, expected, calculatedOffset)) return;
+      throw failures.failure(info, ShouldBeEqualWithinPercentage
+          .shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
+    }
+
 }

--- a/src/main/java/org/assertj/core/internal/Floats.java
+++ b/src/main/java/org/assertj/core/internal/Floats.java
@@ -22,6 +22,7 @@ import org.assertj.core.util.VisibleForTesting;
 import static java.lang.Math.abs;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.*;
 
 
@@ -102,13 +103,10 @@ public class Floats extends RealNumbers<Float> {
         checkNumberIsNotNull(expected);
         assertNotNull(info, actual);
 
-        // doesn't use areEqual method relying on comparisonStrategy attribute
-        if (Objects.areEqual(actual, expected)) return;
-
         Offset<Float> calculatedOffset = offset(percentage.value * expected / 100f);
 
         if (isEqualTo(actual, expected, calculatedOffset)) return;
-        throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
+        throw failures.failure(info,
+                               shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
     }
 }

--- a/src/main/java/org/assertj/core/internal/Floats.java
+++ b/src/main/java/org/assertj/core/internal/Floats.java
@@ -12,15 +12,17 @@
  */
 package org.assertj.core.internal;
 
-import static java.lang.Math.abs;
-
-import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
-import static org.assertj.core.internal.CommonValidations.*;
-
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.Objects;
 import org.assertj.core.util.VisibleForTesting;
+
+import static java.lang.Math.abs;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.internal.CommonValidations.*;
 
 
 /**
@@ -94,4 +96,19 @@ public class Floats extends RealNumbers<Float> {
     throw failures.failure(info, shouldBeEqual(actual, expected, offset, abs(expected - actual)));
   }
 
+    public void assertIsCloseToPercentage(final AssertionInfo info, final Float actual, final Float expected,
+                                final Percentage<Float> percentage) {
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(expected);
+        assertNotNull(info, actual);
+
+        // doesn't use areEqual method relying on comparisonStrategy attribute
+        if (Objects.areEqual(actual, expected)) return;
+
+        Offset<Float> calculatedOffset = offset(percentage.value * expected / 100f);
+
+        if (isEqualTo(actual, expected, calculatedOffset)) return;
+        throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, expected, percentage, abs(expected - actual)));
+    }
 }

--- a/src/main/java/org/assertj/core/internal/Integers.java
+++ b/src/main/java/org/assertj/core/internal/Integers.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import static java.lang.Math.abs;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
@@ -71,12 +72,11 @@ public class Integers extends Numbers<Integer> {
         checkPercentageIsNotNull(percentage);
         checkNumberIsNotNull(other);
 
-        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
-
         Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
 
         Integer absDiff = abs(other - actual);
-        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+        if (absDiff > calculatedOffset.value) throw failures.failure(info,
+                                                                     shouldBeEqualWithinPercentage(actual, other,
+                                                                                                   percentage, absDiff));
     }
 }

--- a/src/main/java/org/assertj/core/internal/Integers.java
+++ b/src/main/java/org/assertj/core/internal/Integers.java
@@ -13,12 +13,16 @@
 package org.assertj.core.internal;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
+import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -61,5 +65,18 @@ public class Integers extends Numbers<Integer> {
     if (absDiff > offset.value) throw failures.failure(info, shouldBeEqual(actual, expected, offset, absDiff));
   }
 
-  
+    public void assertIsCloseToPercentage(AssertionInfo info, Integer actual, Integer other,
+                                Percentage<Integer> percentage) {
+        assertNotNull(info, actual);
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(other);
+
+        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
+
+        Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
+
+        Integer absDiff = abs(other - actual);
+        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+    }
 }

--- a/src/main/java/org/assertj/core/internal/Longs.java
+++ b/src/main/java/org/assertj/core/internal/Longs.java
@@ -13,12 +13,16 @@
 package org.assertj.core.internal;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
+import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -61,5 +65,21 @@ public class Longs extends Numbers<Long> {
     long absDiff = abs(expected - actual);
     if (absDiff > offset.value) throw failures.failure(info, shouldBeEqual(actual, expected, offset, absDiff));
   }
+
+    @Override
+    public void assertIsCloseToPercentage(AssertionInfo info, Long actual, Long other,
+                                                    Percentage<Long> percentage) {
+        assertNotNull(info, actual);
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(other);
+
+        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
+
+        Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
+
+        Long absDiff = abs(other - actual);
+        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+    }
 
 }

--- a/src/main/java/org/assertj/core/internal/Longs.java
+++ b/src/main/java/org/assertj/core/internal/Longs.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import static java.lang.Math.abs;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
@@ -73,13 +74,12 @@ public class Longs extends Numbers<Long> {
         checkPercentageIsNotNull(percentage);
         checkNumberIsNotNull(other);
 
-        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
-
         Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
 
         Long absDiff = abs(other - actual);
-        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+        if (absDiff > calculatedOffset.value) throw failures.failure(info,
+                                                                     shouldBeEqualWithinPercentage(actual, other,
+                                                                                                   percentage, absDiff));
     }
 
 }

--- a/src/main/java/org/assertj/core/internal/Numbers.java
+++ b/src/main/java/org/assertj/core/internal/Numbers.java
@@ -13,6 +13,8 @@
 package org.assertj.core.internal;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 
 /**
  * Base class of reusable assertions for numbers.
@@ -20,7 +22,7 @@ import org.assertj.core.api.AssertionInfo;
  * @author Joel Costigliola
  * @author Nicolas François
  */
-public abstract class Numbers<NUMBER extends Comparable<NUMBER>> extends Comparables {
+public abstract class Numbers<NUMBER extends Number & Comparable<NUMBER>> extends Comparables {
 
   public Numbers() {
     super();
@@ -136,4 +138,26 @@ public abstract class Numbers<NUMBER extends Comparable<NUMBER>> extends Compara
   public void assertIsStrictlyBetween(AssertionInfo info, NUMBER actual, NUMBER start, NUMBER end) {
     assertIsBetween(info, actual, start, end, false, false);
   }
+
+    /**
+     * Asserts that the actual value is close to the offset.
+     *
+     * @param info contains information about the assertion.
+     * @param actual the actual value.
+     * @param other the expected value.
+     * @param offset the given positive offset.
+     */
+  public abstract void assertIsCloseTo(final AssertionInfo info, final NUMBER actual, final NUMBER other,
+                                final Offset<NUMBER> offset);
+
+    /**
+     * Asserts that the actual value is close to the an offset expressed as an percentage value.
+     *
+     * @param info contains information about the assertion.
+     * @param actual the actual value.
+     * @param other the expected value.
+     * @param percentage the given percentage between 0 and 100.
+     */
+    public abstract void assertIsCloseToPercentage(final AssertionInfo info, final NUMBER actual, final NUMBER other,
+                                         final Percentage<NUMBER> percentage);
 }

--- a/src/main/java/org/assertj/core/internal/RealNumbers.java
+++ b/src/main/java/org/assertj/core/internal/RealNumbers.java
@@ -20,7 +20,7 @@ import org.assertj.core.data.Offset;
  * 
  * @author Joel Costigliola
  */
-public abstract class RealNumbers<NUMBER extends Comparable<NUMBER>> extends Numbers<NUMBER> {
+public abstract class RealNumbers<NUMBER extends Number & Comparable<NUMBER>> extends Numbers<NUMBER> {
 
   public RealNumbers() {
     super();
@@ -64,5 +64,4 @@ public abstract class RealNumbers<NUMBER extends Comparable<NUMBER>> extends Num
    * @return true if the two floats parameter are equal within a positive offset, false otherwise.
    */
   protected abstract boolean isEqualTo(NUMBER actual, NUMBER expected, Offset<?> offset);
-
 }

--- a/src/main/java/org/assertj/core/internal/Shorts.java
+++ b/src/main/java/org/assertj/core/internal/Shorts.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import static java.lang.Math.abs;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.*;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
@@ -71,13 +72,12 @@ public class Shorts extends Numbers<Short> {
         checkPercentageIsNotNull(percentage);
         checkNumberIsNotNull(other);
 
-        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
-
         Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
 
         short absDiff = (short) abs(other - actual);
-        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
-            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+        if (absDiff > calculatedOffset.value) throw failures.failure(info,
+                                                                     shouldBeEqualWithinPercentage(actual, other,
+                                                                                                   percentage, absDiff));
 
     }
 }

--- a/src/main/java/org/assertj/core/internal/Shorts.java
+++ b/src/main/java/org/assertj/core/internal/Shorts.java
@@ -13,12 +13,16 @@
 package org.assertj.core.internal;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
+import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeEqualWithinPercentage;
 import org.assertj.core.util.*;
 
 /**
@@ -61,4 +65,19 @@ public class Shorts extends Numbers<Short> {
     if (absDiff > offset.value) throw failures.failure(info, shouldBeEqual(actual, expected, offset, absDiff));
   }
 
+    public void assertIsCloseToPercentage(AssertionInfo info, Short actual, Short other,
+                                Percentage<Short> percentage) {
+        assertNotNull(info, actual);
+        checkPercentageIsNotNull(percentage);
+        checkNumberIsNotNull(other);
+
+        if (org.assertj.core.util.Objects.areEqual(actual, other)) return;
+
+        Offset<Double> calculatedOffset = offset(percentage.value * other / 100d);
+
+        short absDiff = (short) abs(other - actual);
+        if (absDiff > calculatedOffset.value) throw failures.failure(info, ShouldBeEqualWithinPercentage
+            .shouldBeEqualWithinPercentage(actual, other, percentage, absDiff));
+
+    }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_withinPercentage_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_withinPercentage_Test.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+public class Assertions_withinPercentage_Test {
+
+    @Test
+    public void should_create_double() {
+        assertThat(withinPercentage(1d)).isNotNull();
+    }
+
+    @Test
+    public void should_create_float() {
+        assertThat(withinPercentage(1f)).isNotNull();
+    }
+
+    @Test
+    public void should_create_integer() {
+        assertThat(withinPercentage(1)).isNotNull();
+    }
+
+    @Test
+    public void should_create_long() {
+        assertThat(withinPercentage(1L)).isNotNull();
+    }
+
+    @Test
+    public void should_create_short() {
+        assertThat(withinPercentage((short) 1)).isNotNull();
+    }
+
+    @Test
+    public void should_create_byte() {
+        assertThat(withinPercentage((byte) 1)).isNotNull();
+    }
+
+    @Test
+    public void should_create_bigdecimnal() {
+        assertThat(withinPercentage(BigDecimal.ONE)).isNotNull();
+    }
+}

--- a/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isCloseToPercentage_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.bigdecimal;
+
+import org.assertj.core.api.BigDecimalAssert;
+import org.assertj.core.api.BigDecimalAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import java.math.BigDecimal;
+
+import static java.math.BigDecimal.valueOf;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class BigDecimalAssert_isCloseToPercentage_Test extends BigDecimalAssertBaseTest {
+
+    private final Percentage<BigDecimal> percentage = withPercentage(valueOf(5));
+    private final BigDecimal value = BigDecimal.TEN;
+
+    @Override
+    protected BigDecimalAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(bigDecimals).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseToPercentage_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseToPercentage_byte_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.byte_;
+
+import org.assertj.core.api.ByteAssert;
+import org.assertj.core.api.ByteAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class ByteAssert_isCloseToPercentage_byte_Test extends ByteAssertBaseTest {
+
+    private final Percentage<Byte> percentage = withPercentage((byte) 5);
+    private final Byte value = 10;
+
+    @Override
+    protected ByteAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(bytes).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isCloseToPercentage_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class DoubleAssert_isCloseToPercentage_Test extends DoubleAssertBaseTest {
+
+    private final Percentage<Double> percentage = withPercentage(5.0);
+    private final Double value = 10.0;
+
+    @Override
+    protected DoubleAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(doubles).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isCloseToPercentage_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class FloatAssert_isCloseToPercentage_Test extends FloatAssertBaseTest {
+
+    private final Percentage<Float> percentage = withPercentage(5.0f);
+    private final Float value = 10.0f;
+
+    @Override
+    protected FloatAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(floats).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/integer_/IntegerAssert_isCloseToPercentage_integer_Test.java
+++ b/src/test/java/org/assertj/core/api/integer_/IntegerAssert_isCloseToPercentage_integer_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.integer_;
+
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.core.api.IntegerAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class IntegerAssert_isCloseToPercentage_integer_Test extends IntegerAssertBaseTest {
+
+    private final Percentage<Integer> percentage = withPercentage(5);
+    private final Integer value = 10;
+
+    @Override
+    protected IntegerAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(integers).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseToPercentage_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseToPercentage_long_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class LongAssert_isCloseToPercentage_long_Test extends LongAssertBaseTest {
+
+    private final Percentage<Long> percentage = withPercentage(5L);
+    private final Long value = 10L;
+
+    @Override
+    protected LongAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(longs).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseToPercentage_short_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseToPercentage_short_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.short_;
+
+import org.assertj.core.api.ShortAssert;
+import org.assertj.core.api.ShortAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class ShortAssert_isCloseToPercentage_short_Test extends ShortAssertBaseTest {
+
+    private final Percentage<Short> percentage = withPercentage((short) 5);
+    private final Short value = (short)10;
+
+    @Override
+    protected ShortAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(shorts).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_equals_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_equals_hashCode_Test.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.EqualsHashCodeContractAssert.*;
+
+/**
+ * Tests for {@link org.assertj.core.data.Percentage#equals(Object)} and {@link org.assertj.core.data.Percentage#hashCode()}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_equals_hashCode_Test {
+    private static Percentage<Double> percentage;
+
+    @BeforeClass
+    public static void setUpOnce() {
+        percentage = withPercentage(8.0);
+    }
+
+    @Test
+    public void should_have_reflexive_equals() {
+        assertEqualsIsReflexive(percentage);
+    }
+
+    @Test
+    public void should_have_symmetric_equals() {
+        assertEqualsIsSymmetric(percentage, withPercentage(8.0));
+    }
+
+    @Test
+    public void should_have_transitive_equals() {
+        assertEqualsIsTransitive(percentage, withPercentage(8.0), withPercentage(8.0));
+    }
+
+    @Test
+    public void should_maintain_equals_and_hashCode_contract() {
+        assertMaintainsEqualsAndHashCodeContract(percentage, withPercentage(8.0));
+    }
+
+    @Test
+    public void should_not_be_equal_to_Object_of_different_type() {
+        assertThat(percentage.equals("8")).isFalse();
+    }
+
+    @Test
+    public void should_not_be_equal_to_null() {
+        assertThat(percentage.equals(null)).isFalse();
+    }
+
+    @Test
+    public void should_not_be_equal_to_Percentage_with_different_value() {
+        assertThat(percentage.equals(withPercentage(6.0))).isFalse();
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_BigDecimal_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_BigDecimal_Test.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link org.assertj.core.data.Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_BigDecimal_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        BigDecimal value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        BigDecimal negative = BigDecimal.valueOf(-1.0);
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        BigDecimal greaterHundred = BigDecimal.valueOf(101);
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        BigDecimal value = BigDecimal.valueOf(0.8);
+        Percentage<BigDecimal> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Byte_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Byte_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Byte_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Byte value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        byte negative = (byte) -1;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        byte greaterHundred = (byte) 101;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Byte value = 8;
+        Percentage<Byte> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Double_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Double_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Double_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Double value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        double negative = -1d;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        double greaterHundred = 101d;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Double value = 0.8d;
+        Percentage<Double> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Float_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Float_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Float_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Float value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        float negative = -1f;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        float greaterHundred = 101f;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Float value = 0.8f;
+        Percentage<Float> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Integer_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Integer_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Integer_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Integer value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        int negative = -1;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        int greaterHundred = 101;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Integer value = 8;
+        Percentage<Integer> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Long_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Long_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Long_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Long value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        long negative = -1L;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        long greaterHundred = 101L;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Long value = 8L;
+        Percentage<Long> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Short_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Short_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.data;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.test.ErrorMessages.percentageValueIsInRange;
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Tests for {@link Percentage#withPercentage(Number)}.
+ *
+ * @author Alexander Bischof
+ */
+public class Percentage_withPercentage_with_Short_Test {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void should_throw_error_if_value_is_null() {
+        thrown.expect(NullPointerException.class);
+        Short value = null;
+        withPercentage(value);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_negative() {
+        short negative = (short) -1;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(negative));
+        withPercentage(negative);
+    }
+
+    @Test
+    public void should_throw_error_if_value_is_greater_hundred() {
+        short greaterHundred = (short) 101;
+        thrown.expectIllegalArgumentException(percentageValueIsInRange(greaterHundred));
+        withPercentage(greaterHundred);
+    }
+
+    @Test
+    public void should_create_Percentage() {
+        Short value = 8;
+        Percentage<Short> Percentage = withPercentage(value);
+        assertThat(Percentage.value).isSameAs(value);
+    }
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualWithinPercentage_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualWithinPercentage_create_Test.java
@@ -43,7 +43,7 @@ public class ShouldBeEqualWithinPercentage_create_Test {
                                   "  <12.0>%n" +
                                   "to be close to:%n" +
                                   "  <10.0>%n" +
-                                  "by less than <10.0> percent but difference was <20.0> percent.%n" +
+                                  "by less than <10.0>%% but difference was <20.0>%%.%n" +
                                   "(a difference of exactly <10.0> being considered valid)"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualWithinPercentage_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualWithinPercentage_create_Test.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+
+/**
+ * Tests for <code>{@link org.assertj.core.error.ShouldBeEqualWithinPercentage#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Alexander Bischof
+ */
+public class ShouldBeEqualWithinPercentage_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldBeEqualWithinPercentage(12.0, 10.0, withPercentage(10.0), 2d);
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %n" +
+                                  "Expecting:%n" +
+                                  "  <12.0>%n" +
+                                  "to be close to:%n" +
+                                  "  <10.0>%n" +
+                                  "by less than <10.0> percent but difference was <20.0> percent.%n" +
+                                  "(a difference of exactly <10.0> being considered valid)"));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
@@ -53,20 +53,20 @@ public class BigDecimals_assertIsCloseToPercentage_Test extends BigDecimalsBaseT
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(valueOf(101)));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(valueOf(1)));
-        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(50)));
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(100)));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(100)));
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(50)));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.bigdecimals;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.BigDecimalsBaseTest;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class BigDecimals_assertIsCloseToPercentage_Test extends BigDecimalsBaseTest {
+
+    private static final BigDecimal TWO = valueOf(2);
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        bigDecimals.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(valueOf(-1)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(valueOf(101)));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(valueOf(1)));
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(50)));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(valueOf(100)));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            bigDecimals.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         TEN.subtract(ONE)));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.bytes;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.BytesBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Bytes_assertIsCloseToPercentage_Test extends BytesBaseTest {
+
+    private static final Byte ZERO = 0;
+    private static final Byte ONE = 1;
+    private static final Byte TWO = 2;
+    private static final Byte TEN = 10;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        bytes.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((byte) -1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((byte) 101));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage((byte) 1));
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 50));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 100));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            bytes.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         (byte) (TEN - ONE)));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
@@ -54,20 +54,20 @@ public class Bytes_assertIsCloseToPercentage_Test extends BytesBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((byte) 101));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         bytes.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage((byte) 1));
-        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 50));
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 100));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         bytes.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 100));
+        bytes.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((byte) 50));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
@@ -54,20 +54,20 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101.0));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         doubles.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(0.1));
-        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0));
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         doubles.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0));
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.doubles;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.DoublesBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
+
+    private static final Double ZERO = 0d;
+    private static final Double ONE = 1d;
+    private static final Double TWO = 2d;
+    private static final Double TEN = 10d;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        doubles.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101.0));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(0.1));
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        doubles.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            doubles.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         TEN - ONE));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
@@ -54,20 +54,20 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101.0f));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         floats.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(0.1f));
-        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0f));
+        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0f));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         floats.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0f));
+        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0f));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.floats;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.FloatsBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
+
+    private static final Float ZERO = 0f;
+    private static final Float ONE = 1f;
+    private static final Float TWO = 2f;
+    private static final Float TEN = 10f;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        floats.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0f));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101.0f));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(0.1f));
+        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50.0f));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        floats.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        floats.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100.0f));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            floats.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         TEN - ONE));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
@@ -54,20 +54,20 @@ public class Integers_assertIsCloseToPercentage_Test extends IntegersBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         integers.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(1));
-        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50));
+        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         integers.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100));
+        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.integers;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.IntegersBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Integers_assertIsCloseToPercentage_Test extends IntegersBaseTest {
+
+    private static final Integer ZERO = 0;
+    private static final Integer ONE = 1;
+    private static final Integer TWO = 2;
+    private static final Integer TEN = 10;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        integers.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(1));
+        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        integers.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        integers.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            integers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         (TEN - ONE)));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.longs;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.LongsBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Longs_assertIsCloseToPercentage_Test extends LongsBaseTest {
+
+    private static final Long ZERO = 0L;
+    private static final Long ONE = 1L;
+    private static final Long TWO = 2L;
+    private static final Long TEN = 10L;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        longs.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101L));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(1L));
+        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50L));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        longs.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100L));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            longs.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         (TEN - ONE)));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
@@ -53,20 +53,20 @@ public class Longs_assertIsCloseToPercentage_Test extends LongsBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(101L));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         longs.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(1L));
-        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50L));
+        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100L));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         longs.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(100L));
+        longs.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage(50L));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.shorts;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ShortsBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.withinPercentage;
+import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Shorts_assertIsCloseToPercentage_Test extends ShortsBaseTest {
+
+    private static final Short ZERO = (short)0;
+    private static final Short ONE = (short)1;
+    private static final Short TWO = (short)2;
+    private static final Short TEN = (short)10;
+
+    @Test
+    public void should_fail_if_actual_is_null() {
+        thrown.expectAssertionError(actualIsNull());
+        shorts.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_expected_value_is_null() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void should_fail_if_percentage_is_null() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_negative() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) -1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_if_percentage_is_greater_hundred() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) 101));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_less_than_given_percentage() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage((short) 1));
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 50));
+    }
+
+    @Test
+    public void should_pass_if_difference_is_equal_to_given_percentage() {
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 100));
+    }
+
+    @Test
+    public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
+        AssertionInfo info = someInfo();
+        try {
+            shorts.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
+        } catch (AssertionError e) {
+            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                         (short) (TEN - ONE)));
+            return;
+        }
+        failBecauseExpectedAssertionErrorWasNotThrown();
+    }
+}

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
@@ -54,20 +54,20 @@ public class Shorts_assertIsCloseToPercentage_Test extends ShortsBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void should_fail_if_percentage_is_greater_hundred() {
+    public void should_fail_if_percentage_is_greater_than_one_hundred() {
         shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) 101));
     }
 
     @Test
     public void should_pass_if_difference_is_less_than_given_percentage() {
         shorts.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage((short) 1));
-        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 50));
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 100));
     }
 
     @Test
     public void should_pass_if_difference_is_equal_to_given_percentage() {
         shorts.assertIsCloseToPercentage(someInfo(), ONE, ONE, withPercentage(ZERO));
-        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 100));
+        shorts.assertIsCloseToPercentage(someInfo(), ONE, TWO, withPercentage((short) 50));
     }
 
     @Test

--- a/src/test/java/org/assertj/core/test/ErrorMessages.java
+++ b/src/test/java/org/assertj/core/test/ErrorMessages.java
@@ -75,6 +75,10 @@ public final class ErrorMessages {
     return "The value of the offset should be greater than zero";
   }
 
+  public static String percentageValueIsInRange(Number number) {
+        return String.format("The percentage value <%s> should be between zero and hundred.",number.doubleValue());
+    }
+
   public static String regexPatternIsNull() {
     return "The regular expression pattern to match should not be null";
   }

--- a/src/test/java/org/assertj/core/test/ErrorMessages.java
+++ b/src/test/java/org/assertj/core/test/ErrorMessages.java
@@ -76,7 +76,7 @@ public final class ErrorMessages {
   }
 
   public static String percentageValueIsInRange(Number number) {
-        return String.format("The percentage value <%s> should be between zero and hundred.",number.doubleValue());
+        return String.format("The percentage value <%s> should be between 0 and 100.",number.doubleValue());
     }
 
   public static String regexPatternIsNull() {


### PR DESCRIPTION
This PR contains changes so that numbers (incl. BigDecimals) can be checked by closeTo using a percentage value. Internally an offset value is calculated from expected and percentage and is then use the same way as isCloseTo with offset.

In order to integrate this PR as best as possible i had to refactor some things:
* Deleted *BigDecimals.abs*, uses now Jdk7 Method
* Pulled *assertCloseTo* to Numbers (was only in *Doubles* and *Floats*)