### PR TITLE
#438: Better spacing for javadoc code examples

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -83,9 +83,7 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * defined by the user with {@link #overridingErrorMessage(String, Object...)}.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * public TolkienCharacterAssert hasName(String name) {
+   * <pre><code class='java'> public TolkienCharacterAssert hasName(String name) {
    *   // check that actual TolkienCharacter we want to make assertions on is not null.
    *   isNotNull();
    * 
@@ -96,8 +94,7 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * 
    *   // return the current assertion for method chaining
    *   return this;
-   * }
-   * </code></pre>
+   * }</code></pre>
    * 
    * @param errorMessage the error message to format
    * @param arguments the arguments referenced by the format specifiers in the errorMessage string.
@@ -128,28 +125,22 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * thus impossible to find differences from the standard error message:
    * <p/>
    * With standard message:
-   * 
-   * <pre><code class='java'>
-   * assertThat("µµµ").contains("μμμ");
+   * <pre><code class='java'> assertThat("µµµ").contains("μμμ");
    *
    * java.lang.AssertionError:
    * Expecting:
    *   <"µµµ">
    * to contain:
-   *   <"μμμ">
-   * </code></pre>
+   *   <"μμμ"></code></pre>
    *
    * With Hexadecimal message:
-   * 
-   * <pre><code class='java'>
-   * assertThat("µµµ").inHexadecimal().contains("μμμ");
+   * <pre><code class='java'> assertThat("µµµ").inHexadecimal().contains("μμμ");
    *
    * java.lang.AssertionError:
    * Expecting:
    *   <"['00B5', '00B5', '00B5']">
    * to contain:
-   *   <"['03BC', '03BC', '03BC']">
-   * </code></pre>
+   *   <"['03BC', '03BC', '03BC']"></code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -162,14 +153,11 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * Use binary object representation instead of standard representation in error messages.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * assertThat(1).inBinary().isEqualTo(2);
+   * <pre><code class='java'> assertThat(1).inBinary().isEqualTo(2);
    *
    * org.junit.ComparisonFailure:
    * Expected :0b00000000_00000000_00000000_00000010
-   * Actual   :0b00000000_00000000_00000000_00000001
-   * </code></pre>
+   * Actual   :0b00000000_00000000_00000000_00000001</code></pre>
    * 
    * @return {@code this} assertion object.
    */
@@ -398,11 +386,8 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * don't, the error message is taken as it is).
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(player.isRookie()).overridingErrorMessage(&quot;Expecting Player &lt;%s&gt; to be a rookie but was not.&quot;, player)
-   *                              .isTrue();
-   * </code></pre>
+   * <pre><code class='java'>assertThat(player.isRookie()).overridingErrorMessage(&quot;Expecting Player &lt;%s&gt; to be a rookie but was not.&quot;, player)
+   *                              .isTrue();</code></pre>
    * 
    * @param newErrorMessage the error message that will replace the default one provided by Assertj.
    * @param args the args used to fill error message as in {@link String#format(String, Object...)}.

--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -437,24 +437,16 @@ public abstract class AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * 
    * <p>
    * Java 8 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   *  {@literal @}Test
+   * <pre><code class='java'> {@literal @}Test
    *  public void testException() {
    *    BDDSoftAssertions softly = new BDDSoftAssertions();
    *    softly.thenThrownBy(() -> { throw new Exception("boom!") }).isInstanceOf(Exception.class)
    *                                                               .hasMessageContaining("boom");
-   *  }
-   * </code></pre>
+   *  }</code></pre>
    * 
-   * <p>
    * Java 7 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * BDDSoftAssertions softly = new BDDSoftAssertions();
-   * softly.thenThrownBy(new ThrowingCallable()
+   * <pre><code class='java'> BDDSoftAssertions softly = new BDDSoftAssertions();
+   * softly.thenThrownBy(new ThrowingCallable() {
    * 
    *   {@literal @}Override
    *   public Void call() throws Exception {
@@ -462,8 +454,7 @@ public abstract class AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    *   }
    *   
    * }).isInstanceOf(Exception.class)
-   *   .hasMessageContaining("boom");
-   * </code></pre>
+   *   .hasMessageContaining("boom");</code></pre>
    *
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.

--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -49,14 +49,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(BigDecimal.ZERO).isZero();
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;8.00&quot;)).isZero();
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.00&quot;)).isZero();</code></pre>
    * 
    * </p>
    */
@@ -70,14 +67,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;8.00&quot;)).isNotZero();
    * 
    * // assertion will fail
-   * assertThat(BigDecimal.ZERO).isNotZero();
-   * </code></pre>
+   * assertThat(BigDecimal.ZERO).isNotZero();</code></pre>
    * 
    * </p>
    */
@@ -91,14 +85,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isPositive();
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;-8.0&quot;)).isPositive();
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;-8.0&quot;)).isPositive();</code></pre>
    * 
    * </p>
    */
@@ -112,14 +103,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;-8.0&quot;)).isNegative();
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNegative();
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNegative();</code></pre>
    * 
    * </p>
    */
@@ -133,14 +121,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;-8.0&quot;)).isNotPositive();
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotPositive();
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotPositive();</code></pre>
    * 
    * </p>
    */
@@ -154,14 +139,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotNegative();
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;-8.0&quot;)).isNotNegative();
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;-8.0&quot;)).isNotNegative();</code></pre>
    * 
    * </p>
    */
@@ -175,17 +157,15 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * Verifies that the actual value is in [start, end] range (start and end included).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;9.0&quot;));
    * assertThat(new BigDecimal(&quot;8.00&quot;)).isBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;9.0&quot;));
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isBetween(new BigDecimal(&quot;8.0&quot;), new BigDecimal(&quot;9.0&quot;));
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;8.0&quot;));
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isBetween(new BigDecimal(&quot;6.0&quot;), new BigDecimal(&quot;7.0&quot;));
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isBetween(new BigDecimal(&quot;6.0&quot;), new BigDecimal(&quot;7.0&quot;));</code></pre>
+   * 
    * Note that comparison of {@link BigDecimal} is done by value without scale consideration, i.e 2.0 and 2.00 are
    * considered equal in value (not like {@link BigDecimal#equals(Object)}.
    * </p>
@@ -201,15 +181,12 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    *
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isStrictlyBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;9.0&quot;));
    * 
    * // assertions will fail
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isStrictlyBetween(new BigDecimal(&quot;8.0&quot;), new BigDecimal(&quot;9.0&quot;));
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isStrictlyBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;8.0&quot;));
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isStrictlyBetween(new BigDecimal(&quot;7.0&quot;), new BigDecimal(&quot;8.0&quot;));</code></pre>
    * 
    * </p>
    */
@@ -224,14 +201,11 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * {@link BigDecimal} for you.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualTo(&quot;8.0&quot;);
    * 
    * // assertion will fail because 8.00 is not equals to 8.0
-   * assertThat(new BigDecimal(&quot;8.00&quot;)).isEqualTo(&quot;8.0&quot;);
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.00&quot;)).isEqualTo(&quot;8.0&quot;);</code></pre>
    * 
    * </p>
    */
@@ -244,16 +218,13 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * takes care of converting given String to {@link BigDecimal} for you.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualByComparingTo(&quot;8.0&quot;);
    * // assertion will pass because 8.0 is equals to 8.00 using {@link BigDecimal#compareTo(Object)}
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualByComparingTo(&quot;8.00&quot;);
    * 
    * // assertion will fail
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualByComparingTo(&quot;2.0&quot;);
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualByComparingTo(&quot;2.0&quot;);</code></pre>
    */
   public S isEqualByComparingTo(String expected) {
     return isEqualByComparingTo(new BigDecimal(expected));
@@ -278,9 +249,7 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * final BigDecimal actual = new BigDecimal("8.1");
+   * <pre><code class='java'> final BigDecimal actual = new BigDecimal("8.1");
    * final BigDecimal other =  new BigDecimal("8.0");
    *
    * // valid assertion
@@ -293,8 +262,7 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * assertThat(actual).isCloseTo(new BigDecimal("8.00"), within(new BigDecimal("0.100")));
    *
    * // but if difference is greater than given offset value assertion will fail :
-   * assertThat(actual).isCloseTo(other, within(new BigDecimal("0.01")));
-   * </code></pre>
+   * assertThat(actual).isCloseTo(other, within(new BigDecimal("0.01")));</code></pre>
    */
   @Override
   public S isCloseTo(final BigDecimal other, final Offset<BigDecimal> offset) {
@@ -307,17 +275,14 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with BigDecimal:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(20d)));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(10d)));
    *
    * // assertion will fail
-   * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(5d)));
-   * </code></pre>
+   * assertThat(BigDecimal.valueOf(11.0)).isCloseTo(BigDecimal.valueOf(10.0), withinPercentage(BigDecimal.valueOf(5d)));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/AbstractBooleanArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBooleanArrayAssert.java
@@ -51,14 +51,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).hasSize(2);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true }).hasSize(2);
-   * </code></pre>
+   * assertThat(new boolean[] { true }).hasSize(2);</code></pre>
    * 
    * </p>
    * 
@@ -73,14 +70,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).hasSameSizeAs(Arrays.asList(1, 2));
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, false }).hasSameSizeAs(Arrays.asList(1, 2, 3));
-   * </code></pre>
+   * assertThat(new boolean[] { true, false }).hasSameSizeAs(Arrays.asList(1, 2, 3));</code></pre>
    * 
    * </p>
    */
@@ -94,16 +88,13 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains the given values, in any order.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).contains(true, false);
    * assertThat(new boolean[] { false, true }).contains(true, false);
    * assertThat(new boolean[] { true, false }).contains(true);
    *
    * // assertion will fail
-   * assertThat(new boolean[] { true, true }).contains(false);
-   * </code></pre>
+   * assertThat(new boolean[] { true, true }).contains(false);</code></pre>
    * 
    * </p>
    * 
@@ -123,15 +114,12 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).containsOnly(true, false);
    * assertThat(new boolean[] { true, false, false, true }).containsOnly(true, false);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, false }).containsOnly(false);
-   * </code></pre>
+   * assertThat(new boolean[] { true, false }).containsOnly(false);</code></pre>
    * 
    * </p>
    * 
@@ -152,16 +140,13 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).containsOnlyOnce(true, false);
    * 
    * // assertions will fail
    * assertThat(new boolean[] { true, false, true }).containsOnlyOnce(true);
    * assertThat(new boolean[] { true }).containsOnlyOnce(false);
-   * assertThat(new boolean[] { true }).containsOnlyOnce(true, false);
-   * </code></pre>
+   * assertThat(new boolean[] { true }).containsOnlyOnce(true, false);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -180,15 +165,12 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).containsSequence(true, false);
    * assertThat(new boolean[] { true, false, false, true }).containsSequence(false, true);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, true, false }).containsSequence(false, true);
-   * </code></pre>
+   * assertThat(new boolean[] { true, true, false }).containsSequence(false, true);</code></pre>
    * 
    * </p>
    * 
@@ -207,15 +189,12 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).containsSubsequence(true, false);
    * assertThat(new boolean[] { true, false, false, true }).containsSubsequence(true, true);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, true, false }).containsSubsequence(false, true);
-   * </code></pre>
+   * assertThat(new boolean[] { true, true, false }).containsSubsequence(false, true);</code></pre>
    * 
    * </p>
    * 
@@ -234,16 +213,13 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array contains the given value at the given index.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).contains(true, atIndex(O));
    * assertThat(new boolean[] { true, false }).contains(false, atIndex(1));
    * 
    * // assertion will fail
    * assertThat(new boolean[] { true, false }).contains(false, atIndex(0));
-   * assertThat(new boolean[] { true, false }).contains(true, atIndex(1));
-   * </code></pre>
+   * assertThat(new boolean[] { true, false }).contains(true, atIndex(1));</code></pre>
    * 
    * </p>
    * 
@@ -265,14 +241,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array does not contain the given values.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, true }).doesNotContain(false);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, true, false }).doesNotContain(false);
-   * </code></pre>
+   * assertThat(new boolean[] { true, true, false }).doesNotContain(false);</code></pre>
    * 
    * </p>
    * 
@@ -292,16 +265,13 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array does not contain the given value at the given index.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).doesNotContain(true, atIndex(1));
    * assertThat(new boolean[] { true, false }).doesNotContain(false, atIndex(0));
    *
    * // assertion will fail
    * assertThat(new boolean[] { true, false }).doesNotContain(false, atIndex(1));
-   * assertThat(new boolean[] { true, false }).doesNotContain(true, atIndex(0));
-   * </code></pre>
+   * assertThat(new boolean[] { true, false }).doesNotContain(true, atIndex(0));</code></pre>
    *
    * </p>
    * 
@@ -321,14 +291,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual array does not contain duplicates.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false }).doesNotHaveDuplicates();
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, true, false }).doesNotHaveDuplicates();
-   * </code></pre>
+   * assertThat(new boolean[] { true, true, false }).doesNotHaveDuplicates();</code></pre>
    * 
    * </p>
    * 
@@ -347,14 +314,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * sequence is also first element of the actual array.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false, false, true }).startsWith(true, false);
    * 
    * // assertion will fail
-   * assertThat(new boolean[] { true, false, false, true }).startsWith(false, false, true);
-   * </code></pre>
+   * assertThat(new boolean[] { true, false, false, true }).startsWith(false, false, true);</code></pre>
    * 
    * </p>
    * 
@@ -376,14 +340,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * sequence is also last element of the actual array.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false, false, true }).endsWith(false, false, true);
    *
    * // assertion will fail
-   * assertThat(new boolean[] { true, false, false, true }).endsWith(true, false);
-   * </code></pre>
+   * assertThat(new boolean[] { true, false, false, true }).endsWith(true, false);</code></pre>
    *
    * </p>
    * @param sequence the sequence of values to look for.
@@ -440,14 +401,11 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new boolean[] { true, false, true }).containsExactly(true, false, true);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(new boolean[] { true, false, true }).containsExactly(false, true, true);
-   * </code></pre>
+   * assertThat(new boolean[] { true, false, true }).containsExactly(false, true, true);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -52,14 +52,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * {@inheritDoc}
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).hasSize(3);
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 2, 3, 4 }).hasSize(3);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3, 4 }).hasSize(3);</code></pre>
    *
    * </p>
    */
@@ -73,13 +70,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * {@inheritDoc}
    * <p/>
    * Examples:
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2 }).hasSameSizeAs(Arrays.asList(2, 3));
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 2 }).hasSameSizeAs(Arrays.asList(1, 2, 3));
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2 }).hasSameSizeAs(Arrays.asList(1, 2, 3));</code></pre>
    */
   @Override
   public S hasSameSizeAs(Iterable<?> other) {
@@ -91,17 +86,14 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains the given values, in any order.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).contains(1, 2);
    * assertThat(new byte[] { 1, 2, 3 }).contains(3, 1);
    * assertThat(new byte[] { 1, 2, 3 }).contains(1, 3, 2);
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).contains(1, 4);
-   * assertThat(new byte[] { 1, 2, 3 }).contains(4, 7);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).contains(4, 7);</code></pre>
    *
    * </p>
    *
@@ -121,16 +113,13 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).containsOnly(1, 2, 3);
    * assertThat(new byte[] { 1, 2, 3 }).containsOnly(2, 3, 1);
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).containsOnly(1, 2, 3, 4);
-   * assertThat(new byte[] { 1, 2, 3 }).containsOnly(4, 7);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).containsOnly(4, 7);</code></pre>
    *
    * </p>
    *
@@ -153,16 +142,13 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).containsOnlyOnce(1, 2);
    *
    * // assertions will fail
    * assertThat(new byte[] { 1, 2, 1 }).containsOnlyOnce(1);
    * assertThat(new byte[] { 1, 2, 3 }).containsOnlyOnce(4);
-   * assertThat(new byte[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);</code></pre>
    *
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -183,17 +169,14 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).containsSequence(1, 2);
    * assertThat(new byte[] { 1, 2, 3 }).containsSequence(1, 2, 3);
    * assertThat(new byte[] { 1, 2, 3 }).containsSequence(2, 3);
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).containsSequence(1, 3);
-   * assertThat(new byte[] { 1, 2, 3 }).containsSequence(4, 7);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).containsSequence(4, 7);</code></pre>
    *
    * </p>
    *
@@ -212,9 +195,7 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).containsSubsequence(1, 2, 3);
    * assertThat(new byte[] { 1, 2, 3 }).containsSubsequence(1, 2);
    * assertThat(new byte[] { 1, 2, 3 }).containsSubsubsequence(1, 3);
@@ -222,8 +203,7 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).containsSubsequence(2, 1);
-   * assertThat(new byte[] { 1, 2, 3 }).containsSubsequence(4, 7);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).containsSubsequence(4, 7);</code></pre>
    *
    * </p>
    *
@@ -242,16 +222,13 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array contains the given value at the given index.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).contains(1, atIndex(O));
    * assertThat(new byte[] { 1, 2, 3 }).contains(3, atIndex(2));
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).contains(1, atIndex(1));
-   * assertThat(new byte[] { 1, 2, 3 }).contains(4, atIndex(2));
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).contains(4, atIndex(2));</code></pre>
    *
    * </p>
    *
@@ -273,14 +250,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array does not contain the given values.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(4);
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(2);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(2);</code></pre>
    *
    * </p>
    *
@@ -300,16 +274,13 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array does not contain the given value at the given index.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(1, atIndex(1));
    * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(2, atIndex(0));
    *
    * // assertion will fail
    * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(1, atIndex(0));
-   * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(2, atIndex(1));
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).doesNotContain(2, atIndex(1));</code></pre>
    *
    * </p>
    *
@@ -329,14 +300,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual array does not contain duplicates.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).doesNotHaveDuplicates();
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 1, 2, 3 }).doesNotHaveDuplicates();
-   * </code></pre>
+   * assertThat(new byte[] { 1, 1, 2, 3 }).doesNotHaveDuplicates();</code></pre>
    *
    * </p>
    *
@@ -355,14 +323,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * sequence is also first element of the actual array.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).startsWith(1, 2);
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 2, 3 }).startsWith(2, 3);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).startsWith(2, 3);</code></pre>
    *
    * </p>
    *
@@ -384,14 +349,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * sequence is also last element of the actual array.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).endsWith(2, 3);
    *
    * // assertion will fail
-   * assertThat(new byte[] { 1, 2, 3 }).endsWith(3, 4);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).endsWith(3, 4);</code></pre>
    *
    * </p>
    *
@@ -439,14 +401,11 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new byte[] { 1, 2, 3 }).containsExactly(1, 2, 3);
    *
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(new byte[] { 1, 2, 3 }).containsExactly(2, 1, 3);
-   * </code></pre>
+   * assertThat(new byte[] { 1, 2, 3 }).containsExactly(2, 1, 3);</code></pre>
    *
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -88,14 +88,11 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 1).isPositive();
    * 
    * // assertion will fail
-   * assertThat((byte) -1).isPositive();
-   * </code></pre>
+   * assertThat((byte) -1).isPositive();</code></pre>
    * 
    * </p>
    */
@@ -109,14 +106,11 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) -1).isNegative();
    * 
    * // assertion will fail
-   * assertThat((byte) 1).isNegative();
-   * </code></pre>
+   * assertThat((byte) 1).isNegative();</code></pre>
    * 
    * </p>
    */
@@ -130,14 +124,11 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 1).isNotNegative();
    * 
    * // assertion will fail
-   * assertThat((byte) -1).isNotNegative();
-   * </code></pre>
+   * assertThat((byte) -1).isNotNegative();</code></pre>
    * 
    * </p>
    */
@@ -151,14 +142,11 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) -1).isNotPositive();
    * 
    * // assertion will fail
-   * assertThat((byte) 1).isNotPositive();
-   * </code></pre>
+   * assertThat((byte) 1).isNotPositive();</code></pre>
    * 
    * </p>
    */
@@ -172,15 +160,12 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * Verifies that the actual value is less than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 1).isLessThan(2);
    * 
    * // assertion will fail
    * assertThat((byte) 1).isLessThan(0);
-   * assertThat((byte) 1).isLessThan(1);
-   * </code></pre>
+   * assertThat((byte) 1).isLessThan(1);</code></pre>
    * 
    * </p>
    * 
@@ -198,15 +183,12 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * Verifies that the actual value is less than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 1).isLessThanOrEqualTo(2);
    * assertThat((byte) 1).isLessThanOrEqualTo(1);
    * 
    * // assertion will fail
-   * assertThat((byte) 1).isLessThanOrEqualTo(0);
-   * </code></pre>
+   * assertThat((byte) 1).isLessThanOrEqualTo(0);</code></pre>
    * 
    * </p>
    * 
@@ -224,15 +206,12 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * Verifies that the actual value is greater than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 2).isGreaterThan(1);
    * 
    * // assertion will fail
    * assertThat((byte) 2).isGreaterThan(3);
-   * assertThat((byte) 2).isGreaterThan(2);
-   * </code></pre>
+   * assertThat((byte) 2).isGreaterThan(2);</code></pre>
    * 
    * </p>
    * 
@@ -250,15 +229,12 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * Verifies that the actual value is greater than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 2).isGreaterThanOrEqualTo(1);
    * assertThat((byte) 2).isGreaterThanOrEqualTo(2);
    *
    * // assertion will fail
-   * assertThat((byte) 2).isGreaterThanOrEqualTo(3);
-   * </code></pre>
+   * assertThat((byte) 2).isGreaterThanOrEqualTo(3);</code></pre>
    * 
    * </p>
    * 
@@ -277,16 +253,13 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    *
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat((byte) 1).isBetween((byte) -1, (byte) 2);
    * assertThat((byte) 1).isBetween((byte) 1, (byte) 2);
    * assertThat((byte) 1).isBetween((byte) 0, (byte) 1);
    * 
    * // assertion will fail
-   * assertThat((byte) 1).isBetween((byte) 2, (byte) 3);
-   * </code></pre>
+   * assertThat((byte) 1).isBetween((byte) 2, (byte) 3);</code></pre>
    * 
    * </p>
    */
@@ -301,16 +274,13 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    *
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat((byte) 1).isStrictlyBetween((byte) -1, (byte) 2);
    * 
    * // assertions will fail
    * assertThat((byte) 1).isStrictlyBetween((byte) 1, (byte) 2);
    * assertThat((byte) 1).isStrictlyBetween((byte) 0, (byte) 1);
-   * assertThat((byte) 1).isStrictlyBetween((byte) 2, (byte) 3);
-   * </code></pre>
+   * assertThat((byte) 1).isStrictlyBetween((byte) 2, (byte) 3);</code></pre>
    * 
    * </p>
    */
@@ -325,17 +295,14 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((byte)5).isCloseTo((byte)7, within((byte)3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat((byte)5).isCloseTo((byte)7, within((byte)2));
    *
    * // assertion will fail
-   * assertThat((byte)5).isCloseTo((byte)7, within((byte)1));
-   * </code></pre>
+   * assertThat((byte)5).isCloseTo((byte)7, within((byte)1));</code></pre>
    *
    * @param expected the given byte to compare the actual value to.
    * @param offset the given positive offset.
@@ -353,17 +320,14 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((byte)5).isCloseTo(new Byte("7"), within((byte)3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat((byte)5).isCloseTo(new Byte("7"), within((byte)2));
    *
    * // assertion will fail
-   * assertThat((byte)5).isCloseTo(new Byte("7"), within((byte)1));
-   * </code></pre>
+   * assertThat((byte)5).isCloseTo(new Byte("7"), within((byte)1));</code></pre>
    *
    * @param expected the given Byte to compare the actual value to.
    * @param offset the given positive offset.
@@ -383,17 +347,14 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with byte:
-   *
-   * <pre><code class='java'>
-     * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
      * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)20));
      *
      * // if difference is exactly equals to the computed offset (1), it's ok
      * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)10));
      *
      * // assertion will fail
-     * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)5));
-     * </code></pre>
+     * assertThat((byte)11).isCloseTo(Byte.valueOf(10), withinPercentage((byte)5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -413,17 +374,14 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with byte:
-   *
-   * <pre><code class='java'>
-     * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
      * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)20));
      *
      * // if difference is exactly equals to the computed offset (1), it's ok
      * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)10));
      *
      * // assertion will fail
-     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)5));
-     * </code></pre>
+     * assertThat((byte)11).isCloseTo((byte)10, withinPercentage((byte)5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
@@ -52,14 +52,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).hasSize(3);
    * 
    * // assertion will fail
-   * assertThat(new char[] { 'a', 'b', 'c', 'd' }).hasSize(3);
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c', 'd' }).hasSize(3);</code></pre>
    * 
    * </p>
    * 
@@ -74,14 +71,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * {@inheritDoc}
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b' }).hasSameSizeAs(Arrays.asList(1, 2));
    * 
    * // assertion will fail
-   * assertThat(new char[] { 'a', 'b' }).hasSameSizeAs(Arrays.asList(1, 2, 3));
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b' }).hasSameSizeAs(Arrays.asList(1, 2, 3));</code></pre>
    * 
    * </p>
    */
@@ -95,17 +89,14 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains the given values, in any order.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('a', 'b');
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('c', 'a');
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('a', 'c', 'b');
    *
    * // assertion will fail
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('a', 'd');
-   * assertThat(new char[] { 'a', 'b', 'c' }).contains('d', 'f');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).contains('d', 'f');</code></pre>
    * 
    * </p>
    * 
@@ -125,16 +116,13 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).containsOnly('a', 'b', 'c');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsOnly('b', 'c', 'a');
    *
    * // assertion will fail
    * * assertThat(new char[] { 'a', 'b', 'c' }).containsOnly('a', 'b', 'c', 'd');
-   * * assertThat(new char[] { 'a', 'b', 'c' }).containsOnly('d', 'f');
-   * </code></pre>
+   * * assertThat(new char[] { 'a', 'b', 'c' }).containsOnly('d', 'f');</code></pre>
    * 
    * </p>
    * 
@@ -155,16 +143,13 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).containsOnlyOnce('a', 'b');
    * 
    * // assertions will fail
    * assertThat(new char[] { 'a', 'b', 'a' }).containsOnlyOnce('a');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsOnlyOnce('d');
-   * assertThat(new char[] { 'a', 'b', 'c', 'c' }).containsOnlyOnce(0, 'a', 'b', 'c', 'd', 'e');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c', 'c' }).containsOnlyOnce(0, 'a', 'b', 'c', 'd', 'e');</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -183,17 +168,14 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('a', 'b');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('a', 'b', 'c');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('b', 'c');
    *
    * // assertion will fail
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('c', 'a');
-   * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('d', 'f');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).containsSequence('d', 'f');</code></pre>
    * 
    * </p>
    * 
@@ -212,9 +194,7 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('a', 'b');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('a', 'c');
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('b', 'c');
@@ -222,8 +202,7 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * 
    * // assertion will fail
    * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('c', 'a');
-   * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('d', 'f');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).containsSubsequence('d', 'f');</code></pre>
    * 
    * </p>
    * 
@@ -242,16 +221,13 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array contains the given value at the given index.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('a', atIndex(O));
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('c', atIndex(2));
    *
    * // assertion will fail
    * assertThat(new char[] { 'a', 'b', 'c' }).contains('a', atIndex(1));
-   * assertThat(new char[] { 'a', 'b', 'c' }).contains('d', atIndex(2));
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).contains('d', atIndex(2));</code></pre>
    * 
    * </p>
    * 
@@ -273,14 +249,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array does not contain the given values.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('d');
    * 
    * // assertion will fail
-   * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('b');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('b');</code></pre>
    * 
    * </p>
    * 
@@ -300,16 +273,13 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array does not contain the given value at the given index.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('a', atIndex(1));
    * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('b', atIndex(0));
    *
    * // assertion will fail
    * * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('a', atIndex(0));
-   * * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('b', atIndex(1));
-   * </code></pre>
+   * * assertThat(new char[] { 'a', 'b', 'c' }).doesNotContain('b', atIndex(1));</code></pre>
    * 
    * </p>
    * 
@@ -329,14 +299,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual array does not contain duplicates.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).doesNotHaveDuplicates();
    * 
    * // assertion will fail
-   * assertThat(new byte[] { 'a', 'a', 'b', 'c' }).doesNotHaveDuplicates();
-   * </code></pre>
+   * assertThat(new byte[] { 'a', 'a', 'b', 'c' }).doesNotHaveDuplicates();</code></pre>
    * 
    * </p>
    * 
@@ -355,14 +322,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * sequence is also first element of the actual array.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).startsWith('a', 'b');
    * 
    * // assertion will fail
-   * assertThat(new char[] { 'a', 'b', 'c' }).startsWith('b', 'c');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).startsWith('b', 'c');</code></pre>
    * 
    * </p>
    * 
@@ -384,14 +348,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * sequence is also last element of the actual array.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).endsWith('b', 'c');
    * 
    * // assertion will fail
-   * assertThat(new char[] { 'a', 'b', 'c' }).endsWith('c', 'd');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).endsWith('c', 'd');</code></pre>
    * 
    * </p>
    * 
@@ -439,14 +400,11 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new char[] { 'a', 'b', 'c' }).containsExactly('a', 'b', 'c');
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(new char[] { 'a', 'b', 'c' }).containsExactly('b', 'a', 'c');
-   * </code></pre>
+   * assertThat(new char[] { 'a', 'b', 'c' }).containsExactly('b', 'a', 'c');</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -465,22 +423,18 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
    * Use unicode character representation instead of standard representation in error messages.
    * <p/>
    * With standard error message:
-   * <pre><code class='java'>
-   * assertThat("a6c".toCharArray()).isEqualTo("abó".toCharArray());
+   * <pre><code class='java'> assertThat("a6c".toCharArray()).isEqualTo("abó".toCharArray());
    *
    * org.junit.ComparisonFailure:
    * Expected :['a', 'b', 'ó']
-   * Actual   :[a, 6, c]
-   * </code></pre>
+   * Actual   :[a, 6, c]</code></pre>
    *
    * With unicode based error message:
-   * <pre><code class='java'>
-   * assertThat("a6c".toCharArray()).inUnicode().isEqualTo("abó".toCharArray());
+   * <pre><code class='java'> assertThat("a6c".toCharArray()).inUnicode().isEqualTo("abó".toCharArray());
    *
    * org.junit.ComparisonFailure:
    * Expected :[a, b, \u00f3]
-   * Actual   :[a, 6, c]
-   * </code></pre>
+   * Actual   :[a, 6, c]</code></pre>
    *
    * @return {@code this} assertion object.
    */

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -57,14 +57,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * {@link org.assertj.core.api.AbstractCharSequenceAssert#isEmpty()} instead.
    * <p>
    * Both of these assertions will succeed:
-   * 
-   * <pre><code class='java'>
-   * String emptyString = &quot;&quot;
+   * <pre><code class='java'> String emptyString = &quot;&quot;
    * assertThat(emptyString).isNullOrEmpty();
    * 
    * String nullString = null;
-   * assertThat(nullString).isNullOrEmpty();
-   * </code></pre>
+   * assertThat(nullString).isNullOrEmpty();</code></pre>
    *
    * @throws AssertionError if the actual {@code CharSequence} has a non-zero length.
    */
@@ -80,18 +77,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * {@link org.assertj.core.api.AbstractCharSequenceAssert#isNullOrEmpty()} instead.
    * <p>
    * This assertion will succeed:
-   * 
-   * <pre><code class='java'>
-   * String emptyString = &quot;&quot;
-   * assertThat(emptyString).isEmpty();
-   * </code></pre>
+   * <pre><code class='java'> String emptyString = &quot;&quot;
+   * assertThat(emptyString).isEmpty();</code></pre>
    * 
    * Whereas this assertion will fail:
-   * 
-   * <pre><code class='java'>
-   * String nullString = null;
-   * assertThat(nullString).isEmpty();
-   * </code></pre>
+   * <pre><code class='java'> String nullString = null;
+   * assertThat(nullString).isEmpty();</code></pre>
    *
    * @throws AssertionError if the actual {@code CharSequence} has a non-zero length or is null.
    */
@@ -105,18 +96,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * more.
    * <p>
    * This assertion will succeed:
-   * 
-   * <pre><code class='java'>
-   * String bookName = &quot;A Game of Thrones&quot;
-   * assertThat(bookName).isNotEmpty();
-   * </code></pre>
+   * <pre><code class='java'> String bookName = &quot;A Game of Thrones&quot;
+   * assertThat(bookName).isNotEmpty();</code></pre>
    * 
    * Whereas this assertion will fail:
-   * 
-   * <pre><code class='java'>
-   * String emptyString = &quot;&quot;
-   * assertThat(emptyString).isNotEmpty();
-   * </code></pre>
+   * <pre><code class='java'> String emptyString = &quot;&quot;
+   * assertThat(emptyString).isNotEmpty();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code CharSequence} is empty (has a length of 0).
@@ -131,18 +116,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} has the expected length using the {@code length()} method.
    * <p>
    * This assertion will succeed:
-   * 
-   * <pre><code class='java'>
-   * String bookName = &quot;A Game of Thrones&quot;
-   * assertThat(bookName).hasSize(17);
-   * </code></pre>
+   * <pre><code class='java'> String bookName = &quot;A Game of Thrones&quot;
+   * assertThat(bookName).hasSize(17);</code></pre>
    * 
    * Whereas this assertion will fail:
-   * 
-   * <pre><code class='java'>
-   * String bookName = &quot;A Clash of Kings&quot;
-   * assertThat(bookName).hasSize(4);
-   * </code></pre>
+   * <pre><code class='java'> String bookName = &quot;A Clash of Kings&quot;
+   * assertThat(bookName).hasSize(4);</code></pre>
    *
    * @param expected the expected length of the actual {@code CharSequence}.
    * @return {@code this} assertion object.
@@ -161,18 +140,13 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * or a carriage return followed immediately by a linefeed (see {@link LineNumberReader}).
    * <p>
    * This assertion will succeed:
-   * 
-   * <pre><code class='java'>
-   * String multiLine = &quot;First line\n&quot; +
+   * <pre><code class='java'> String multiLine = &quot;First line\n&quot; +
    *                    &quot;Last line&quot;;
-   * assertThat(multiLine).hasLineCount(2);
-   * </code></pre>
-   * Whereas this assertion will fail:
+   * assertThat(multiLine).hasLineCount(2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * String bookName = &quot;A Clash of Kings&quot;;
-   * assertThat(bookName).hasLineCount(3);
-   * </code></pre>
+   * Whereas this assertion will fail:
+   * <pre><code class='java'> String bookName = &quot;A Clash of Kings&quot;;
+   * assertThat(bookName).hasLineCount(3);</code></pre>
    *
    * @param expectedLineCount the expected line count of the actual {@code CharSequence}.
    * @return {@code this} assertion object.
@@ -188,14 +162,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * {@code CharSequence}.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;C-3PO&quot;).hasSameSizeAs(&quot;R2-D2&quot;);
    * 
    * // assertion will fail as actual and expected sizes differ
-   * assertThat(&quot;C-3PO&quot;).hasSameSizeAs(&quot;B1 battle droid&quot;);
-   * </code></pre>
+   * assertThat(&quot;C-3PO&quot;).hasSameSizeAs(&quot;B1 battle droid&quot;);</code></pre>
    * 
    * @param other the given {@code CharSequence} to be used for size comparison.
    * @return {@code this} assertion object.
@@ -244,15 +215,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} is equal to the given one, ignoring case considerations.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Gandalf the grey&quot;).isEqualToIgnoringCase(&quot;GaNdAlF tHe GREY&quot;);
    * assertThat(&quot;Gandalf the grey&quot;).isEqualToIgnoringCase(&quot;Gandalf the grey&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Gandalf the grey&quot;).isEqualToIgnoringCase(&quot;Gandalf the white&quot;);
-   * </code></pre>
+   * assertThat(&quot;Gandalf the grey&quot;).isEqualToIgnoringCase(&quot;Gandalf the white&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -269,9 +237,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} is not equal to the given one, ignoring case considerations.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat("Gandalf").isNotEqualToIgnoringCase("Hobbit");
    * assertThat("Gandalf").isNotEqualToIgnoringCase("HOBit");
    * assertThat((String)null).isNotEqualToIgnoringCase("Gandalf");
@@ -280,8 +246,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * // assertions will fail
    * assertThat("Gandalf").isNotEqualToIgnoringCase("Gandalf");
    * assertThat("Gandalf").isNotEqualToIgnoringCase("GaNDalf");
-   * assertThat((String)null).isNotEqualToIgnoringCase(null);
-   * </code></pre>
+   * assertThat((String)null).isNotEqualToIgnoringCase(null);</code></pre>
    *
    * @param expected the given {@code CharSequence} to compare the actual {@code CharSequence} to.
    * @return {@code this} assertion object.
@@ -297,17 +262,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * characters or is empty.
    * <p>
    * This assertion succeeds:
-   *
-   * <pre><code class='java'>
-   * assertThat("10").containsOnlyDigits();
-   * </code></pre>
+   * <pre><code class='java'> assertThat("10").containsOnlyDigits();</code></pre>
    *
    * Whereas these assertions fail:
-   *
-   * <pre><code class='java'>
-   * assertThat("10$").containsOnlyDigits();
-   * assertThat("").containsOnlyDigits();
-   * </code></pre>
+   * <pre><code class='java'> assertThat("10$").containsOnlyDigits();
+   * assertThat("").containsOnlyDigits();</code></pre>
    *
    * </p>
    *
@@ -324,14 +283,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} contains the given sequence <b>only once</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).containsOnlyOnce(&quot;do&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).containsOnlyOnce(&quot;o&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).containsOnlyOnce(&quot;o&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -349,11 +305,8 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} contains all the given strings.
    * <p>
    * You can use one or several strings as in this example:
-   *
-   * <pre><code class='java'>
-   * assertThat(&quot;Gandalf the grey&quot;).contains(&quot;alf&quot;);
-   * assertThat(&quot;Gandalf the grey&quot;).contains(&quot;alf&quot;, &quot;grey&quot;);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(&quot;Gandalf the grey&quot;).contains(&quot;alf&quot;);
+   * assertThat(&quot;Gandalf the grey&quot;).contains(&quot;alf&quot;, &quot;grey&quot;);</code></pre>
    *
    * @param values the Strings to look for.
    * @return {@code this} assertion object.
@@ -371,11 +324,8 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} contains all the strings of the given Iterable.
    * <p>
    * Examples:
-   * 
-   * <pre><code class='java'>
-   * assertThat(&quot;Gandalf the grey&quot;).contains(Arrays.asList(&quot;alf&quot;));
-   * assertThat(&quot;Gandalf the grey&quot;).contains(Arrays.asList(&quot;alf&quot;, &quot;grey&quot;));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(&quot;Gandalf the grey&quot;).contains(Arrays.asList(&quot;alf&quot;));
+   * assertThat(&quot;Gandalf the grey&quot;).contains(Arrays.asList(&quot;alf&quot;, &quot;grey&quot;));</code></pre>
    *
    * @param values the Strings to look for.
    * @return {@code this} assertion object.
@@ -393,16 +343,13 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} contains all the given strings <b>in the given order</b>.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * String book = &quot;{ 'title':'A Game of Thrones', 'author':'George Martin'}&quot;;
+   * <pre><code class='java'> String book = &quot;{ 'title':'A Game of Thrones', 'author':'George Martin'}&quot;;
    * 
    * // this assertion succeeds ...
    * assertThat(book).containsSequence(&quot;{&quot;, &quot;title&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;);
    * 
    * // ... but this one fails as &quot;author&quot; must come after &quot;A Game of Thrones&quot;
-   * assertThat(book).containsSequence(&quot;{&quot;, &quot;author&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;);
-   * </code></pre>
+   * assertThat(book).containsSequence(&quot;{&quot;, &quot;author&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;);</code></pre>
    *
    * @param values the Strings to look for, in order.
    * @return {@code this} assertion object.
@@ -422,16 +369,13 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * iteration order</b>.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * String book = &quot;{ 'title':'A Game of Thrones', 'author':'George Martin'}&quot;;
+   * <pre><code class='java'> String book = &quot;{ 'title':'A Game of Thrones', 'author':'George Martin'}&quot;;
    *
    * // this assertion succeeds ...
    * assertThat(book).containsSequence(Arrays.asList(&quot;{&quot;, &quot;title&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;));
    *
    * // ... but this one fails as &quot;author&quot; must come after &quot;A Game of Thrones&quot;
-   * assertThat(book).containsSequence(Arrays.asList(&quot;{&quot;, &quot;author&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;));
-   * </code></pre>
+   * assertThat(book).containsSequence(Arrays.asList(&quot;{&quot;, &quot;author&quot;, &quot;A Game of Thrones&quot;, &quot;}&quot;));</code></pre>
    *
    * @param values the Strings to look for, in order.
    * @return {@code this} assertion object.
@@ -450,14 +394,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} contains the given sequence, ignoring case considerations.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Gandalf the grey&quot;).containsIgnoringCase(&quot;gandalf&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Gandalf the grey&quot;).containsIgnoringCase(&quot;white&quot;);
-   * </code></pre>
+   * assertThat(&quot;Gandalf the grey&quot;).containsIgnoringCase(&quot;white&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -476,15 +417,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} does not contain the given sequence.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;fro&quot;);
    * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;gandalf&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;Fro&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;Fro&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -503,16 +441,13 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} starts with the given prefix.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).startsWith(&quot;Fro&quot;);
    * assertThat(&quot;Gandalf the grey&quot;).startsWith(&quot;Gandalf&quot;);
    * 
    * // assertion will fail
    * assertThat(&quot;Frodo&quot;).startsWith(&quot;fro&quot;);
-   * assertThat(&quot;Gandalf the grey&quot;).startsWith(&quot;grey&quot;);
-   * </code></pre>
+   * assertThat(&quot;Gandalf the grey&quot;).startsWith(&quot;grey&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -531,16 +466,13 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} does not start with the given prefix.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat(&quot;Frodo&quot;).doesNotStartWith(&quot;fro&quot;);
    * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWith(&quot;grey&quot;);
    *
    * // assertions will fail
    * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWith(&quot;Gandalf&quot;);
-   * assertThat(&quot;Frodo&quot;).doesNotStartWith(&quot;&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).doesNotStartWith(&quot;&quot;);</code></pre>
    *
    * @param prefix the given prefix.
    * @return {@code this} assertion object.
@@ -557,14 +489,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} ends with the given suffix.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).endsWith(&quot;do&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).endsWith(&quot;Fro&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).endsWith(&quot;Fro&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -583,15 +512,12 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} does not end with the given suffix.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).doesNotEndWith(&quot;Fro&quot;);
    *
    * // assertions will fail
    * assertThat(&quot;Frodo&quot;).doesNotEndWith(&quot;do&quot;);
-   * assertThat(&quot;Frodo&quot;).doesNotEndWith(&quot;&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).doesNotEndWith(&quot;&quot;);</code></pre>
    *
    * @param suffix the given suffix.
    * @return {@code this} assertion object.
@@ -608,14 +534,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} matches the given regular expression.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).matches(&quot;..o.o&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).matches(&quot;.*d&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).matches(&quot;.*d&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -635,14 +558,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} does not match the given regular expression.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).doesNotMatch(&quot;.*d&quot;);
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).doesNotMatch(&quot;..o.o&quot;);
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).doesNotMatch(&quot;..o.o&quot;);</code></pre>
    *
    * </p>
    *
@@ -662,14 +582,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} matches the given regular expression pattern.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).matches(Pattern.compile(&quot;..o.o&quot;));
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).matches(Pattern.compile(&quot;.*d&quot;));
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).matches(Pattern.compile(&quot;.*d&quot;));</code></pre>
    *
    * </p>
    *
@@ -688,14 +605,11 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * Verifies that the actual {@code CharSequence} does not match the given regular expression pattern.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;Frodo&quot;).doesNotMatch(Pattern.compile(&quot;.*d&quot;));
    * 
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).doesNotMatch(Pattern.compile(&quot;..o.o&quot;));
-   * </code></pre>
+   * assertThat(&quot;Frodo&quot;).doesNotMatch(Pattern.compile(&quot;..o.o&quot;));</code></pre>
    *
    * </p>
    *
@@ -714,10 +628,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * formatted the same way.
    * <p>
    * Example :
-   * </p>
-   *
-   * <pre><code class='java'>
-   * String expectedXml =
+   * <pre><code class='java'> String expectedXml =
    *     &quot;&lt;rings&gt;\n&quot; +
    *         &quot;  &lt;bearer&gt;\n&quot; +
    *         &quot;    &lt;name&gt;Frodo&lt;/name&gt;\n&quot; +
@@ -748,8 +659,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * assertThat(xmlWithNewLine).isXmlEqualTo(oneLineXml);
    * 
    * // Tip : use isXmlEqualToContentOf assertion to compare your XML String with the content of an XML file :
-   * assertThat(oneLineXml).isXmlEqualToContentOf(new File(&quot;src/test/resources/formatted.xml&quot;));
-   * </code></pre>
+   * assertThat(oneLineXml).isXmlEqualToContentOf(new File(&quot;src/test/resources/formatted.xml&quot;));</code></pre>
    *
    * @param expectedXml the XML {@code CharSequence} to which the actual {@code CharSequence} is to be compared to.
    * @return {@code this} assertion object to chain other assertions.
@@ -767,15 +677,10 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * <p/>
    * This is an handy shortcut that calls : {@code isXmlEqualTo(contentOf(xmlFile))}
    * </p>
-   * <p>
    * Example :
-   * </p>
-   *
-   * <pre><code class='java'>
-   * // You can easily compare your XML String to the content of an XML file, whatever how formatted they are.
+   * <pre><code class='java'> // You can easily compare your XML String to the content of an XML file, whatever how formatted they are.
    * String oneLineXml = &quot;&lt;rings&gt;&lt;bearer&gt;&lt;name&gt;Frodo&lt;/name&gt;&lt;ring&gt;&lt;name&gt;one ring&lt;/name&gt;&lt;createdBy&gt;Sauron&lt;/createdBy&gt;&lt;/ring&gt;&lt;/bearer&gt;&lt;/rings&gt;&quot;;
-   * assertThat(oneLineXml).isXmlEqualToContentOf(new File(&quot;src/test/resources/formatted.xml&quot;));
-   * </code></pre>
+   * assertThat(oneLineXml).isXmlEqualToContentOf(new File(&quot;src/test/resources/formatted.xml&quot;));</code></pre>
    * 
    * @param xmlFile the file to read the expected XML String to compare with actual {@code CharSequence}
    * @return {@code this} assertion object to chain other assertions.
@@ -838,28 +743,22 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * thus impossible to find differences from the standard error message:
    * <p/>
    * With standard message:
-   * 
-   * <pre><code class='java'>
-   * assertThat("µµµ").contains("μμμ");
+   * <pre><code class='java'> assertThat("µµµ").contains("μμμ");
    * 
    * java.lang.AssertionError:
    * Expecting:
    *   <"µµµ">
    * to contain:
-   *   <"μμμ">
-   * </code></pre>
+   *   <"μμμ"></code></pre>
    *
    * With Hexadecimal message:
-   * 
-   * <pre><code class='java'>
-   * assertThat("µµµ").inUnicode().contains("μμμ");
+   * <pre><code class='java'> assertThat("µµµ").inUnicode().contains("μμμ");
    * 
    * java.lang.AssertionError:
    * Expecting:
    *   <\u00b5\u00b5\u00b5>
    * to contain:
-   *   <\u03bc\u03bc\u03bc>
-   * </code></pre>
+   *   <\u03bc\u03bc\u03bc></code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -878,9 +777,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * </ul>
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(&quot;my      foo bar&quot;).isEqualToIgnoringWhitespace(&quot;my foo bar&quot;);
    * assertThat(&quot;  my foo bar  &quot;).isEqualToIgnoringWhitespace(&quot;my foo bar&quot;);
    * assertThat(&quot; my     foo bar &quot;).isEqualToIgnoringWhitespace(&quot;my foo bar&quot;);
@@ -888,8 +785,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * assertThat(&quot;my foo bar&quot;).isEqualToIgnoringWhitespace(&quot;   my foo bar   &quot;);
    *
    * // assertion will fail
-   * assertThat(&quot; my\tfoo bar &quot;).isEqualToIgnoringWhitespace(&quot; my foobar&quot;);
-   * </code></pre>
+   * assertThat(&quot; my\tfoo bar &quot;).isEqualToIgnoringWhitespace(&quot; my foobar&quot;);</code></pre>
    *
    * </p>
    *

--- a/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
@@ -72,16 +72,13 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is less than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('A').isLessThan('a');
    * assertThat('a').isLessThan('b');
    *
    * // assertion will fail
    * assertThat('a').isLessThan('A');
-   * assertThat('b').isLessThan('a');
-   * </code></pre>
+   * assertThat('b').isLessThan('a');</code></pre>
    * 
    * </p>
    * 
@@ -99,15 +96,12 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is less than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('A').isLessThanOrEqualTo('a');
    * assertThat('A').isLessThanOrEqualTo('A');
    *
    * // assertion will fail
-   * assertThat('b').isLessThanOrEqualTo('a');
-   * </code></pre>
+   * assertThat('b').isLessThanOrEqualTo('a');</code></pre>
    * 
    * </p>
    * 
@@ -125,16 +119,13 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is greater than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('a').isGreaterThan('A');
    * assertThat('b').isGreaterThan('a');
    *
    * // assertion will fail
    * assertThat('A').isGreaterThan('a');
-   * assertThat('a').isGreaterThan('b');
-   * </code></pre>
+   * assertThat('a').isGreaterThan('b');</code></pre>
    * 
    * </p>
    * 
@@ -155,22 +146,18 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * it is thus impossible to find differences from the standard error message:
    * <p/>
    * With standard error message:
-   * <pre><code class='java'>
-   * assertThat('µ').isEqualTo('μ');
+   * <pre><code class='java'> assertThat('µ').isEqualTo('μ');
    *
    * org.junit.ComparisonFailure:
    * Expected :'μ'
-   * Actual   :'µ'
-   * </code></pre>
+   * Actual   :'µ'</code></pre>
    *
    * With unicode based error message:
-   * <pre><code class='java'>
-   * assertThat('µ').inUnicode().isEqualTo('μ');
+   * <pre><code class='java'> assertThat('µ').inUnicode().isEqualTo('μ');
    *
    * org.junit.ComparisonFailure:
    * Expected :\u03bc
-   * Actual   :\u00b5
-   * </code></pre>
+   * Actual   :\u00b5</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -183,15 +170,12 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is greater than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('A').isGreaterThanOrEqualTo('A');
    * assertThat('b').isGreaterThanOrEqualTo('a');
    * 
    * // assertion will fail
-   * assertThat('a').isGreaterThanOrEqualTo('b');
-   * </code></pre>
+   * assertThat('a').isGreaterThanOrEqualTo('b');</code></pre>
    * 
    * </p>
    * 
@@ -209,14 +193,11 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is a lowercase character.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('a').isLowerCase();
    *
    * // assertion will fail
-   * assertThat('A').isLowerCase();
-   * </code></pre>
+   * assertThat('A').isLowerCase();</code></pre>
    *
    * </p>
    * 
@@ -234,14 +215,11 @@ public abstract class AbstractCharacterAssert<S extends AbstractCharacterAssert<
    * Verifies that the actual value is a uppercase character.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat('A').isLowerCase();
    * 
    * // assertion will fail
-   * assertThat('a').isLowerCase();
-   * </code></pre>
+   * assertThat('a').isLowerCase();</code></pre>
    * 
    * </p>
    * 

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -37,16 +37,14 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is assignable from others {@code Class}
    * 
-   * <pre><code class='java'>
-   * class Jedi {}
+   * <pre><code class='java'> class Jedi {}
    * class HumanJedi extends Jedi {}
    * 
    * // Should pass if :
    * assertThat(Jedi.class).isAssignableFrom(HumanJedi.class);
    * 
    * // Should fail if :
-   * assertThat(HumanJedi.class).isAssignableFrom(Jedi.class);
-   * </code></pre>
+   * assertThat(HumanJedi.class).isAssignableFrom(Jedi.class);</code></pre>
    * 
    * @see Class#isAssignableFrom(Class)
    * @param others {@code Class} who can be assignable from.
@@ -63,16 +61,14 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is not an interface.
    * 
-   * <pre><code class='java'>
-   * interface Jedi {}
+   * <pre><code class='java'> interface Jedi {}
    * class HumanJedi implements Jedi {}
    * 
    * // Should pass if :
    * assertThat(HumanJedi.class).isNotInterface();
    * 
    * // Should fail if :
-   * assertThat(Jedi.class).isNotInterface();
-   * </code></pre>
+   * assertThat(Jedi.class).isNotInterface();</code></pre>
    * 
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is not an interface.
@@ -85,16 +81,14 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is an interface.
    * 
-   * <pre><code class='java'>
-   * interface Jedi {}
+   * <pre><code class='java'> interface Jedi {}
    * class HumanJedi implements Jedi {}
    * 
    * // Should pass if :
    * assertThat(Jedi.class).isInterface();
    * 
    * // Should fail if :
-   * assertThat(HumanJedi.class).isInterface();
-   * </code></pre>
+   * assertThat(HumanJedi.class).isInterface();</code></pre>
    * 
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is not an interface.
@@ -107,8 +101,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is an annotation.
    * 
-   * <pre><code class='java'>
-   * public @interface Jedi {}
+   * <pre><code class='java'> public @interface Jedi {}
    * 
    * // Should pass if :
    * assertThat(Jedi.class).isAnnotation();
@@ -116,9 +109,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * assertThat(Deprecated.class).isAnnotation();
    * 
    * // Should fail if :
-   * assertThat(String.class).isAnnotation();
-   * </code></pre>
-   * 
+   * assertThat(String.class).isAnnotation();</code></pre>
    * 
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is not an annotation.
@@ -131,8 +122,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is not an annotation.
    * 
-   * <pre><code class='java'>
-   * public @interface Jedi {}
+   * <pre><code class='java'> public @interface Jedi {}
    * 
    * // Should pass if :
    * assertThat(String.class).isNotAnnotation();
@@ -140,8 +130,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * // Should fail if :
    * assertThat(Jedi.class).isNotAnnotation();
    * assertThat(Override.class).isNotAnnotation();
-   * assertThat(Deprecated.class).isNotAnnotation();
-   * </code></pre>
+   * assertThat(Deprecated.class).isNotAnnotation();</code></pre>
    * 
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is an annotation.
@@ -154,15 +143,13 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is final (has {@code final} modifier).
    *
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(String.class).isFinal();
    * assertThat(Math.class).isFinal();
    *
    * // These assertions fail:
    * assertThat(Object.class).isFinal();
-   * assertThat(Throwable.class).isFinal();
-   * </code></pre>
+   * assertThat(Throwable.class).isFinal();</code></pre>
    *
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is not final.
@@ -175,15 +162,13 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} is not final (does not have {@code final} modifier).
    *
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(Object.class).isNotFinal();
    * assertThat(Throwable.class).isNotFinal();
    *
    * // These assertions fail:
    * assertThat(String.class).isNotFinal();
-   * assertThat(Math.class).isNotFinal();
-   * </code></pre>
+   * assertThat(Math.class).isNotFinal();</code></pre>
    *
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is final.
@@ -196,8 +181,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} has the given {@code Annotation}s.
    * 
-   * <pre><code class='java'>
-   * &#64;Target(ElementType.TYPE)
+   * <pre><code class='java'> &#64;Target(ElementType.TYPE)
    * &#64;Retention(RetentionPolicy.RUNTIME)
    * private static @interface Force { }
    * 
@@ -216,8 +200,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * assertThat(Jedi.class).containsAnnotations(Force.class, Hero.class);
    * 
    * // Should fail:
-   * assertThat(Jedi.class).containsAnnotations(Force.class, DarkSide.class);
-   * </code></pre>
+   * assertThat(Jedi.class).containsAnnotations(Force.class, DarkSide.class);</code></pre>
    * 
    * @param annotations annotations who must be attached to the class
    * @throws AssertionError if {@code actual} is {@code null}.
@@ -231,8 +214,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} has the given {@code Annotation}.
    * 
-   * <pre><code class='java'>
-   * &#64;Target(ElementType.TYPE)
+   * <pre><code class='java'> &#64;Target(ElementType.TYPE)
    * &#64;Retention(RetentionPolicy.RUNTIME)
    * private static @interface Force { }
    * &#64;Force
@@ -242,8 +224,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * assertThat(Jedi.class).containsAnnotation(Force.class);
    * 
    * // Should fail if :
-   * assertThat(Jedi.class).containsAnnotation(DarkSide.class);
-   * </code></pre>
+   * assertThat(Jedi.class).containsAnnotation(DarkSide.class);</code></pre>
    * 
    * @param annotation annotations who must be attached to the class
    * @throws AssertionError if {@code actual} is {@code null}.
@@ -258,8 +239,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} has the {@code fields}.
    * 
-   * <pre><code class='java'>
-   * class MyClass {
+   * <pre><code class='java'> class MyClass {
    *     public String fieldOne;
    *     private String fieldTwo;
    * }
@@ -269,8 +249,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * 
    * // This one should fail :
    * assertThat(MyClass.class).hasFields("fieldTwo");
-   * assertThat(MyClass.class).hasDeclaredFields("fieldThree");
-   * </code></pre>
+   * assertThat(MyClass.class).hasDeclaredFields("fieldThree");</code></pre>
    * 
    * @see Class#getField(String)
    * @param fields the fields who must be in the class.
@@ -285,8 +264,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   /**
    * Verifies that the actual {@code Class} has the declared {@code fields}.
    * 
-   * <pre><code class='java'>
-   * class MyClass {
+   * <pre><code class='java'> class MyClass {
    *     public String fieldOne;
    *     private String fieldTwo;
    * }
@@ -295,8 +273,7 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    * assertThat(MyClass.class).hasDeclaredFields("fieldOne", "fieldTwo");
    * 
    * // This one should fail :
-   * assertThat(MyClass.class).hasDeclaredFields("fieldThree");
-   * </code></pre>
+   * assertThat(MyClass.class).hasDeclaredFields("fieldThree");</code></pre>
    * 
    * @see Class#getDeclaredField(String)
    * @param fields the fields who must be declared in the class.

--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -99,14 +99,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isEqualTo("2002-12-18");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isEqualTo("2002-12-19");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isEqualTo("2002-12-19");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -140,14 +138,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // OK : all dates fields are the same up to minutes excluded
+   * <pre><code class='java'> // OK : all dates fields are the same up to minutes excluded
    * assertThat("2003-04-26T13:01:35").isEqualToIgnoringHours("2003-04-26T14:02:35");
    *
    * // KO : fail as day fields differ
-   * assertThat("2003-04-26T14:01:35").isEqualToIgnoringHours("2003-04-27T13:02:35");
-   * </code></pre>
+   * assertThat("2003-04-26T14:01:35").isEqualToIgnoringHours("2003-04-27T13:02:35");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -182,9 +178,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:01:35");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:01:35");
    * Date date2 = parseDatetime("2003-04-26T14:01:00");
    * Date date3 = parseDatetime("2003-04-27T13:01:35");
    *
@@ -192,8 +186,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date1).isEqualToIgnoringHours(date2);
    *
    * // KO : fail as day fields differ
-   * assertThat(date1).isEqualToIgnoringHours(date3);
-   * </code></pre>
+   * assertThat(date1).isEqualToIgnoringHours(date3);</code></pre>
    *
    * @param date the given Date.
    * @return this assertion object.
@@ -214,15 +207,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * withDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+   * <pre><code class='java'> withDateFormat("yyyy-MM-dd'T'HH:mm:ss");
    * // OK : all dates fields are the same up to minutes excluded
    * assertThat("2003-04-26T13:01:35").isEqualToIgnoringMinutes("2003-04-26T13:02:35");
    *
    * // KO : fail as hour fields differ
-   * assertThat("2003-04-26T14:01:35").isEqualToIgnoringMinutes("2003-04-26T13:02:35");
-   * </code></pre>
+   * assertThat("2003-04-26T14:01:35").isEqualToIgnoringMinutes("2003-04-26T13:02:35");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -254,9 +245,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * seconds and milliseconds precision.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:01:35");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:01:35");
    * Date date2 = parseDatetime("2003-04-26T13:02:00");
    * Date date3 = parseDatetime("2003-04-26T14:02:00");
    *
@@ -264,8 +253,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date1).isEqualToIgnoringMinutes(date2);
    *
    * // KO : fail as hour fields differ
-   * assertThat(date1).isEqualToIgnoringMinutes(date3);
-   * </code></pre>
+   * assertThat(date1).isEqualToIgnoringMinutes(date3);</code></pre>
    *
    * @param date the given Date.
    * @return this assertion object.
@@ -287,16 +275,14 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:01:35");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:01:35");
    *
    * // OK : all dates fields are the same up to seconds excluded
    * assertThat(date1).isEqualToIgnoringSeconds("2003-04-26T13:01:57");
    *
    * // KO : fail as minute fields differ
-   * assertThat(date1).isEqualToIgnoringMinutes("2003-04-26T13:02:00");
-   * </code></pre>
+   * assertThat(date1).isEqualToIgnoringMinutes("2003-04-26T13:02:00");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -328,9 +314,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * milliseconds precision.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:01:35");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:01:35");
    * Date date2 = parseDatetime("2003-04-26T13:01:36");
    * Date date3 = parseDatetime("2003-04-26T14:02:00");
    *
@@ -338,8 +322,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date1).isEqualToIgnoringSeconds(date2);
    *
    * // KO : fail as minute fields differ
-   * assertThat(date1).isEqualToIgnoringSeconds(date3);
-   * </code></pre>
+   * assertThat(date1).isEqualToIgnoringSeconds(date3);</code></pre>
    *
    * @param date the given Date represented as String in default or custom date format.
    * @return this assertion object.
@@ -360,16 +343,14 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-04-26T13:01:35.998");
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-04-26T13:01:35.998");
    *
    * // OK : all dates fields are the same up to milliseconds excluded
    * assertThat().isEqualToIgnoringMillis("2003-04-26T13:01:35.997");
    *
    * // KO : fail as seconds fields differ
-   * assertThat("2003-04-26T13:01:35.998").isEqualToIgnoringMinutes("2003-04-26T13:01:36.998");
-   * </code></pre>
+   * assertThat("2003-04-26T13:01:35.998").isEqualToIgnoringMinutes("2003-04-26T13:01:36.998");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -400,9 +381,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * precision.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeAndMs("2003-04-26T13:01:35.001");
+   * <pre><code class='java'> Date date1 = parseDatetimeAndMs("2003-04-26T13:01:35.001");
    * Date date2 = parseDatetimeAndMs("2003-04-26T13:01:35.002");
    * Date date3 = parseDatetimeAndMs("2003-04-26T14:01:36.001");
    *
@@ -410,8 +389,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date1).isEqualToIgnoringMillis(date2);
    *
    * // KO : fail as second fields differ
-   * assertThat(date1).isEqualToIgnoringMillis(date3);
-   * </code></pre>
+   * assertThat(date1).isEqualToIgnoringMillis(date3);</code></pre>
    *
    * @param date the given Date represented as String in default or custom date format.
    * @return this assertion object.
@@ -431,14 +409,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isNotEqualTo("2002-12-19");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isNotEqualTo("2002-12-18");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isNotEqualTo("2002-12-18");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -471,14 +447,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isIn("2002-12-17", "2002-12-18", "2002-12-19");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isIn("2002-12-17", "2002-12-19", "2002-12-20");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isIn("2002-12-17", "2002-12-19", "2002-12-20");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -515,16 +489,14 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isInWithStringDateCollection(
    *     Arrays.asList("2002-12-17", "2002-12-18", "2002-12-19"));
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isInWithStringDateCollection(
-   *     Arrays.asList("2002-12-17", "2002-12-19", "2002-12-20"));
-   * </code></pre>
+   *     Arrays.asList("2002-12-17", "2002-12-19", "2002-12-20"));</code></pre>
+   *
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -564,14 +536,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isNotIn("2002-12-17", "2002-12-19");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isNotIn("2002-12-17", "2002-12-18");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isNotIn("2002-12-17", "2002-12-18");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -608,16 +578,14 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isNotInWithStringDateCollection(Arrays.asList("2002-12-17",
    * "2002-12-19"));
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isNotInWithStringDateCollection(Arrays.asList("2002-12-17",
-   * "2002-12-18"));
-   * </code></pre>
+   * "2002-12-18"));</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -653,14 +621,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is <b>strictly</b> before the given one.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBefore(theReturnOfTheKing.getReleaseDate());
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isBefore(theFellowshipOfTheRing.getReleaseDate());
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBefore(theFellowshipOfTheRing.getReleaseDate());</code></pre>
    *
    * @param other the given Date.
    * @return this assertion object.
@@ -680,15 +645,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBefore("2002-12-19");
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isBefore("2002-12-17");
-   * assertThat(theTwoTowers.getReleaseDate()).isBefore("2002-12-18");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBefore("2002-12-18");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -738,15 +701,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBeforeOrEqualsTo("2002-12-19");
    * assertThat(theTwoTowers.getReleaseDate()).isBeforeOrEqualsTo("2002-12-18");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isBeforeOrEqualsTo("2002-12-17");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBeforeOrEqualsTo("2002-12-17");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -779,14 +740,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is <b>strictly</b> after the given one.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isAfter(theFellowshipOfTheRing.getReleaseDate());
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isAfter(theReturnOfTheKing.getReleaseDate());
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isAfter(theReturnOfTheKing.getReleaseDate());</code></pre>
    *
    * @param other the given Date.
    * @return this assertion object.
@@ -806,15 +764,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isAfter("2002-12-17");
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isAfter("2002-12-18");
-   * assertThat(theTwoTowers.getReleaseDate()).isAfter("2002-12-19");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isAfter("2002-12-19");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -864,15 +820,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isAfterOrEqualsTo("2002-12-17");
    * assertThat(theTwoTowers.getReleaseDate()).isAfterOrEqualsTo("2002-12-18");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isAfterOrEqualsTo("2002-12-19");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isAfterOrEqualsTo("2002-12-19");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -905,16 +859,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is in [start, end[ period (start included, end excluded).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBetween(theFellowshipOfTheRing.getReleaseDate(),
    *     theReturnOfTheKing.getReleaseDate());
    *
    * // assertion will fail
    * assertThat(theFellowshipOfTheRing.getReleaseDate()).isBetween(theTwoTowers.getReleaseDate(),
-   *     theReturnOfTheKing.getReleaseDate());
-   * </code></pre>
+   *     theReturnOfTheKing.getReleaseDate());</code></pre>
    *
    * @param start the period start (inclusive), expected not to be null.
    * @param end the period end (exclusive), expected not to be null.
@@ -935,14 +886,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-17", "2002-12-19");
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-15", "2002-12-17");
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-15", "2002-12-17");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1002,15 +951,13 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-17", "2002-12-18", false, true);
    * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-18", "2002-12-19", true, false);
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-17", "2002-12-18", false, false);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBetween("2002-12-17", "2002-12-18", false, false);</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1073,9 +1020,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isNotBetween("2002-12-17", "2002-12-18", false,
    * false);
    *
@@ -1083,8 +1028,8 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(theTwoTowers.getReleaseDate()).isNotBetween("2002-12-17", "2002-12-18", false,
    * true);
    * assertThat(theTwoTowers.getReleaseDate()).isNotBetween("2002-12-18", "2002-12-19", true,
-   * false);
-   * </code></pre>
+   * false);</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1139,14 +1084,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theFellowshipOfTheRing.getReleaseDate()).isNotBetween("2002-12-01", "2002-12-10");
    *
    * // assertion will fail
-   * assertThat(theFellowshipOfTheRing.getReleaseDate()).isNotBetween("2002-12-01", "2002-12-19");
-   * </code></pre>
+   * assertThat(theFellowshipOfTheRing.getReleaseDate()).isNotBetween("2002-12-01", "2002-12-19");</code></pre>
+   * 
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1180,11 +1123,8 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is strictly in the past.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
-   * assertThat(theTwoTowers.getReleaseDate()).isInThePast();
-   * </code></pre>
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(theTwoTowers.getReleaseDate()).isInThePast();</code></pre>
    *
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Date} is {@code null}.
@@ -1200,14 +1140,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * minute, second, milliseconds).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new Date()).isToday();
    *
    * // assertion will fail
-   * assertThat(theFellowshipOfTheRing.getReleaseDate()).isToday();
-   * </code></pre>
+   * assertThat(theFellowshipOfTheRing.getReleaseDate()).isToday();</code></pre>
    *
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Date} is {@code null}.
@@ -1222,11 +1159,8 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is strictly in the future.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isInTheFuture();
-   * </code></pre>
+   * <pre><code class='java'> // assertion will fail
+   * assertThat(theTwoTowers.getReleaseDate()).isInTheFuture();</code></pre>
    *
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Date} is {@code null}.
@@ -1241,15 +1175,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is <b>strictly</b> before the given year.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isBeforeYear(2004);
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isBeforeYear(2002);
-   * assertThat(theTwoTowers.getReleaseDate()).isBeforeYear(2000);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isBeforeYear(2000);</code></pre>
    *
    * @param year the year to compare actual year to
    * @return this assertion object.
@@ -1265,15 +1196,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} is <b>strictly</b> after the given year.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isAfterYear(2001);
    *
    * // assertion will fail
    * assertThat(theTwoTowers.getReleaseDate()).isAfterYear(2002);
-   * assertThat(theTwoTowers.getReleaseDate()).isAfterYear(2004);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isAfterYear(2004);</code></pre>
    *
    * @param year the year to compare actual year to
    * @return this assertion object.
@@ -1291,14 +1219,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isWithinYear(2002);
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isWithinYear(2004);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isWithinYear(2004);</code></pre>
    *
    * @param year the year to compare actual year to
    * @return this assertion object.
@@ -1317,14 +1242,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isWithinMonth(12);
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isWithinMonth(10);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isWithinMonth(10);</code></pre>
    *
    * @param month the month to compare actual month to, <b>month value starting at 1</b> (January=1, February=2, ...).
    * @return this assertion object.
@@ -1342,14 +1264,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(theTwoTowers.getReleaseDate()).isWithinDayOfMonth(18);
    *
    * // assertion will fail
-   * assertThat(theTwoTowers.getReleaseDate()).isWithinDayOfMonth(20);
-   * </code></pre>
+   * assertThat(theTwoTowers.getReleaseDate()).isWithinDayOfMonth(20);</code></pre>
    *
    * @param dayOfMonth the day of month to compare actual day of month to
    * @return this assertion object.
@@ -1368,14 +1287,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinDayOfWeek(Calendar.SATURDAY);
    *
    * // assertion will fail
-   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinDayOfWeek(Calendar.MONDAY);
-   * </code></pre>
+   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinDayOfWeek(Calendar.MONDAY);</code></pre>
    *
    * @param dayOfWeek the day of week to compare actual day of week to, see {@link Calendar#DAY_OF_WEEK} for valid
    *          values
@@ -1394,14 +1310,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinHourOfDay(13);
    *
    * // assertion will fail
-   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinHourOfDay(22);
-   * </code></pre>
+   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinHourOfDay(22);</code></pre>
    *
    * @param hourOfDay the hour of day to compare actual hour of day to (24-hour clock)
    * @return this assertion object.
@@ -1419,14 +1332,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinMinute(20);
    *
    * // assertion will fail
-   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinMinute(17);
-   * </code></pre>
+   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinMinute(17);</code></pre>
    *
    * @param minute the minute to compare actual minute to
    * @return this assertion object.
@@ -1444,14 +1354,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinSecond(35);
    *
    * // assertion will fail
-   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinSecond(11);
-   * </code></pre>
+   * assertThat(new Date(parseDatetime("2003-04-26T13:20:35").getTime()).isWithinSecond(11);</code></pre>
    *
    * @param second the second to compare actual second to
    * @return this assertion object.
@@ -1467,14 +1374,12 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that the actual {@code Date} millisecond is equal to the given millisecond.
    * <p/>
    * Examples:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(parseDatetimeWithMs("2003-04-26T13:20:35.017")).isWithinMillisecond(17);
    *
    * // assertion will fail
-   * assertThat(parseDatetimeWithMs("2003-04-26T13:20:35.017")).isWithinMillisecond(25);
-   * </code></pre>
+   * assertThat(parseDatetimeWithMs("2003-04-26T13:20:35.017")).isWithinMillisecond(25);</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    *
    * @param millisecond the millisecond to compare actual millisecond to
@@ -1491,13 +1396,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that actual and given {@code Date} are in the same year.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parse("2003-04-26");
+   * <pre><code class='java'> Date date1 = parse("2003-04-26");
    * Date date2 = parse("2003-05-27");
    *
-   * assertThat(date1).isInSameYearAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameYearAs(date2);</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    *
    * @param other the given {@code Date} to compare actual {@code Date} to.
@@ -1518,11 +1421,9 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
+   * <pre><code class='java'> Date date1 = parse("2003-04-26");
+   * assertThat(date1).isInSameYearAs("2003-05-27");</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parse("2003-04-26");
-   * assertThat(date1).isInSameYearAs("2003-05-27");
-   * </code></pre>
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1554,13 +1455,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that actual and given {@code Date} have same month and year fields.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parse("2003-04-26");
+   * <pre><code class='java'> Date date1 = parse("2003-04-26");
    * Date date2 = parse("2003-04-27");
    *
-   * assertThat(date1).isInSameMonthAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameMonthAs(date2);</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    *
    * @param other the given {@code Date} to compare actual {@code Date} to.
@@ -1581,11 +1480,9 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
+   * <pre><code class='java'> Date date1 = parse("2003-04-26");
+   * assertThat(date1).isInSameMonthAs("2003-04-27");</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parse("2003-04-26");
-   * assertThat(date1).isInSameMonthAs("2003-04-27");
-   * </code></pre>
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1616,13 +1513,11 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that actual and given {@code Date} have the same day of month, month and year fields values.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T23:17:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T23:17:00");
    * Date date2 = parseDatetime("2003-04-26T12:30:00");
    *
-   * assertThat(date1).isInSameDayAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameDayAs(date2);</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    *
    * @param other the given {@code Date} to compare actual {@code Date} to.
@@ -1643,11 +1538,9 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local timezone.
    * <p/>
    * Example:
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T23:17:00");
+   * assertThat(date1).isInSameDayAs("2003-04-26");</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T23:17:00");
-   * assertThat(date1).isInSameDayAs("2003-04-26");
-   * </code></pre>
    * Defaults date format (expressed in the local time zone) are :
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -1679,32 +1572,24 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * hour).
    * <p/>
    * This assertion succeeds as time difference is exactly = 1h:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:00:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:00:00");
    * Date date2 = parseDatetime("2003-04-26T14:00:00");
-   * assertThat(date1).isInSameHourWindowAs(date2)
-   * </code></pre>
-   * Two dates can have different hour fields and yet be in the same chronological hour, example:
+   * assertThat(date1).isInSameHourWindowAs(date2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:00:00");
+   * Two dates can have different hour fields and yet be in the same chronological hour, example:
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:00:00");
    * Date date2 = parseDatetime("2003-04-26T12:59:59");
    * // succeeds as time difference == 1s
-   * assertThat(date1).isInSameHourWindowAs(date2)
-   * </code></pre>
+   * assertThat(date1).isInSameHourWindowAs(date2);</code></pre>
+   * 
    * This assertion fails as time difference is more than one hour:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-04-26T13:00:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-04-26T13:00:00");
    * Date date2 = parseDatetime("2003-04-26T14:00:01");
-   * assertThat(date1).isInSameHourWindowAs(date2)
-   * </code></pre>
-   * To compare date's hour fields only (without day, month and year), you can write :
+   * assertThat(date1).isInSameHourWindowAs(date2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * assertThat(myDate).isWithinHour(hourOfDayOf(otherDate))
-   * </code></pre>
+   * To compare date's hour fields only (without day, month and year), you can write :
+   * <pre><code class='java'> assertThat(myDate).isWithinHour(hourOfDayOf(otherDate));</code></pre>
+   * 
    * see {@link org.assertj.core.util.DateUtil#hourOfDayOf(java.util.Date) hourOfDayOf} to get the hour of a given Date.
    * <p/>
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}).
@@ -1757,22 +1642,19 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that actual and given {@code Date} have same hour, day, month and year fields values.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-01-01T12:00:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-01-01T12:00:00");
    * Date date2 = parseDatetime("2003-01-01T12:30:00");
    *
    * // succeeds
-   * assertThat(date1).isInSameHourAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameHourAs(date2);</code></pre>
+   * 
    * <b>This assertion does not make a true chronological comparison</b> since two dates can have different hour fields
    * and yet be in the same chronological hour, e.g:
    * 
-   * <pre><code class='java'>
-   * // dates in the same hour time window but with different hour fields
+   * <pre><code class='java'> // dates in the same hour time window but with different hour fields
    * Date date1 = parseDatetime("2003-01-01T12:00:00");
-   * Date date2 = parseDatetime("2003-01-01T11:59:00");
-   * </code></pre>
+   * Date date2 = parseDatetime("2003-01-01T11:59:00");</code></pre>
+   * 
    * If you want to assert that two dates are chronologically in the same hour time window use
    * {@link #isInSameHourWindowAs(java.util.Date) isInSameHourWindowAs} assertion (note that if
    * <code>isInSameHourAs</code> succeeds then <code>isInSameHourWindowAs</code> will succeed too).
@@ -1831,32 +1713,26 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * minute).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-01-01T12:01:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-01-01T12:01:00");
    * Date date2 = parseDatetime("2003-01-01T12:01:30");
    *
    * // succeeds because date time difference < 1 min
-   * assertThat(date1).isInSameMinuteWindowAs(date2);
-   * </code></pre>
-   * Two dates can have different minute fields and yet be in the same chronological minute, example:
+   * assertThat(date1).isInSameMinuteWindowAs(date2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-01-01T12:01:00");
+   * Two dates can have different minute fields and yet be in the same chronological minute, example:
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-01-01T12:01:00");
    * Date date3 = parseDatetime("2003-01-01T12:00:59");
    *
    * // succeeds as time difference == 1s even though minutes fields differ
-   * assertThat(date1).isInSameMinuteWindowAs(date3)
-   * </code></pre>
-   * This assertion fails as time difference is >= one minute:
+   * assertThat(date1).isInSameMinuteWindowAs(date3);</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-01-01T12:01:00");
+   * This assertion fails as time difference is >= one minute:
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-01-01T12:01:00");
    * Date date2 = parseDatetime("2003-01-01T12:02:00");
    *
    * // fails, time difference should hae been < 1 min
-   * assertThat(date1).isInSameMinuteWindowAs(date2); // ERROR
-   * </code></pre>
+   * assertThat(date1).isInSameMinuteWindowAs(date2); // ERROR</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}).
    *
    * @param other the given {@code Date} to compare actual {@code Date} to.
@@ -1907,25 +1783,21 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Verifies that actual and given {@code Date} have same minute, same hour, day, month and year fields values.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetime("2003-01-01T12:01:00");
+   * <pre><code class='java'> Date date1 = parseDatetime("2003-01-01T12:01:00");
    * Date date2 = parseDatetime("2003-01-01T12:01:30");
    *
    * // succeeds because the all the fields up to minutes are the same
-   * assertThat(date1).isInSameMinuteAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameMinuteAs(date2);</code></pre>
+   * 
    * <b>It does not make a true chronological comparison</b> since two dates can have different minute fields and yet be
    * in the same chronological minute, e.g:
-   * 
-   * <pre><code class='java'>
-   * // dates in the same minute time window but with different minute fields
+   * <pre><code class='java'> // dates in the same minute time window but with different minute fields
    * Date date1 = parseDatetime("2003-01-01T12:01:00");
    * Date date3 = parseDatetime("2003-01-01T12:00:59");
    *
    * // fails because minutes fields differ even though time difference is only 1s !
-   * assertThat(date1).isInSameMinuteAs(date3); // ERROR
-   * </code></pre>
+   * assertThat(date1).isInSameMinuteAs(date3); // ERROR</code></pre>
+   * 
    * If you want to assert that two dates are in the same minute time window use
    * {@link #isInSameMinuteWindowAs(java.util.Date) isInSameMinuteWindowAs} assertion (note that if
    * <code>isInSameMinuteAs</code> succeeds then <code>isInSameMinuteWindowAs</code> will succeed too).
@@ -1984,27 +1856,21 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * difference < 1 second).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-04-26T13:01:02.123");
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-04-26T13:01:02.123");
    * Date date2 = parseDatetimeWithMs("2003-04-26T13:01:02.456");
    *
    * // succeeds as time difference is < 1s
-   * assertThat(date1).isInSameSecondWindowAs(date2);
-   * </code></pre>
-   * Two dates can have different second fields and yet be in the same chronological second, example:
+   * assertThat(date1).isInSameSecondWindowAs(date2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-04-26T13:01:02.999");
+   * Two dates can have different second fields and yet be in the same chronological second, example:
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-04-26T13:01:02.999");
    * Date date2 = parseDatetimeWithMs("2003-04-26T13:01:03.000");
    *
    * // succeeds as time difference is 1ms < 1s
-   * assertThat(date1).isInSameSecondWindowAs(date2);
-   * </code></pre>
-   * Those assertions fail as time difference is greater or equal to one second:
+   * assertThat(date1).isInSameSecondWindowAs(date2);</code></pre>
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-04-26T13:01:01.000");
+   * Those assertions fail as time difference is greater or equal to one second:
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-04-26T13:01:01.000");
    * Date date2 = parseDatetimeWithMs("2003-04-26T13:01:02.000");
    *
    * // fails as time difference = 1s
@@ -2012,8 +1878,8 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    *
    * Date date3 = parseDatetimeWithMs("2003-04-26T13:01:02.001");
    * // fails as time difference > 1s
-   * assertThat(date1).isInSameSecondWindowAs(date3); // ERROR
-   * </code></pre>
+   * assertThat(date1).isInSameSecondWindowAs(date3); // ERROR</code></pre>
+   * 
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    *
    * @param other the given {@code Date} to compare actual {@code Date} to.
@@ -2062,25 +1928,20 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
   /**
    * Verifies that actual and given {@code Date} have same second, minute, hour, day, month and year fields values.
    * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-01-01T12:00:01.000");
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-01-01T12:00:01.000");
    * Date date2 = parseDatetimeWithMs("2003-01-01T12:00:01.250");
    *
    * // succeeds because the all the time fields up to seconds are the same
-   * assertThat(date1).isInSameSecondAs(date2);
-   * </code></pre>
+   * assertThat(date1).isInSameSecondAs(date2);</code></pre>
    * 
    * <b>It does not make a true chronological comparison</b> since two dates can have different second fields and yet
    * be
    * in the same chronological second, e.g:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = parseDatetimeWithMs("2003-01-01T12:00:01.000");
+   * <pre><code class='java'> Date date1 = parseDatetimeWithMs("2003-01-01T12:00:01.000");
    * Date date3 = parseDatetimeWithMs("2003-01-01T12:00:00.999");
    *
    * // fails because seconds fields differ even though time difference is only 1ms !
-   * assertThat(date1).isInSameSecondAs(date3); // ERROR
-   * </code></pre>
+   * assertThat(date1).isInSameSecondAs(date3); // ERROR</code></pre>
    * 
    * If you want to assert that two dates are in the same second time window use
    * {@link #isInSameSecondWindowAs(java.util.Date) isInSameSecondWindowAs} assertion.
@@ -2139,9 +2000,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Note that using a custom comparator has no effect on this assertion (see {@link #usingComparator(Comparator)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date1 = new Date();
+   * <pre><code class='java'> Date date1 = new Date();
    * Date date2 = new Date(date1.getTime() + 100);
    *
    * // assertion will pass
@@ -2149,8 +2008,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date1).isCloseTo(date2, 100);
    *
    * // assertion will fail
-   * assertThat(date1).isCloseTo(date2, 101);
-   * </code></pre>
+   * assertThat(date1).isCloseTo(date2, 101);</code></pre>
    *
    * @param other the date to compare actual to
    * @param deltaInMilliseconds the delta used for date comparison, expressed in milliseconds
@@ -2203,10 +2061,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Both time or timestamp express a number of milliseconds since January 1, 1970, 00:00:00 GMT.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * assertThat(new Date(42)).hasTime(42);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(new Date(42)).hasTime(42);</code></pre>
    *
    * @param timestamp the timestamp to compare actual time to.
    * @return this assertion object.
@@ -2224,17 +2079,14 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * {@link Timestamp}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Date date = new Date();
+   * <pre><code class='java'> Date date = new Date();
    * Timestamp timestamp = new Timestamp(date.getTime());
    * 
    * // Fail as date is not an instance of Timestamp
    * assertThat(date).isEqualTo(timestamp);
    * 
    * // Succeed as we compare date and timestamp time. 
-   * assertThat(date).hasSameTimeAs(timestamp);
-   * </code></pre>
+   * assertThat(date).hasSameTimeAs(timestamp);</code></pre>
    *
    * @param date the date to compare actual time to.
    * @return this assertion object.
@@ -2258,17 +2110,15 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * Beware that the default formats are expressed in the current local time zone.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * Date date = parseDatetime("2003-04-26T12:00:00");
+   * <pre><code class='java'> Date date = parseDatetime("2003-04-26T12:00:00");
    *
    * // assertion will pass
    * assertThat(date).hasSameTimeAs("2003-04-26T12:00:00");
    *
    * // assertion will fail
    * assertThat(date).hasSameTimeAs("2003-04-26T12:00:01");
-   * assertThat(date).hasSameTimeAs("2003-04-27T12:00:00");
-   * </code></pre>
+   * assertThat(date).hasSameTimeAs("2003-04-27T12:00:00");</code></pre>
+   * 
    * Default date formats (expressed in the local time zone) are:
    * <ul>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
@@ -2356,13 +2206,9 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * formats parser to interpret inputs that do not precisely match supported date formats (lenient parsing).
    * <p/>
    * With strict parsing, inputs must match exactly date/time format.
-   *
    * <p>
    * Example:
-   * </p>
-   *
-   * <pre><code class='java'>
-   * final Date date = Dates.parse("2001-02-03");
+   * <pre><code class='java'> final Date date = Dates.parse("2001-02-03");
    * final Date dateTime = parseDatetime("2001-02-03T04:05:06");
    * final Date dateTimeWithMs = parseDatetimeWithMs("2001-02-03T04:05:06.700");
    *
@@ -2378,8 +2224,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    *
    * // assertions will fail
    * assertThat(date).hasSameTimeAs("2001-02-04"); // different date
-   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here
-   * </code></pre>
+   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here</code></pre>
    *
    * To revert to default strict date parsing, call {@code setLenientDateParsing(false)}.
    *
@@ -2412,9 +2257,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * {@link #withDefaultDateFormatsOnly()}.
    * <p/>
    * Code examples:
-   * 
-   * <pre><code class='java'>
-   * Date date = ... // set to 2003 April the 26th
+   * <pre><code class='java'> Date date = ... // set to 2003 April the 26th
    * assertThat(date).isEqualTo("2003-04-26");
    *
    * try {
@@ -2430,8 +2273,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date).isEqualTo("2003/04/26");
    *
    * // the default formats are still available and should work
-   * assertThat(date).isEqualTo("2003-04-26");
-   * </code></pre>
+   * assertThat(date).isEqualTo("2003-04-26");</code></pre>
    *
    * @param userCustomDateFormat the new Date format used for String based Date assertions.
    */
@@ -2461,9 +2303,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * {@link #withDefaultDateFormatsOnly()}.
    * <p/>
    * Code examples:
-   * 
-   * <pre><code class='java'>
-   * Date date = ... // set to 2003 April the 26th
+   * <pre><code class='java'> Date date = ... // set to 2003 April the 26th
    * assertThat(date).isEqualTo("2003-04-26");
    *
    * try {
@@ -2479,8 +2319,7 @@ public abstract class AbstractDateAssert<S extends AbstractDateAssert<S>> extend
    * assertThat(date).isEqualTo("2003/04/26");
    *
    * // the default formats are still available and should work
-   * assertThat(date).isEqualTo("2003-04-26");
-   * </code></pre>
+   * assertThat(date).isEqualTo("2003-04-26");</code></pre>
    *
    * @param userCustomDateFormatPattern the new Date format pattern used for String based Date assertions.
    */

--- a/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
@@ -52,14 +52,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * {@inheritDoc}
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).hasSize(3);
    * 
    * // assertions will fail
-   * assertThat(new double[] { 1.0, 2.0, 1.0 }).hasSize(2);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 1.0 }).hasSize(2);</code></pre>
    * 
    * </p>
    */
@@ -73,13 +70,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * {@inheritDoc}
    * <p>
    * Examples :
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).hasSameSizeAs(Arrays.asList(1, 2, 3));
    * 
    * // assertions will fail
-   * assertThat(new double[] { 1.0, 2.0, 1.0 }).hasSameSizeAs(Arrays.asList(1, 2);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 1.0 }).hasSameSizeAs(Arrays.asList(1, 2);</code></pre>
    */
   @Override
   public S hasSameSizeAs(Iterable<?> other) {
@@ -91,17 +86,14 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains the given values, in any order.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, 3.0, 2.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(3.0, 1.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, 2.0);
    * 
    * // assertions will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, 4.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(4.0, 7.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(4.0, 7.0);</code></pre>
    * 
    * </p>
    * 
@@ -121,16 +113,13 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(1.0, 2.0, 3.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(2.0, 3.0, 1.0);
    * 
    * // assertions will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(1.0, 4.0, 2.0, 3.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(4.0, 7.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(4.0, 7.0);</code></pre>
    * 
    * </p>
    * 
@@ -151,16 +140,13 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnlyOnce(1.0, 2.0);
    * 
    * // assertions will fail
    * assertThat(new double[] { 1.0, 2.0, 1.0 }).containsOnlyOnce(1.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnlyOnce(4.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0, 3.0 }).containsOnlyOnce(0.0, 1.0, 2.0, 3.0, 4.0, 5.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0, 3.0 }).containsOnlyOnce(0.0, 1.0, 2.0, 3.0, 4.0, 5.0);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -179,17 +165,14 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(1.0, 2.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(1.0, 2.0, 3.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(2.0, 3.0);
    * 
    * // assertions will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(1.0, 3.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(4.0, 7.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(4.0, 7.0);</code></pre>
    * 
    * </p>
    * 
@@ -208,17 +191,14 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(1.0, 2.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(1.0, 2.0, 3.0);
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(2.0, 3.0);
    * 
    * // assertions will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(1.0, 3.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(4.0, 7.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(4.0, 7.0);</code></pre>
    * 
    * </p>
    * 
@@ -236,16 +216,13 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array contains the given value at the given index.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, atIndex(O));
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(3.0, atIndex(2));
    * 
    * // assertion will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, atIndex(1));
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(4.0, atIndex(2));
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(4.0, atIndex(2));</code></pre>
    * 
    * </p>
    * 
@@ -267,15 +244,12 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array does not contain the given values.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(4.0, 8.0);
    * 
    * // assertion will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(1.0, 2.0, 3.0);
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(3.0, 1.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(3.0, 1.0);</code></pre>
    * 
    * </p>
    * 
@@ -295,16 +269,13 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array does not contain the given value at the given index.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(1.0, atIndex(1));
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(2.0, atIndex(0));
    * 
    * // assertion will fail
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(1.0, atIndex(0));
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(2.0, atIndex(1));
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(2.0, atIndex(1));</code></pre>
    * 
    * </p>
    * 
@@ -324,14 +295,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual array does not contain duplicates.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotHaveDuplicates();
    * 
    * // assertion will fail
-   * assertThat(new double[] { 1.0, 1.0, 2.0, 3.0 }).doesNotHaveDuplicates();
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 1.0, 2.0, 3.0 }).doesNotHaveDuplicates();</code></pre>
    * 
    * </p>
    * 
@@ -350,14 +318,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * sequence is also first element of the actual array.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).startsWith(1.0, 2.0);
    * 
    * // assertion will fail
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).startsWith(2.0, 3.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).startsWith(2.0, 3.0);</code></pre>
    * 
    * </p>
    * 
@@ -379,14 +344,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * sequence is also last element of the actual array.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).endsWith(2.0, 3.0);
    * 
    * // assertion will fail
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).endsWith(1.0, 3.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).endsWith(1.0, 3.0);</code></pre>
    * 
    * </p>
    * 
@@ -434,14 +396,11 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsExactly(1.0, 2.0, 3.0);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsExactly(2.0, 1.0, 3.0);
-   * </code></pre>
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsExactly(2.0, 1.0, 3.0);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -106,9 +106,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(8.1).isCloseTo(8.0, within(0.2));
    *
    * // you can use offset if you prefer
@@ -118,8 +116,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * assertThat(8.1).isCloseTo(8.0, within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isCloseTo(8.0, within(0.01));
-   * </code></pre>
+   * assertThat(8.1).isCloseTo(8.0, within(0.01));</code></pre>
    *
    * @param other the given number to compare the actual value to.
    * @param offset the given positive offset.
@@ -139,9 +136,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.2));
    *
    * // you can use offset if you prefer
@@ -151,8 +146,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.01));
-   * </code></pre>
+   * assertThat(8.1).isCloseTo(Double.valueOf(8.0), within(0.01));</code></pre>
    *
    * @param other the given number to compare the actual value to.
    * @param offset the given positive offset.
@@ -172,17 +166,14 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(20d));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(10d));
    *
    * // assertion will fail
-   * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(5d));
-   * </code></pre>
+   * assertThat(11.0).isCloseTo(Double.valueOf(10.0), withinPercentage(5d));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -202,17 +193,14 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11.0).isCloseTo(10.0, withinPercentage(20d));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(11.0).isCloseTo(10.0, withinPercentage(10d));
    *
    * // assertion will fail
-   * assertThat(11.0).isCloseTo(10.0, withinPercentage(5d));
-   * </code></pre>
+   * assertThat(11.0).isCloseTo(10.0, withinPercentage(5d));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -230,16 +218,13 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
 	 * assertThat(1.0).isEqualTo(1.0);
 	 * assertThat(1D).isEqualTo(1.0);
 	 * 
 	 * // assertions will fail:
 	 * assertThat(0.0).isEqualTo(1.0);
-	 * assertThat(-1.0).isEqualTo(1.0);
-	 * </code></pre>
+	 * assertThat(-1.0).isEqualTo(1.0);</code></pre>
    * </p>
    *
    * @param expected the given value to compare the actual value to.
@@ -264,9 +249,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(8.1).isEqualTo(8.0, offset(0.2));
    *
    * // if difference is exactly equals to the offset (0.1), it's ok
@@ -276,8 +259,7 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * assertThat(8.1).isEqualTo(8.0, within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isEqualTo(8.0, offset(0.01));
-   * </code></pre>
+   * assertThat(8.1).isEqualTo(8.0, offset(0.01));</code></pre>
    *
    * @param expected the given value to compare the actual value to.
    * @param offset the given positive offset.
@@ -295,16 +277,13 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is not equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
 	 * assertThat(0.0).isNotEqualTo(1.0);
 	 * assertThat(-1.0).isNotEqualTo(1.0);
 	 * 
 	 * // assertions will fail:
 	 * assertThat(1.0).isNotEqualTo(1.0);
-	 * assertThat(1D).isNotEqualTo(1.0);
-	 * </code></pre>
+	 * assertThat(1D).isNotEqualTo(1.0);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -321,15 +300,12 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is less than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
 	 * assertThat(1.0).isLessThan(2.0);
 	 * 
 	 * // assertions will fail:
 	 * assertThat(2.0).isLessThan(1.0);
-	 * assertThat(1.0).isLessThan(1.0);
-	 * </code></pre>
+	 * assertThat(1.0).isLessThan(1.0);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -346,15 +322,12 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is less than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
 	 * assertThat(-1.0).isLessThanOrEqualTo(1.0);
 	 * assertThat(1.0).isLessThanOrEqualTo(1.0);
 	 * 
 	 * // assertion will fail:
-	 * assertThat(2.0).isLessThanOrEqualTo(1.0);
-	 * </code></pre>
+	 * assertThat(2.0).isLessThanOrEqualTo(1.0);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -371,15 +344,12 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is greater than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
 	 * assertThat(2.0).isGreaterThan(1.0);
 	 * 
 	 * // assertions will fail:
 	 * assertThat(1.0).isGreaterThan(1.0);
-	 * assertThat(1.0).isGreaterThan(2.0);
-	 * </code></pre>
+	 * assertThat(1.0).isGreaterThan(2.0);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -396,15 +366,12 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
    * Verifies that the actual value is greater than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-	 * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
 	 * assertThat(2.0).isGreaterThanOrEqualTo(1.0);
 	 * assertThat(1.0).isGreaterThanOrEqualTo(1.0);
 	 * 
 	 * // assertion will fail:
-	 * assertThat(1.0).isGreaterThanOrEqualTo(2.0);
-	 * </code></pre>
+	 * assertThat(1.0).isGreaterThanOrEqualTo(2.0);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.

--- a/src/main/java/org/assertj/core/api/AbstractEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractEnumerableAssert.java
@@ -32,16 +32,14 @@ public abstract class AbstractEnumerableAssert<S extends AbstractEnumerableAsser
    * {@inheritDoc}
    * <p>
    * Example with byte array:
-   * <pre><code class='java'>
-   * // assertions will pass
+   * <pre><code class='java'> // assertions will pass
    * assertThat(new byte[]{1, 2}).hasSameSizeAs(new byte[]{2, 3});
    * assertThat(new byte[]{1, 2}).hasSameSizeAs(new Byte[]{2, 3});
    * assertThat(new byte[]{1, 2}).hasSameSizeAs(new int[]{2, 3});
    * assertThat(new byte[]{1, 2}).hasSameSizeAs(new String[]{"1", "2"});
    *
    * // assertion will fail
-   * assertThat(new byte[]{ 1, 2 }).hasSameSizeAs(new byte[]{ 1, 2, 3 });
-   * </code></pre>
+   * assertThat(new byte[]{ 1, 2 }).hasSameSizeAs(new byte[]{ 1, 2, 3 });</code></pre>
    */
   public S hasSameSizeAs(Object other) {
     assertIsArray(info, other);
@@ -59,29 +57,23 @@ public abstract class AbstractEnumerableAssert<S extends AbstractEnumerableAsser
    * It can be useful to better understand what the error was with a more meaningful error message.
    * <p/>
    * Example
-   * <pre><code class='java'>
-   * assertThat(new byte[]{0x10,0x20}).inHexadecimal().contains(new byte[]{0x30});
-   * </code></pre>
+   * <pre><code class='java'> assertThat(new byte[]{0x10,0x20}).inHexadecimal().contains(new byte[]{0x30});</code></pre>
    *
    * With standard error message:
-   * <pre><code class='java'>
-   * Expecting:
+   * <pre><code class='java'> Expecting:
    *  <[16, 32]>
    * to contain:
    *  <[48]>
    * but could not find:
-   *  <[48]>
-   * </code></pre>
+   *  <[48]></code></pre>
    *
    * With Hexadecimal error message:
-   * <pre><code class='java'>
-   * Expecting:
+   * <pre><code class='java'> Expecting:
    *  <[0x10, 0x20]>
    * to contain:
    *  <[0x30]>
    * but could not find:
-   *  <[0x30]>
-   * </code></pre>
+   *  <[0x30]></code></pre>
    *
    * @return {@code this} assertion object.
    */

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -248,16 +248,13 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    *
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * File xFile = new File(&quot;mulder/xFile&quot;);
+   * <pre><code class='java'> File xFile = new File(&quot;mulder/xFile&quot;);
    * 
    * // assertion will pass
    * assertThat(xFile).hasParent(new File(&quot;mulder&quot;));
    *
    * // assertion will fail
-   * assertThat(xFile).hasParent(new File(&quot;scully&quot;));
-   * </code></pre>
+   * assertThat(xFile).hasParent(new File(&quot;scully&quot;));</code></pre>
    * 
    * </p>
    * 
@@ -280,16 +277,13 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * File xFile = new File(&quot;mulder/xFile&quot;);
+   * <pre><code class='java'> File xFile = new File(&quot;mulder/xFile&quot;);
    * 
    * // assertion will pass
    * assertThat(xFile).hasParent(&quot;mulder&quot;);
    *
    * // assertion will fail
-   * assertThat(xFile).hasParent(&quot;scully&quot;);
-   * </code></pre>
+   * assertThat(xFile).hasParent(&quot;scully&quot;);</code></pre>
    * 
    * </p>
    */
@@ -303,16 +297,13 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * File xFile = new File(&quot;xFile.java&quot;);
+   * <pre><code class='java'> File xFile = new File(&quot;xFile.java&quot;);
    * 
    * // assertion will pass
    * assertThat(xFile).hasExtension(&quot;java&quot;);
    * 
    * // assertion will fail
-   * assertThat(xFile).hasExtension(&quot;png&quot;);
-   * </code></pre>
+   * assertThat(xFile).hasExtension(&quot;png&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -335,9 +326,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * File xFile = new File(&quot;somewhere/xFile.java&quot;);
+   * <pre><code class='java'> File xFile = new File(&quot;somewhere/xFile.java&quot;);
    * File xDirectory = new File(&quot;somewhere/xDirectory&quot;);
    * 
    * // assertion will pass
@@ -346,8 +335,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * // assertion will fail
    * assertThat(xFile).hasName(&quot;xFile&quot;);
-   * assertThat(xDirectory).hasName(&quot;somewhere&quot;);
-   * </code></pre>
+   * assertThat(xDirectory).hasName(&quot;somewhere&quot;);</code></pre>
    * 
    * </p>
    * 
@@ -369,17 +357,14 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * File xFile = new File(&quot;somewhere/xFile.java&quot;);
+   * <pre><code class='java'> File xFile = new File(&quot;somewhere/xFile.java&quot;);
    * File xDirectory = new File(&quot;xDirectory&quot;);
    * 
    * // assertion will pass
    * assertThat(xDirectory).hasNoParent();
    * 
    * // assertion will fail
-   * assertThat(xFile).hasNoParent();
-   * </code></pre>
+   * assertThat(xFile).hasNoParent();</code></pre>
    * 
    * </p>
    * 

--- a/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
@@ -97,16 +97,13 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new float[] { 1.0f, 2.0f, 3.0f }).containsOnlyOnce(1.0f, 2.0f);
    * 
    * // assertions will fail
    * assertThat(new float[] { 1.0f, 2.0f, 1.0f }).containsOnlyOnce(1.0f);
    * assertThat(new float[] { 1.0f, 2.0f, 3.0f }).containsOnlyOnce(4.0f);
-   * assertThat(new float[] { 1.0f, 2.0f, 3.0f, 3.0f }).containsOnlyOnce(0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
-   * </code></pre>
+   * assertThat(new float[] { 1.0f, 2.0f, 3.0f, 3.0f }).containsOnlyOnce(0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -125,15 +122,12 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new float[] { 1, 2, 3 }).containsSequence(1, 2);
    * 
    * // assertion will fail
    * assertThat(new float[] { 1, 2, 3 }).containsSequence(1, 3);
-   * assertThat(new float[] { 1, 2, 3 }).containsSequence(2, 1);
-   * </code></pre>
+   * assertThat(new float[] { 1, 2, 3 }).containsSequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -152,15 +146,12 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new float[] { 1, 2, 3 }).containsSubsequence(1, 2);
    * assertThat(new float[] { 1, 2, 3 }).containsSubsequence(1, 3);
    * 
    * // assertion will fail
-   * assertThat(new float[] { 1, 2, 3 }).containsSubsequence(2, 1);
-   * </code></pre>
+   * assertThat(new float[] { 1, 2, 3 }).containsSubsequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -174,6 +165,7 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
     arrays.assertContainsSubsequence(info, actual, subsequence);
     return myself;
   }
+  
   /**
    * Verifies that the actual array contains the given value at the given index.
    * 
@@ -299,16 +291,13 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * float[] floats = { 1.0f, 2.0f, 3.0f };
+   * <pre><code class='java'> float[] floats = { 1.0f, 2.0f, 3.0f };
    * 
    * // assertion will pass
    * assertThat(floats).containsExactly(1.0f, 2.0f, 3.0f);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(floats).containsExactly(2.0f, 1.0f, 3.0f);
-   * </code></pre>
+   * assertThat(floats).containsExactly(2.0f, 1.0f, 3.0f);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -117,9 +117,7 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(8.1f).isCloseTo(8.2f, within(0.2f));
    *
    * // you can use offset if you prefer
@@ -129,15 +127,12 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * assertThat(8.1f).isCloseTo(8.2f, within(0.1f));
    *
    * // assertion will fail
-   * assertThat(8.1f).isCloseTo(8.2f, within(0.01f));
-   * </code></pre>
+   * assertThat(8.1f).isCloseTo(8.2f, within(0.01f));</code></pre>
+   * 
    * Beware that java floating point number precision might have some unexpected behavior, e.g. the assertion below
    * fails:
-   * 
-   * <pre><code class='java'>
-   *  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
-   * assertThat(8.1f).isCloseTo(8.0f, within(0.1f));
-   * </code></pre>
+   * <pre><code class='java'>  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
+   * assertThat(8.1f).isCloseTo(8.0f, within(0.1f));</code></pre>
    *
    * @param other the given number to compare the actual value to.
    * @param offset the given positive offset.
@@ -156,9 +151,7 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(8.1f).isCloseTo(new Float(8.2f), within(0.2f));
    *
    * // you can use offset if you prefer
@@ -168,15 +161,12 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * assertThat(8.1f).isCloseTo(new Float(8.2f), within(0.1f));
    *
    * // assertion will fail
-   * assertThat(8.1f).isCloseTo(new Float(8.2f), within(0.01f));
-   * </code></pre>
+   * assertThat(8.1f).isCloseTo(new Float(8.2f), within(0.01f));</code></pre>
+   * 
    * Beware that java floating point number precision might have some unexpected behavior, e.g. the assertion below
    * fails:
-   * 
-   * <pre><code class='java'>
-   *  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
-   * assertThat(8.1f).isCloseTo(new Float(8.0f), within(0.1f));
-   * </code></pre>
+   * <pre><code class='java'>  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
+   * assertThat(8.1f).isCloseTo(new Float(8.0f), within(0.1f));</code></pre>
    *
    * @param other the given number to compare the actual value to.
    * @param offset the given positive offset.
@@ -196,17 +186,14 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with float:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(20f));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(10f));
    *
    * // assertion will fail
-   * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(5f));
-   * </code></pre>
+   * assertThat(11.0f).isCloseTo(new Float(10.0f), withinPercentage(5f));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -226,17 +213,14 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with float:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(20f));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(10f));
    *
    * // assertion will fail
-   * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(5f));
-   * </code></pre>
+   * assertThat(11.0f).isCloseTo(10.0f, withinPercentage(5f));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -262,25 +246,19 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(8.1f).isEqualTo(8.2f, offset(0.1f));
    *
    * // within is an alias of offset
    * assertThat(8.1f).isEqualTo(8.2f, within(0.1f));
    *
    * // assertion will fail
-   * assertThat(8.1f).isEqualTo(8.2f, offset(0.01f));
-   * </code></pre>
+   * assertThat(8.1f).isEqualTo(8.2f, offset(0.01f));</code></pre>
    *
    * Beware that java floating point number precision might have some unexpected behavior, e.g. the assertion below
    * fails:
-   * 
-   * <pre><code class='java'>
-   *  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
-   * assertThat(8.1f).isEqualTo(8.0f, offset(0.1f));
-   * </code></pre>
+   * <pre><code class='java'>  // fails because 8.1f - 8.0f is evaluated to 0.10000038f in java.
+   * assertThat(8.1f).isEqualTo(8.0f, offset(0.1f));</code></pre>
    *
    * @param expected the given value to compare the actual value to.
    * @param offset the given positive offset.

--- a/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
@@ -97,16 +97,13 @@ public abstract class AbstractIntArrayAssert<S extends AbstractIntArrayAssert<S>
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(1, 2);
    * 
    * // assertions will fail
    * assertThat(new int[] { 1, 2, 1 }).containsOnlyOnce(1);
    * assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(4);
-   * assertThat(new int[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);
-   * </code></pre>
+   * assertThat(new int[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -125,15 +122,12 @@ public abstract class AbstractIntArrayAssert<S extends AbstractIntArrayAssert<S>
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new int[] { 1, 2, 3 }).containsSequence(1, 2);
    * 
    * // assertion will fail
    * assertThat(new int[] { 1, 2, 3 }).containsSequence(1, 3);
-   * assertThat(new int[] { 1, 2, 3 }).containsSequence(2, 1);
-   * </code></pre>
+   * assertThat(new int[] { 1, 2, 3 }).containsSequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -152,15 +146,12 @@ public abstract class AbstractIntArrayAssert<S extends AbstractIntArrayAssert<S>
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new int[] { 1, 2, 3 }).containsSubsequence(1, 2);
    * assertThat(new int[] { 1, 2, 3 }).containsSubsequence(1, 3);
    * 
    * // assertion will fail
-   * assertThat(new int[] { 1, 2, 3 }).containsSubsequence(2, 1);
-   * </code></pre>
+   * assertThat(new int[] { 1, 2, 3 }).containsSubsequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -299,16 +290,13 @@ public abstract class AbstractIntArrayAssert<S extends AbstractIntArrayAssert<S>
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * int[] ints = { 1, 2, 3 };
+   * <pre><code class='java'> int[] ints = { 1, 2, 3 };
    * 
    * // assertion will pass
    * assertThat(ints).containsExactly(1, 2, 3);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(ints).containsExactly(2, 1, 3);
-   * </code></pre>
+   * assertThat(ints).containsExactly(2, 1, 3);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -188,17 +188,14 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(5).isCloseTo(7, within(3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat(5).isCloseTo(7, within(2));
    *
    * // assertion will fail
-   * assertThat(5).isCloseTo(7, within(1));
-   * </code></pre>
+   * assertThat(5).isCloseTo(7, within(1));</code></pre>
    *
    * @param expected the given int to compare the actual value to.
    * @param offset the given positive offset.
@@ -216,17 +213,14 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(5).isCloseTo(Integer.valueOf(7), within(3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat(5).isCloseTo(Integer.valueOf(7), within(2));
    *
    * // assertion will fail
-   * assertThat(5).isCloseTo(Integer.valueOf(7), within(1));
-   * </code></pre>
+   * assertThat(5).isCloseTo(Integer.valueOf(7), within(1));</code></pre>
    *
    * @param expected the given int to compare the actual value to.
    * @param offset the given positive offset.
@@ -245,17 +239,14 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with integer:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(20));
    *
    * // if difference is exactly equals to the computed offset (1), it's ok
    * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(10));
    *
    * // assertion will fail
-   * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(5));
-   * </code></pre>
+   * assertThat(11).isCloseTo(Integer.valueOf(10), withinPercentage(5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -275,17 +266,14 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with integer:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11).isCloseTo(10, withinPercentage(20));
    *
    * // if difference is exactly equals to the computed offset (1), it's ok
    * assertThat(11).isCloseTo(10, withinPercentage(10));
    *
    * // assertion will fail
-   * assertThat(11).isCloseTo(10, withinPercentage(5));
-   * </code></pre>
+   * assertThat(11).isCloseTo(10, withinPercentage(5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -355,9 +355,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * subclasses of the given type).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * List&lt;Number&gt; numbers = new ArrayList&lt;Number&gt;();
+   * <pre><code class='java'> List&lt;Number&gt; numbers = new ArrayList&lt;Number&gt;();
    * numbers.add(1);
    * numbers.add(2L);
    * 
@@ -365,8 +363,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(numbers).hasAtLeastOneElementOfType(Long.class);
    * 
    * // assertion failure:
-   * assertThat(numbers).hasAtLeastOneElementOfType(Float.class);
-   * </code></pre>
+   * assertThat(numbers).hasAtLeastOneElementOfType(Float.class);</code></pre>
    *
    * @param expectedType the expected type.
    * @return this assertion object.
@@ -386,9 +383,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * subclasses of the given type).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * List&lt;Number&gt; numbers = new ArrayList&lt;Number&gt;();
+   * <pre><code class='java'> List&lt;Number&gt; numbers = new ArrayList&lt;Number&gt;();
    * numbers.add(1);
    * numbers.add(2);
    * numbers.add(3);
@@ -398,8 +393,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(numbers).hasOnlyElementsOfType(Integer.class);
    * 
    * // assertion failure:
-   * assertThat(numbers).hasOnlyElementsOfType(Long.class);
-   * </code></pre>
+   * assertThat(numbers).hasOnlyElementsOfType(Long.class);</code></pre>
    *
    * @param expectedType the expected type.
    * @return this assertion object.
@@ -453,9 +447,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * it can be sometimes much less work !
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
+   * <pre><code class='java'> // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
    * // they can be public field or properties, both can be extracted.
    * List&lt;TolkienCharacter&gt; fellowshipOfTheRing = new ArrayList&lt;TolkienCharacter&gt;();
    * 
@@ -478,8 +470,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * 
    * assertThat(fellowshipOfTheRing).extracting(&quot;race.name&quot;)
    *                                .contains(&quot;Hobbit&quot;, &quot;Elf&quot;)
-   *                                .doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   *                                .doesNotContain(&quot;Orc&quot;);</code></pre>
    * <p/>
    * A property with the given name is looked for first, if it doesn't exist then a field with the given name is looked
    * for, if the field does not exist an {@link IntrospectionError} is thrown, by default private fields are read but
@@ -498,9 +489,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * corresponding to the given keys.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda = new Employee(1L, new Name("Yoda"), 800);
    * Employee luke = new Employee(2L, new Name("Luke"), 22);
    * Employee han = new Employee(3L, new Name("Han"), 31);
    * 
@@ -527,8 +516,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(maps).extracting("key1", "key2").containsExactly(tuple(yoda, luke), tuple(yoda, han));
    * 
    * // unknown keys leads to null (map behavior)
-   * assertThat(maps).extracting("bad key").containsExactly(null, null);
-   * </code></pre>
+   * assertThat(maps).extracting("bad key").containsExactly(null, null);</code></pre>
    *
    * @param propertyOrField the property/field to extract from the elements of the Iterable under test
    * @return a new assertion object whose object under test is the list of extracted property/field values.
@@ -549,9 +537,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * toString() or public String status() instead of public String getStatus()).
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
+   * <pre><code class='java'> // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
    * 
    * List&lt;WesterosHouse&gt; greatHouses = new ArrayList&lt;WesterosHouse&gt;();
    * greatHouses.add(new WesterosHouse(&quot;Stark&quot;, &quot;Winter is Coming&quot;));
@@ -565,8 +551,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * 
    * assertThat(greatHouses).extractingResultOf(&quot;sayTheWords&quot;)
    *                        .contains(&quot;Winter is Coming&quot;, &quot;We Do Not Sow&quot;, &quot;Hear Me Roar&quot;)
-   *                        .doesNotContain(&quot;Lannisters always pay their debts&quot;);
-   * </code></pre>
+   *                        .doesNotContain(&quot;Lannisters always pay their debts&quot;);</code></pre>
    * 
    * Following requirements have to be met to extract method results:
    * <ul>
@@ -597,9 +582,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * toString() or public String status() instead of public String getStatus()).
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
+   * <pre><code class='java'> // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
    * List&lt;WesterosHouse&gt; greatHouses = new ArrayList&lt;WesterosHouse&gt;();
    * greatHouses.add(new WesterosHouse(&quot;Stark&quot;, &quot;Winter is Coming&quot;));
    * greatHouses.add(new WesterosHouse(&quot;Lannister&quot;, &quot;Hear Me Roar!&quot;));
@@ -612,8 +595,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * 
    * assertThat(greatHouses).extractingResultOf(&quot;sayTheWords&quot;, String.class)
    *                        .contains(&quot;Winter is Coming&quot;, &quot;We Do Not Sow&quot;, &quot;Hear Me Roar&quot;)
-   *                        .doesNotContain(&quot;Lannisters always pay their debts&quot;);
-   * </code></pre>
+   *                        .doesNotContain(&quot;Lannisters always pay their debts&quot;);</code></pre>
    * 
    * Following requirements have to be met to extract method results:
    * <ul>
@@ -646,9 +628,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * it can be sometimes much less work !
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
+   * <pre><code class='java'> // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
    * // they can be public field or properties, both can be extracted.
    * List&lt;TolkienCharacter&gt; fellowshipOfTheRing = new ArrayList&lt;TolkienCharacter&gt;();
    * 
@@ -671,8 +651,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * 
    * assertThat(fellowshipOfTheRing).extracting(&quot;race.name&quot;, String.class)
    *                                .contains(&quot;Hobbit&quot;, &quot;Elf&quot;)
-   *                                .doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   *                                .doesNotContain(&quot;Orc&quot;);</code></pre>
    * 
    * A property with the given name is looked for first, if it doesn't exist then a field with the given name is looked
    * for, if the field does not exist an {@link IntrospectionError} is thrown, by default private fields are read but
@@ -691,9 +670,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * corresponding to the given keys.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda = new Employee(1L, new Name("Yoda"), 800);
    * Employee luke = new Employee(2L, new Name("Luke"), 22);
    * Employee han = new Employee(3L, new Name("Han"), 31);
    * 
@@ -720,8 +697,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(maps).extracting("key1", "key2").containsExactly(tuple(yoda, luke), tuple(yoda, han));
    * 
    * // unknown keys leads to null (map behavior)
-   * assertThat(maps).extracting("bad key").containsExactly(null, null);
-   * </code></pre>
+   * assertThat(maps).extracting("bad key").containsExactly(null, null);</code></pre>
    *
    * @param propertyOrField the property/field to extract from the Iterable under test
    * @param extractingType type to return
@@ -747,9 +723,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * element of the initial Iterable (the Tuple's data order is the same as the given fields/properties order).
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
+   * <pre><code class='java'> // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
    * // they can be public field or properties, both can be extracted.
    * List&lt;TolkienCharacter&gt; fellowshipOfTheRing = new ArrayList&lt;TolkienCharacter&gt;();
    * 
@@ -775,8 +749,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(fellowshipOfTheRing).extracting(&quot;name&quot;, &quot;age&quot;, &quot;race.name&quot;)
    *                                .contains(tuple(&quot;Boromir&quot;, 37, &quot;Man&quot;),
    *                                          tuple(&quot;Sam&quot;, 38, &quot;Hobbit&quot;),
-   *                                          tuple(&quot;Legolas&quot;, 1000, &quot;Elf&quot;));
-   * </code></pre>
+   *                                          tuple(&quot;Legolas&quot;, 1000, &quot;Elf&quot;));</code></pre>
    * 
    * A property with the given name is looked for first, if it doesn't exist then a field with the given name is looked
    * for, if the field does not exist an {@link IntrospectionError} is thrown, by default private fields are read but
@@ -795,9 +768,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * corresponding to the given keys.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda = new Employee(1L, new Name("Yoda"), 800);
    * Employee luke = new Employee(2L, new Name("Luke"), 22);
    * Employee han = new Employee(3L, new Name("Han"), 31);
    * 
@@ -821,8 +792,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * assertThat(maps).extracting("key1", "key2").containsExactly(tuple(yoda, luke), tuple(yoda, han));
    * 
    * // unknown keys leads to null (map behavior)
-   * assertThat(maps).extracting("bad key").containsExactly(null, null);
-   * </code></pre>
+   * assertThat(maps).extracting("bad key").containsExactly(null, null);</code></pre>
    *
    * @param propertiesOrFields the properties/fields to extract from the elements of the Iterable under test
    * @return a new assertion object whose object under test is the list of Tuple with extracted properties/fields values
@@ -843,9 +813,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * doesn't utilize introspection.
    * <p/>
    * Let's have a look at an example :
-   * 
-   * <pre><code class='java'>
-   * // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
+   * <pre><code class='java'> // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
    * // they can be public field or properties, both can be extracted.
    * List&lt;TolkienCharacter&gt; fellowshipOfTheRing = new ArrayList&lt;TolkienCharacter&gt;();
    * 
@@ -867,8 +835,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * }
    * 
    * // fellowship has hobbitses, right, my presioussss?
-   * assertThat(fellowshipOfTheRing).extracting(race).contains(HOBBIT);
-   * </code></pre>
+   * assertThat(fellowshipOfTheRing).extracting(race).contains(HOBBIT);</code></pre>
    * 
    * Note that the order of extracted property/field values is consistent with the iteration order of the Iterable under
    * test, for example if it's a {@link HashSet}, you won't be able to make any assumptions on the extracted values
@@ -889,9 +856,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * It allows testing the results of extracting values that are represented by Iterables.
    * <p/>
    * For example:
-   * 
-   * <pre><code class='java'>
-   * CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
+   * <pre><code class='java'> CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
    * CartoonCharacter lisa = new CartoonCharacter("Lisa Simpson");
    * CartoonCharacter maggie = new CartoonCharacter("Maggie Simpson");
    * CartoonCharacter homer = new CartoonCharacter("Homer Simpson");
@@ -911,8 +876,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * List&lt;CartoonCharacter&gt; parents = newArrayList(homer, fred);
    * // check children
    * assertThat(parent).flatExtracting(childrenOf)
-   *                   .containsOnly(bart, lisa, maggie, pebbles);
-   * </code></pre>
+   *                   .containsOnly(bart, lisa, maggie, pebbles);</code></pre>
    * 
    * The order of extracted values is consisted with both the order of the collection itself, as well as the extracted
    * collections.
@@ -938,9 +902,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * It allows testing the elements of extracting values that are represented by iterables or arrays.
    * <p/>
    * For example:
-   *
-   * <pre><code class='java'>
-   * CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
+   * <pre><code class='java'> CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
    * CartoonCharacter lisa = new CartoonCharacter("Lisa Simpson");
    * CartoonCharacter maggie = new CartoonCharacter("Maggie Simpson");
    * CartoonCharacter homer = new CartoonCharacter("Homer Simpson");
@@ -953,8 +915,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * List&lt;CartoonCharacter&gt; parents = newArrayList(homer, fred);
    * // check children
    * assertThat(parents).flatExtracting("children")
-   *                    .containsOnly(bart, lisa, maggie, pebbles);
-   * </code></pre>
+   *                    .containsOnly(bart, lisa, maggie, pebbles);</code></pre>
    *
    * The order of extracted values is consisted with both the order of the collection itself, as well as the extracted
    * collections.
@@ -1020,17 +981,14 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT);
    * 
    * // Fail if equals has not been overridden in TolkienCharacter as equals default implementation only compares references
    * assertThat(newArrayList(frodo)).contains(frodoClone);
    * 
    * // frodo and frodoClone are equals when doing a field by field comparison.
-   * assertThat(newArrayList(frodo)).usingFieldByFieldElementComparator().contains(frodoClone);
-   * </code></pre>
+   * assertThat(newArrayList(frodo)).usingFieldByFieldElementComparator().contains(frodoClone);</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -1050,17 +1008,14 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter("Sam", 38, HOBBIT);
    * 
    * // frodo and sam both are hobbits, so they are equals when comparing only race
    * assertThat(newArrayList(frodo)).usingElementComparatorOnFields("race").contains(sam); // OK
    * 
    * // ... but not when comparing both name and race
-   * assertThat(newArrayList(frodo)).usingElementComparatorOnFields("name", "race").contains(sam); // FAIL
-   * </code></pre>
+   * assertThat(newArrayList(frodo)).usingElementComparatorOnFields("name", "race").contains(sam); // FAIL</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -1085,17 +1040,14 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter("Sam", 38, HOBBIT);
    * 
    * // frodo and sam both are hobbits, so they are equals when comparing only race (i.e. ignoring all other fields)
    * assertThat(newArrayList(frodo)).usingElementComparatorIgnoringFields("name", "age").contains(sam); // OK
    * 
    * // ... but not when comparing both name and race
-   * assertThat(newArrayList(frodo)).usingElementComparatorIgnoringFields("age").contains(sam); // FAIL
-   * </code></pre>
+   * assertThat(newArrayList(frodo)).usingElementComparatorIgnoringFields("age").contains(sam); // FAIL</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -1109,36 +1061,27 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * It can be useful to better understand what the error was with a more meaningful error message.
    * <p/>
    * Example
-   * 
-   * <pre><code class='java'>
-   * final List&lt;Byte&gt; bytes = newArrayList((byte) 0x10, (byte) 0x20);
-   * </code></pre>
+   * <pre><code class='java'> final List&lt;Byte&gt; bytes = newArrayList((byte) 0x10, (byte) 0x20);</code></pre>
    *
    * With standard error message:
-   * 
-   * <pre><code class='java'>
-   * assertThat(bytes).contains((byte)0x30);
+   * <pre><code class='java'> assertThat(bytes).contains((byte)0x30);
    * 
    * Expecting:
    *  <[16, 32]>
    * to contain:
    *  <[48]>
    * but could not find:
-   *  <[48]>
-   * </code></pre>
+   *  <[48]></code></pre>
    *
    * With Hexadecimal error message:
-   * 
-   * <pre><code class='java'>
-   * assertThat(bytes).inHexadecimal().contains((byte)0x30);
+   * <pre><code class='java'> assertThat(bytes).inHexadecimal().contains((byte)0x30);
    * 
    * Expecting:
    *  <[0x10, 0x20]>
    * to contain:
    *  <[0x30]>
    * but could not find:
-   *  <[0x30]>
-   * </code></pre>
+   *  <[0x30]></code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -1151,36 +1094,27 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * Enable binary representation of Iterable elements instead of standard representation in error messages.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * final List&lt;Byte&gt; bytes = newArrayList((byte) 0x10, (byte) 0x20);
-   * </code></pre>
+   * <pre><code class='java'> final List&lt;Byte&gt; bytes = newArrayList((byte) 0x10, (byte) 0x20);</code></pre>
    *
    * With standard error message:
-   * 
-   * <pre><code class='java'>
-   * assertThat(bytes).contains((byte)0x30);
+   * <pre><code class='java'> assertThat(bytes).contains((byte)0x30);
    * 
    * Expecting:
    *  <[16, 32]>
    * to contain:
    *  <[48]>
    * but could not find:
-   *  <[48]>
-   * </code></pre>
+   *  <[48]></code></pre>
    *
    * With binary error message:
-   * 
-   * <pre><code class='java'>
-   * assertThat(bytes).inBinary().contains((byte)0x30);
+   * <pre><code class='java'> assertThat(bytes).inBinary().contains((byte)0x30);
    * 
    * Expecting:
    *  <[0b00010000, 0b00100000]>
    * to contain:
    *  <[0b00110000]>
    * but could not find:
-   *  <[0b00110000]>
-   * </code></pre>
+   *  <[0b00110000]></code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -1203,9 +1137,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * <p>
    * 
    * As an example, let's check all employees 800 years old (yes, special employees):
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1213,20 +1145,17 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
    *
    * assertThat(employees).filteredOn("age", 800)
-   *                      .containsOnly(yoda, obiwan);
-   * </code></pre>
+   *                      .containsOnly(yoda, obiwan);</code></pre>
+   *                      
    * Nested properties/fields are supported:
-   * 
-   * <pre><code class='java'>
-   * // Name is bean class with 'first' and 'last' String properties 
+   * <pre><code class='java'> // Name is bean class with 'first' and 'last' String properties
    *
    * // name is null for noname => it does not match the filter on "name.first" 
    * assertThat(employees).filteredOn("name.first", "Luke")
    *                      .containsOnly(luke);
    * 
    * assertThat(employees).filteredOn("name.last", "Vader")
-   *                      .isEmpty();
-   * </code></pre>
+   *                      .isEmpty();</code></pre>
    * <p>
    * If you want to filter on null value, use {@link #filteredOnNull(String)} as Java will resolve the call to
    * {@link #filteredOn(String, FilterOperator)} instead of this method.
@@ -1235,15 +1164,13 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * elements.
    * <p>
    * You can chain filters:
-   * 
-   * <pre><code class='java'>
-   * // fellowshipOfTheRing is a list of TolkienCharacter having race and name fields
+   * <pre><code class='java'> // fellowshipOfTheRing is a list of TolkienCharacter having race and name fields
    * // 'not' filter is statically imported from Assertions.not 
    * 
    * assertThat(fellowshipOfTheRing).filteredOn("race.name", "Man")
    *                                .filteredOn("name", not("Boromir"))
-   *                                .containsOnly(aragorn);
-   * </code></pre>
+   *                                .containsOnly(aragorn);</code></pre>
+   * 
    * If you need more complex filter, use {@link #filteredOn(Condition)} and provide a {@link Condition} to specify the
    * filter to apply.
    * 
@@ -1273,9 +1200,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * considered to be null, thus reading "address.street.name" value will return null if "street" value is null.
    * <p>
    * As an example, let's check all employees 800 years old (yes, special employees):
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1283,16 +1208,14 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
    *
    * assertThat(employees).filteredOnNull("name")
-   *                      .containsOnly(noname);
-   * </code></pre>
-   * Nested properties/fields are supported:
+   *                      .containsOnly(noname);</code></pre>
    * 
-   * <pre><code class='java'>
-   * // Name is bean class with 'first' and 'last' String properties 
+   * Nested properties/fields are supported:
+   * <pre><code class='java'> // Name is bean class with 'first' and 'last' String properties
    *
    * assertThat(employees).filteredOnNull("name.last")
-   *                      .containsOnly(yoda, obiwan, noname);
-   * </code></pre>
+   *                      .containsOnly(yoda, obiwan, noname);</code></pre>
+   * 
    * An {@link IntrospectionError} is thrown if the given propertyOrFieldName can't be found in one of the iterable
    * elements.
    * <p>
@@ -1330,9 +1253,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * <p>
    * 
    * As an example, let's check stuff on some special employees :
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * 
@@ -1349,30 +1270,25 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * 
    * // 'notIn' filter is statically imported from Assertions.notIn
    * assertThat(employees).filteredOn("name.first", notIn("Yoda", "Luke"))
-   *                      .containsOnly(obiwan);
-   * </code></pre>
+   *                      .containsOnly(obiwan);</code></pre>
+   * 
    * An {@link IntrospectionError} is thrown if the given propertyOrFieldName can't be found in one of the iterable
    * elements.
    * <p>
    * Note that combining filter operators is not supported, thus the following code is not correct:
-   * 
-   * <pre><code class='java'>
-   * // Combining filter operators like not(in(800)) is NOT supported
+   * <pre><code class='java'> // Combining filter operators like not(in(800)) is NOT supported
    * // -&gt; throws UnsupportedOperationException
    * assertThat(employees).filteredOn("age", not(in(800)))
-   *                      .contains(luke);
-   * </code></pre>
+   *                      .contains(luke);</code></pre>
    * <p>
    * You can chain filters:
-   * 
-   * <pre><code class='java'>
-   * // fellowshipOfTheRing is a list of TolkienCharacter having race and name fields
+   * <pre><code class='java'> // fellowshipOfTheRing is a list of TolkienCharacter having race and name fields
    * // 'not' filter is statically imported from Assertions.not 
    * 
    * assertThat(fellowshipOfTheRing).filteredOn("race.name", "Man")
    *                                .filteredOn("name", not("Boromir"))
-   *                                .containsOnly(aragorn);
-   * </code></pre>
+   *                                .containsOnly(aragorn);</code></pre>
+   * 
    * If you need more complex filter, use {@link #filteredOn(Condition)} and provide a {@link Condition} to specify the
    * filter to apply.
    * 
@@ -1393,9 +1309,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * Filter the iterable under test keeping only elements matching the given {@link Condition}.
    * <p>
    * Example : check old employees whose age > 100:
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1412,15 +1326,12 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    *     };
    *   }
    * assertThat(employees).filteredOn(oldEmployees)
-   *                      .containsOnly(yoda, obiwan);
-   * </code></pre>
-   * You can combine {@link Condition} with condition operator like {@link Not}:
+   *                      .containsOnly(yoda, obiwan);</code></pre>
    * 
-   * <pre><code class='java'>
-   * // 'not' filter is statically imported from Assertions.not 
+   * You can combine {@link Condition} with condition operator like {@link Not}:
+   * <pre><code class='java'> // 'not' filter is statically imported from Assertions.not
    * assertThat(employees).filteredOn(not(oldEmployees))
-   *                      .contains(luke, noname);
-   * </code></pre>
+   *                      .contains(luke, noname);</code></pre>
    * 
    * @param condition the filter condition / predicate
    * @return a new assertion object with the filtered iterable under test

--- a/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
@@ -97,16 +97,13 @@ public abstract class AbstractLongArrayAssert<S extends AbstractLongArrayAssert<
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new long[] { 1, 2, 3 }).containsOnlyOnce(1, 2);
    * 
    * // assertions will fail
    * assertThat(new long[] { 1, 2, 1 }).containsOnlyOnce(1);
    * assertThat(new long[] { 1, 2, 3 }).containsOnlyOnce(4);
-   * assertThat(new long[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);
-   * </code></pre>
+   * assertThat(new long[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -125,15 +122,12 @@ public abstract class AbstractLongArrayAssert<S extends AbstractLongArrayAssert<
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new long[] { 1, 2, 3 }).containsSequence(1, 2);
    * 
    * // assertion will fail
    * assertThat(new long[] { 1, 2, 3 }).containsSequence(1, 3);
-   * assertThat(new long[] { 1, 2, 3 }).containsSequence(2, 1);
-   * </code></pre>
+   * assertThat(new long[] { 1, 2, 3 }).containsSequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -152,15 +146,12 @@ public abstract class AbstractLongArrayAssert<S extends AbstractLongArrayAssert<
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(1, 2);
    * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(1, 3);
    * 
    * // assertion will fail
-   * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(2, 1);
-   * </code></pre>
+   * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -300,16 +291,13 @@ public abstract class AbstractLongArrayAssert<S extends AbstractLongArrayAssert<
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * long[] longs = { 1, 2, 3 };
+   * <pre><code class='java'> long[] longs = { 1, 2, 3 };
    * 
    * // assertion will pass
    * assertThat(longs).containsExactly(1, 2, 3);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(longs).containsExactly(2, 1, 3);
-   * </code></pre>
+   * assertThat(longs).containsExactly(2, 1, 3);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -184,17 +184,14 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(5l).isCloseTo(7l, within(3l));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat(5l).isCloseTo(7l, within(2l));
    *
    * // assertion will fail
-   * assertThat(5l).isCloseTo(7l, within(1l));
-   * </code></pre>
+   * assertThat(5l).isCloseTo(7l, within(1l));</code></pre>
    *
    * @param expected the given long to compare the actual value to.
    * @param offset the given positive offset.
@@ -212,17 +209,14 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(5l).isCloseTo(Long.valueOf(7l), within(3l));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat(5l).isCloseTo(Long.valueOf(7l), within(2l));
    *
    * // assertion will fail
-   * assertThat(5l).isCloseTo(Long.valueOf(7l), within(1l));
-   * </code></pre>
+   * assertThat(5l).isCloseTo(Long.valueOf(7l), within(1l));</code></pre>
    *
    * @param expected the given long to compare the actual value to.
    * @param offset the given positive offset.
@@ -241,17 +235,14 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with long:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(20L));
    *
    * // if difference is exactly equals to the computed offset (1L), it's ok
    * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(10L));
    *
    * // assertion will fail
-   * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(5L));
-   * </code></pre>
+   * assertThat(11L).isCloseTo(Long.valueOf(10L), withinPercentage(5L));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -271,17 +262,14 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with long:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11L).isCloseTo(10L, withinPercentage(20L));
    *
    * // if difference is exactly equals to the computed offset (1L), it's ok
    * assertThat(11L).isCloseTo(10L, withinPercentage(10L));
    *
    * // assertion will fail
-   * assertThat(11L).isCloseTo(10L, withinPercentage(5L));
-   * </code></pre>
+   * assertThat(11L).isCloseTo(10L, withinPercentage(5L));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -92,15 +92,12 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map has the same size as the given {@link Map}.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
    * assertThat(ringBearers).hasSameSizeAs(mapOf(entry(oneRing, frodo),
    *                                             entry(narya, gandalf),
    *                                             entry(nenya, galadriel),
-   *                                             entry(vilya, elrond)));
-   * </code></pre>
+   *                                             entry(vilya, elrond)));</code></pre>
    * 
    * @param other the {@code Map} to compare size with actual map
    * @return {@code this} assertion object
@@ -117,12 +114,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given entries, in any order.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));
-   * </code></pre>
+   * assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));</code></pre>
    *
    * @param entries the given entries.
    * @return {@code this} assertion object.
@@ -141,12 +135,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given entry.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).containsEntry(oneRing, frodo).containsEntry(nenya, galadriel);
-   * </code></pre>
+   * assertThat(ringBearers).containsEntry(oneRing, frodo).containsEntry(nenya, galadriel);</code></pre>
    * 
    * @param key the given key to check.
    * @param value the given value to check.
@@ -166,11 +157,8 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map does not contain the given entries.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init omitted
-   * assertThat(ringBearers).doesNotContain(entry(oneRing, aragorn));
-   * </code></pre>
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init omitted
+   * assertThat(ringBearers).doesNotContain(entry(oneRing, aragorn));</code></pre>
    * 
    * @param entries the given entries.
    * @return {@code this} assertion object.
@@ -188,12 +176,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map does not contain the given entry.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).doesNotContainEntry(oneRing, aragorn);
-   * </code></pre>
+   * assertThat(ringBearers).doesNotContainEntry(oneRing, aragorn);</code></pre>
    * 
    * @param key key of the entry.
    * @param value value of the entry.
@@ -212,12 +197,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given key.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).containsKey(oneRing);
-   * </code></pre>
+   * assertThat(ringBearers).containsKey(oneRing);</code></pre>
    * 
    * @param key the given key
    * @throws AssertionError if the actual map is {@code null}.
@@ -232,12 +214,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given keys.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).containsKeys(nenya, oneRing);
-   * </code></pre>
+   * assertThat(ringBearers).containsKeys(nenya, oneRing);</code></pre>
    * 
    * @param keys the given keys
    * @throws AssertionError if the actual map is {@code null}.
@@ -254,12 +233,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map does not contain the given key.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings only
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings only
-   * 
-   * assertThat(ringBearers).doesNotContainKey(oneRing);
-   * </code></pre>
+   * assertThat(ringBearers).doesNotContainKey(oneRing);</code></pre>
    * 
    * @param key the given key
    * @throws AssertionError if the actual map is {@code null}.
@@ -274,12 +250,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map does not contain any of the given keys.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings only
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings only
-   * 
-   * assertThat(ringBearers).doesNotContainKeys(oneRing, someManRing);
-   * </code></pre>
+   * assertThat(ringBearers).doesNotContainKeys(oneRing, someManRing);</code></pre>
    * 
    * @param key the given key
    * @throws AssertionError if the actual map is {@code null}.
@@ -296,16 +269,13 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    *
    * <p>
    * Examples :
-   *
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
    * // assertion will pass
    * assertThat(ringBearers).containsOnlyKeys(oneRing, nenya, narya, vilya);
    * 
    * // assertion will fail
-   * assertThat(ringBearers).containsOnlyKeys(oneRing, nenya);
-   * </code></pre>
+   * assertThat(ringBearers).containsOnlyKeys(oneRing, nenya);</code></pre>
    * 
    * @param keys the given keys that should be in the actual map.
    * @throws AssertionError if the actual map is {@code null}.
@@ -323,12 +293,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given value.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).containsValue(frodo);
-   * </code></pre>
+   * assertThat(ringBearers).containsValue(frodo);</code></pre>
    * 
    * @param value the value to look for.
    * @throws AssertionError if the actual map is {@code null}.
@@ -343,12 +310,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map contains the given values.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    *
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   *
-   * assertThat(ringBearers).containsValues(frodo, galadriel);
-   * </code></pre>
+   * assertThat(ringBearers).containsValues(frodo, galadriel);</code></pre>
    *
    * @param values the values to look for in the actual map.
    * @throws AssertionError if the actual map is {@code null}.
@@ -364,12 +328,9 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * Verifies that the actual map does not contain the given value.
    * <p>
    * Example :
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
-   * 
-   * assertThat(ringBearers).doesNotContainValue(aragorn);
-   * </code></pre>
+   * assertThat(ringBearers).doesNotContainValue(aragorn);</code></pre>
    * 
    * @param value the value that should not be in actual map.
    * @throws AssertionError if the actual map is {@code null}.
@@ -385,16 +346,13 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * 
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init with elves rings and the one ring
    * 
    * // assertion will pass
    * assertThat(ringBearers).containsOnly(entry(oneRing, frodo), entry(nenya, galadriel), entry(narya, gandalf), entry(vilya, elrond));
    * 
    * // assertion will fail
-   * assertThat(ringBearers).containsOnly(entry(oneRing, frodo), entry(nenya, galadriel));
-   * </code></pre>
+   * assertThat(ringBearers).containsOnly(entry(oneRing, frodo), entry(nenya, galadriel));</code></pre>
    * 
    * @param entries the entries that should be in the actual map.
    * @throws AssertionError if the actual map is {@code null}.
@@ -414,17 +372,14 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * {@link java.util.HashMap}, prefer {@link #containsOnly(org.assertj.core.data.MapEntry...)} in that case).
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * Map&lt;Ring, TolkienCharacter&gt; ringBearers = newLinkedHashMap(entry(oneRing, frodo), entry(nenya, galadriel),
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = newLinkedHashMap(entry(oneRing, frodo), entry(nenya, galadriel),
    *                                                            entry(narya, gandalf));
    * 
    * // assertion will pass
    * assertThat(ringBearers).containsExactly(entry(oneRing, frodo), entry(nenya, galadriel), entry(narya, gandalf));
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(ringBearers).containsExactly(entry(nenya, galadriel), entry(narya, gandalf), entry(oneRing, frodo));
-   * </code></pre>
+   * assertThat(ringBearers).containsExactly(entry(nenya, galadriel), entry(narya, gandalf), entry(oneRing, frodo));</code></pre>
    * 
    * @param entries the given entries.
    * @throws NullPointerException if the given entries array is {@code null}.

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -405,17 +405,14 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT);
    * 
    * // Fail if equals has not been overridden in TolkienCharacter as equals default implementation only compares references
    * assertThat(array(frodo)).contains(frodoClone);
    * 
    * // frodo and frodoClone are equals when doing a field by field comparison.
-   * assertThat(array(frodo)).usingFieldByFieldElementComparator().contains(frodoClone);
-   * </code></pre>
+   * assertThat(array(frodo)).usingFieldByFieldElementComparator().contains(frodoClone);</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -435,17 +432,14 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter("Sam", 38, HOBBIT);
    * 
    * // frodo and sam both are hobbits, so they are equals when comparing only race
    * assertThat(array(frodo)).usingElementComparatorOnFields("race").contains(sam); // OK
    * 
    * // ... but not when comparing both name and race
-   * assertThat(array(frodo)).usingElementComparatorOnFields("name", "race").contains(sam); // FAIL
-   * </code></pre>
+   * assertThat(array(frodo)).usingElementComparatorOnFields("name", "race").contains(sam); // FAIL</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -465,17 +459,14 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * to the other field/property using its <code>equals</code> method.
    * </p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter("Sam", 38, HOBBIT);
    * 
    * // frodo and sam both are hobbits, so they are equals when comparing only race (i.e. ignoring all other fields)
    * assertThat(array(frodo)).usingElementComparatorIgnoringFields("name", "age").contains(sam); // OK
    * 
    * // ... but not when comparing both name and race
-   * assertThat(array(frodo)).usingElementComparatorIgnoringFields("age").contains(sam); // FAIL
-   * </code></pre>
+   * assertThat(array(frodo)).usingElementComparatorIgnoringFields("age").contains(sam); // FAIL</code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -491,9 +482,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * be sometimes much less work !
    * <p>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
+   * <pre><code class='java'> // Build a array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
    * // they can be public field or properties, both works when extracting their values.
    * TolkienCharacter[] fellowshipOfTheRing = new TolkienCharacter[] {
    *   new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT),
@@ -516,8 +505,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * 
    * assertThat(fellowshipOfTheRing).extracting(&quot;race.name&quot;)
    *                                .contains(&quot;Hobbit&quot;, &quot;Elf&quot;)
-   *                                .doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   *                                .doesNotContain(&quot;Orc&quot;);</code></pre>
    * 
    * A field with the given name is looked for first, if it is not accessible (ie. does not exist or is not public) then
    * a property with the given name is looked for.
@@ -544,9 +532,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * be sometimes much less work !
    * <p>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build an array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
+   * <pre><code class='java'> // Build an array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
    * // they can be public field or properties, both works when extracting their values.
    * TolkienCharacter[] fellowshipOfTheRing = new TolkienCharacter[] {
    *   new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT),
@@ -569,8 +555,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * 
    * assertThat(fellowshipOfTheRing).extracting(&quot;race.name&quot;, String.class)
    *                                .contains(&quot;Hobbit&quot;, &quot;Elf&quot;)
-   *                                .doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   *                                .doesNotContain(&quot;Orc&quot;);</code></pre>
    * 
    * A field with the given name is looked for first, if it is not accessible (ie. does not exist or is not public) then
    * a property with the given name is looked for.
@@ -603,9 +588,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * element of the initial array (the Tuple's data order is the same as the given fields/properties order).
    * <p/>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build an array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
+   * <pre><code class='java'> // Build an array of TolkienCharacter, a TolkienCharacter has a name (String) and a Race (a class)
    * // they can be public field or properties, both works when extracting their values.
    * TolkienCharacter[] fellowshipOfTheRing = new TolkienCharacter[] {
    *   new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT),
@@ -631,8 +614,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * assertThat(fellowshipOfTheRing).extracting(&quot;name&quot;, &quot;age&quot;, &quot;race.name&quot;)
    *                                .contains(tuple(&quot;Boromir&quot;, 37, &quot;Man&quot;),
    *                                          tuple(&quot;Sam&quot;, 38, &quot;Hobbit&quot;),
-   *                                          tuple(&quot;Legolas&quot;, 1000, &quot;Elf&quot;));
-   * </code></pre>
+   *                                          tuple(&quot;Legolas&quot;, 1000, &quot;Elf&quot;));</code></pre>
    * 
    * A property with the given name is looked for first, if it doesn't exist then a field with the given name is looked
    * for, if no field accessible (ie. does not exist or is not public) an IntrospectionError is thrown.
@@ -664,9 +646,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * doesn't utilize introspection.
    * <p/>
    * Let's take a look an example
-   * 
-   * <pre><code class='java'>
-   * // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
+   * <pre><code class='java'> // Build a list of TolkienCharacter, a TolkienCharacter has a name, and age and a Race (a specific class)
    * // they can be public field or properties, both can be extracted.
    * List&lt;TolkienCharacter&gt; fellowshipOfTheRing = new ArrayList&lt;TolkienCharacter&gt;();
    * 
@@ -688,8 +668,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * }
    * 
    * // fellowship has hobbitses, right, my presioussss?
-   * assertThat(fellowshipOfTheRing).extracting(race).contains(HOBBIT);
-   * </code></pre>
+   * assertThat(fellowshipOfTheRing).extracting(race).contains(HOBBIT);</code></pre>
    * 
    * Note that the order of extracted property/field values is consistent with the iteration order of the Iterable under
    * test, for example if it's a {@link HashSet}, you won't be able to make any assumptions on the extracted values
@@ -711,9 +690,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * It allows testing the results of extracting values that are represented by Iterables.
    * <p/>
    * For example:
-   * 
-   * <pre><code class='java'>
-   * CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
+   * <pre><code class='java'> CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
    * CartoonCharacter lisa = new CartoonCharacter("Lisa Simpson");
    * CartoonCharacter maggie = new CartoonCharacter("Maggie Simpson");
    * CartoonCharacter homer = new CartoonCharacter("Homer Simpson");
@@ -733,8 +710,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * CartoonCharacter[] parents = new CartoonCharacter[] { homer, fred };
    * // check children
    * assertThat(parents).flatExtracting(childrenOf)
-   *                    .containsOnly(bart, lisa, maggie, pebbles);
-   * </code></pre>
+   *                    .containsOnly(bart, lisa, maggie, pebbles);</code></pre>
    * 
    * The order of extracted values is consisted with both the order of the collection itself, as well as the extracted
    * collections.
@@ -760,9 +736,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * It allows testing the elements of extracting values that are represented by iterables or arrays.
    * <p/>
    * For example:
-   *
-   * <pre><code class='java'>
-   * CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
+   * <pre><code class='java'> CartoonCharacter bart = new CartoonCharacter("Bart Simpson");
    * CartoonCharacter lisa = new CartoonCharacter("Lisa Simpson");
    * CartoonCharacter maggie = new CartoonCharacter("Maggie Simpson");
    * CartoonCharacter homer = new CartoonCharacter("Homer Simpson");
@@ -775,8 +749,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * CartoonCharacter[] parents = new CartoonCharacter[] { homer, fred };
    * // check children
    * assertThat(parents).flatExtracting("children")
-   *                    .containsOnly(bart, lisa, maggie, pebbles);
-   * </code></pre>
+   *                    .containsOnly(bart, lisa, maggie, pebbles);</code></pre>
    *
    * The order of extracted values is consisted with both the order of the collection itself, as well as the extracted
    * collections.
@@ -818,9 +791,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * toString() or public String status() instead of public String getStatus()).
    * <p>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
+   * <pre><code class='java'> // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
    * WesterosHouse[] greatHousesOfWesteros = new WesterosHouse[] { new WesterosHouse(&quot;Stark&quot;, &quot;Winter is Coming&quot;),
    *     new WesterosHouse(&quot;Lannister&quot;, &quot;Hear Me Roar!&quot;), new WesterosHouse(&quot;Greyjoy&quot;, &quot;We Do Not Sow&quot;),
    *     new WesterosHouse(&quot;Baratheon&quot;, &quot;Our is the Fury&quot;), new WesterosHouse(&quot;Martell&quot;, &quot;Unbowed, Unbent, Unbroken&quot;),
@@ -830,8 +801,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * 
    * assertThat(greatHousesOfWesteros).extractingResultOf(&quot;sayTheWords&quot;)
    *                                  .contains(&quot;Winter is Coming&quot;, &quot;We Do Not Sow&quot;, &quot;Hear Me Roar&quot;)
-   *                                  .doesNotContain(&quot;Lannisters always pay their debts&quot;);
-   * </code></pre>
+   *                                  .doesNotContain(&quot;Lannisters always pay their debts&quot;);</code></pre>
    * 
    * <p>
    * Following requirements have to be met to extract method results:
@@ -864,9 +834,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * toString() or public String status() instead of public String getStatus()).
    * <p>
    * Let's take an example to make things clearer :
-   * 
-   * <pre><code class='java'>
-   * // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
+   * <pre><code class='java'> // Build a array of WesterosHouse, a WesterosHouse has a method: public String sayTheWords()
    * WesterosHouse[] greatHousesOfWesteros = new WesterosHouse[] { new WesterosHouse(&quot;Stark&quot;, &quot;Winter is Coming&quot;),
    *     new WesterosHouse(&quot;Lannister&quot;, &quot;Hear Me Roar!&quot;), new WesterosHouse(&quot;Greyjoy&quot;, &quot;We Do Not Sow&quot;),
    *     new WesterosHouse(&quot;Baratheon&quot;, &quot;Our is the Fury&quot;), new WesterosHouse(&quot;Martell&quot;, &quot;Unbowed, Unbent, Unbroken&quot;),
@@ -876,8 +844,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * 
    * assertThat(greatHousesOfWesteros).extractingResultOf(&quot;sayTheWords&quot;, String.class)
    *                                  .contains(&quot;Winter is Coming&quot;, &quot;We Do Not Sow&quot;, &quot;Hear Me Roar&quot;)
-   *                                  .doesNotContain(&quot;Lannisters always pay their debts&quot;);
-   * </code></pre>
+   *                                  .doesNotContain(&quot;Lannisters always pay their debts&quot;);</code></pre>
    * 
    * <p>
    * Following requirements have to be met to extract method results:
@@ -908,32 +875,23 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * It can be useful to better understand what the error was with a more meaningful error message.
    * <p/>
    * Example
-   * 
-   * <pre><code class='java'>
-   * assertThat(new Byte[] { 0x10, 0x20 }).inHexadecimal().contains(new Byte[] { 0x30 });
-   * </code></pre>
+   * <pre><code class='java'> assertThat(new Byte[] { 0x10, 0x20 }).inHexadecimal().contains(new Byte[] { 0x30 });</code></pre>
    *
    * With standard error message:
-   * 
-   * <pre><code class='java'>
-   * Expecting:
+   * <pre><code class='java'> Expecting:
    *  <[16, 32]>
    * to contain:
    *  <[48]>
    * but could not find:
-   *  <[48]>
-   * </code></pre>
+   *  <[48]></code></pre>
    *
    * With Hexadecimal error message:
-   * 
-   * <pre><code class='java'>
-   * Expecting:
+   * <pre><code class='java'> Expecting:
    *  <[0x10, 0x20]>
    * to contain:
    *  <[0x30]>
    * but could not find:
-   *  <[0x30]>
-   * </code></pre>
+   *  <[0x30]></code></pre>
    *
    * @return {@code this} assertion object.
    */
@@ -961,9 +919,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * <p>
    * 
    * As an example, let's check all employees 800 years old (yes, special employees):
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -971,20 +927,17 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * Employee[] employees = new Employee[] { yoda, luke, obiwan, noname };
    *
    * assertThat(employees).filteredOn("age", 800)
-   *                      .containsOnly(yoda, obiwan);
-   * </code></pre>
+   *                      .containsOnly(yoda, obiwan);</code></pre>
+   *                      
    * Nested properties/fields are supported:
-   * 
-   * <pre><code class='java'>
-   * // Name is bean class with 'first' and 'last' String properties 
+   * <pre><code class='java'> // Name is bean class with 'first' and 'last' String properties
    *
    * // name is null for noname => it does not match the filter on "name.first" 
    * assertThat(employees).filteredOn("name.first", "Luke")
    *                      .containsOnly(luke);
    * 
    * assertThat(employees).filteredOn("name.last", "Vader")
-   *                      .isEmpty();
-   * </code></pre>
+   *                      .isEmpty();</code></pre>
    * <p>
    * If you want to filter on null value, use {@link #filteredOnNull(String)} as Java will resolve the call to
    * {@link #filteredOn(String, FilterOperator)} instead of this method.
@@ -993,15 +946,12 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * elements.
    * <p>
    * You can chain filters:
-   * 
-   * <pre><code class='java'>
-   * // fellowshipOfTheRing is an array of TolkienCharacter having race and name fields
+   * <pre><code class='java'> // fellowshipOfTheRing is an array of TolkienCharacter having race and name fields
    * // 'not' filter is statically imported from Assertions.not 
    * 
    * assertThat(fellowshipOfTheRing).filteredOn("race.name", "Man")
    *                                .filteredOn("name", not("Boromir"))
-   *                                .containsOnly(aragorn);
-   * </code></pre>
+   *                                .containsOnly(aragorn);</code></pre>
    * If you need more complex filter, use {@link #filteredOn(Condition)} and provide a {@link Condition} to specify the
    * filter to apply.
    * 
@@ -1029,9 +979,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * considered to be null, thus reading "address.street.name" value will return null if "street" value is null.
    * <p>
    * As an example, let's check all employees 800 years old (yes, special employees):
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1039,16 +987,14 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * Employee[] employees = new Employee[] { yoda, luke, obiwan, noname };
    *
    * assertThat(employees).filteredOnNull("name")
-   *                      .containsOnly(noname);
-   * </code></pre>
+   *                      .containsOnly(noname);</code></pre>
+   *                      
    * Nested properties/fields are supported:
-   * 
-   * <pre><code class='java'>
-   * // Name is bean class with 'first' and 'last' String properties 
+   * <pre><code class='java'> // Name is bean class with 'first' and 'last' String properties
    *
    * assertThat(employees).filteredOnNull("name.last")
-   *                      .containsOnly(yoda, obiwan, noname);
-   * </code></pre>
+   *                      .containsOnly(yoda, obiwan, noname);</code></pre>
+   * 
    * An {@link IntrospectionError} is thrown if the given propertyOrFieldName can't be found in one of the array
    * elements.
    * <p>
@@ -1086,9 +1032,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * <p>
    * 
    * As an example, let's check stuff on some special employees :
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * 
@@ -1105,30 +1049,25 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * 
    * // 'notIn' filter is statically imported from Assertions.notIn
    * assertThat(employees).filteredOn("name.first", notIn("Yoda", "Luke"))
-   *                      .containsOnly(obiwan);
-   * </code></pre>
+   *                      .containsOnly(obiwan);</code></pre>
+   *                      
    * An {@link IntrospectionError} is thrown if the given propertyOrFieldName can't be found in one of the array
    * elements.
    * <p>
    * Note that combining filter operators is not supported, thus the following code is not correct:
-   * 
-   * <pre><code class='java'>
-   * // Combining filter operators like not(in(800)) is NOT supported
+   * <pre><code class='java'> // Combining filter operators like not(in(800)) is NOT supported
    * // -&gt; throws UnsupportedOperationException
    * assertThat(employees).filteredOn("age", not(in(800)))
-   *                      .contains(luke);
-   * </code></pre>
+   *                      .contains(luke);</code></pre>
    * <p>
    * You can chain filters:
-   * 
-   * <pre><code class='java'>
-   * // fellowshipOfTheRing is an array of TolkienCharacter having race and name fields
+   * <pre><code class='java'> // fellowshipOfTheRing is an array of TolkienCharacter having race and name fields
    * // 'not' filter is statically imported from Assertions.not 
    * 
    * assertThat(fellowshipOfTheRing).filteredOn("race.name", "Man")
    *                                .filteredOn("name", not("Boromir"))
-   *                                .containsOnly(aragorn);
-   * </code></pre>
+   *                                .containsOnly(aragorn);</code></pre>
+   * 
    * If you need more complex filter, use {@link #filteredOn(Condition)} and provide a {@link Condition} to specify the
    * filter to apply.
    * 
@@ -1149,11 +1088,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * Filter the array under test keeping only elements matching the given {@link Condition}.
    * <p>
    * Let's check old employees whose age > 100:
-   * 
-   * 
-   * 
-   * <pre><code class='java'> 
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1170,16 +1105,12 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    *     };
    *   }
    * assertThat(employees).filteredOn(oldEmployees)
-   *                      .containsOnly(yoda, obiwan);
+   *                      .containsOnly(yoda, obiwan);</code></pre>
    *                      
-   * </code></pre>
    * You can combine {@link Condition} with condition operator like {@link Not}:
-   * 
-   * <pre><code class='java'>
-   * // 'not' filter is statically imported from Assertions.not 
+   * <pre><code class='java'> // 'not' filter is statically imported from Assertions.not
    * assertThat(employees).filteredOn(not(oldEmployees))
-   *                      .contains(luke, noname);
-   * </code></pre>
+   *                      .contains(luke, noname);</code></pre>
    * 
    * @param condition the filter condition / predicate
    * @return a new assertion object with the filtered array under test

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -50,19 +50,14 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
    * <p/>
    * 
    * Example:
-   * 
-   * <pre><code class='java'>
-   * 
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter mysteriousHobbit = new TolkienCharacter(null, 33, HOBBIT);
    * 
    * // Null fields in other/expected object are ignored, the mysteriousHobbit has null name thus name is ignored
    * assertThat(frodo).isEqualToIgnoringNullFields(mysteriousHobbit); // OK
    * 
    * // ... but the lenient equality is not reversible !
-   * assertThat(mysteriousHobbit).isEqualToIgnoringNullFields(frodo); // FAIL
-   * 
-   * </code></pre>
+   * assertThat(mysteriousHobbit).isEqualToIgnoringNullFields(frodo); // FAIL</code></pre>
    * 
    * @param other the object to compare {@code actual} to.
    * @throws NullPointerException if the actual or other object is {@code null}.
@@ -89,9 +84,7 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
    * <p/>
    * 
    * Example:
-   * 
-   * <pre><code class='java'>
-   * TolkienCharacter frodo = new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter(&quot;Sam&quot;, 38, HOBBIT);
    * 
    * // frodo and sam both are hobbits, so they are equals when comparing only race
@@ -101,9 +94,7 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
    * assertThat(frodo).isEqualToComparingOnlyGivenFields(sam, &quot;race.name&quot;); // OK
    * 
    * // ... but not when comparing both name and race
-   * assertThat(frodo).isEqualToComparingOnlyGivenFields(sam, &quot;name&quot;, &quot;race&quot;); // FAIL
-   * 
-   * </code></pre>
+   * assertThat(frodo).isEqualToComparingOnlyGivenFields(sam, &quot;name&quot;, &quot;race&quot;); // FAIL</code></pre>
    * 
    * @param other the object to compare {@code actual} to.
    * @param fieldsUsedInComparison accepted fieldsUsedInComparison for lenient equality.
@@ -131,18 +122,14 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
    * <p/>
    * 
    * Example:
-   * <pre><code class='java'>
-   * 
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter sam = new TolkienCharacter("Sam", 38, HOBBIT);
    * 
    * // frodo and sam are equals when ignoring name and age since the only remaining field is race which they share as HOBBIT.
    * assertThat(frodo).isEqualToIgnoringGivenFields(sam, "name", "age"); // OK
    * 
    * // ... but they are not equals if only age is ignored as their names differ.
-   * assertThat(frodo).isEqualToIgnoringGivenFields(sam, "age"); // FAIL
-   * 
-   * </code></pre>
+   * assertThat(frodo).isEqualToIgnoringGivenFields(sam, "age"); // FAIL</code></pre>
    * 
    * @param other the object to compare {@code actual} to.
    * @param fieldsToIgnore ignored fieldsToIgnore for lenient equality.
@@ -168,18 +155,14 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
    * <p/>
    * 
    * Example:
-   * <pre><code class='java'>
-   * 
-   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <pre><code class='java'> TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
    * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT);
    * 
    * // Fail if equals has not been overridden in TolkienCharacter as equals default implementation only compares references
    * assertThat(frodo).isEqualsTo(frodoClone);
    * 
    * // frodo and frodoClone are equals when doing a field by field comparison.
-   * assertThat(frodo).isEqualToComparingFieldByField(frodoClone);
-   * 
-   * </code></pre>
+   * assertThat(frodo).isEqualToComparingFieldByField(frodoClone);</code></pre>
    * 
    * @param other the object to compare {@code actual} to.
    * @throws NullPointerException if the actual or given object is {@code null}.

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -91,12 +91,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * Verifies that the content of the actual {@code Path} is the same as the given one (both paths must be a readable
    * files). The default charset is used to read each files.
    * 
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // use the default charset 
+   * <pre><code class="java"> // use the default charset
    * Path xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes());
    * Path xFileClone = Files.write(Paths.get("xfile-clone.txt"), "The Truth Is Out There".getBytes());
    * Path xFileFrench = Files.write(Paths.get("xfile-french.txt"), "La Vérité Est Ailleurs".getBytes());
@@ -105,8 +101,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(xFile).hasSameContentAs(xFileClone);
    * 
    * // The following assertion fails:
-   * assertThat(xFile).hasSameContentAs(xFileFrench);
-   * </code></pre>
+   * assertThat(xFile).hasSameContentAs(xFileFrench);</code></pre>
    * 
    * @param expected the given {@code Path} to compare the actual {@code Path} to.
    * @return {@code this} assertion object.
@@ -124,12 +119,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
   /**
    * Verifies that the binary content of the actual {@code Path} is <b>exactly</b> equal to the given one.
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // using the default charset, the following assertion succeeds:
+   * <pre><code class="java"> // using the default charset, the following assertion succeeds:
    * Path xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes());
    * assertThat(xFile).hasBinaryContent("The Truth Is Out There".getBytes());
    *
@@ -143,8 +134,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(xFileTurkish).hasBinaryContent(binaryContent);
    * 
    * // The following assertion fails ... unless you are in Turkey ;-):
-   * assertThat(xFileTurkish).hasBinaryContent("Gerçek Başka bir yerde mi".getBytes());
-   * </code></pre>
+   * assertThat(xFileTurkish).hasBinaryContent("Gerçek Başka bir yerde mi".getBytes());</code></pre>
    * 
    * @param expected the expected binary content to compare the actual {@code File}'s content to.
    * @return {@code this} assertion object.
@@ -163,17 +153,12 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * Specifies the name of the charset to use for text-based assertions on the path's contents (path must be a readable
    * file).
    * 
-   * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class="java">
-   * Charset turkishCharset = Charset.forName("windows-1254");
+   * <pre><code class="java"> Charset turkishCharset = Charset.forName("windows-1254");
    * Path xFileTurkish = Files.write(Paths.get("xfile.turk"), Collections.singleton("Gerçek Başka bir yerde mi"), turkishCharset);
    * 
    * // The following assertion succeeds:
-   * assertThat(xFileTurkish).usingCharset("windows-1254").hasContent("Gerçek Başka bir yerde mi");
-   * </code></pre>
+   * assertThat(xFileTurkish).usingCharset("windows-1254").hasContent("Gerçek Başka bir yerde mi");</code></pre>
    * 
    * @param charsetName the name of the charset to use.
    * @return {@code this} assertion object.
@@ -188,17 +173,12 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
   /**
    * Specifies the charset to use for text-based assertions on the path's contents (path must be a readable file).
    * 
-   * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class="java">
-   * Charset turkishCharset = Charset.forName("windows-1254");
+   * <pre><code class="java"> Charset turkishCharset = Charset.forName("windows-1254");
    * Path xFileTurkish = Files.write(Paths.get("xfile.turk"), Collections.singleton("Gerçek Başka bir yerde mi"), turkishCharset);
    * 
    * // The following assertion succeeds:
-   * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent("Gerçek Başka bir yerde mi");
-   * </code></pre>
+   * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent("Gerçek Başka bir yerde mi");</code></pre>
    * 
    * @param charset the charset to use.
    * @return {@code this} assertion object.
@@ -217,12 +197,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
    * {@link Charset#defaultCharset()}) will be used.
    * 
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // use the default charset 
+   * <pre><code class="java"> // use the default charset
    * Path xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes());
    * 
    * // The following assertion succeeds (default charset is used):
@@ -240,8 +216,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent("Gerçek Başka bir yerde mi");
    * 
    * // The following assertion fails ... unless you are in Turkey ;-):
-   * assertThat(xFileTurkish).hasContent("Gerçek Başka bir yerde mi");
-   * </code></pre>
+   * assertThat(xFileTurkish).hasContent("Gerçek Başka bir yerde mi");</code></pre>
    *
    * @param expected the expected text content to compare the actual {@code File}'s content to.
    * @return {@code this} assertion object.
@@ -260,12 +235,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * Assert that the tested {@link Path} is a readable file, it checks that the file exists (according to
    * {@link Files#exists(Path, LinkOption...)}) and that it is readable(according to {@link Files#isReadable(Path)}).
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // Create a file and set permissions to be readable by all.
+   * <pre><code class="java"> // Create a file and set permissions to be readable by all.
    * Path readableFile = Paths.get("readableFile");
    * Set&lt;PosixFilePermission&gt; perms = PosixFilePermissions.fromString("r--r--r--");
    * Files.createFile(readableFile, PosixFilePermissions.asFileAttribute(perms));
@@ -286,8 +257,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // The following assertions fail:
    * assertThat(nonReadableFile).isReadable();
-   * assertThat(nonExistentPath).isReadable();
-   * </code></pre>
+   * assertThat(nonExistentPath).isReadable();</code></pre>
    *
    * @return self
    *
@@ -302,12 +272,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * Assert that the tested {@link Path} is a writable file, it checks that the file exists (according to
    * {@link Files#exists(Path, LinkOption...)}) and that it is writable(according to {@link Files#isWritable(Path)}).
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // Create a file and set permissions to be writable by all.
+   * <pre><code class="java"> Create a file and set permissions to be writable by all.
    * Path writableFile = Paths.get("writableFile");
    * Set&lt;PosixFilePermission&gt; perms = PosixFilePermissions.fromString("rw-rw-rw-");
    * Files.createFile(writableFile, PosixFilePermissions.asFileAttribute(perms));
@@ -328,8 +294,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // The following assertions fail:
    * assertThat(nonWritableFile).isWritable();
-   * assertThat(nonExistentPath).isWritable();
-   * </code></pre>
+   * assertThat(nonExistentPath).isWritable();</code></pre>
    *
    * @return self
    *
@@ -345,12 +310,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@link Files#exists(Path, LinkOption...)}) and that it is executable(according to {@link Files#isExecutable(Path)}
    * ).
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // Create a file and set permissions to be executable by all.
+   * <pre><code class="java"> // Create a file and set permissions to be executable by all.
    * Path executableFile = Paths.get("executableFile");
    * Set&lt;PosixFilePermission&gt; perms = PosixFilePermissions.fromString("r-xr-xr-x");
    * Files.createFile(executableFile, PosixFilePermissions.asFileAttribute(perms));
@@ -371,8 +332,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // The following assertions fail:
    * assertThat(nonExecutableFile).isExecutable();
-   * assertThat(nonExistentPath).isExecutable();
-   * </code></pre>
+   * assertThat(nonExistentPath).isExecutable();</code></pre>
    *
    * @return self
    *
@@ -397,12 +357,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@link #existsNoFollowLinks()} instead.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * // Create a regular file, and a symbolic link pointing to it
    * final Path existingFile = fs.getPath("somefile");
    * Files.createFile(existingFile);
@@ -420,8 +376,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // The following assertions fail:
    * assertThat(nonExistentPath).exists();
-   * assertThat(symlinkToNonExistentPath).exists();
-   * </code></pre>
+   * assertThat(symlinkToNonExistentPath).exists();</code></pre>
    *
    * @return self
    *
@@ -441,12 +396,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * symbolic link even if its target is invalid.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * // Create a regular file, and a symbolic link pointing to it
    * final Path existingFile = fs.getPath("somefile");
    * Files.createFile(existingFile);
@@ -464,8 +415,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(symlinkToNonExistentPath).existsNoFollowLinks();
    *
    * // The following assertion fails
-   * assertThat(nonExistentPath).existsNoFollowLinks();
-   * </code></pre>
+   * assertThat(nonExistentPath).existsNoFollowLinks();</code></pre>
    *
    * @return self
    *
@@ -492,10 +442,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * <p>
    * If you are a Windows user, the above does not apply to you; if you are a Unix user however, this is important.
    * Consider the following:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a FileSystem
+   * <pre><code class="java"> // fs is a FileSystem
    * // Create a regular file, and a symbolic link pointing to it
    * final Path existingFile = fs.getPath("somefile");
    * Files.createFile(existingFile);
@@ -514,8 +461,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(existingFile).doesNotExist();
    * assertThat(symlinkToExistingFile).doesNotExist();
    * // fail because symlinkToNonExistentPath exists even though its target does not.
-   * assertThat(symlinkToNonExistentPath).doesNotExist();
-   * </code></pre>
+   * assertThat(symlinkToNonExistentPath).doesNotExist();</code></pre>
    *
    * @return self
    *
@@ -540,12 +486,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * regular file.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // Create a regular file, and a symbolic link to that regular file
    * final Path existingFile = fs.getPath("existingFile");
@@ -574,8 +516,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // the following assertions fail because paths exist but are not regular files:
    * assertThat(dir).isRegularFile();
-   * assertThat(dirSymlink).isRegularFile();
-   * </code></pre>
+   * assertThat(dirSymlink).isRegularFile();</code></pre>
    *
    * @return self
    */
@@ -596,12 +537,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * directory.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // Create a regular file, and a symbolic link to that regular file
    * final Path existingFile = fs.getPath("existingFile");
@@ -630,8 +567,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // the following assertions fail because paths exist but are not directories:
    * assertThat(existingFile).isDirectory();
-   * assertThat(symlinkToExistingFile).isDirectory();
-   * </code></pre>
+   * assertThat(symlinkToExistingFile).isDirectory();</code></pre>
    *
    * @return self
    */
@@ -647,12 +583,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * the path is a symbolic link.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // Create a regular file, and a symbolic link to that regular file
    * final Path existingFile = fs.getPath("existingFile");
@@ -681,8 +613,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // the following assertions fail because paths exist but are not symbolic links
    * assertThat(existingFile).isSymbolicLink();
-   * assertThat(dir).isSymbolicLink();
-   * </code></pre>
+   * assertThat(dir).isSymbolicLink();</code></pre>
    *
    * @return self
    */
@@ -699,12 +630,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@code /foo/..} is absolute, for instance, but it is not normalized.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // unixFs is a Unix FileSystem
+   * <pre><code class="java"> // unixFs is a Unix FileSystem
    *
    * // The following assertion succeeds:
    * assertThat(unixFs.getPath("/foo/bar")).isAbsolute();
@@ -720,8 +647,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // The following assertions fail:
    * assertThat(windowsFs.getPath("foo\\bar")).isAbsolute();
    * assertThat(windowsFs.getPath("c:foo")).isAbsolute();
-   * assertThat(windowsFs.getPath("\\foo\\bar")).isAbsolute();
-   * </code></pre>
+   * assertThat(windowsFs.getPath("\\foo\\bar")).isAbsolute();</code></pre>
    *
    * @return self
    *
@@ -735,12 +661,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
   /**
    * Assert that the tested {@link Path} is relative (opposite to {@link Path#isAbsolute()}).
    *
-   * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class="java">
-   * // unixFs is a Unix FileSystem
+   * <pre><code class="java"> // unixFs is a Unix FileSystem
    *
    * // The following assertions succeed:
    * assertThat(unixFs.getPath("./foo/bar")).isRelative();
@@ -757,8 +679,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(windowsFs.getPath("\\foo\\bar")).isRelative();
    *
    * // The following assertions fail:
-   * assertThat(windowsFs.getPath("c:\\foo")).isRelative();
-   * </code></pre>
+   * assertThat(windowsFs.getPath("c:\\foo")).isRelative();</code></pre>
    *
    * @return self
    *
@@ -778,12 +699,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * beginning of the path.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // the following assertions succeed:
    * assertThat(fs.getPath("/usr/lib")).isNormalized();
@@ -793,8 +710,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // the following assertions fail:
    * assertThat(fs.getPath("/a/./b")).isNormalized();
    * assertThat(fs.getPath("c/b/..")).isNormalized();
-   * assertThat(fs.getPath("/../../e")).isNormalized();
-   * </code></pre>
+   * assertThat(fs.getPath("/../../e")).isNormalized();</code></pre>
    *
    * @return self
    */
@@ -813,12 +729,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@link Files#isSymbolicLink(Path) symbolic link} to the actual resource, even if the path is absolute.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * // Create a directory
    * final Path basedir = fs.getPath("/tmp/foo");
    * Files.createDirectories(basedir);
@@ -835,8 +747,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(existingFile).isCanonical();
    *
    * // The following assertion fails:
-   * assertThat(symlinkToExistingFile).isCanonical();
-   * </code></pre>
+   * assertThat(symlinkToExistingFile).isCanonical();</code></pre>
    *
    * @throws PathsException an I/O error occurred while evaluating the path
    *
@@ -854,12 +765,9 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * <p>
    * Note that the path does not need to exist to check its file name.
    * </p>
-   * <p>
-   * Examples:
-   * </p>
    *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * Examples:
+   * <pre><code class="java"> // fs is a Unix filesystem
    * final Path file = fs.getPath("/foo/foo.txt");
    * final Path symlink = fs.getPath("/home/symlink-to-foo");
    * Files.createSymbolicLink(symlink, file);
@@ -876,8 +784,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // fail because, last element is "." 
    * assertThat(fs.getPath("/dir1/.")).hasFileName("dir1");
    * // fail because a link filename is not the same as its target filename
-   * assertThat(symlink).hasFileName("file.txt");
-   * </code></pre>
+   * assertThat(symlink).hasFileName("file.txt");</code></pre>
    *
    * @param fileName the expected filename
    * @return self
@@ -903,12 +810,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * or has a different parent than what is expected.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * final Path actual = fs.getPath("/dir1/dir2/file");
    *
    * // the following assertion succeeds:
@@ -917,8 +820,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(actual).hasParent(fs.getPath("/dir1/dir3/../dir2/."));
    *
    * // the following assertion fails:
-   * assertThat(actual).hasParent(fs.getPath("/dir1"));
-   * </code></pre>
+   * assertThat(actual).hasParent(fs.getPath("/dir1"));</code></pre>
    *
    * @param expected the expected parent path
    * @return self
@@ -958,12 +860,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * directory respectively. In fact, it is not even required that a {@link FileSystem} be hierarchical at all.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * final Path actual = fs.getPath("/dir1/dir2/file");
    *
    * // the following assertion succeeds:
@@ -972,8 +870,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // the following assertions fails:
    * assertThat(actual).hasParent(fs.getPath("/dir1"));
    * // ... and this one too as expected path is not canonicalized.
-   * assertThat(actual).hasParentRaw(fs.getPath("/dir1/dir3/../dir2"));
-   * </code></pre>
+   * assertThat(actual).hasParentRaw(fs.getPath("/dir1/dir3/../dir2"));</code></pre>
    *
    * @param expected the expected parent path
    * @return self
@@ -999,12 +896,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * about canonicalization.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // the following assertion succeeds:
    * assertThat(fs.getPath("/")).hasNoParent();
@@ -1013,8 +906,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    *
    * // the following assertions fail:
    * assertThat(fs.getPath("/usr/lib")).hasNoParent();
-   * assertThat(fs.getPath("/usr")).hasNoParent();
-   * </code></pre>
+   * assertThat(fs.getPath("/usr")).hasNoParent();</code></pre>
    *
    * @return self
    *
@@ -1045,12 +937,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * parent is {@code /usr}.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    *
    * // the following assertions succeed:
    * assertThat(fs.getPath("/")).hasNoParentRaw();
@@ -1060,8 +948,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(fs.getPath("/usr/lib")).hasNoParentRaw();
    * assertThat(fs.getPath("/usr")).hasNoParentRaw();
    * // this one fails as canonicalization is not performed, leading to parent being /usr
-   * assertThat(fs.getPath("/usr/..")).hasNoParent();
-   * </code></pre>
+   * assertThat(fs.getPath("/usr/..")).hasNoParent();</code></pre>
    *
    * @return self
    *
@@ -1086,12 +973,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@code /home/foo}.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * final Path tested = fs.getPath("/home/joe/myfile");
    *
    * // the following assertion succeeds:
@@ -1102,8 +985,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * assertThat(tested).startsWith(fs.getPath("/home/jane/../joe/."));
    *
    * // the following assertion fails:
-   * assertThat(tested).startsWith(fs.getPath("/home/harry"));
-   * </code></pre>
+   * assertThat(tested).startsWith(fs.getPath("/home/harry"));</code></pre>
    *
    * @param other the other path
    * @return self
@@ -1141,12 +1023,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * the latter ({@code home}).
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * final Path tested = fs.getPath("/home/joe/myfile");
    *
    * // the following assertion succeeds:
@@ -1155,8 +1033,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // the following assertion fails:
    * assertThat(tested).startsWithRaw(fs.getPath("/home/harry"));
    * // .... and this one too as given path is not canonicalized
-   * assertThat(tested).startsWithRaw(fs.getPath("/home/joe/.."));
-   * </code></pre>
+   * assertThat(tested).startsWithRaw(fs.getPath("/home/joe/.."));</code></pre>
    *
    * @param other the other path
    * @return self
@@ -1183,12 +1060,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * {@code /home/foobar/baz} does <em>not</em> end with {@code bar/baz}.
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem.
+   * <pre><code class="java"> // fs is a Unix filesystem.
    * // the current directory is supposed to be /home.
    * final Path tested = fs.getPath("/home/joe/myfile");
    * // as tested will be canonicalized, it could have been written: /home/jane/../joe/myfile
@@ -1199,8 +1072,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // the following assertions fail:
    * assertThat(tested).endsWith(fs.getPath("joe/otherfile"));
    * // this path will be normalized to joe/otherfile
-   * assertThat(tested).endsWith(fs.getPath("joe/myfile/../otherfile"));
-   * </code></pre>
+   * assertThat(tested).endsWith(fs.getPath("joe/myfile/../otherfile"));</code></pre>
    *
    * @param other the other path
    * @return self
@@ -1233,12 +1105,8 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * the latter ({@code .}).
    * </p>
    *
-   * <p>
    * Examples:
-   * </p>
-   *
-   * <pre><code class="java">
-   * // fs is a Unix filesystem
+   * <pre><code class="java"> // fs is a Unix filesystem
    * // the current directory is supposed to be /home.
    * final Path tested = fs.getPath("/home/joe/myfile");
    *
@@ -1248,8 +1116,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * // But the following assertion fails:
    * assertThat(tested).endsWithRaw(fs.getPath("harry/myfile"));
    * // and this one too as the given path is not normalized
-   * assertThat(tested).endsWithRaw(fs.getPath("harry/../joe/myfile"));
-   * </code></pre>
+   * assertThat(tested).endsWithRaw(fs.getPath("harry/../joe/myfile"));</code></pre>
    *
    * @param other the other path
    * @return self

--- a/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
@@ -97,16 +97,13 @@ public abstract class AbstractShortArrayAssert<S extends AbstractShortArrayAsser
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new short[] { 1, 2, 3 }).containsOnlyOnce(1, 2);
    * 
    * // assertions will fail
    * assertThat(new short[] { 1, 2, 1 }).containsOnlyOnce(1);
    * assertThat(new short[] { 1, 2, 3 }).containsOnlyOnce(4);
-   * assertThat(new short[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);
-   * </code></pre>
+   * assertThat(new short[] { 1, 2, 3, 3 }).containsOnlyOnce(0, 1, 2, 3, 4, 5);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -125,15 +122,12 @@ public abstract class AbstractShortArrayAssert<S extends AbstractShortArrayAsser
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new short[] { 1, 2, 3 }).containsSequence(1, 2);
    * 
    * // assertion will fail
    * assertThat(new short[] { 1, 2, 3 }).containsSequence(1, 3);
-   * assertThat(new short[] { 1, 2, 3 }).containsSequence(2, 1);
-   * </code></pre>
+   * assertThat(new short[] { 1, 2, 3 }).containsSequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -152,15 +146,12 @@ public abstract class AbstractShortArrayAssert<S extends AbstractShortArrayAsser
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new short[] { 1, 2, 3 }).containsSubsequence(1, 2);
    * assertThat(new short[] { 1, 2, 3 }).containsSubsequence(1, 3);
    * 
    * // assertion will fail
-   * assertThat(new short[] { 1, 2, 3 }).containsSubsequence(2, 1);
-   * </code></pre>
+   * assertThat(new short[] { 1, 2, 3 }).containsSubsequence(2, 1);</code></pre>
    * 
    * </p>
    * 
@@ -300,16 +291,13 @@ public abstract class AbstractShortArrayAssert<S extends AbstractShortArrayAsser
    * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * short[] shorts = { 1, 2, 3 };
+   * <pre><code class='java'> short[] shorts = { 1, 2, 3 };
    * 
    * // assertion will pass
    * assertThat(shorts).containsExactly(1, 2, 3);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(shorts).containsExactly(2, 1, 3);
-   * </code></pre>
+   * assertThat(shorts).containsExactly(2, 1, 3);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -48,14 +48,11 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf(&quot;1&quot;)).isEqualTo((short) 1);
    * 
    * // assertion will fail:
-   * assertThat(Short.valueOf(&quot;-1&quot;)).isEqualTo((short) 1);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;-1&quot;)).isEqualTo((short) 1);</code></pre>
    * </p>
    *
    * @param expected the given value to compare the actual value to.
@@ -72,14 +69,11 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is not equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf((&quot;-1&quot;)).isNotEqualTo((short) 1);
    * 
    * // assertion will fail:
-   * assertThat(Short.valueOf(&quot;1&quot;)).isNotEqualTo((short) 1);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;1&quot;)).isNotEqualTo((short) 1);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -138,15 +132,12 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is less than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf(&quot;1&quot;)).isLessThan((short) 2);
    * 
    * // assertion will fail:
    * assertThat(Short.valueOf(&quot;1&quot;)).isLessThan((short) 0);
-   * assertThat(Short.valueOf(&quot;1&quot;)).isLessThan((short) 1);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;1&quot;)).isLessThan((short) 1);</code></pre>
    * </p>
    * 
    * @param other the given value to compare the actual value to.
@@ -163,14 +154,11 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is less than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf(&quot;1&quot;)).isLessThanOrEqualTo((short) 1);
    * 
    * // assertion will fail:
-   * assertThat(Short.valueOf(&quot;1&quot;)).isLessThanOrEqualTo((short) 0);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;1&quot;)).isLessThanOrEqualTo((short) 0);</code></pre>
    * </p>
    * 
    * @param other the given value to compare the actual value to.
@@ -187,15 +175,12 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is greater than the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf(&quot;1&quot;)).isGreaterThan((short) 0);
    * 
    * // assertions will fail:
    * assertThat(Short.valueOf(&quot;0&quot;)).isGreaterThan((short) 1);
-   * assertThat(Short.valueOf(&quot;0&quot;)).isGreaterThan((short) 0);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;0&quot;)).isGreaterThan((short) 0);</code></pre>
    * </p>
    * 
    * @param other the given value to compare the actual value to.
@@ -212,14 +197,11 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * Verifies that the actual value is greater than or equal to the given one.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(Short.valueOf(&quot;1&quot;)).isGreaterThanOrEqualTo((short) 1);
    * 
    * // assertion will fail:
-   * assertThat(Short.valueOf(&quot;0&quot;)).isGreaterThanOrEqualTo((short) 1);
-   * </code></pre>
+   * assertThat(Short.valueOf(&quot;0&quot;)).isGreaterThanOrEqualTo((short) 1);</code></pre>
    * </p>
    *
    * @param other the given value to compare the actual value to.
@@ -251,17 +233,14 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((short)5).isCloseTo((short)7, within((short)3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat((short)5).isCloseTo((short)7, within((short)2));
    *
    * // assertion will fail
-   * assertThat((short)5).isCloseTo((short)7, within((short)1));
-   * </code></pre>
+   * assertThat((short)5).isCloseTo((short)7, within((short)1));</code></pre>
    *
    * @param expected the given short to compare the actual value to.
    * @param offset the given positive offset.
@@ -279,17 +258,14 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)3));
    *
    * // if difference is exactly equals to the offset, it's ok
    * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)2));
    *
    * // assertion will fail
-   * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)1));
-   * </code></pre>
+   * assertThat((short)5).isCloseTo(Short.valueOf(7), within((short)1));</code></pre>
    *
    * @param expected the given short to compare the actual value to.
    * @param offset the given positive offset.
@@ -308,17 +284,14 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with short:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)20));
    *
    * // if difference is exactly equals to the computed offset (1), it's ok
    * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)10));
    *
    * // assertion will fail
-   * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)5));
-   * </code></pre>
+   * assertThat((short)11).isCloseTo(Short.valueOf(10), withinPercentage((short)5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.
@@ -338,17 +311,14 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with short:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)20));
    *
    * // if difference is exactly equals to the computed offset (1), it's ok
    * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)10));
    *
    * // assertion will fail
-   * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)5));
-   * </code></pre>
+   * assertThat((short)11).isCloseTo((short)10, withinPercentage((short)5));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -435,26 +435,17 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
   /**
    * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
    * 
-   * <p>
    * Java 8 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   *  {@literal @}Test
+   * <pre><code class='java'>  {@literal @}Test
    *  public void testException() {
    *    SoftAssertions softly = new SoftAssertions();
    *    softly.assertThatThrownBy(() -> { throw new Exception("boom!") }).isInstanceOf(Exception.class)
    *                                                                     .hasMessageContaining("boom");
-   *  }
-   * </code></pre>
+   *  }</code></pre>
    * 
-   * <p>
    * Java 7 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * SoftAssertions softly = new SoftAssertions();
-   * softly.assertThatThrownBy(new ThrowingCallable()
+   * <pre><code class='java'> SoftAssertions softly = new SoftAssertions();
+   * softly.assertThatThrownBy(new ThrowingCallable() {
    * 
    *   {@literal @}Override
    *   public Void call() throws Exception {
@@ -462,8 +453,7 @@ public abstract class AbstractStandardSoftAssertions extends AbstractSoftAsserti
    *   }
    *   
    * }).isInstanceOf(Exception.class)
-   *   .hasMessageContaining("boom");
-   * </code></pre>
+   *   .hasMessageContaining("boom");</code></pre>
    *
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -61,12 +61,8 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * Verifies that the actual {@code Throwable} has a cause similar to the given one, that is with same type and message
    * (it does not use {@link Throwable#equals(Object) equals} method for comparison).
    *
-   * <p>
    * Example:
-   * </p>
-   *
-   * <pre><code class='java'>
-   * Throwable invalidArgException = new IllegalArgumentException("invalid arg");
+   * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("invalid arg");
    * Throwable throwable = new Throwable(invalidArgException);
    *
    * // This assertion succeeds:
@@ -75,8 +71,7 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * // These assertions fail:
    * assertThat(throwable).hasCause(new IllegalArgumentException("bad arg"));
    * assertThat(throwable).hasCause(new NullPointerException());
-   * assertThat(throwable).hasCause(null); // prefer hasNoCause()
-   * </code></pre>
+   * assertThat(throwable).hasCause(null); // prefer hasNoCause()</code></pre>
    * 
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Throwable} is {@code null}.
@@ -142,18 +137,14 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * Verifies that the cause of the actual {@code Throwable} is an instance of the given type.
    * <p>
    * Example:
-   * </p>
-   *
-   * <pre><code class='java'>
-   * Throwable throwable = new Throwable(new NullPointerException());
+   * <pre><code class='java'> Throwable throwable = new Throwable(new NullPointerException());
    *
    * // assertion will pass
    * assertThat(throwable).hasCauseInstanceOf(NullPointerException.class);
    * assertThat(throwable).hasCauseInstanceOf(RuntimeException.class);
    *
    * // assertion will fail
-   * assertThat(throwable).hasCauseInstanceOf(IllegalArgumentException.class);
-   * </code></pre>
+   * assertThat(throwable).hasCauseInstanceOf(IllegalArgumentException.class);</code></pre>
    *
    * @param type the expected cause type.
    * @return this assertion object.
@@ -171,17 +162,14 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * Verifies that the cause of the actual {@code Throwable} is <b>exactly</b> an instance of the given type.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-	 * Throwable throwable = new Throwable(new NullPointerException());
+   * <pre><code class='java'> Throwable throwable = new Throwable(new NullPointerException());
 	 *
 	 * // assertion will pass
 	 * assertThat(throwable).hasCauseExactlyInstanceOf(NullPointerException.class);
 	 *
 	 * // assertions will fail (even if NullPointerException is a RuntimeException since we want an exact match)
 	 * assertThat(throwable).hasCauseExactlyInstanceOf(RuntimeException.class);
-	 * assertThat(throwable).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
-	 * </code></pre>
+	 * assertThat(throwable).hasCauseExactlyInstanceOf(IllegalArgumentException.class);</code></pre>
    *
    * </p>
    *
@@ -202,17 +190,14 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * Verifies that the root cause of the actual {@code Throwable} is an instance of the given type.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-	 * Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException()));
+   * <pre><code class='java'> Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException()));
 	 *
 	 * // assertion will pass
 	 * assertThat(throwable).hasRootCauseInstanceOf(NullPointerException.class);
 	 * assertThat(throwable).hasRootCauseInstanceOf(RuntimeException.class);
 	 *
 	 * // assertion will fail
-	 * assertThat(throwable).hasRootCauseInstanceOf(IllegalStateException.class);
-	 * </code></pre>
+	 * assertThat(throwable).hasRootCauseInstanceOf(IllegalStateException.class);</code></pre>
    *
    * </p>
    *
@@ -232,17 +217,14 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
    * Verifies that the root cause of the actual {@code Throwable} is <b>exactly</b> an instance of the given type.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-	 * Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException()));
+   * <pre><code class='java'> Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException()));
 	 *
 	 * // assertion will pass
 	 * assertThat(throwable).hasRootCauseExactlyInstanceOf(NullPointerException.class);
 	 *
 	 * // assertion will fail (even if NullPointerException is a RuntimeException since we want an exact match)
 	 * assertThat(throwable).hasRootCauseExactlyInstanceOf(RuntimeException.class);
-	 * assertThat(throwable).hasRootCauseExactlyInstanceOf(IllegalStateException.class);
-	 * </code></pre>
+	 * assertThat(throwable).hasRootCauseExactlyInstanceOf(IllegalStateException.class);</code></pre>
    *
    * </p>
    *

--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -36,16 +36,12 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected path.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://helloworld.org/pages")).hasPath("/pages");
    * assertThat(new URI("http://www.helloworld.org")).hasPath("");
    * 
    * // this assertion fails:
-   * assertThat(new URI("http://helloworld.org/pickme")).hasPath("/pages");
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org/pickme")).hasPath("/pages");</code></pre>
    *
    * @param expected the expected path of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -60,16 +56,12 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has no path.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("mailto:java-net@java.sun.com")).hasNoPath();
    * 
    * // this assertions fail:
    * assertThat(new URI("http://helloworld.org")).hasNoPath(); // empty path
-   * assertThat(new URI("http://helloworld.org/france")).hasNoPath();
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org/france")).hasNoPath();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a path.
@@ -83,17 +75,13 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected port.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://helloworld.org:8080")).hasPort(8080);
    * 
    * // These assertions fail:
    * assertThat(new URI("http://helloworld.org:8080")).hasPort(9876);
    * assertThat(new URI("http://helloworld.org")).hasPort(8080);
-   * assertThat(new URI("helloworld.org:8080")).hasPort(8080);
-   * </code></pre>
+   * assertThat(new URI("helloworld.org:8080")).hasPort(8080);</code></pre>
    *
    * @param expected the expected port of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -108,15 +96,11 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has no port.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://helloworld.org")).hasNoPort();
    * 
    * // These assertion fails:
-   * assertThat(new URI("http://helloworld.org:8080")).hasNoPort();
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org:8080")).hasNoPort();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a port.
@@ -130,18 +114,14 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected host.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://helloworld.org")).hasAuthority("helloworld.org");
    * assertThat(new URI("http://helloworld.org/pages")).hasHost("helloworld.org");
    * assertThat(new URI("http://helloworld.org:8080")).hasHost("helloworld.org");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://www.helloworld.org")).hasHost("helloworld.org");
-   * assertThat(new URI("http://www.helloworld.org:8080")).hasHost("helloworld.org");
-   * </code></pre>
+   * assertThat(new URI("http://www.helloworld.org:8080")).hasHost("helloworld.org");</code></pre>
    *
    * @param expected the expected host of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -156,17 +136,13 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected authority.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://helloworld.org:8080")).hasAuthority("helloworld.org:8080");
    * assertThat(new URI("http://www.helloworld.org:8080/news")).hasAuthority("www.helloworld.org:8080");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://www.helloworld.org:8080")).hasAuthority("www.helloworld.org");
-   * assertThat(new URI("http://www.helloworld.org")).hasAuthority("www.helloworld.org:8080");
-   * </code></pre>
+   * assertThat(new URI("http://www.helloworld.org")).hasAuthority("www.helloworld.org:8080");</code></pre>
    *
    * @param expected the expected authority of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -181,16 +157,12 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected fragment.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("http://helloworld.org:8080/index.html#print")).hasFragment("print");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://helloworld.org:8080/index.html#print")).hasFragment("hello");
-   * assertThat(new URI("http://helloworld.org:8080/index.html")).hasFragment("hello");
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org:8080/index.html")).hasFragment("hello");</code></pre>
    *
    * @param expected the expected fragment of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -205,15 +177,11 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has no fragment.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("http://www.helloworld.org/index.html")).hasNoFragment();
    * 
    * // This assertion fail:
-   * assertThat(new URI("http://helloworld.org:8080/index.html#print")).hasNoFragment();
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org:8080/index.html#print")).hasNoFragment();</code></pre>
    * 
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a fragment.
@@ -227,16 +195,12 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected query.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("http://www.helloworld.org/index.html?type=test")).hasQuery("type=test");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://www.helloworld.org/index.html?type=test")).hasQuery("type=hello");
-   * assertThat(new URI("http://www.helloworld.org/index.html")).hasQuery("type=hello");
-   * </code></pre>
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasQuery("type=hello");</code></pre>
    *
    * @param expected the expected query of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -251,15 +215,11 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has no query.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("http://www.helloworld.org/index.html")).hasNoQuery();
    * 
    * // These assertions fail:
-   * assertThat(new URI("http://www.helloworld.org/index.html?type=test")).hasNoQuery();
-   * </code></pre>
+   * assertThat(new URI("http://www.helloworld.org/index.html?type=test")).hasNoQuery();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a query.
@@ -273,15 +233,11 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected scheme.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("ftp://helloworld.org")).hasScheme("ftp");
    * 
    * // These assertion fails:
-   * assertThat(new URI("http://helloworld.org")).hasScheme("ftp");
-   * </code></pre>
+   * assertThat(new URI("http://helloworld.org")).hasScheme("ftp");</code></pre>
    *
    * @param expected the expected scheme of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -296,18 +252,14 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has the expected userinfo.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URI("http://test:pass@www.helloworld.org/index.html")).hasUserInfo("test:pass");
    * assertThat(new URI("http://test@www.helloworld.org/index.html")).hasUserInfo("test");
    * assertThat(new URI("http://:pass@www.helloworld.org/index.html")).hasUserInfo(":pass");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://test:pass@www.helloworld.org/index.html")).hasUserInfo("test:fail");
-   * assertThat(new URI("http://www.helloworld.org/index.html")).hasUserInfo("test:pass");
-   * </code></pre>
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasUserInfo("test:pass");</code></pre>
    *
    * @param expected the expected userinfo of the actual {@code URI}.
    * @return {@code this} assertion object.
@@ -322,15 +274,11 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * Verifies that the actual {@code URI} has no userinfo.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URI("http://www.helloworld.org/index.html")).hasNoUserInfo();
    * 
    * // This assertion fails:
-   * assertThat(new URI("http://test:pass@www.helloworld.org/index.html")).hasNoUserInfo();
-   * </code></pre>
+   * assertThat(new URI("http://test:pass@www.helloworld.org/index.html")).hasNoUserInfo();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has some userinfo.

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -36,15 +36,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected protocol.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("ftp://helloworld.org")).hasProtocol("ftp");
    * 
    * // These assertion fails:
-   * assertThat(new URL("http://helloworld.org")).hasProtocol("ftp");
-   * </code></pre>
+   * assertThat(new URL("http://helloworld.org")).hasProtocol("ftp");</code></pre>
    *
    * @param expected the expected protocol of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -59,10 +55,7 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected path (which must not be null).
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URL("http://helloworld.org/pages")).hasPath("/pages");
    * assertThat(new URL("http://www.helloworld.org")).hasPath("");
    * // or preferably:  
@@ -72,8 +65,7 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * assertThat(new URL("http://helloworld.org/pickme")).hasPath("/pages/");
    * 
    * // this assertion throws an IllegalArgumentException:
-   * assertThat(new URL("http://helloworld.org/pages")).hasPath(null);
-   * </code></pre>
+   * assertThat(new URL("http://helloworld.org/pages")).hasPath(null);</code></pre>
    *
    * @param expected the expected path of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -89,15 +81,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has no path.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org")).hasNoPath();
    * 
    * // this assertion fails:
-   * assertThat(new URL("http://helloworld.org/france")).hasNoPath();
-   * </code></pre>
+   * assertThat(new URL("http://helloworld.org/france")).hasNoPath();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a path.
@@ -111,16 +99,12 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected port.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URL("http://helloworld.org:8080")).hasPort(8080);
    * 
    * // These assertions fail:
    * assertThat(new URL("http://helloworld.org:8080")).hasPort(9876);
-   * assertThat(new URL("http://helloworld.org")).hasPort(8080);
-   * </code></pre>
+   * assertThat(new URL("http://helloworld.org")).hasPort(8080);</code></pre>
    *
    * @param expected the expected port of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -135,15 +119,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has no port.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://helloworld.org")).hasNoPort();
    * 
-   * // These assertion fails:
-   * assertThat(new URL("http://helloworld.org:8080")).hasNoPort();
-   * </code></pre>
+   * // This assertion fails:
+   * assertThat(new URL("http://helloworld.org:8080")).hasNoPort();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a port.
@@ -157,17 +137,13 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected host.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URL("http://helloworld.org/pages")).hasHost("helloworld.org");
    * assertThat(new URL("http://helloworld.org:8080")).hasHost("helloworld.org");
    * 
    * // These assertions fail:
    * assertThat(new URL("http://www.helloworld.org")).hasHost("helloworld.org");
-   * assertThat(new URL("http://www.helloworld.org:8080")).hasHost("helloworld.org");
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org:8080")).hasHost("helloworld.org");</code></pre>
    *
    * @param expected the expected host of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -182,18 +158,14 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected authority.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URL("http://helloworld.org")).hasAuthority("helloworld.org");
    * assertThat(new URL("http://helloworld.org:8080")).hasAuthority("helloworld.org:8080");
    * assertThat(new URL("http://www.helloworld.org:8080/news")).hasAuthority("www.helloworld.org:8080");
    * 
    * // These assertions fail:
    * assertThat(new URL("http://www.helloworld.org:8080")).hasAuthority("www.helloworld.org");
-   * assertThat(new URL("http://www.helloworld.org")).hasAuthority("www.helloworld.org:8080");
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org")).hasAuthority("www.helloworld.org:8080");</code></pre>
    *
    * @param expected the expected authority of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -208,16 +180,12 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected query.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org/index.html?type=test")).hasQuery("type=test");
    * 
    * // These assertions fail:
    * assertThat(new URL("http://www.helloworld.org/index.html?type=test")).hasQuery("type=hello");
-   * assertThat(new URL("http://www.helloworld.org/index.html")).hasQuery("type=hello");
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasQuery("type=hello");</code></pre>
    *
    * @param expected the expected query of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -232,15 +200,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has no query.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org/index.html")).hasNoQuery();
    * 
    * // These assertions fail:
-   * assertThat(new URL("http://www.helloworld.org/index.html?type=test")).hasNoQuery();
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org/index.html?type=test")).hasNoQuery();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a query.
@@ -254,16 +218,12 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected anchor.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org/news.html#sport")).hasAnchor("sport");
    * 
    * // These assertions fail:
    * assertThat(new URL("http://www.helloworld.org/news.html#sport")).hasAnchor("war");
-   * assertThat(new URL("http://www.helloworld.org/news.html")).hasAnchor("sport");
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org/news.html")).hasAnchor("sport");</code></pre>
    *
    * @param expected the expected anchor of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -278,15 +238,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has no anchor.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org/news.html")).hasNoAnchor();
    * 
    * // These assertions fail:
-   * assertThat(new URL("http://www.helloworld.org/news.html#sport")).hasNoAnchor();
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org/news.html#sport")).hasNoAnchor();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has a anchor.
@@ -300,18 +256,14 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has the expected userinfo.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // These assertions succeed:
+   * <pre><code class='java'> // These assertions succeed:
    * assertThat(new URL("http://test:pass@www.helloworld.org/index.html")).hasUserInfo("test:pass");
    * assertThat(new URL("http://test@www.helloworld.org/index.html")).hasUserInfo("test");
    * assertThat(new URL("http://:pass@www.helloworld.org/index.html")).hasUserInfo(":pass");
    * 
    * // These assertions fail:
    * assertThat(new URL("http://test:pass@www.helloworld.org/index.html")).hasUserInfo("test:fail");
-   * assertThat(new URL("http://www.helloworld.org/index.html")).hasUserInfo("test:pass");
-   * </code></pre>
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasUserInfo("test:pass");</code></pre>
    *
    * @param expected the expected userinfo of the actual {@code URL}.
    * @return {@code this} assertion object.
@@ -326,15 +278,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * Verifies that the actual {@code URL} has no userinfo.
    * <p>
    * Examples:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * // This assertion succeeds:
+   * <pre><code class='java'> // This assertion succeeds:
    * assertThat(new URL("http://www.helloworld.org/index.html")).hasNoUserInfo();
    * 
    * // This assertion fails:
-   * assertThat(new URL("http://test:pass@www.helloworld.org/index.html")).hasNoUserInfo();
-   * </code></pre>
+   * assertThat(new URL("http://test:pass@www.helloworld.org/index.html")).hasNoUserInfo();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual has some userinfo.

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -66,9 +66,7 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * Verifies that the actual value is the same as the given one, ie using == comparison.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // Name is a class with first and last fields, two Names are equals if both first and last are equals.
+   * <pre><code class='java'> // Name is a class with first and last fields, two Names are equals if both first and last are equals.
    * Name tyrion = new Name("Tyrion", "Lannister");
    * Name alias  = tyrion;
    * Name clone  = new Name("Tyrion", "Lannister");
@@ -78,8 +76,7 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    *                   .isEqualTo(clone);
    *                      
    * // assertion fails:
-   * assertThat(tyrion).isSameAs(clone);
-   * </code></pre>
+   * assertThat(tyrion).isSameAs(clone);</code></pre>
    * 
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -91,9 +88,7 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * Verifies that the actual value is not the same as the given one, ie using == comparison.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // Name is a class with first and last fields, two Names are equals if both first and last are equals.
+   * <pre><code class='java'> // Name is a class with first and last fields, two Names are equals if both first and last are equals.
    * Name tyrion = new Name("Tyrion", "Lannister");
    * Name alias  = tyrion;
    * Name clone  = new Name("Tyrion", "Lannister");
@@ -103,8 +98,7 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    *                  .isEqualTo(tyrion);
    *                      
    * // assertion fails:
-   * assertThat(alias).isNotSameAs(tyrion);
-   * </code></pre>
+   * assertThat(alias).isNotSameAs(tyrion);</code></pre>
    * 
    * @param other the given value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -163,12 +157,9 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * comparison strategy.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // frodo and sam are instances of Character with Hobbit race (obviously :).
+   * <pre><code class='java'> // frodo and sam are instances of Character with Hobbit race (obviously :).
    * // raceComparator implements Comparator&lt;Character&gt; 
-   * assertThat(frodo).usingComparator(raceComparator).isEqualTo(sam); 
-   * </code></pre>
+   * assertThat(frodo).usingComparator(raceComparator).isEqualTo(sam);</code></pre>
    * 
    * @param customComparator the comparator to use for incoming assertion checks.
    * @throws NullPointerException if the given comparator is {@code null}.
@@ -247,15 +238,12 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * Verifies that actual <code>actual.toString()</code> is equal to the given <code>String</code>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * CartoonCaracter homer = new CartoonCaracter("Homer");
+   * <pre><code class='java'> CartoonCaracter homer = new CartoonCaracter("Homer");
    *
    * // Instead of writing ...  
    * assertThat(homer.toString()).isEqualTo("Homer");
    * // ... you can simply write: 
-   * assertThat(homer).hasToString("Homer");
-   * </code></pre>
+   * assertThat(homer).hasToString("Homer");</code></pre>
    * 
    * @param expectedToString the expected String description of actual.
    * @return this assertion object.
@@ -325,12 +313,9 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * assertions from this call.
    * <p>
    * Example :
+   * <pre><code class='java'> Object listAsObject = newArrayList(1, 2, 3);
    *
-   * <pre><code class='java'>
-   * Object listAsObject = newArrayList(1, 2, 3);
-   *
-   * assertThat(listAsObject).asList().isSorted();
-   * </code></pre>
+   * assertThat(listAsObject).asList().isSorted();</code></pre>
    *
    * @return a list assertion object
    */
@@ -342,12 +327,9 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * assertions from this call.
    * <p>
    * Example :
+   * <pre><code class='java'> Object stringAsObject = "hello world";
    *
-   * <pre><code class='java'>
-   * Object stringAsObject = "hello world";
-   *
-   * assertThat(stringAsObject).asString().contains("hello");
-   * </code></pre>
+   * assertThat(stringAsObject).asString().contains("hello");</code></pre>
    *
    * @return a string assertion object
    */
@@ -367,14 +349,10 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * In case of assertion error, the thread dump will be printed on {@link System#err}.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat("Messi").withThreadDumpOnError().isEqualTo("Ronaldo");
-   * </code></pre>
-   * will print the thread dump, something looking like:
+   * <pre><code class='java'> assertThat("Messi").withThreadDumpOnError().isEqualTo("Ronaldo");</code></pre>
    * 
-   * <pre><code>
-   * "JDWP Command Reader"
+   * will print the thread dump, something looking like:
+   * <pre><code>"JDWP Command Reader"
    * 	java.lang.Thread.State: RUNNABLE
    * 
    * "JDWP Event Helper Thread"
@@ -408,8 +386,7 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * 		at org.assertj.core.internal.Failures.failure(Failures.java:91)
    * 		at org.assertj.core.internal.Objects.assertEqual(Objects.java:314)
    * 		at org.assertj.core.api.AbstractAssert.isEqualTo(AbstractAssert.java:198)
-   * 		at org.assertj.examples.ThreadDumpOnErrorExample.main(ThreadDumpOnErrorExample.java:28)
-   * </code></pre>
+   * 		at org.assertj.examples.ThreadDumpOnErrorExample.main(ThreadDumpOnErrorExample.java:28)</code></pre>
    * 
    * @return this assertion object.
    */

--- a/src/main/java/org/assertj/core/api/AssertDelegateTarget.java
+++ b/src/main/java/org/assertj/core/api/AssertDelegateTarget.java
@@ -16,9 +16,7 @@ package org.assertj.core.api;
  * A marker interface that can be used to wrap your assertion within assertThat method for better readability.
  * <p>
  * Consider the following MyButton and MyButtonAssert classes:
- * 
- * <pre><code class='java'>
- * public class MyButton extends JButton {
+ * <pre><code class='java'> public class MyButton extends JButton {
  *
  *   private boolean blinking;
  *
@@ -42,14 +40,12 @@ package org.assertj.core.api;
  *     // standard assertion from core Assertions.assertThat
  *     assertThat(button.isBlinking()).isFalse();
  *   }
- * }
- * </code></pre>
+ * }</code></pre>
  *
  * As MyButtonAssert implements AssertDelegateTarget, you can use <code>assertThat(buttonAssert).isBlinking();</code>
  * instead of <code>buttonAssert.isBlinking();</code> to have easier to read assertions.
  *
- * <pre><code class='java'>
- * {@literal @}Test
+ * <pre><code class='java'> {@literal @}Test
  * public void AssertDelegateTarget_example() {
  *
  *   MyButton button = new MyButton();
@@ -61,8 +57,7 @@ package org.assertj.core.api;
  *   button.setBlinking(true);
  *
  *   assertThat(buttonAssert).isBlinking(); // same as : buttonAssert.isBlinking();
- * }
- * </code></pre>
+ * }</code></pre>
  *
  * @author Christian Rösch
  */

--- a/src/main/java/org/assertj/core/api/AssertProvider.java
+++ b/src/main/java/org/assertj/core/api/AssertProvider.java
@@ -17,8 +17,8 @@ package org.assertj.core.api;
  * 
  * <p>Used to map an object to its Assert without having to create a new "Assertions" class.</p>
  * 
- * Usage: <pre><code class='java'>
- * public class Button implements AssertProvider&lt;ButtonAssert&gt; {
+ * Usage:
+ * <pre><code class='java'> public class Button implements AssertProvider&lt;ButtonAssert&gt; {
  *   public ButtonAssert assertThat() { 
  *     return new ButtonAssert(this); 
  *   } 
@@ -38,8 +38,7 @@ package org.assertj.core.api;
  *   
  *   // Second option
  *   button.assertThat().containsText("Test");
- * }
- * </code></pre>
+ * }</code></pre>
  * 
  * @param <A>
  *          the type of the assert (not typed - to allow any kind of assert)

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -55,15 +55,11 @@ import org.assertj.core.util.introspection.FieldSupport;
  * type-specific assertion objects. The purpose of this class is to make test code more readable.
  * <p>
  * For example:
- * <p/>
- *
- * <pre><code class='java'>
- * int removed = employees.removeFired();
+ * <pre><code class='java'> int removed = employees.removeFired();
  * {@link Assertions#assertThat(int) assertThat}(removed).{@link IntegerAssert#isZero isZero}();
  *
  * List&lt;Employee&gt; newEmployees = employees.hired(TODAY);
- * {@link Assertions#assertThat(Iterable) assertThat}(newEmployees).{@link IterableAssert#hasSize(int) hasSize}(6);
- * </code></pre>
+ * {@link Assertions#assertThat(Iterable) assertThat}(newEmployees).{@link IterableAssert#hasSize(int) hasSize}(6);</code></pre>
  * <p/>
  * </p>
  *
@@ -423,9 +419,7 @@ public class Assertions {
    * <code>assertThat</code>.
    * <p>
    * Consider for example the following MyButton and MyButtonAssert classes:
-   *
-   * <pre><code class='java'>
-   * public class MyButton extends JButton {
+   * <pre><code class='java'> public class MyButton extends JButton {
    *
    *   private boolean blinking;
    *
@@ -449,14 +443,11 @@ public class Assertions {
    *     // standard assertion from core Assertions.assertThat
    *     assertThat(button.isBlinking()).isFalse();
    *   }
-   * }
-   * </code></pre>
+   * }</code></pre>
    *
    * As MyButtonAssert implements AssertDelegateTarget, you can use <code>assertThat(buttonAssert).isBlinking();</code>
-   * instead of <code>buttonAssert.isBlinking();</code> to have easier to read assertions.
-   *
-   * <pre><code class='java'>
-   * {@literal @}Test
+   * instead of <code>buttonAssert.isBlinking();</code> to have easier to read assertions:
+   * <pre><code class='java'> {@literal @}Test
    * public void AssertDelegateTarget_example() {
    *
    *   MyButton button = new MyButton();
@@ -468,8 +459,7 @@ public class Assertions {
    *   button.setBlinking(true);
    *
    *   assertThat(buttonAssert).isBlinking(); // same as : buttonAssert.isBlinking();
-   * }
-   * </code></pre>
+   * }</code></pre>
    * 
    * @param <T> the generic type of the user-defined assert.
    * @param assertion the assertion to return.
@@ -592,22 +582,15 @@ public class Assertions {
    * 
    * <p>
    * Java 8 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   *  {@literal @}Test
+   * <pre><code class='java'>  {@literal @}Test
    *  public void testException() {
    *    assertThatThrownBy(() -> { throw new Exception("boom!") }).isInstanceOf(Exception.class)
    *                                                              .hasMessageContaining("boom");
-   *  }
-   * </code></pre>
+   *  }</code></pre>
    * 
    * <p>
    * Java 7 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * assertThatThrownBy(new ThrowingCallable()
+   * <pre><code class='java'> assertThatThrownBy(new ThrowingCallable() {
    * 
    *   {@literal @}Override
    *   public void call() throws Exception {
@@ -615,8 +598,7 @@ public class Assertions {
    *   }
    *   
    * }).isInstanceOf(Exception.class)
-   *   .hasMessageContaining("boom");
-   * </code></pre>
+   *   .hasMessageContaining("boom");</code></pre>
    *
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
@@ -634,10 +616,7 @@ public class Assertions {
    * 
    * <p>
    * Java 8 example:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   *  {@literal @}Test
+   * <pre><code class='java'> {@literal @}Test
    *  public void testException() {
    *    // when
    *    Throwable thrown = catchThrowable(() -> { throw new Exception("boom!") });
@@ -645,18 +624,14 @@ public class Assertions {
    *    // then
    *    assertThat(thrown).isInstanceOf(Exception.class)
    *                      .hasMessageContaining("boom");
-   *  }
-   * </code></pre>
+   *  }</code></pre>
    *
    * <p>
    * Java 7 example:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * {@literal @}Test
+   * <pre><code class='java'> {@literal @}Test
    * public void testException() {
    *   // when
-   *   Throwable thrown = catchThrowable(new ThrowingCallable()
+   *   Throwable thrown = catchThrowable(new ThrowingCallable() {
    *   
    *     {@literal @}Override
    *     public void call() throws Exception {
@@ -667,8 +642,7 @@ public class Assertions {
    *   // then
    *   assertThat(thrown).isInstanceOf(Exception.class)
    *                     .hasMessageContaining("boom");
-   * }
-   * </code></pre>
+   * }</code></pre>
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
@@ -727,27 +701,22 @@ public class Assertions {
    * In error messages, sets the threshold when iterable/array formatting will on one line (if their String description
    * is less than this parameter) or it will be formatted with one element per line.
    * <p>
-   * The following array will be formatted on one line as its length < 80
-   * 
-   * <pre><code class='java'>
-   * String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice");
+   * The following array will be formatted on one line as its length < 80:
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice");
    * 
    * // formatted as:
    * 
-   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice"]
-   * </code></pre>
-   * whereas this array is formatted on multiple lines (one element per line)
+   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice"]</code></pre>
    * 
-   * <pre><code class='java'>
-   * String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", "Guards! Guards! (Discworld)");
+   * whereas this array is formatted on multiple lines (one element per line):
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", "Guards! Guards! (Discworld)");
    * 
    * // formatted as:
    * 
    * ["A Game of Thrones",
    *  "The Lord of the Rings",
    *  "Assassin's Apprentice",
-   *  "Guards! Guards! (Discworld)"]
-   * </code></pre>
+   *  "Guards! Guards! (Discworld)"]</code></pre>
    * 
    * @param maxLengthForSingleLineDescription the maximum lenght for an iterable/array to be displayed on one line
    */
@@ -765,10 +734,7 @@ public class Assertions {
    * all AssertJ features (but you can use {@link Properties} if you prefer).
    * <p/>
    * Typical usage is to chain <code>extractProperty</code> with <code>from</code> method, see examples below :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * // extract simple property values having a java standard type (here String)
+   * <pre><code class='java'> // extract simple property values having a java standard type (here String)
    * assertThat(extractProperty(&quot;name&quot;, String.class).from(fellowshipOfTheRing)).contains(&quot;
    * Boromir&quot;, &quot;Gandalf&quot;, &quot;Frodo&quot;,
    *     &quot;Legolas&quot;).doesNotContain(&quot;Sauron&quot;, &quot;Elrond&quot;);
@@ -780,8 +746,7 @@ public class Assertions {
    * // extract nested property on Race
    * assertThat(extractProperty(&quot;race.name&quot;, String.class).from(fellowshipOfTheRing)).contains(&quot;
    * Hobbit&quot;, &quot;Elf&quot;)
-   *     .doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   *     .doesNotContain(&quot;Orc&quot;);</code></pre>
    */
   public static <T> Properties<T> extractProperty(String propertyName, Class<T> propertyType) {
     return Properties.extractProperty(propertyName, propertyType);
@@ -793,10 +758,7 @@ public class Assertions {
    * all AssertJ features (but you can use {@link Properties} if you prefer).
    * <p/>
    * Typical usage is to chain <code>extractProperty</code> with <code>from</code> method, see examples below :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * // extract simple property values, as no type has been defined the extracted property will be considered as Object
+   * <pre><code class='java'> // extract simple property values, as no type has been defined the extracted property will be considered as Object
    * // to define the real property type (here String) use extractProperty(&quot;name&quot;, String.class) instead.
    * assertThat(extractProperty(&quot;name&quot;).from(fellowshipOfTheRing)).contains(&quot;Boromir&quot;,
    * &quot;Gandalf&quot;, &quot;Frodo&quot;, &quot;Legolas&quot;)
@@ -808,8 +770,7 @@ public class Assertions {
    *
    * // extract nested property on Race
    * assertThat(extractProperty(&quot;race.name&quot;).from(fellowshipOfTheRing)).contains(&quot;Hobbit&quot;,
-   * &quot;Elf&quot;).doesNotContain(&quot;Orc&quot;);
-   * </code></pre>
+   * &quot;Elf&quot;).doesNotContain(&quot;Orc&quot;);</code></pre>
    */
   public static Properties<Object> extractProperty(String propertyName) {
     return Properties.extractProperty(propertyName);
@@ -867,13 +828,9 @@ public class Assertions {
    * AssertJ features (but you can use {@link MapEntry} if you prefer).
    * <p/>
    * Typical usage is to call <code>entry</code> in MapAssert <code>contains</code> assertion, see examples below :
-   * <p/>
+   * <pre><code class='java'> Map<Ring, TolkienCharacter> ringBearers = ... // init omitted
    * 
-   * <pre><code class='java'>
-   * Map<Ring, TolkienCharacter> ringBearers = ... // init omitted
-   * 
-   * assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));
-   * </code></pre>
+   * assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));</code></pre>
    */
   public static <K, V> MapEntry<K, V> entry(K key, V value) {
     return MapEntry.entry(key, value);
@@ -884,11 +841,8 @@ public class Assertions {
    * features (but you can use {@link Index} if you prefer).
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * List&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
-   * assertThat(elvesRings).contains(vilya, atIndex(0)).contains(nenya, atIndex(1)).contains(narya, atIndex(2));
-   * </code></pre>
+   * <pre><code class='java'> List&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
+   * assertThat(elvesRings).contains(vilya, atIndex(0)).contains(nenya, atIndex(1)).contains(narya, atIndex(2));</code></pre>
    */
   public static Index atIndex(int index) {
     return Index.atIndex(index);
@@ -898,10 +852,7 @@ public class Assertions {
    * Assertions entry point for double {@link Offset}.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(8.1).isEqualTo(8.0, offset(0.1));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(8.1).isEqualTo(8.0, offset(0.1));</code></pre>
    */
   public static Offset<Double> offset(Double value) {
     return Offset.offset(value);
@@ -911,10 +862,7 @@ public class Assertions {
    * Assertions entry point for float {@link Offset}.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(8.2f).isCloseTo(8.0f, offset(0.2f));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(8.2f).isCloseTo(8.0f, offset(0.2f));</code></pre>
    */
   public static Offset<Float> offset(Float value) {
     return Offset.offset(value);
@@ -924,10 +872,7 @@ public class Assertions {
    * Alias for {@link #offset(Double)} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(8.1).isCloseTo(8.0, within(0.1));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(8.1).isCloseTo(8.0, within(0.1));</code></pre>
    */
   public static Offset<Double> within(Double value) {
     return Offset.offset(value);
@@ -937,10 +882,7 @@ public class Assertions {
    * Alias for {@link #offset(Float)} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(8.2f).isCloseTo(8.0f, within(0.2f));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(8.2f).isCloseTo(8.0f, within(0.2f));</code></pre>
    */
   public static Offset<Float> within(Float value) {
     return Offset.offset(value);
@@ -950,10 +892,7 @@ public class Assertions {
    * Assertions entry point for BigDecimal {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(BigDecimal.TEN).isCloseTo(new BigDecimal("10.5"), within(BigDecimal.ONE));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(BigDecimal.TEN).isCloseTo(new BigDecimal("10.5"), within(BigDecimal.ONE));</code></pre>
    */
   public static Offset<BigDecimal> within(BigDecimal value) {
     return Offset.offset(value);
@@ -963,10 +902,7 @@ public class Assertions {
    * Assertions entry point for Byte {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat((byte)10).isCloseTo((byte)11, within((byte)1));
-   * </code></pre>
+   * <pre><code class='java'> assertThat((byte)10).isCloseTo((byte)11, within((byte)1));</code></pre>
    */
   public static Offset<Byte> within(Byte value) {
     return Offset.offset(value);
@@ -976,10 +912,7 @@ public class Assertions {
    * Assertions entry point for Integer {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(10).isCloseTo(11, within(1));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(10).isCloseTo(11, within(1));</code></pre>
    */
   public static Offset<Integer> within(Integer value) {
     return Offset.offset(value);
@@ -989,10 +922,7 @@ public class Assertions {
    * Assertions entry point for Short {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(10).isCloseTo(11, within(1));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(10).isCloseTo(11, within(1));</code></pre>
    */
   public static Offset<Short> within(Short value) {
     return Offset.offset(value);
@@ -1002,10 +932,7 @@ public class Assertions {
    * Assertions entry point for Long {@link Offset} to use with isCloseTo assertions.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(5l).isCloseTo(7l, within(2l));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(5l).isCloseTo(7l, within(2l));</code></pre>
    */
   public static Offset<Long> within(Long value) {
     return Offset.offset(value);
@@ -1016,10 +943,7 @@ public class Assertions {
    * percentages.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(11.0).isCloseTo(10.0, withinPercentage(10.0));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(11.0).isCloseTo(10.0, withinPercentage(10.0));</code></pre>
    */
   public static Percentage withinPercentage(Double value) {
     return withPercentage(value);
@@ -1030,10 +954,7 @@ public class Assertions {
    * percentages.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-   * assertThat(11).isCloseTo(10, withinPercentage(10));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(11).isCloseTo(10, withinPercentage(10));</code></pre>
    */
   public static Percentage withinPercentage(Integer value) {
     return withPercentage(value);
@@ -1044,10 +965,7 @@ public class Assertions {
    * percentages.
    * <p/>
    * Typical usage :
-   *
-   * <pre><code class='java'>
-     * assertThat(11L).isCloseTo(10L, withinPercentage(10L));
-     * </code></pre>
+   * <pre><code class='java'> assertThat(11L).isCloseTo(10L, withinPercentage(10L));</code></pre>
    */
   public static Percentage withinPercentage(Long value) {
     return withPercentage(value);
@@ -1089,11 +1007,7 @@ public class Assertions {
    * AssertJ features (but you can use {@link AnyOf} if you prefer).
    * <p/>
    * Typical usage (<code>jedi</code> and <code>sith</code> are {@link Condition}) :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * assertThat(&quot;Vader&quot;).is(anyOf(jedi, sith));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(&quot;Vader&quot;).is(anyOf(jedi, sith));</code></pre>
    */
   @SafeVarargs
   public static <T> Condition<T> anyOf(Condition<? super T>... conditions) {
@@ -1144,20 +1058,11 @@ public class Assertions {
    * Note that the given array is not modified, the filters are performed on an {@link Iterable} copy of the array.
    * <p/>
    * Typical usage with {@link Condition} :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
    * <p/>
    * and with filter language based on java bean property :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * assertThat(filter(players).with(&quot;pointsPerGame&quot;).greaterThan(20).and(&quot;assistsPerGame&quot;)
-   * .greaterThan(7).get())
-   *     .containsOnly(james, rose);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(filter(players).with(&quot;pointsPerGame&quot;).greaterThan(20).and(&quot;assistsPerGame&quot;)
+   *     .greaterThan(7).get()).containsOnly(james, rose);</code></pre>
    */
   public static <E> Filters<E> filter(E[] array) {
     return Filters.filter(array);
@@ -1170,20 +1075,11 @@ public class Assertions {
    * Note that the given {@link Iterable} is not modified, the filters are performed on a copy.
    * <p/>
    * Typical usage with {@link Condition} :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
    * <p/>
    * and with filter language based on java bean property :
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * assertThat(filter(players).with(&quot;pointsPerGame&quot;).greaterThan(20).and(&quot;assistsPerGame&quot;)
-   * .greaterThan(7).get())
-   *     .containsOnly(james, rose);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(filter(players).with(&quot;pointsPerGame&quot;).greaterThan(20).and(&quot;assistsPerGame&quot;)
+   *     .greaterThan(7).get()).containsOnly(james, rose);</code></pre>
    */
   public static <E> Filters<E> filter(Iterable<E> iterableToFilter) {
     return Filters.filter(iterableToFilter);
@@ -1195,9 +1091,7 @@ public class Assertions {
    * value matches one of the given values.
    * <p/>
    * As often, an example helps:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1205,8 +1099,7 @@ public class Assertions {
    * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
    * 
    * assertThat(employees).filteredOn("age", in(800, 26))
-   *                      .containsOnly(yoda, obiwan, luke);
-   * </code></pre>
+   *                      .containsOnly(yoda, obiwan, luke);</code></pre>
    * 
    * @param values values to match (one match is sufficient)
    * @return the created "in" filter
@@ -1221,9 +1114,7 @@ public class Assertions {
    * value matches does not match any of the given values.
    * <p/>
    * As often, an example helps:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1231,8 +1122,7 @@ public class Assertions {
    * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
    * 
    * assertThat(employees).filteredOn("age", notIn(800, 50))
-   *                      .containsOnly(luke);
-   * </code></pre>
+   *                      .containsOnly(luke);</code></pre>
    * 
    * @param valuesNotToMatch values not to match (none of the values must match)
    * @return the created "not in" filter
@@ -1247,9 +1137,7 @@ public class Assertions {
    * value matches does not match the given value.
    * <p>
    * As often, an example helps:
-   * 
-   * <pre><code class='java'>
-   * Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
    * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
    * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
    * Employee noname = new Employee(4L, null, 50);
@@ -1257,8 +1145,7 @@ public class Assertions {
    * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
    * 
    * assertThat(employees).filteredOn("age", not(800))
-   *                      .containsOnly(luke, noname);
-   * </code></pre>
+   *                      .containsOnly(luke, noname);</code></pre>
    * 
    * @param valueNotToMatch the value not to match
    * @return the created "not" filter
@@ -1468,10 +1355,7 @@ public class Assertions {
    *
    * <p>
    * Example:
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * final Date date = Dates.parse("2001-02-03");
+   * <pre><code class='java'> final Date date = Dates.parse("2001-02-03");
    * final Date dateTime = parseDatetime("2001-02-03T04:05:06");
    * final Date dateTimeWithMs = parseDatetimeWithMs("2001-02-03T04:05:06.700");
    *
@@ -1487,8 +1371,7 @@ public class Assertions {
    *
    * // assertions will fail
    * assertThat(date).hasSameTimeAs("2001-02-04"); // different date
-   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here
-   * </code></pre>
+   * assertThat(dateTime).hasSameTimeAs("2001-02-03 04:05:06"); // leniency does not help here</code></pre>
    *
    * To revert to default strict date parsing, call {@code setLenientDateParsing(false)}.
    *
@@ -1519,9 +1402,7 @@ public class Assertions {
    * {@link org.assertj.core.api.AbstractDateAssert#withDefaultDateFormatsOnly()}.
    * <p/>
    * Code examples:
-   *
-   * <pre><code class='java'>
-   * Date date = ... // set to 2003 April the 26th
+   * <pre><code class='java'> Date date = ... // set to 2003 April the 26th
    * assertThat(date).isEqualTo("2003-04-26");
    *
    * try {
@@ -1537,8 +1418,7 @@ public class Assertions {
    * assertThat(date).isEqualTo("2003/04/26");
    *
    * // the default formats are still available and should work
-   * assertThat(date).isEqualTo("2003-04-26");
-   * </code></pre>
+   * assertThat(date).isEqualTo("2003-04-26");</code></pre>
    *
    * @param userCustomDateFormat the new Date format used for String based Date assertions.
    */
@@ -1567,9 +1447,7 @@ public class Assertions {
    * {@link org.assertj.core.api.AbstractDateAssert#withDefaultDateFormatsOnly()}.
    * <p/>
    * Code examples:
-   * 
-   * <pre><code class='java'>
-   * Date date = ... // set to 2003 April the 26th
+   * <pre><code class='java'> Date date = ... // set to 2003 April the 26th
    * assertThat(date).isEqualTo("2003-04-26");
    *
    * try {
@@ -1585,8 +1463,7 @@ public class Assertions {
    * assertThat(date).isEqualTo("2003/04/26");
    *
    * // the default formats are still available and should work
-   * assertThat(date).isEqualTo("2003-04-26");
-   * </code></pre>
+   * assertThat(date).isEqualTo("2003-04-26");</code></pre>
    *
    * @param userCustomDateFormatPattern the new Date format pattern used for String based Date assertions.
    */

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -32,9 +32,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
  * <code>assertThat</code>.
  * <p>
  * For example:
- * 
- * <pre><code class='java'>
- * {@literal @}Test
+ * <pre><code class='java'> {@literal @}Test
  * public void bdd_assertions_examples() {
  *
  *   //given
@@ -45,8 +43,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
  *   bulls.add(noah);
  *
  *   then(bulls).contains(rose, noah).doesNotContain(james);
- * }
- * </code></pre>
+ * }</code></pre>
  *
  * @author Alex Ruiz
  * @author Yvonne Wang
@@ -461,22 +458,14 @@ public class BDDAssertions extends Assertions {
    * 
    * <p>
    * Java 8 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   *  {@literal @}Test
+   * <pre><code class='java'> {@literal @}Test
    *  public void testException() {
    *    thenThrownBy(() -> { throw new Exception("boom!") }).isInstanceOf(Exception.class)
    *                                                        .hasMessageContaining("boom");
-   *  }
-   * </code></pre>
+   *  }</code></pre>
    * 
-   * <p>
    * Java 7 example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * thenThrownBy(new ThrowingCallable()
+   * <pre><code class='java'> thenThrownBy(new ThrowingCallable() {
    * 
    *   {@literal @}Override
    *   public Void call() throws Exception {
@@ -484,8 +473,7 @@ public class BDDAssertions extends Assertions {
    *   }
    *   
    * }).isInstanceOf(Exception.class)
-   *   .hasMessageContaining("boom");
-   * </code></pre>
+   *   .hasMessageContaining("boom");</code></pre>
    *
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
@@ -21,10 +21,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * Suppose we have a test case and in it we'd like to make numerous BDD assertions. In this case, we're hosting a dinner
  * party and we want to ensure not only that all our guests survive but also that nothing in the mansion has been unduly
  * disturbed:
- * </p>
- * 
- * <pre><code class='java'>
- * &#064;Test
+ * <pre><code class='java'> &#064;Test
  * public void host_dinner_party_where_nobody_dies() {
  *   Mansion mansion = new Mansion();
  *   mansion.hostPotentiallyMurderousDinnerParty();
@@ -35,16 +32,12 @@ import static org.assertj.core.groups.Properties.extractProperty;
  *   then(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
  *   then(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
  *   then(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
- * }
- * </code></pre>
+ * }</code></pre>
+ * </p>
  * 
  * <p>
  * After running the test, JUnit provides us with the following exception message:
- * </p>
- * 
- * <pre><code class='java'>
- * org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;
- * </code></pre>
+ * <pre><code class='java'> org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;</code></pre>
  * 
  * <p>
  * Oh no! A guest has been murdered! But where, how, and by whom?
@@ -59,10 +52,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * <p>
  * Instead let's change the test so that at its completion we get the result of all assertions at once. We can do that
  * by using a BDDSoftAssertions instance instead of the static methods on {@link BDDAssertions} as follows:
- * </p>
- * 
- * <pre><code class='java'>
- * &#064;Test
+ * <pre><code class='java'> &#064;Test
  * public void host_dinner_party_where_nobody_dies() {
  *   Mansion mansion = new Mansion();
  *   mansion.hostPotentiallyMurderousDinnerParty();
@@ -75,20 +65,15 @@ import static org.assertj.core.groups.Properties.extractProperty;
  *   softly.then(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.then(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.assertAll();
- * }
- * </code></pre>
+ * } </code></pre>
  * 
  * <p>
  * Now upon running the test our JUnit exception message is far more detailed:
- * </p>
- * 
- * <pre><code class='java'>
- * org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
+ * <pre><code class='java'> org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
  * 1) [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;
  * 2) [Library] expected:&lt;'[clean]'&gt; but was:&lt;'[messy]'&gt;
  * 3) [Candlestick] expected:&lt;'[pristine]'&gt; but was:&lt;'[bent]'&gt;
- * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;
- * </code></pre>
+ * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;</code></pre>
  * 
  * <p>
  * Aha! It appears that perhaps the Professor used the candlestick to perform the nefarious deed in the library. We

--- a/src/main/java/org/assertj/core/api/ComparableAssert.java
+++ b/src/main/java/org/assertj/core/api/ComparableAssert.java
@@ -33,16 +33,13 @@ public interface ComparableAssert<S extends ComparableAssert<S, A>, A extends Co
    * <code>{@link Comparable#compareTo(Object)}</code>.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(1.0).isEqualByComparingTo(1.0);
    * // assertion will pass because 8.0 is equal to 8.00 using {@link BigDecimal#compareTo(BigDecimal)}
    * assertThat(new BigDecimal(&quot;8.0&quot;)).isEqualByComparingTo(new BigDecimal(&quot;8.00&quot;));
    *
    * // assertion will fail
-   * assertThat(new BigDecimal(1.0)).isEqualByComparingTo(new BigDecimal(2.0));
-   * </code></pre>
+   * assertThat(new BigDecimal(1.0)).isEqualByComparingTo(new BigDecimal(2.0));</code></pre>
    * 
    * @param other the given value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -56,16 +53,13 @@ public interface ComparableAssert<S extends ComparableAssert<S, A>, A extends Co
    * <code>{@link Comparable#compareTo(Object)}</code>.
    * <p>
    * Example:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass
+   * <pre><code class='java'> // assertion will pass
    * assertThat(new BigDecimal(1.0)).isNotEqualByComparingTo(new BigDecimal(2.0));
    *
    * // assertion will fail
    * assertThat(1.0).isNotEqualByComparingTo(1.0);
    * // assertion will fail because 8.0 is equal to 8.00 using {@link BigDecimal#compareTo(BigDecimal)}
-   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualByComparingTo(new BigDecimal(&quot;8.00&quot;));
-   * </code></pre>
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualByComparingTo(new BigDecimal(&quot;8.00&quot;));</code></pre>
    * 
    * @param other the given value to compare the actual value to.
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/Descriptable.java
+++ b/src/main/java/org/assertj/core/api/Descriptable.java
@@ -32,19 +32,14 @@ public interface Descriptable<S extends Descriptable<S>> {
    * Sets the description of this object supporting {@link String#format(String, Object...)} syntax.
    * <p>
    * Example :
-   * </p>
-   * 
-   * <pre><code class='java'>
-   * try {
+   * <pre><code class='java'> try {
    *   // set a bad age to Mr Frodo which is really 33 years old.
    *   frodo.setAge(50);
    *   // you can specify a test description with as() method or describedAs(), it supports String format args
    *   assertThat(frodo.getAge()).as(&quot;check %s's age&quot;, frodo.getName()).isEqualTo(33);
    * } catch (AssertionError e) {
    *   assertThat(e).hasMessage(&quot;[check Frodo's age] expected:&lt;[33]&gt; but was:&lt;[50]&gt;&quot;);
-   * }
-   * 
-   * </code></pre>
+   * }</code></pre>
    * 
    * @param description the new description to set.
    * @param args optional parameter if description is a format String.

--- a/src/main/java/org/assertj/core/api/EnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/EnumerableAssert.java
@@ -64,14 +64,11 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, E>, E> {
    * Verifies that the actual group has the same size as given {@link Iterable}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
+   * <pre><code class='java'> Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya); 
    * 
    * // assertions will pass
-   * assertThat(elvesRings).hasSameSizeAs(abc);
-   * </code></pre>
+   * assertThat(elvesRings).hasSameSizeAs(abc);</code></pre>
    * 
    * @param other the {@code Iterable} to compare size with actual group.
    * @return {@code this} assertion object.
@@ -87,14 +84,11 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, E>, E> {
    * Parameter is declared as Object to accept both Object[] and primitive arrays (e.g. int[]).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * int[] oneTwoThree = {1, 2, 3};
+   * <pre><code class='java'> int[] oneTwoThree = {1, 2, 3};
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya); 
    * 
    * // assertions will pass
-   * assertThat(elvesRings).hasSameSizeAs(oneTwoThree);
-   * </code></pre>
+   * assertThat(elvesRings).hasSameSizeAs(oneTwoThree);</code></pre>
    * 
    * @param array the array to compare size with actual group.
    * @return {@code this} assertion object.
@@ -113,9 +107,7 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, E>, E> {
    * comparison strategy.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // compares invoices by payee 
+   * <pre><code class='java'> // compares invoices by payee
    * assertThat(invoiceList).usingComparator(invoicePayeeComparator).isEqualTo(expectedInvoiceList).
    * 
    * // compares invoices by date, doesNotHaveDuplicates and contains both use the given invoice date comparator
@@ -131,8 +123,7 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, E>, E> {
    * 
    * // ... but if we compare only races, Sauron is in fellowshipOfTheRing because he's a Maia like Gandalf.
    * assertThat(fellowshipOfTheRing).usingElementComparator(raceComparator)
-   *                                .contains(sauron);
-   * </code></pre>
+   *                                .contains(sauron);</code></pre>
    * 
    * @param customComparator the comparator to use for incoming assertion checks.
    * @throws NullPointerException if the given comparator is {@code null}.

--- a/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
+++ b/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
@@ -31,9 +31,7 @@ public interface FloatingPointNumberAssert<S extends  FloatingPointNumberAssert<
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertion will pass:
+   * <pre><code class='java'> // assertion will pass:
    * assertThat(8.1).isEqualTo(new Double(8.0), offset(0.2));
    *
    * // if difference is exactly equals to the offset (0.1), it's ok
@@ -43,8 +41,7 @@ public interface FloatingPointNumberAssert<S extends  FloatingPointNumberAssert<
    * assertThat(8.1).isEqualTo(new Double(8.0), within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isEqualTo(new Double(8.0), offset(0.01));
-   * </code></pre>
+   * assertThat(8.1).isEqualTo(new Double(8.0), offset(0.01));</code></pre>
    *
    * @param expected the given value to compare the actual value to.
    * @param offset the given positive offset.
@@ -60,9 +57,7 @@ public interface FloatingPointNumberAssert<S extends  FloatingPointNumberAssert<
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(8.1).isCloseTo(new Double(8.0), within(0.2));
    *
    * // you can use offset if you prefer
@@ -72,8 +67,7 @@ public interface FloatingPointNumberAssert<S extends  FloatingPointNumberAssert<
    * assertThat(8.1).isCloseTo(new Double(8.0), within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isCloseTo(new Double(8.0), within(0.01));
-   * </code></pre>
+   * assertThat(8.1).isCloseTo(new Double(8.0), within(0.01));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param offset the given positive offset.

--- a/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
@@ -24,9 +24,7 @@ import java.util.List;
  * Same as {@link SoftAssertions}, but with the following differences: <br/>
  * First, it's a junit rule, which can be used without having to call {@link SoftAssertions#assertAll() assertAll()},
  * example:
- *
- * <pre><code class='java'>
- *   public class SoftlyTest {
+ * <pre><code class='java'> public class SoftlyTest {
  *
  *     &#064;Rule
  *     public final JUnitBDDSoftAssertions softly = new JUnitBDDSoftAssertions();
@@ -36,8 +34,7 @@ import java.util.List;
  *       softly.then(1).isEqualTo(2);
  *       softly.then(Lists.newArrayList(1, 2)).containsOnly(1, 2);
  *     }
- *  }
- * </code></pre>
+ *  }</code></pre>
  *
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */

--- a/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
@@ -24,9 +24,7 @@ import java.util.List;
  * Same as {@link SoftAssertions}, but with the following differences: <br/>
  * First, it's a junit rule, which can be used without having to call {@link SoftAssertions#assertAll() assertAll()},
  * example:
- *
- * <pre><code class='java'>
- *   public class SoftlyTest {
+ * <pre><code class='java'> public class SoftlyTest {
  *
  *     &#064;Rule
  *     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
@@ -36,8 +34,7 @@ import java.util.List;
  *       softly.assertThat(1).isEqualTo(2);
  *       softly.assertThat(Lists.newArrayList(1, 2)).containsOnly(1, 2);
  *     }
- *  }
- * </code></pre>
+ *  }</code></pre>
  *
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */

--- a/src/main/java/org/assertj/core/api/NumberAssert.java
+++ b/src/main/java/org/assertj/core/api/NumberAssert.java
@@ -86,15 +86,13 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
   /**
    * Verifies that the actual value is in [start, end] range (start included, end included).
    * 
-   * <pre><code class='java'>
-   * // these assertions succeed ... 
+   * <pre><code class='java'> // these assertions succeed ...
    * assertThat(12).isBetween(10, 14);
    * assertThat(12).isBetween(12, 14);
    * assertThat(12).isBetween(10, 12);
    * 
    * // ... but these one fails
-   * assertThat(12).isBetween(14, 16);
-   * </code></pre>
+   * assertThat(12).isBetween(14, 16);</code></pre>
    * 
    * @param start the start value (inclusive), expected not to be null.
    * @param end the end value (inclusive), expected not to be null.
@@ -109,15 +107,13 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
   /**
    * Verifies that the actual value is in ]start, end[ range (start excluded, end excluded).
    * 
-   * <pre><code class='java'>
-   * // this assertion succeeds ... 
+   * <pre><code class='java'> // this assertion succeeds ...
    * assertThat(12).isBetween(10, 14);
    * 
    * // ... but these one fails
    * assertThat(12).isBetween(12, 14);
    * assertThat(12).isBetween(10, 12);
-   * assertThat(12).isBetween(16, 18);
-   * </code></pre>
+   * assertThat(12).isBetween(16, 18);</code></pre>
    * 
    * @param start the start value (exclusive), expected not to be null.
    * @param end the end value (exclusive), expected not to be null.
@@ -134,9 +130,7 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
    * If difference is equal to offset value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(8.1).isCloseTo(new Double(8.0), within(0.2));
    *
    * // you can use offset if you prefer
@@ -146,8 +140,7 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
    * assertThat(8.1).isCloseTo(new Double(8.0), within(0.1));
    *
    * // assertion will fail
-   * assertThat(8.1).isCloseTo(new Double(8.0), within(0.01));
-   * </code></pre>
+   * assertThat(8.1).isCloseTo(new Double(8.0), within(0.01));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param offset the given positive offset.
@@ -163,17 +156,14 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
    * If difference is equal to the percentage value, assertion is considered valid.
    * <p>
    * Example with double:
-   *
-   * <pre><code class='java'>
-   * // assertions will pass:
+   * <pre><code class='java'> // assertions will pass:
    * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(20d));
    *
    * // if difference is exactly equals to the computed offset (1.0), it's ok
    * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(10d));
    *
    * // assertion will fail
-   * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));
-   * </code></pre>
+   * assertThat(11.0).isCloseTo(new Double(10.0), withinPercentage(5d));</code></pre>
    *
    * @param expected the given number to compare the actual value to.
    * @param percentage the given positive percentage between 0 and 100.

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -35,9 +35,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains the given values, in any order.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * 
    * // assertions will pass
@@ -45,8 +43,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).contains("b", "a", "b");
    * 
    * // assertions will fail
-   * assertThat(abc).contains("d");
-   * </code></pre>
+   * assertThat(abc).contains("d");</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -61,17 +58,14 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains only the given values and nothing else, in any order.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    *
    *  // assertion will pass
    * assertThat(abc).containsOnly("c", "b", "a");
    * 
    *  // assertion will fail as some elements of abc are missing
-   * assertThat(abc).containsOnly("a", "b");
-   * </code></pre>
+   * assertThat(abc).containsOnly("a", "b");</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -87,9 +81,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains the given values only once.
    * <p>
    * Examples :
-   * 
-   * <pre><code class='java'>
-   * // lists are used in the examples but it would also work with arrays
+   * <pre><code class='java'> // lists are used in the examples but it would also work with arrays
    * 
    * // assertions will pass
    * assertThat(newArrayList(&quot;winter&quot;, &quot;is&quot;, &quot;coming&quot;)).containsOnlyOnce(&quot;winter&quot;);
@@ -98,8 +90,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * // assertions will fail
    * assertThat(newArrayList(&quot;winter&quot;, &quot;is&quot;, &quot;coming&quot;)).containsOnlyOnce(&quot;Lannister&quot;);
    * assertThat(newArrayList(&quot;Aria&quot;, &quot;Stark&quot;, &quot;daughter&quot;, &quot;of&quot;, &quot;Ned&quot;, &quot;Stark&quot;)).containsOnlyOnce(&quot;Stark&quot;);
-   * assertThat(newArrayList(&quot;Aria&quot;, &quot;Stark&quot;, &quot;daughter&quot;, &quot;of&quot;, &quot;Ned&quot;, &quot;Stark&quot;)).containsOnlyOnce(&quot;Stark&quot;, &quot;Lannister&quot;, &quot;Aria&quot;);
-   * </code></pre>
+   * assertThat(newArrayList(&quot;Aria&quot;, &quot;Stark&quot;, &quot;daughter&quot;, &quot;of&quot;, &quot;Ned&quot;, &quot;Stark&quot;)).containsOnlyOnce(&quot;Stark&quot;, &quot;Lannister&quot;, &quot;Aria&quot;);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -117,17 +108,14 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * {@link HashSet}, prefer {@link #containsOnly(Object...)} in that case).
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
    * // assertion will pass
    * assertThat(elvesRings).containsExactly(vilya, nenya, narya);
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(elvesRings).containsExactly(nenya, vilya, narya);
-   * </code></pre>
+   * assertThat(elvesRings).containsExactly(nenya, vilya, narya);</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -143,9 +131,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains the given sequence, without any other values between them.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
    * // assertion will pass
@@ -153,8 +139,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * 
    * // assertions will fail
    * assertThat(elvesRings).containsSequence(vilya, narya);
-   * assertThat(elvesRings).containsSequence(nenya, vilya);
-   * </code></pre>
+   * assertThat(elvesRings).containsSequence(nenya, vilya);</code></pre>
    * 
    * @param sequence the sequence of objects to look for.
    * @return this assertion object.
@@ -168,9 +153,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
    * // assertions will pass
@@ -178,8 +161,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(elvesRings).containsSubsequence(vilya, narya);
    * 
    * // assertion will fail
-   * assertThat(elvesRings).containsSubsequence(nenya, vilya);
-   * </code></pre>
+   * assertThat(elvesRings).containsSubsequence(nenya, vilya);</code></pre>
    * 
    * @param sequence the sequence of objects to look for.
    * @return this assertion object.
@@ -193,14 +175,11 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group does not contain the given values.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    *
    * // assertion will pass
-   * assertThat(abc).doesNotContain("d", "e");
-   * </code></pre>
+   * assertThat(abc).doesNotContain("d", "e");</code></pre>
    * 
    * @param values the given values.
    * @return {@code this} assertion object.
@@ -215,9 +194,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group does not contain duplicates.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; lotsOfAs = newArrayList("a", "a", "a");
    *
@@ -225,8 +202,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).doesNotHaveDuplicates();
    * 
    * // assertion will fail
-   * assertThat(lotsOfAs).doesNotHaveDuplicates();
-   * </code></pre>
+   * assertThat(lotsOfAs).doesNotHaveDuplicates();</code></pre>
    * 
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual group is {@code null}.
@@ -240,17 +216,14 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * sequence is also first element of the actual group.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    *
    * // assertion will pass
    * assertThat(abc).startsWith("a", "b");
    * 
    * // assertion will fail
-   * assertThat(abc).startsWith("c");
-   * </code></pre>
+   * assertThat(abc).startsWith("c");</code></pre>
    * 
    * @param sequence the sequence of objects to look for.
    * @return this assertion object.
@@ -267,17 +240,14 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * sequence is also last element of the actual group.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    *
    * // assertion will pass
    * assertThat(abc).endsWith("b", "c");
    * 
    * // assertion will fail
-   * assertThat(abc).endsWith("a");
-   * </code></pre>
+   * assertThat(abc).endsWith("a");</code></pre>
    * 
    * @param sequence the sequence of objects to look for.
    * @return this assertion object.
@@ -292,9 +262,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains at least a null element.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abNull = newArrayList("a", "b", null);
    *
@@ -302,8 +270,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abNull).containsNull();
    * 
    * // assertion will fail
-   * assertThat(abc).containsNull();
-   * </code></pre>
+   * assertThat(abc).containsNull();</code></pre>
    * 
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual group is {@code null}.
@@ -315,9 +282,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group does not contain null elements.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abNull = newArrayList("a", "b", null);
    *
@@ -325,8 +290,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).doesNotContainNull();
    *
    * // assertion will fail
-   * assertThat(abNull).doesNotContainNull();
-   * </code></pre>
+   * assertThat(abNull).doesNotContainNull();</code></pre>
    * 
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual group is {@code null}.
@@ -338,9 +302,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that each element value satisfies the given condition
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
    *
@@ -354,8 +316,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).are(singleCharacterString);
    * 
    * // assertion will fail
-   * assertThat(abcc).are(singleCharacterString);
-   * </code></pre>
+   * assertThat(abcc).are(singleCharacterString);</code></pre>
    *
    * @param condition the given condition.
    * @return {@code this} object.
@@ -369,9 +330,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that each element value does not satisfy the given condition
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
    *
@@ -385,8 +344,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).areNot(longerThanOneCharacter);
    * 
    * // assertion will fail
-   * assertThat(abcc).areNot(longerThanOneCharacter);
-   * </code></pre>
+   * assertThat(abcc).areNot(longerThanOneCharacter);</code></pre>
    * 
    * @param condition the given condition.
    * @return {@code this} object.
@@ -400,9 +358,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that all elements satisfy the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
    *
@@ -416,8 +372,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).have(singleCharacterStringOnly);
    * 
    * // assertion will fail
-   * assertThat(abcc).have(singleCharacterStringOnly);
-   * </code></pre>
+   * assertThat(abcc).have(singleCharacterStringOnly);</code></pre>
    * 
    * @param condition the given condition.
    * @return {@code this} object.
@@ -431,9 +386,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that all elements don't satisfy the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
    *
@@ -447,8 +400,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(abc).doNotHave(longerThanOneCharacterString);
    * 
    * // assertion will fail
-   * assertThat(abcc).doNotHave(longerThanOneCharacterString);
-   * </code></pre>
+   * assertThat(abcc).doNotHave(longerThanOneCharacterString);</code></pre>
    * 
    * @param condition the given condition.
    * @return {@code this} object.
@@ -462,9 +414,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>at least</b> <i>n</i> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -477,8 +427,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * oneTwoThree.areAtLeast(2, odd);
    * 
    * // assertion will fail
-   * oneTwoThree.areAtLeast(3, odd);
-   * </code></pre>
+   * oneTwoThree.areAtLeast(3, odd);</code></pre>
    * 
    * @param n the minimum number of times the condition should be verified.
    * @param condition the given condition.
@@ -495,13 +444,10 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * This method is an alias for {@code areAtLeast(1, condition)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * 
    * // jedi is a Condition&lt;String&gt;
-   * assertThat(newLinkedHashSet("Luke", "Solo", "Leia")).areAtLeastOne(jedi);
-   * </code></pre>
+   * assertThat(newLinkedHashSet("Luke", "Solo", "Leia")).areAtLeastOne(jedi);</code></pre>
    *
    * @see #haveAtLeast(int, Condition)
    */
@@ -511,9 +457,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>at most</b> <i>n</i> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -527,8 +471,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * oneTwoThree.areAtMost(3, odd);
    * 
    * // assertions will fail
-   * oneTwoThree.areAtMost(1, odd);
-   * </code></pre>
+   * oneTwoThree.areAtMost(1, odd);</code></pre>
    * 
    * @param n the number of times the condition should be at most verified.
    * @param condition the given condition.
@@ -543,9 +486,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>exactly</b> <i>n</i> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -559,8 +500,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * 
    * // assertions will fail
    * oneTwoThree.areExactly(1, odd);
-   * oneTwoThree.areExactly(3, odd);
-   * </code></pre>
+   * oneTwoThree.areExactly(3, odd);</code></pre>
    * 
    * @param n the exact number of times the condition should be verified.
    * @param condition the given condition.
@@ -577,15 +517,12 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * This method is an alias for {@code haveAtLeast(1, condition)}.
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * 
    * List&lt;BasketBallPlayer&gt; bullsPlayers = newArrayList(noah, rose);
    * 
    * // potentialMvp is a Condition&lt;BasketBallPlayer&gt;
-   * assertThat(bullsPlayers).haveAtLeastOne(potentialMvp);
-   * </code></pre>
+   * assertThat(bullsPlayers).haveAtLeastOne(potentialMvp);</code></pre>
    *
    * @see #haveAtLeast(int, Condition)
    */
@@ -595,9 +532,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>at least <i>n</i></b> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -610,8 +545,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * oneTwoThree.haveAtLeast(2, odd);
    * 
    * // assertion will fail
-   * oneTwoThree.haveAtLeast(3, odd);
-   * </code></pre>
+   * oneTwoThree.haveAtLeast(3, odd);</code></pre>
    *
    * This method is an alias for {@link #areAtLeast(int, Condition)}.
    */
@@ -621,9 +555,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>at most</b> <i>n</i> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -637,8 +569,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * oneTwoThree.haveAtMost(3, odd);
    * 
    * // assertion will fail
-   * oneTwoThree.haveAtMost(1, odd);
-   * </code></pre>
+   * oneTwoThree.haveAtMost(1, odd);</code></pre>
    *
    * This method is an alias {@link #areAtMost(int, Condition)}.
    */
@@ -648,9 +579,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that there is <b>exactly</b> <i>n</i> elements in the actual group satisfying the given condition.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Integer&gt; oneTwoThree = newArrayList(1, 2, 3);
    *
    * Condition&lt;Integer&gt; odd = new Condition&lt;Integer&gt;() {
@@ -664,8 +593,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * 
    * // assertions will fail
    * oneTwoThree.haveExactly(1, odd);
-   * oneTwoThree.haveExactly(3, odd);
-   * </code></pre>
+   * oneTwoThree.haveExactly(3, odd);</code></pre>
    *
    * This method is an alias {@link #areExactly(int, Condition)}.
    */
@@ -675,15 +603,12 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that the actual group contains all the elements of given {@code Iterable}, in any order.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
    * Iterable&lt;String&gt; cb = newArrayList("c", "b");
    *
    * // assertion will pass
-   * assertThat(abc).containsAll(cb);
-   * </code></pre>
+   * assertThat(abc).containsAll(cb);</code></pre>
    * 
    * @param iterable the given {@code Iterable} we will get elements from.
    * @return {@code this} assertion object.
@@ -698,9 +623,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * includes subclasses of the given type).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an array is used in the example but it would also work with an Iterable
+   * <pre><code class='java'> // an array is used in the example but it would also work with an Iterable
    * 
    * Number[] numbers = { 2, 6L, 8.0 };
    * 
@@ -708,8 +631,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(numbers).hasAtLeastOneElementOfType(Long.class);
    * 
    * // assertion failure:
-   * assertThat(numbers).hasAtLeastOneElementOfType(Float.class);
-   * </code></pre>
+   * assertThat(numbers).hasAtLeastOneElementOfType(Float.class);</code></pre>
    *
    * @param expectedType the expected type.
    * @return this assertion object.
@@ -723,9 +645,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * subclasses of the given type).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an array is used in the example but it would also work with an Iterable
+   * <pre><code class='java'> // an array is used in the example but it would also work with an Iterable
    * 
    * Number[] numbers = { 2, 6, 8 };
    * 
@@ -733,8 +653,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(numbers).hasOnlyElementsOfType(Integer.class);
    * 
    * // assertion failure:
-   * assertThat(numbers).hasOnlyElementsOfType(Long.class);
-   * </code></pre>
+   * assertThat(numbers).hasOnlyElementsOfType(Long.class);</code></pre>
    *
    * @param expectedType the expected type.
    * @return this assertion object.
@@ -748,17 +667,14 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * actual contains all the elements of the given iterable and nothing else <b>in the same order</b>.
    * <p/>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
    * // assertion will pass
    * assertThat(elvesRings).containsExactlyElementsOf(newLinkedList(vilya, nenya, narya));
    * 
    * // assertion will fail as actual and expected orders differ.
-   * assertThat(elvesRings).containsExactlyElementsOf(newLinkedList(nenya, vilya, narya));
-   * </code></pre>
+   * assertThat(elvesRings).containsExactlyElementsOf(newLinkedList(nenya, vilya, narya));</code></pre>
    *
    * @param iterable the given {@code Iterable} we will get elements from.
    */
@@ -769,9 +685,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * iterable and nothing else, <b>in any order</b>.
    * <p/>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; rings = newArrayList(nenya, vilya);
    * 
    * // assertion will pass
@@ -781,8 +695,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * // assertion will fail as actual does not contain narya.
    * assertThat(rings).containsOnlyElementsOf(newLinkedList(nenya, vilya, narya));
    * // assertion will fail as actual contain nenya.
-   * assertThat(rings).containsOnlyElementsOf(newLinkedList(vilya));
-   * </code></pre>
+   * assertThat(rings).containsOnlyElementsOf(newLinkedList(vilya));</code></pre>
    * 
    * @param iterable the given {@code Iterable} we will get elements from.
    */
@@ -793,9 +706,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * given iterable and nothing else, <b>in any order</b>.
    * </p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
    * // assertions will pass:
@@ -804,8 +715,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * 
    * // assertions will fail:
    * assertThat(elvesRings).hasSameElementsAs(newArrayList(nenya, narya));
-   * assertThat(elvesRings).hasSameElementsAs(newArrayList(nenya, narya, vilya, oneRing));
-   * </code></pre>
+   * assertThat(elvesRings).hasSameElementsAs(newArrayList(nenya, narya, vilya, oneRing));</code></pre>
    * 
    * @param iterable the Iterable whose elements we expect to be present
    * @return this assertion object
@@ -820,9 +730,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that actual does not contain any elements of the given {@link Iterable} (i.e. none).
    * <p/>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * 
    * // These assertions succeed:
    * List&lt;String&gt; actual = newArrayList(&quot;GIT&quot;, &quot;CVS&quot;, &quot;SOURCESAFE&quot;);
@@ -832,8 +740,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * // These fail:
    * List&lt;String&gt; actual = newArrayList(&quot;GIT&quot;, &quot;cvs&quot;, &quot;SOURCESAFE&quot;);
    * List&lt;String&gt; values = newArrayList(&quot;git&quot;, &quot;cvs&quot;, &quot;subversion&quot;);
-   * assertThat(actual).doesNotContainAnyElementsOf(values);
-   * </code></pre>
+   * assertThat(actual).doesNotContainAnyElementsOf(values);</code></pre>
    *
    * @param iterable the {@link Iterable} whose elements must not be in the actual group.
    * @return {@code this} assertion object.
@@ -848,9 +755,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * Verifies that all the elements of actual are present in the given {@code Iterable}.
    *
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // an Iterable is used in the example but it would also work with an array
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
    * List&lt;Ring&gt; ringsOfPower = newArrayList(oneRing, vilya, nenya, narya, dwarfRing, manRing);
    * Iterable&lt;Ring&gt; elvesRings = newArrayList(vilya, nenya, narya);
    * 
@@ -858,8 +763,7 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * assertThat(elvesRings).isSubsetOf(ringsOfPower);
    * 
    * // assertions will fail:
-   * assertThat(elvesRings).isSubsetOf(newArrayList(nenya, narya));
-   * </code></pre>
+   * assertThat(elvesRings).isSubsetOf(newArrayList(nenya, narya));</code></pre>
    * 
    * @param values the {@code Iterable} that should contain all actual elements.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -21,10 +21,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * Suppose we have a test case and in it we'd like to make numerous assertions. In this case, we're hosting a dinner
  * party and we want to ensure not only that all our guests survive but also that nothing in the mansion has been unduly
  * disturbed:
- * </p>
- * 
- * <pre><code class='java'>
- * &#064;Test
+ * <pre><code class='java'> &#064;Test
  * public void host_dinner_party_where_nobody_dies() {
  *   Mansion mansion = new Mansion();
  *   mansion.hostPotentiallyMurderousDinnerParty();
@@ -35,16 +32,11 @@ import static org.assertj.core.groups.Properties.extractProperty;
  *   assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
  *   assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
  *   assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
- * }
- * </code></pre>
+ * }</code></pre>
  * 
  * <p>
  * After running the test, JUnit provides us with the following exception message:
- * </p>
- * 
- * <pre><code class='java'>
- * org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;
- * </code></pre>
+ * <pre><code class='java'> org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;</code></pre>
  * 
  * <p>
  * Oh no! A guest has been murdered! But where, how, and by whom?
@@ -59,10 +51,7 @@ import static org.assertj.core.groups.Properties.extractProperty;
  * <p>
  * Instead let's change the test so that at its completion we get the result of all assertions at once. We can do that
  * by using a SoftAssertions instance instead of the static methods on {@link Assertions} as follows:
- * </p>
- * 
- * <pre><code class='java'>
- * &#064;Test
+ * <pre><code class='java'> &#064;Test
  * public void host_dinner_party_where_nobody_dies() {
  *   Mansion mansion = new Mansion();
  *   mansion.hostPotentiallyMurderousDinnerParty();
@@ -75,20 +64,15 @@ import static org.assertj.core.groups.Properties.extractProperty;
  *   softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.assertAll();
- * }
- * </code></pre>
+ * }</code></pre>
  * 
  * <p>
  * Now upon running the test our JUnit exception message is far more detailed:
- * </p>
- * 
- * <pre><code class='java'>
- * org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
+ * <pre><code class='java'> org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
  * 1) [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;
  * 2) [Library] expected:&lt;'[clean]'&gt; but was:&lt;'[messy]'&gt;
  * 3) [Candlestick] expected:&lt;'[pristine]'&gt; but was:&lt;'[bent]'&gt;
- * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;
- * </code></pre>
+ * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;</code></pre>
  * 
  * <p>
  * Aha! It appears that perhaps the Professor used the candlestick to perform the nefarious deed in the library. We

--- a/src/main/java/org/assertj/core/api/filter/Filters.java
+++ b/src/main/java/org/assertj/core/api/filter/Filters.java
@@ -30,17 +30,12 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
  * Filter criteria can be expressed either by a {@link Condition} or a pseudo filter language on elements properties.
  * <p>
  * With fluent filter language on element properties/fields :
- * 
- * <pre><code class='java'>
- * assertThat(filter(players).with("pointsPerGame").greaterThan(20)
+ * <pre><code class='java'> assertThat(filter(players).with("pointsPerGame").greaterThan(20)
  *                           .and("assistsPerGame").greaterThan(7).get())
  *                           .containsOnly(james, rose);</code></pre>
- * </code></pre>
  * 
  * With {@link Condition} :
- * 
- * <pre><code class='java'>
- * List&lt;Player&gt; players = ...; 
+ * <pre><code class='java'> List&lt;Player&gt; players = ...; 
  *   
  * Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP"){
  *   public boolean matches(Player player) {
@@ -49,8 +44,7 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
  * };
  * 
  * // use filter static method to build Filters
- * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose)
- * </code></pre>
+ * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
  * 
  * @param <E> the type of element of group to filter.
  * 
@@ -81,27 +75,21 @@ public class Filters<E> {
    * Note that the given {@link Iterable} is not modified, the filters are performed on a copy.
    * <p>
    * With fluent filter language on element properties/fields :
-   * 
-   * <pre><code class='java'>
-   * List&lt;Player&gt; players = ...; 
+   * <pre><code class='java'> List&lt;Player&gt; players = ...; 
    *   
    * assertThat(filter(players).with("pointsPerGame").greaterThan(20)
    *                           .and("assistsPerGame").greaterThan(7).get())
-   *                           .containsOnly(james, rose);
-   * </code></pre>
+   *                           .containsOnly(james, rose);</code></pre>
    * 
    * With {@link Condition} :
-   * 
    * <pre><code class='java'>
-   * Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP"){
    *   public boolean matches(Player player) {
    *     return player.getPointsPerGame() > 20 && player.getAssistsPerGame() > 7;
    *   };
    * };
    * 
    * // use filter static method to build Filters
-   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose)
-   * </code></pre>
+   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
    * 
    * @param iterable the {@code Iterable} to filter.
    * @throws NullPointerException if the given iterable is {@code null}.
@@ -121,27 +109,21 @@ public class Filters<E> {
    * Note that the given array is not modified, the filters are performed on an {@link Iterable} copy of the array.
    * <p>
    * With {@link Condition} :
-   * 
-   * <pre><code class='java'>
-   * Player[] players = ...; 
+   * <pre><code class='java'> Player[] players = ...; 
    *   
    * assertThat(filter(players).with("pointsPerGame").greaterThan(20)
    *                           .and("assistsPerGame").greaterThan(7).get())
-   *                           .containsOnly(james, rose);
-   * </code></pre>
+   *                           .containsOnly(james, rose);</code></pre>
    * 
    * With {@link Condition} :
-   * 
-   * <pre><code class='java'>
-   * Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP"){
+   * <pre><code class='java'> Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP"){
    *   public boolean matches(Player player) {
    *     return player.getPointsPerGame() > 20 && player.getAssistsPerGame() > 7;
    *   };
    * };
    * 
    * // use filter static method to build Filters
-   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose)
-   * </code></pre>
+   * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
    * 
    * @param array the array to filter.
    * @throws NullPointerException if the given array is {@code null}.
@@ -166,8 +148,7 @@ public class Filters<E> {
    * Filter the underlying group, keeping only elements satisfying the given {@link Condition}.<br>
    * Same as {@link #having(Condition)} - pick the method you prefer to have the most readable code.
    * 
-   * <pre><code class='java'>
-   * List&lt;Player&gt; players = ...; 
+   * <pre><code class='java'> List&lt;Player&gt; players = ...;
    *   
    * Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP") {
    *   public boolean matches(Player player) {
@@ -191,8 +172,7 @@ public class Filters<E> {
    * Filter the underlying group, keeping only elements satisfying the given {@link Condition}.<br>
    * Same as {@link #being(Condition)} - pick the method you prefer to have the most readable code.
    * 
-   * <pre><code class='java'>
-   * List&lt;Player&gt; players = ...; 
+   * <pre><code class='java'> List&lt;Player&gt; players = ...;
    *   
    * Condition&lt;Player&gt; mvpStats = new Condition&lt;Player&gt;("is a possible MVP") {
    *   public boolean matches(Player player) {
@@ -227,15 +207,10 @@ public class Filters<E> {
    * Filter the underlying group, keeping only elements with a property equals to given value.
    * <p>
    * Let's, for example, filter Employees with name "Alex" :
+   * <pre><code class='java'> filter(employees).with("name", "Alex").get();</code></pre>
    * 
-   * <pre><code class='java'>
-   * filter(employees).with("name", "Alex").get();
-   * </code></pre>
    * which is shortcut of :
-   * 
-   * <pre><code class='java'>
-   * filter(employees).with("name").equalsTo("Alex").get();
-   * </code></pre>
+   * <pre><code class='java'> filter(employees).with("name").equalsTo("Alex").get();</code></pre>
    * 
    * @param propertyOrFieldName the name of the property/field whose value will compared to given value. It may be a
    *          nested property.
@@ -256,10 +231,7 @@ public class Filters<E> {
    * <code>"adress.street.name"</code>.
    * <p>
    * The typical usage is to chain this call with a comparison method, for example :
-   * 
-   * <pre><code class='java'>
-   * filter(employees).with("name").equalsTo("Alex").get();
-   * </code></pre>
+   * <pre><code class='java'> filter(employees).with("name").equalsTo("Alex").get();</code></pre>
    * 
    * @param propertyOrFieldName the name of the property/field used for filtering. It may be a nested property.
    * @return this {@link Filters} to chain other filter operation.
@@ -277,11 +249,8 @@ public class Filters<E> {
   }
 
   /**
-   * Alias of {@link #with(String)} for synthetic sugar to write things like :.
-   * 
-   * <pre><code class='java'>
-   * filter(employees).with("name").equalsTo("Alex").and("job").notEqualsTo("lawyer").get();
-   * </code></pre>
+   * Alias of {@link #with(String)} for synthetic sugar to write things like :
+   * <pre><code class='java'> filter(employees).with("name").equalsTo("Alex").and("job").notEqualsTo("lawyer").get();</code></pre>
    * 
    * @param propertyOrFieldName the name of the property/field used for filtering. It may be a nested property.
    * @return this {@link Filters} to chain other filter operation.
@@ -297,10 +266,7 @@ public class Filters<E> {
    * value.
    * <p>
    * Typical usage :
-   * 
-   * <pre><code class='java'>
-   * filter(employees).with("name").equalsTo("Luke").get();
-   * </code></pre>
+   * <pre><code class='java'> filter(employees).with("name").equalsTo("Luke").get();</code></pre>
    * 
    * @param propertyValue the filter value.
    * @return this {@link Filters} to chain other filter operation.
@@ -323,10 +289,7 @@ public class Filters<E> {
    * value.
    * <p>
    * Typical usage :
-   * 
-   * <pre><code class='java'>
-   * filter(employees).with("name").notEqualsTo("Vader").get();
-   * </code></pre>
+   * <pre><code class='java'> filter(employees).with("name").notEqualsTo("Vader").get();</code></pre>
    * 
    * @param propertyValue the filter value.
    * @return this {@link Filters} to chain other filter operation.
@@ -354,10 +317,7 @@ public class Filters<E> {
    * given values.
    * <p>
    * Typical usage :
-   * 
-   * <pre><code class='java'>
-   * filter(players).with("team").in("Bulls", "Lakers").get();
-   * </code></pre>
+   * <pre><code class='java'>filter(players).with("team").in("Bulls", "Lakers").get();</code></pre>
    * 
    * @param propertyValues the filter values.
    * @return this {@link Filters} to chain other filter operation.
@@ -380,10 +340,7 @@ public class Filters<E> {
    * values.
    * <p>
    * Typical usage :
-   * 
-   * <pre><code class='java'>
-   * filter(players).with("team").notIn("Heat", "Lakers").get();
-   * </code></pre>
+   * <pre><code class='java'> filter(players).with("team").notIn("Heat", "Lakers").get();</code></pre>
    * 
    * @param propertyValues the filter values.
    * @return this {@link Filters} to chain other filter operation.

--- a/src/main/java/org/assertj/core/extractor/Extractors.java
+++ b/src/main/java/org/assertj/core/extractor/Extractors.java
@@ -20,10 +20,8 @@ import org.assertj.core.groups.Tuple;
  * <p>
  * 
  * For example:
- * <pre><code class='java'>
- * assertThat(objectsList).extracting(toStringMethod()).contains("toString 1", "toString 2");
- * assertThat(objectsList).extracting(byName("field")).contains("someResult1", "someResult2");
- * </code></pre>
+ * <pre><code class='java'> assertThat(objectsList).extracting(toStringMethod()).contains("toString 1", "toString 2");
+ * assertThat(objectsList).extracting(byName("field")).contains("someResult1", "someResult2");</code></pre>
  * 
  * @author Mateusz Haligowski
  *

--- a/src/main/java/org/assertj/core/groups/Properties.java
+++ b/src/main/java/org/assertj/core/groups/Properties.java
@@ -81,13 +81,10 @@ public class Properties<T> {
    * Specifies the target type of an instance that was previously created with {@link #extractProperty(String)}.
    * <p>
    * This is so that you can write:
-   * <pre><code class='java'>
-   * extractProperty("name").ofType(String.class).from(fellowshipOfTheRing)
-   * </code></pre>
+   * <pre><code class='java'> extractProperty("name").ofType(String.class).from(fellowshipOfTheRing);</code></pre>
+   * 
    * instead of:
-   * <pre><code class='java'>
-   * extractProperty("name", String.class).from(fellowshipOfTheRing)
-   * </code></pre>
+   * <pre><code class='java'> extractProperty("name", String.class).from(fellowshipOfTheRing);</code></pre>
    * </p>
    * @param propertyType the type of property to extract.
    * @return a new {@code Properties} with the given type.

--- a/src/main/java/org/assertj/core/internal/Failures.java
+++ b/src/main/java/org/assertj/core/internal/Failures.java
@@ -146,8 +146,7 @@ public class Failures {
    * by removing stack trace elements related to AssertJ in order to get a more readable stack trace.
    * <p>
    * See example below :
-   * <pre><code class='java'>
---------------- stack trace not filtered -----------------
+   * <pre><code class='java'> --------------- stack trace not filtered -----------------
 org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
@@ -167,8 +166,7 @@ org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
-  at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:20)
-   * </code></pre>
+  at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:20)</code></pre>
    * 
    * Method is public because we need to call it from {@link ShouldBeEqual#newAssertionError(Description, org.assertj.core.presentation.Representation)} that is building a junit ComparisonFailure by reflection.
    *  

--- a/src/main/java/org/assertj/core/util/DateUtil.java
+++ b/src/main/java/org/assertj/core/util/DateUtil.java
@@ -141,10 +141,9 @@ public class DateUtil {
 
   /**
    * Utility method to parse a Date following {@link #ISO_DATE_TIME_FORMAT}, returns null if the given String is null.
-   * <p> Example:
-   * <pre><code class='java'>
-   * Date date = parseDatetime("2003-04-26T03:01:02");
-   * </code></pre>
+   * <p> 
+   * Example:
+   * <pre><code class='java'> Date date = parseDatetime("2003-04-26T03:01:02");</code></pre>
    * </p>
    *
    * @param dateAsString the string to parse as a Date following {@link #ISO_DATE_TIME_FORMAT}
@@ -161,10 +160,10 @@ public class DateUtil {
 
   /**
    * Utility method to parse a Date following {@link #ISO_DATE_TIME_FORMAT_WITH_MS}, returns null if the given String is
-   * null. <p> Example:
-   * <pre><code class='java'>
-   * Date date = parseDatetimeWithMs("2003-04-26T03:01:02.999");
-   * </code></pre>
+   * null.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Date date = parseDatetimeWithMs("2003-04-26T03:01:02.999");</code></pre>
    * </p>
    *
    * @param dateAsString the string to parse as a Date following {@link #ISO_DATE_TIME_FORMAT_WITH_MS}

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -109,11 +109,7 @@ public class Files {
 
   /**
    * Creates a new file in the system's temporary directory. The name of the file will be the result of:
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * concat(String.valueOf(System.currentTimeMillis()), &quot;.txt&quot;);
-   * </code></pre>
+   * <pre><code class='java'> concat(String.valueOf(System.currentTimeMillis()), &quot;.txt&quot;);</code></pre>
    * 
    * @return the created file.
    */
@@ -124,11 +120,7 @@ public class Files {
 
   /**
    * Creates a new directory in the system's temporary directory. The name of the directory will be the result of:
-   * <p/>
-   * 
-   * <pre><code class='java'>
-   * System.currentTimeMillis();
-   * </code></pre>
+   * <pre><code class='java'> System.currentTimeMillis();</code></pre>
    * 
    * @return the created file.
    */

--- a/src/main/java/org/assertj/core/util/IterableUtil.java
+++ b/src/main/java/org/assertj/core/util/IterableUtil.java
@@ -79,12 +79,9 @@ public final class IterableUtil extends GroupFormatUtil {
    * <p/>
    * Note: this method will return Object[]. If you require a typed array please use {@link #toArray(Iterable, Class)}.
    * It's main usage is to keep the generic type for chaining call like in:
-   * 
-   * <pre><code class='java'>
-   * public S containsOnlyElementsOf(Iterable<? extends T> iterable) {
+   * <pre><code class='java'> public S containsOnlyElementsOf(Iterable<? extends T> iterable) {
    *   return containsOnly(toArray(iterable));
-   * }
-   * </code></pre>
+   * }</code></pre>
    * 
    * @param iterable an {@link Iterable} to translate in an array.
    * @param <T> the type of elements of the {@code Iterable}.

--- a/src/main/java/org/assertj/core/util/Strings.java
+++ b/src/main/java/org/assertj/core/util/Strings.java
@@ -94,10 +94,7 @@ public final class Strings {
   /**
    * Joins the given {@code String}s using a given delimiter. The following example illustrates proper usage of this
    * method:
-   * 
-   * <pre><code class='java'>
-   * Strings.join(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;).with(&quot;|&quot;)
-   * </code></pre>
+   * <pre><code class='java'> Strings.join(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;).with(&quot;|&quot;);</code></pre>
    * 
    * which will result in the {@code String} <code>"a|b|c"</code>.
    * 
@@ -112,10 +109,7 @@ public final class Strings {
   /**
    * Joins the given {@code Object}s using a given delimiter. The following example illustrates proper usage of this
    * method:
-   * 
-   * <pre><code class='java'>
-   * Strings.join(new ArrayList(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)).with(&quot;|&quot;)
-   * </code></pre>
+   * <pre><code class='java'> Strings.join(new ArrayList(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)).with(&quot;|&quot;);</code></pre>
    * 
    * which will result in the {@code String} <code>"a|b|c"</code>.
    * 
@@ -194,11 +188,8 @@ public final class Strings {
   /**
    * Appends a given {@code String} to the given target, only if the target does not end with the given {@code String}
    * to append. The following example illustrates proper usage of this method:
-   * 
-   * <pre><code class='java'>
-   * Strings.append(&quot;c&quot;).to(&quot;ab&quot;);
-   * Strings.append(&quot;c&quot;).to(&quot;abc&quot;);
-   * </code></pre>
+   * <pre><code class='java'> Strings.append(&quot;c&quot;).to(&quot;ab&quot;);
+   * Strings.append(&quot;c&quot;).to(&quot;abc&quot;);</code></pre>
    * 
    * resulting in the {@code String} <code>"abc"</code> for both cases.
    * 

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -54,9 +54,7 @@ public final class Throwables {
 /**
    * Removes the AssertJ-related elements from the <code>{@link Throwable}</code> stack trace that have little value for
    * end user. Therefore, instead of seeing this:
-   *
-   * <pre><code class='java'>
-   * org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
+   * <pre><code class='java'> org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
    *   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    *   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
    *   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
@@ -68,18 +66,14 @@ public final class Throwables {
    *   at org.assertj.core.internal.Failures.failure(Failures.java:76)
    *   at org.assertj.core.internal.Objects.assertEqual(Objects.java:116)
    *   at org.assertj.core.api.AbstractAssert.isEqualTo(AbstractAssert.java:74)
-   *   at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:13)
-   * </code></pre>
+   *   at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:13)</code></pre>
    *
    * We get this:
-   *
-   * <pre><code class='java'>
-   * org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
+   * <pre><code class='java'> org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
    *   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    *   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
    *   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
-   *   at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:20)
-   * </code></pre>
+   *   at examples.StackTraceFilterExample.main(StackTraceFilterExample.java:20)</code></pre>
    * @param throwable the {@code Throwable} to filter stack trace.
    */
   public static void removeAssertJRelatedElementsFromStackTrace(Throwable throwable) {

--- a/src/main/java/org/assertj/core/util/introspection/FieldSupport.java
+++ b/src/main/java/org/assertj/core/util/introspection/FieldSupport.java
@@ -148,8 +148,7 @@ public enum FieldSupport {
   }
 
   /**
-   * <pre><code class='java'>
-   * isNestedField(&quot;address.street&quot;); // true
+   * <pre><code class='java'> isNestedField(&quot;address.street&quot;); // true
    * isNestedField(&quot;address.street.name&quot;); // true
    * isNestedField(&quot;person&quot;); // false
    * isNestedField(&quot;.name&quot;); // false
@@ -157,8 +156,7 @@ public enum FieldSupport {
    * isNestedField(&quot;person.name.&quot;); // false
    * isNestedField(&quot;.person.name&quot;); // false
    * isNestedField(&quot;.&quot;); // false
-   * isNestedField(&quot;&quot;); // false
-   * </code></pre>
+   * isNestedField(&quot;&quot;); // false</code></pre>
    */
   private boolean isNestedField(String fieldName) {
 	return fieldName.contains(SEPARATOR) && !fieldName.startsWith(SEPARATOR) && !fieldName.endsWith(SEPARATOR);
@@ -168,10 +166,7 @@ public enum FieldSupport {
    * Return the value of field from a target object.
    * <p>
    * Return null if field is nested and one of the nested value is null, ex :
-   * 
-   * <pre><code class='java'>
-   * fieldValue(race.name, String.class, frodo) will return null if frodo.race is null
-   * </code></pre>
+   * <pre><code class='java'> fieldValue(race.name, String.class, frodo); // will return null if frodo.race is null</code></pre>
    * 
    * @param fieldName the name of the field. It may be a nested field. It is left to the clients to validate for
    *          {@code null} or empty.

--- a/src/main/java/org/assertj/core/util/introspection/PropertySupport.java
+++ b/src/main/java/org/assertj/core/util/introspection/PropertySupport.java
@@ -117,8 +117,7 @@ public class PropertySupport {
   }
 
   /**
-   * <pre><code class='java'>
-   * isNestedProperty(&quot;address.street&quot;); // true
+   * <pre><code class='java'> isNestedProperty(&quot;address.street&quot;); // true
    * isNestedProperty(&quot;address.street.name&quot;); // true
    * isNestedProperty(&quot;person&quot;); // false
    * isNestedProperty(&quot;.name&quot;); // false
@@ -126,8 +125,7 @@ public class PropertySupport {
    * isNestedProperty(&quot;person.name.&quot;); // false
    * isNestedProperty(&quot;.person.name&quot;); // false
    * isNestedProperty(&quot;.&quot;); // false
-   * isNestedProperty(&quot;&quot;); // false
-   * </code></pre>
+   * isNestedProperty(&quot;&quot;); // false</code></pre>
    */
   private boolean isNestedProperty(String propertyName) {
     return propertyName.contains(SEPARATOR) && !propertyName.startsWith(SEPARATOR) && !propertyName.endsWith(SEPARATOR);


### PR DESCRIPTION
I tried to follow https://github.com/joel-costigliola/assertj-guava/commit/841ee1b60df12a59b5e7528901a07e9d18c0f618 

Once we are satisfied with this change I will create another pull request for the 3.0 classes.