### PR TITLE
Implement 'containsSame' on 'OptionalAssert'

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
+import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
 
 import java.util.Optional;
 
@@ -23,6 +24,7 @@ import java.util.Optional;
  *
  * @param <T> type of the value contained in the {@link java.util.Optional}.
  * @author Jean-Christophe Gay
+ * @author Nicolai Parlog
  */
 public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S, T>, T> extends
     AbstractAssert<S, Optional<T>> {
@@ -78,7 +80,8 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
   }
 
   /**
-   * Verifies that the actual {@link java.util.Optional} contains the value in argument.
+   * Verifies that the actual {@link java.util.Optional} contains a value {@link Object#equals(Object) equal} to the
+   * argument.
    * </p>
    * Assertion will pass :
    * 
@@ -102,6 +105,42 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
     if (expectedValue == null) throw new IllegalArgumentException("The expected value should not be <null>.");
     if (!actual.isPresent()) throw failure(shouldContain(expectedValue));
     if (!actual.get().equals(expectedValue)) throw failure(shouldContain(actual, expectedValue));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@link java.util.Optional} contains the instance given as an argument.
+   * </p>
+   * Assertion will pass :
+   * 
+   * <pre><code class='java'>
+   * String someString = "something";
+   * assertThat(Optional.of(someString)).contains(someString);
+   * 
+   * // Java will create the same 'Integer' instance when boxing small ints
+   * assertThat(Optional.of(10)).contains(10);
+   * </code></pre>
+   * 
+   * Assertion will fail :
+   * 
+   * <pre><code class='java'>
+   * // not even equal:
+   * assertThat(Optional.of("something")).contains("something else");
+   * assertThat(Optional.of(20)).contains(10);
+   * 
+   * // equal but not the same: 
+   * assertThat(Optional.of(new String("something"))).contains(new String("something"));
+   * assertThat(Optional.of(new Integer(10))).contains(new Integer(10));
+   * </code></pre>
+   *
+   * @param expectedValue the expected value inside the {@link java.util.Optional}.
+   * @return this assertion object.
+   */
+  public S containsSame(T expectedValue) {
+    isNotNull();
+    if (expectedValue == null) throw new IllegalArgumentException("The expected value should not be <null>.");
+    if (!actual.isPresent()) throw failure(shouldContain(expectedValue));
+    if (actual.get() != expectedValue) throw failure(shouldContainSame(actual, expectedValue));
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -109,28 +109,29 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
   }
 
   /**
-   * Verifies that the actual {@link java.util.Optional} contains the instance given as an argument.
+   * Verifies that the actual {@link java.util.Optional} contains the instance given as an argument (i.e. it must be the
+   * same instance).
    * </p>
    * Assertion will pass :
    * 
    * <pre><code class='java'>
    * String someString = "something";
-   * assertThat(Optional.of(someString)).contains(someString);
+   * assertThat(Optional.of(someString)).containsSame(someString);
    * 
    * // Java will create the same 'Integer' instance when boxing small ints
-   * assertThat(Optional.of(10)).contains(10);
+   * assertThat(Optional.of(10)).containsSame(10);
    * </code></pre>
    * 
    * Assertion will fail :
    * 
    * <pre><code class='java'>
    * // not even equal:
-   * assertThat(Optional.of("something")).contains("something else");
-   * assertThat(Optional.of(20)).contains(10);
+   * assertThat(Optional.of("something")).containsSame("something else");
+   * assertThat(Optional.of(20)).containsSame(10);
    * 
    * // equal but not the same: 
-   * assertThat(Optional.of(new String("something"))).contains(new String("something"));
-   * assertThat(Optional.of(new Integer(10))).contains(new Integer(10));
+   * assertThat(Optional.of(new String("something"))).containsSame(new String("something"));
+   * assertThat(Optional.of(new Integer(10))).containsSame(new Integer(10));
    * </code></pre>
    *
    * @param expectedValue the expected value inside the {@link java.util.Optional}.

--- a/src/main/java/org/assertj/core/error/OptionalShouldContain.java
+++ b/src/main/java/org/assertj/core/error/OptionalShouldContain.java
@@ -20,19 +20,24 @@ import java.util.Optional;
  * Build error message when an {@link Optional} should contain a specific value.
  *
  * @author Jean-Christophe Gay
+ * @author Nicolai Parlog
  */
 public class OptionalShouldContain extends BasicErrorMessageFactory {
 
-  private OptionalShouldContain(Object actual, Object expected) {
-	super("%nExpecting:%n  <%s>%nto contains:%n  <%s>%nbut was not.", actual, expected);
+  private static final String EXPECTING_TO_CONTAIN = "%nExpecting:%n  <%s>%nto contain:%n  <%s>%nbut was not equal.";
+  private static final String EXPECTING_TO_CONTAIN_SAME = "%nExpecting:%n  <%s>%nto contain:%n  <%s>%nbut was not the same.";
+
+  private OptionalShouldContain(String message, Object actual, Object expected) {
+    super(message, actual, expected);
   }
 
   private OptionalShouldContain(Object expected) {
-	super("%nExpecting an Optional with value:%n  <%s>%nbut was empty.", expected);
+    super("%nExpecting an Optional with value:%n  <%s>%nbut was empty.", expected);
   }
 
   /**
-   * Indicates that the provided {@link java.util.Optional} does not contain the provided argument.
+   * Indicates that the provided {@link java.util.Optional} does not contain a value {@link Object#equals(Object) equal}
+   * to the provided argument.
    *
    * @param optional the {@link java.util.Optional} which contains a value.
    * @param expectedValue the value we expect to be in the provided {@link java.util.Optional}.
@@ -40,7 +45,20 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static <T> OptionalShouldContain shouldContain(Optional<T> optional, T expectedValue) {
-	return new OptionalShouldContain(optional, expectedValue);
+    return new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue);
+  }
+
+  /**
+   * Indicates that the provided {@link java.util.Optional} does not contain the provided argument (judging by reference
+   * equality).
+   *
+   * @param optional the {@link java.util.Optional} which contains a value.
+   * @param expectedValue the value we expect to be in the provided {@link java.util.Optional}.
+   * @param <T> the type of the value contained in the {@link java.util.Optional}.
+   * @return a error message factory
+   */
+  public static <T> OptionalShouldContain shouldContainSame(Optional<T> optional, T expectedValue) {
+    return new OptionalShouldContain(EXPECTING_TO_CONTAIN_SAME, optional, expectedValue);
   }
 
   /**
@@ -50,6 +68,7 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory.
    */
   public static OptionalShouldContain shouldContain(Object expectedValue) {
-	return new OptionalShouldContain(expectedValue);
+    return new OptionalShouldContain(expectedValue);
   }
+
 }

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_containsSame_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_containsSame_Test.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.OptionalShouldContain.shouldContain;
+import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+public class OptionalAssert_containsSame_Test extends BaseTest {
+
+  @Test
+  public void should_fail_when_optional_is_null() throws Exception {
+    thrown.expectAssertionError(actualIsNull());
+
+    assertThat((Optional<String>) null).containsSame("something");
+  }
+
+  @Test
+  public void should_fail_if_expected_value_is_null() throws Exception {
+    thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+
+    assertThat(Optional.of("something")).containsSame(null);
+  }
+
+  @Test
+  public void should_pass_if_optional_contains_expected_value() throws Exception {
+    String containedAndExpected = "something";
+
+    assertThat(Optional.of(containedAndExpected)).containsSame(containedAndExpected);
+  }
+
+  @Test
+  public void should_fail_if_optional_does_not_contain_expected_value() throws Exception {
+    Optional<String> actual = Optional.of("not-expected");
+    String expectedValue = "something";
+
+    thrown.expectAssertionError(shouldContainSame(actual, expectedValue).create());
+
+    assertThat(actual).containsSame(expectedValue);
+  }
+
+  @Test
+  public void should_fail_if_optional_contains_equal_but_not_same_value() throws Exception {
+    Optional<String> actual = Optional.of(new String("something"));
+    String expectedValue = new String("something");
+
+    thrown.expectAssertionError(shouldContainSame(actual, expectedValue).create());
+
+    assertThat(actual).containsSame(expectedValue);
+  }
+
+  @Test
+  public void should_fail_if_optional_is_empty() throws Exception {
+    String expectedValue = "something";
+
+    thrown.expectAssertionError(shouldContain(expectedValue).create());
+
+    assertThat(Optional.empty()).containsSame(expectedValue);
+  }
+}


### PR DESCRIPTION
There are times when it is necessary to assert that an `Optional` not only contains an equal instance but a specific one, i.e. the _same_ which is given to the assertion. (E.g. when working with classes which do not properly implement `equals` or the implemented `equals` is - for some reason or another - not sufficient in a given situation.)

These assertions should then fail:

```java
	assertThat(Optional.of(new String("something"))).containsSame(new String("something"));
	assertThat(Optional.of(new Integer(10))).containsSame(new Integer(10));
```

This pull request implements `containsSame` which tests for reference equality.