### PR TITLE
Fix typos ('proxyies' -> 'proxies') and broken bit.ly links (bit.ly/a…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -28,7 +28,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all assertions.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -24,7 +24,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link BigDecimal}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractBooleanAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBooleanAssert.java
@@ -20,7 +20,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Boolean}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Byte}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -28,7 +28,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@code CharSequence}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
@@ -21,7 +21,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Character}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -19,7 +19,7 @@ import org.assertj.core.internal.Classes;
 /**
  * Base class for all implementations of assertions for {@link Class}es.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractComparableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractComparableAssert.java
@@ -21,7 +21,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of <code>{@link ComparableAssert}</code>.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -51,7 +51,7 @@ import org.assertj.core.util.VisibleForTesting;
  * the test suite.<br>
  * To turn back to default format, simply call {@link #withDefaultDateFormatsOnly()}.
  *
- * @param <S> the "self" type of this assertion class. Please read "<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read "<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>" for
  *          more details.
  * @author Tomasz Nurkiewicz (thanks for giving assertions idea)

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Double}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -22,7 +22,7 @@ import java.nio.charset.Charset;
 /**
  * Base class for all implementations of assertions for {@link File}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Float}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -21,7 +21,7 @@ import org.assertj.core.util.VisibleForTesting;
 
 /**
  * Base class for all implementations of assertions for {@link InputStream}s.
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Integer}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -49,7 +49,7 @@ import org.assertj.core.util.introspection.IntrospectionError;
  * Base class for implementations of <code>{@link ObjectEnumerableAssert}</code> whose actual value type is
  * <code>{@link Collection}</code>.
  *
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractListAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractListAssert.java
@@ -22,7 +22,7 @@ import org.assertj.core.util.VisibleForTesting;
 
 /**
  * Base class for all implementations of assertions for {@link List}s.
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Long}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -25,7 +25,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Map}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -17,7 +17,7 @@ import org.assertj.core.util.introspection.IntrospectionError;
 /**
  * Base class for all implementations of assertions for {@link Object}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Short}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -19,7 +19,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Base class for all implementations of assertions for {@link Throwable}s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/ArraySortedAssert.java
+++ b/src/main/java/org/assertj/core/api/ArraySortedAssert.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
  * comparator due to type erasure.
  * 
  * @param <S> the "self" type of this assertion class that must be a array type (e.g. arrays, collections).<br>
- *          Please read &quot;<a href="http://bit.ly/anMa4g" target="_blank">Emulating 'self types' using Java Generics to
+ *          Please read &quot;<a href="http://bit.ly/1IZIRcY" target="_blank">Emulating 'self types' using Java Generics to
  *          simplify fluent API implementation</a>&quot; for more details.
  * @param <E> the array element type.
  * 

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -17,7 +17,7 @@ import java.util.Comparator;
 /**
  * Base contract of all assertion objects: the minimum functionality that any assertion object should provide.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/AutoCloseableBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AutoCloseableBDDSoftAssertions.java
@@ -95,7 +95,7 @@ package org.assertj.core.api;
  * </p>
  * 
  * <p>
- * SoftAssertions works by providing you with proxyies of the AssertJ assertion objects (those created by
+ * SoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link Assertions}#assertThat...) whose assertion failures are caught and stored. Only when you call
  * {@link AutoCloseableBDDSoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error
  * messages of those previously caught assertion failures.

--- a/src/main/java/org/assertj/core/api/AutoCloseableSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AutoCloseableSoftAssertions.java
@@ -95,7 +95,7 @@ package org.assertj.core.api;
  * </p>
  * 
  * <p>
- * SoftAssertions works by providing you with proxyies of the AssertJ assertion objects (those created by
+ * SoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link Assertions}#assertThat...) whose assertion failures are caught and stored. Only when you call
  * {@link AutoCloseableSoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error
  * messages of those previously caught assertion failures.

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
@@ -96,7 +96,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * </p>
  * 
  * <p>
- * BDDSoftAssertions works by providing you with proxyies of the AssertJ assertion objects (those created by
+ * BDDSoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link BDDAssertions}#then...) whose assertion failures are caught and stored. Only when you call
  * {@link BDDSoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of
  * those previously caught assertion failures.

--- a/src/main/java/org/assertj/core/api/ComparableAssert.java
+++ b/src/main/java/org/assertj/core/api/ComparableAssert.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 /**
  * Assertion methods applicable to <code>{@link Comparable}</code>s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/Descriptable.java
+++ b/src/main/java/org/assertj/core/api/Descriptable.java
@@ -18,7 +18,7 @@ import org.assertj.core.description.EmptyTextDescription;
 /**
  * An object that has a description.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 

--- a/src/main/java/org/assertj/core/api/EnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/EnumerableAssert.java
@@ -17,7 +17,7 @@ import java.util.Comparator;
 /**
  * Assertions applicable to groups of values that can be enumerated (e.g. arrays, collections or strings.)
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <E> the type of elements of the "actual" value.

--- a/src/main/java/org/assertj/core/api/ExtensionPoints.java
+++ b/src/main/java/org/assertj/core/api/ExtensionPoints.java
@@ -15,7 +15,7 @@ package org.assertj.core.api;
 
 /**
  * Mechanism for extending assertion classes.
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g" target="_blank">Emulating
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY" target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.
  * 

--- a/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
+++ b/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
@@ -16,7 +16,7 @@ import org.assertj.core.data.Offset;
 
 /**
  * Assertion methods applicable to floating-point <code>{@link Number}</code>s.
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g" target="_blank">Emulating
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY" target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.
  * 

--- a/src/main/java/org/assertj/core/api/IndexedObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/IndexedObjectEnumerableAssert.java
@@ -16,7 +16,7 @@ import org.assertj.core.data.Index;
 
 /**
  * Assertions methods applicable to indexed groups of objects (e.g. arrays or lists.)
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g" target="_blank">Emulating
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY" target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <T> the type of elements of the "actual" value.
  * 

--- a/src/main/java/org/assertj/core/api/NumberAssert.java
+++ b/src/main/java/org/assertj/core/api/NumberAssert.java
@@ -18,7 +18,7 @@ import org.assertj.core.data.Percentage;
 /**
  * Assertion methods applicable to <code>{@link Number}</code>s.
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -17,7 +17,7 @@ import java.util.HashSet;
 /**
  * Assertions methods applicable to groups of objects (e.g. arrays or collections.)
  * 
- * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <T> the type of elements of the "actual" value.

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -96,7 +96,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * </p>
  * 
  * <p>
- * SoftAssertions works by providing you with proxyies of the AssertJ assertion objects (those created by
+ * SoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link Assertions}#assertThat...) whose assertion failures are caught and stored. Only when you call
  * {@link SoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of those
  * previously caught assertion failures.


### PR DESCRIPTION
…nMa4g is now a dead link; updated to bit.ly/1IZIRcY, which is the Internet Archive's most recent scrape of the dead link's target).