### PR TITLE
Add assertThatThrownBy & catchThrowable to WithAssertions

### DIFF
--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.DoesNotHave;
 import org.assertj.core.condition.Not;
@@ -606,6 +607,20 @@ public interface WithAssertions {
    */
   default public AbstractOffsetDateTimeAssert<?> assertThat(final OffsetDateTime offsetDateTime) {
       return Assertions.assertThat(offsetDateTime);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThatThrownBy(ThrowingCallable)}
+   */
+  default public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
+    return Assertions.assertThatThrownBy(shouldRaiseThrowable);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#catchThrowable(ThrowingCallable)}
+   */
+  default public Throwable catchThrowable(final ThrowingCallable shouldRaiseThrowable) {
+    return Assertions.catchThrowable(shouldRaiseThrowable);
   }
 
   // --------------------------------------------------------------------------------------------------

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.time.LocalDate;
@@ -676,5 +677,24 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   @Test
   public void withAssertions_assertThat_offset_date_time_Test() {
         assertThat(OffsetDateTime.now()).isNotNull();
-    }
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThatThrownBy_Test() {
+    assertThatThrownBy(() -> { throw new IOException("message"); }).hasMessage("message");
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_catchThrowable_Test() {
+    Throwable t = catchThrowable(() -> {
+      throw new IOException("message");
+    });
+    assertThat(t).hasMessage("message");
+  }
 }


### PR DESCRIPTION
This patch adds `assertThatThrownBy` and `catchThrowable` to the `WithAssertions` interface. 

Having to import `Assertions` because those two very useful methods are absent from the interface is annoying. Lets add them ! 