### PR TITLE
CheckReturnValue annotation on *Assert objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
       <version>2.2.2</version>

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -36,6 +36,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BigDecimalAssert assertThat(BigDecimal actual) {
 	return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -46,6 +47,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert assertThat(boolean actual) {
 	return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -56,6 +58,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert assertThat(Boolean actual) {
 	return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -66,6 +69,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanArrayAssert assertThat(boolean[] actual) {
 	return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -76,6 +80,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert assertThat(byte actual) {
 	return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -86,6 +91,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert assertThat(Byte actual) {
 	return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -96,6 +102,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteArrayAssert assertThat(byte[] actual) {
 	return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -106,6 +113,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert assertThat(char actual) {
 	return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -116,6 +124,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharArrayAssert assertThat(char[] actual) {
 	return proxy(CharArrayAssert.class, char[].class, actual);
   }
@@ -126,6 +135,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert assertThat(Character actual) {
 	return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -138,6 +148,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public SoftAssertionClassAssert assertThat(Class<?> actual) {
 	return proxy(SoftAssertionClassAssert.class, Class.class, actual);
   }
@@ -149,6 +160,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> assertThat(Iterable<? extends T> actual) {
 	return proxy(IterableAssert.class, Iterable.class, actual);
   }
@@ -162,6 +174,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> assertThat(Iterator<T> actual) {
 	return proxy(IterableAssert.class, Iterator.class, actual);
   }
@@ -172,6 +185,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert assertThat(double actual) {
 	return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -182,6 +196,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert assertThat(Double actual) {
 	return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -192,6 +207,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleArrayAssert assertThat(double[] actual) {
 	return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -202,6 +218,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FileAssert assertThat(File actual) {
 	return proxy(FileAssert.class, File.class, actual);
   }
@@ -212,6 +229,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the path
    * @return the created assertion object
    */
+  @CheckReturnValue
   public PathAssert assertThat(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
@@ -222,6 +240,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public InputStreamAssert assertThat(InputStream actual) {
 	return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -232,6 +251,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert assertThat(float actual) {
 	return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -242,6 +262,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert assertThat(Float actual) {
 	return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -252,6 +273,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatArrayAssert assertThat(float[] actual) {
 	return proxy(FloatArrayAssert.class, float[].class, actual);
   }
@@ -262,6 +284,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert assertThat(int actual) {
 	return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -272,6 +295,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntArrayAssert assertThat(int[] actual) {
 	return proxy(IntArrayAssert.class, int[].class, actual);
   }
@@ -282,6 +306,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert assertThat(Integer actual) {
 	return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -293,6 +318,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ListAssert<T> assertThat(List<? extends T> actual) {
 	return proxy(ListAssert.class, List.class, actual);
   }
@@ -303,6 +329,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert assertThat(long actual) {
 	return proxy(LongAssert.class, Long.class, actual);
   }
@@ -313,6 +340,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert assertThat(Long actual) {
 	return proxy(LongAssert.class, Long.class, actual);
   }
@@ -323,6 +351,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongArrayAssert assertThat(long[] actual) {
 	return proxy(LongArrayAssert.class, long[].class, actual);
   }
@@ -334,6 +363,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectAssert<T> assertThat(T actual) {
 	return proxy(ObjectAssert.class, Object.class, actual);
   }
@@ -345,6 +375,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectArrayAssert<T> assertThat(T[] actual) {
 	return proxy(ObjectArrayAssert.class, Object[].class, actual);
   }
@@ -358,6 +389,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <K, V> SoftAssertionMapAssert<K, V> assertThat(Map<K, V> actual) {
 	return proxy(SoftAssertionMapAssert.class, Map.class, actual);
   }
@@ -368,6 +400,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert assertThat(short actual) {
 	return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -378,6 +411,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert assertThat(Short actual) {
 	return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -388,6 +422,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortArrayAssert assertThat(short[] actual) {
 	return proxy(ShortArrayAssert.class, short[].class, actual);
   }
@@ -398,6 +433,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharSequenceAssert assertThat(CharSequence actual) {
 	return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -408,6 +444,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public StringAssert assertThat(String actual) {
 	return proxy(StringAssert.class, String.class, actual);
   }
@@ -418,6 +455,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DateAssert assertThat(Date actual) {
 	return proxy(DateAssert.class, Date.class, actual);
   }
@@ -428,6 +466,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
+  @CheckReturnValue
   public ThrowableAssert assertThat(Throwable actual) {
 	return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -468,6 +507,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -478,6 +518,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public UriAssert assertThat(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/AssertProvider.java
+++ b/src/main/java/org/assertj/core/api/AssertProvider.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * Provides a {@link Assert} for the current object.
  * 
@@ -53,6 +55,7 @@ public interface AssertProvider<A> {
    * 
    * @return the assert object for use in cunjunction with {@link Assertions#assertThat(AssertProvider)}
    */
+  @CheckReturnValue
   A assertThat();
 
 }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.CheckReturnValue;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.api.filter.FilterOperator;
@@ -88,6 +89,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
@@ -98,6 +100,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return new UriAssert(actual);
   }
@@ -108,6 +111,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return new UrlAssert(actual);
   }
@@ -118,6 +122,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -128,6 +133,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -138,6 +144,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
@@ -148,6 +155,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return new ByteAssert(actual);
   }
@@ -158,6 +166,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
@@ -168,6 +177,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
@@ -178,6 +188,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return new CharacterAssert(actual);
   }
@@ -188,6 +199,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
@@ -198,6 +210,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
@@ -208,6 +221,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
@@ -219,6 +233,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
@@ -229,6 +244,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, ? extends Iterable<? extends T>, T> assertThat(Iterable<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
@@ -243,6 +259,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, ? extends Iterable<? extends T>, T> assertThat(Iterator<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
@@ -253,6 +270,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return new DoubleAssert(actual);
   }
@@ -263,6 +281,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
@@ -273,6 +292,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
@@ -283,6 +303,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return new FileAssert(actual);
   }
@@ -293,6 +314,7 @@ public class Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
+  @CheckReturnValue
   public static AbstractPathAssert<?> assertThat(Path actual)
   {
     return new PathAssert(actual);
@@ -304,6 +326,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
@@ -314,6 +337,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return new FloatAssert(actual);
   }
@@ -324,6 +348,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return new FloatAssert(actual);
   }
@@ -334,6 +359,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
@@ -344,6 +370,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return new IntegerAssert(actual);
   }
@@ -354,6 +381,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
@@ -364,6 +392,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
@@ -374,6 +403,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractListAssert<?, ? extends List<? extends T>, T> assertThat(List<? extends T> actual) {
     return new ListAssert<>(actual);
   }
@@ -384,6 +414,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return new LongAssert(actual);
   }
@@ -394,6 +425,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return new LongAssert(actual);
   }
@@ -404,6 +436,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
@@ -414,6 +447,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
@@ -475,6 +509,7 @@ public class Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
@@ -490,6 +525,7 @@ public class Assertions {
    *          the component that creates its own assert
    * @return the associated {@link Assert} of the given component
    */
+  @CheckReturnValue
   public static <T> T assertThat(final AssertProvider<T> component) {
     return component.assertThat();
   }
@@ -500,6 +536,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
@@ -513,6 +550,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return new MapAssert<>(actual);
   }
@@ -523,6 +561,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return new ShortAssert(actual);
   }
@@ -533,6 +572,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return new ShortAssert(actual);
   }
@@ -543,6 +583,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
@@ -553,6 +594,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
@@ -563,6 +605,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> assertThat(String actual) {
     return new StringAssert(actual);
   }
@@ -573,6 +616,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return new DateAssert(actual);
   }
@@ -583,6 +627,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
@@ -621,6 +666,7 @@ public class Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }


### PR DESCRIPTION
A common mistake programmers make when using assertj is to create an assertion object but forget to call any methods on it (e.g. `assertThat(obj);` vs. `assertThat(obj).isTrue();`).

By adding the`@CheckReturnValue` annotation to `public static *Assert assertThat(*)` methods, static analysis tools will warn when programmers forget to call any methods on the returned assertion object.