### PR TITLE
#463: OptionalAssert.contains does not use the specified comparator

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -12,12 +12,18 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.FieldByFieldComparator;
+import org.assertj.core.internal.StandardComparisonStrategy;
+
+import java.util.Comparator;
+import java.util.Optional;
+
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
-
-import java.util.Optional;
 
 /**
  * Assertions for {@link java.util.Optional}.
@@ -28,21 +34,24 @@ import java.util.Optional;
 public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S, T>, T> extends
     AbstractAssert<S, Optional<T>> {
 
+  private ComparisonStrategy comparisonStrategy;
+
   protected AbstractOptionalAssert(Optional<T> actual, Class<?> selfType) {
     super(actual, selfType);
+    this.comparisonStrategy = StandardComparisonStrategy.instance();
   }
 
   /**
    * Verifies that there is a value present in the actual {@link java.util.Optional}.
    * </p>
    * Assertion will pass :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.of("something")).isPresent();
    * </code></pre>
-   * 
+   *
    * Assertion will fail :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.empty()).isPresent();
    * </code></pre>
@@ -59,13 +68,13 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * Verifies that the actual {@link java.util.Optional} is empty.
    * </p>
    * Assertion will pass :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.empty()).isEmpty();
    * </code></pre>
-   * 
+   *
    * Assertion will fail :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.of("something")).isEmpty();
    * </code></pre>
@@ -82,14 +91,14 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * Verifies that the actual {@link java.util.Optional} contains the value in argument.
    * </p>
    * Assertion will pass :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.of("something")).contains("something");
    * assertThat(Optional.of(10)).contains(10);
    * </code></pre>
-   * 
+   *
    * Assertion will fail :
-   * 
+   *
    * <pre><code class='java'>
    * assertThat(Optional.of("something")).contains("something else");
    * assertThat(Optional.of(20)).contains(10);
@@ -102,7 +111,7 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
     isNotNull();
     if (expectedValue == null) throw new IllegalArgumentException("The expected value should not be <null>.");
     if (!actual.isPresent()) throw failure(shouldContain(expectedValue));
-    if (!actual.get().equals(expectedValue)) throw failure(shouldContain(actual, expectedValue));
+    if (!comparisonStrategy.areEqual(actual.get(), expectedValue)) throw failure(shouldContain(actual, expectedValue));
     return myself;
   }
 
@@ -114,7 +123,7 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * <pre><code class='java'>
    * assertThat(Optional.of("something")).containsInstanceOf(String.class)
    *                                     .containsInstanceOf(Object.class);
-   *                                     
+   *
    * assertThat(Optional.of(10)).containsInstanceOf(Integer.class)
    * </code></pre>
    *
@@ -133,4 +142,81 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
     if (!clazz.isInstance(actual.get())) throw failure(shouldContainInstanceOf(actual, clazz));
     return myself;
   }
+
+  /**
+   * Use field/property by field/property comparison (including inherited fields/properties) instead of relying on
+   * actual type A <code>equals</code> method to compare the {@link Optional} value's object for incoming assertion
+   * checks. Private fields are included but this can be disabled using
+   * {@link Assertions#setAllowExtractingPrivateFields(boolean)}.
+   * <p/>
+   * This can be handy if <code>equals</code> method of the {@link Optional} value's object to compare does not suit
+   * you.
+   * <p/>
+   * Note that the comparison is <b>not</b> recursive, if one of the fields/properties is an Object, it will be
+   * compared to the other field/property using its <code>equals</code> method.
+   * </p>
+   * Example:
+   * <p/>
+   * <pre><code class='java'>
+   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <p/>
+   * // Fail if equals has not been overridden in TolkienCharacter as equals default implementation only compares
+   * references
+   * assertThat(Optional.of(frodo)).contains(frodoClone);
+   * <p/>
+   * // frodo and frodoClone are equals when doing a field by field comparison.
+   * assertThat(Optional.of(frodo)).usingFieldByFieldValueComparator().contains(frodoClone);
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   */
+  public S usingFieldByFieldValueComparator() {
+    return usingValueComparator(new FieldByFieldComparator());
+  }
+
+  /**
+   * Use given custom comparator instead of relying on actual type A <code>equals</code> method to compare the
+   * {@link Optional} value's object for incoming assertion checks.
+   * <p>
+   * Custom comparator is bound to assertion instance, meaning that if a new assertion is created, it will use default
+   * comparison strategy.
+   * <p>
+   * Examples :
+   *
+   <pre><code class='java'>
+   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * <p/>
+   * // Fail if equals has not been overridden in TolkienCharacter as equals default implementation only compares
+   * references
+   * assertThat(Optional.of(frodo)).contains(frodoClone);
+   * <p/>
+   * // frodo and frodoClone are equals when doing a field by field comparison.
+   * assertThat(Optional.of(frodo)).usingValueComparator(new FieldByFieldComparator()).contains(frodoClone);
+   * </code></pre>
+   *
+   * @param customComparator the comparator to use for incoming assertion checks.
+   * @throws NullPointerException if the given comparator is {@code null}.
+   * @return {@code this} assertion object.
+   */
+  public S usingValueComparator(Comparator<? super T> customComparator) {
+    comparisonStrategy = new ComparatorBasedComparisonStrategy(customComparator);
+    return myself;
+  }
+
+  /**
+   * Revert to standard comparison for incoming assertion {@link Optional} value checks.
+   * <p>
+   * This method should be used to disable a custom comparison strategy set by calling
+   * {@link #usingValueComparator(Comparator)}.
+   *
+   * @return {@code this} assertion object.
+   */
+  public S usingDefaultValueComparator() {
+    // fall back to default strategy to compare actual with other objects.
+    comparisonStrategy = StandardComparisonStrategy.instance();
+    return myself;
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingDefaultVauleComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingDefaultVauleComparator_Test.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.optional;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.OptionalShouldContain.shouldContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OptionalAssert_contains_usingDefaultVauleComparator_Test extends BaseTest {
+
+  @Test
+  public void should_fail_when_optional_is_null() throws Exception {
+    thrown.expectAssertionError(actualIsNull());
+
+    assertThat((Optional<Foo>) null).usingDefaultValueComparator().contains(new Foo("something"));
+  }
+
+  @Test
+  public void should_fail_if_expected_value_is_null() throws Exception {
+    thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+
+    assertThat(Optional.of(new Foo("something"))).usingDefaultValueComparator().contains(null);
+  }
+
+  @Test
+  public void should_pass_if_optional_contains_expected_value() throws Exception {
+    Foo foo = new Foo("something");
+    assertThat(Optional.of(foo)).usingDefaultValueComparator().contains(foo);
+  }
+
+  @Test
+  public void should_fail_if_optional_does_not_contain_expected_value() throws Exception {
+    Optional<Foo> actual = Optional.of(new Foo("something"));
+	  Foo expectedValue = new Foo("something else");
+
+    thrown.expectAssertionError(shouldContain(actual, expectedValue).create());
+
+	  assertThat(actual).usingDefaultValueComparator().contains(expectedValue);
+  }
+
+  @Test
+  public void should_fail_if_optional_is_empty() throws Exception {
+    Foo expectedValue = new Foo("test");
+
+    thrown.expectAssertionError(shouldContain(expectedValue).create());
+
+	  assertThat(Optional.empty()).usingDefaultValueComparator().contains(expectedValue);
+  }
+
+  private static class Foo {
+
+    private final String value;
+
+    public Foo(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override public String toString() {
+      return "Foo{" +
+             "value='" + value + '\'' +
+             '}';
+    }
+  }
+}

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingFieldByFieldValueComparator_Test.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.optional;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.OptionalShouldContain.shouldContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OptionalAssert_contains_usingFieldByFieldValueComparator_Test extends BaseTest {
+
+  @Test
+  public void should_fail_when_optional_is_null() throws Exception {
+    thrown.expectAssertionError(actualIsNull());
+
+    assertThat((Optional<Foo>) null).usingFieldByFieldValueComparator().contains(new Foo("something"));
+  }
+
+  @Test
+  public void should_fail_if_expected_value_is_null() throws Exception {
+    thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+
+    assertThat(Optional.of(new Foo("something"))).usingFieldByFieldValueComparator().contains(null);
+  }
+
+  @Test
+  public void should_pass_if_optional_contains_expected_value() throws Exception {
+    assertThat(Optional.of(new Foo("something"))).usingFieldByFieldValueComparator().contains(
+        new Foo("something"));
+  }
+
+  @Test
+  public void should_fail_if_optional_does_not_contain_expected_value() throws Exception {
+    Optional<Foo> actual = Optional.of(new Foo("something"));
+	  Foo expectedValue = new Foo("something else");
+
+    thrown.expectAssertionError(shouldContain(actual, expectedValue).create());
+
+	  assertThat(actual).usingFieldByFieldValueComparator().contains(expectedValue);
+  }
+
+  @Test
+  public void should_fail_if_optional_is_empty() throws Exception {
+    Foo expectedValue = new Foo("test");
+
+    thrown.expectAssertionError(shouldContain(expectedValue).create());
+
+	  assertThat(Optional.empty()).usingFieldByFieldValueComparator().contains(expectedValue);
+  }
+
+  private static class Foo {
+
+    private final String value;
+
+    public Foo(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override public String toString() {
+      return "Foo{" +
+             "value='" + value + '\'' +
+             '}';
+    }
+  }
+}

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_contains_usingValueComparator_Test.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.optional;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.OptionalShouldContain.shouldContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class OptionalAssert_contains_usingValueComparator_Test extends BaseTest {
+
+  private Comparator<Foo> fooComparator;
+
+  @Before
+  public void before() {
+    fooComparator = (o1, o2) -> o1.getValue().compareTo(o2.getValue());
+  }
+
+  @Test
+  public void should_fail_when_optional_is_null() throws Exception {
+    thrown.expectAssertionError(actualIsNull());
+
+    assertThat((Optional<Foo>) null).usingValueComparator(fooComparator).contains(new Foo("something"));
+  }
+
+  @Test
+  public void should_fail_if_expected_value_is_null() throws Exception {
+    thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+
+    assertThat(Optional.of(new Foo("something"))).usingValueComparator(fooComparator).contains(null);
+  }
+
+  @Test
+  public void should_pass_if_optional_contains_expected_value() throws Exception {
+    assertThat(Optional.of(new Foo("something"))).usingValueComparator(fooComparator).contains( new Foo("something"));
+  }
+
+  @Test
+  public void should_fail_if_optional_does_not_contain_expected_value() throws Exception {
+    Optional<Foo> actual = Optional.of(new Foo("something"));
+	  Foo expectedValue = new Foo("something else");
+
+    thrown.expectAssertionError(shouldContain(actual, expectedValue).create());
+
+	  assertThat(actual).usingValueComparator(fooComparator).contains(expectedValue);
+  }
+
+  @Test
+  public void should_fail_if_optional_is_empty() throws Exception {
+    Foo expectedValue = new Foo("test");
+
+    thrown.expectAssertionError(shouldContain(expectedValue).create());
+
+    Optional<Foo> actual = Optional.empty();
+	  assertThat(actual).usingValueComparator(fooComparator).contains(expectedValue);
+  }
+
+  private static class Foo {
+
+    private final String value;
+
+    public Foo(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override public String toString() {
+      return "Foo{" +
+             "value='" + value + '\'' +
+             '}';
+    }
+  }
+}


### PR DESCRIPTION
Added ```usingDefaultValueComparator```, ```usingFieldByFieldValueComparator``` and ```usingValueComparator``` to OptionalAssert. This allows you to specify the comparator that should be used when asserting an Optional contains a value.