### PR TITLE
#438: Better spacing for javadoc code examples (java 8 classes)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
@@ -49,10 +49,7 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * Verifies that the actual {@code LocalDate} is <b>strictly</b> before the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01")).isBefore(parse("2000-01-02"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01")).isBefore(parse("2000-01-02"));</code></pre>
    * 
    * @param other the given {@link LocalDate}.
    * @return this assertion object.
@@ -74,11 +71,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01")).isBefore("2000-01-02");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01")).isBefore("2000-01-02");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -96,11 +90,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * Verifies that the actual {@code LocalDate} is before or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01")).isBeforeOrEqualTo(parse("2000-01-01"))
-   *                                .isBeforeOrEqualTo(parse("2000-01-02"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01")).isBeforeOrEqualTo(parse("2000-01-01"))
+   *                                .isBeforeOrEqualTo(parse("2000-01-02"));</code></pre>
    * 
    * @param other the given {@link LocalDate}.
    * @return this assertion object.
@@ -124,12 +115,9 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01")).isBeforeOrEqualTo("2000-01-01")
-   *                                .isBeforeOrEqualTo("2000-01-02");
-   * </code></pre>
+   *                                .isBeforeOrEqualTo("2000-01-02");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -147,11 +135,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * Verifies that the actual {@code LocalDate} is after or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01")).isAfterOrEqualTo(parse("2000-01-01"))
-   *                                .isAfterOrEqualTo(parse("1999-12-31"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01")).isAfterOrEqualTo(parse("2000-01-01"))
+   *                                .isAfterOrEqualTo(parse("1999-12-31"));</code></pre>
    * 
    * @param other the given {@link LocalDate}.
    * @return this assertion object.
@@ -175,12 +160,9 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01")).isAfterOrEqualTo("2000-01-01")
-   *                                .isAfterOrEqualTo("1999-12-31");
-   * </code></pre>
+   *                                .isAfterOrEqualTo("1999-12-31");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -198,10 +180,7 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * Verifies that the actual {@code LocalDate} is <b>strictly</b> after the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01")).isAfter(parse("1999-12-31"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01")).isAfter(parse("1999-12-31"));</code></pre>
    * 
    * @param other the given {@link LocalDate}.
    * @return this assertion object.
@@ -225,11 +204,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
-   * assertThat(parse("2000-01-01")).isAfter("1999-12-31");
-   * </code></pre>
+   * <pre><code class='java'> // use String in comparison to avoid conversion
+   * assertThat(parse("2000-01-01")).isAfter("1999-12-31");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -250,11 +226,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01")).isEqualTo("2000-01-01");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01")).isEqualTo("2000-01-01");</code></pre>
    * 
    * @param dateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -275,11 +248,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01")).isNotEqualTo("2000-01-15");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01")).isNotEqualTo("2000-01-15");</code></pre>
    * 
    * @param dateTimeAsString String representing a {@link LocalDate}.
    * @return this assertion object.
@@ -300,11 +270,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String based representation of LocalDate
-   * assertThat(parse("2000-01-01")).isIn("1999-12-31", "2000-01-01");
-   * </code></pre>
+   * <pre><code class='java'> // use String based representation of LocalDate
+   * assertThat(parse("2000-01-01")).isIn("1999-12-31", "2000-01-01");</code></pre>
    * 
    * @param dateTimesAsString String array representing {@link LocalDate}s.
    * @return this assertion object.
@@ -325,11 +292,8 @@ public abstract class AbstractLocalDateAssert<S extends AbstractLocalDateAssert<
    * >ISO LocalDate format</a> to allow calling {@link LocalDate#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String based representation of LocalDate
-   * assertThat(parse("2000-01-01")).isNotIn("1999-12-31", "2000-01-02");
-   * </code></pre>
+   * <pre><code class='java'> // use String based representation of LocalDate
+   * assertThat(parse("2000-01-01")).isNotIn("1999-12-31", "2000-01-02");</code></pre>
    * 
    * @param dateTimesAsString Array of String representing a {@link LocalDate}.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractLocalDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLocalDateTimeAssert.java
@@ -57,10 +57,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Verifies that the actual {@code LocalDateTime} is <b>strictly</b> before the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T23:59:59")).isBefore(parse("2000-01-02T00:00:00"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T23:59:59")).isBefore(parse("2000-01-02T00:00:00"));</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -84,11 +81,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01T23:59:59")).isBefore("2000-01-02T00:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01T23:59:59")).isBefore("2000-01-02T00:00:00");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -106,11 +100,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Verifies that the actual {@code LocalDateTime} is before or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T23:59:59")).isBeforeOrEqualTo(parse("2000-01-01T23:59:59"))
-   *                                         .isBeforeOrEqualTo(parse("2000-01-02T00:00:00"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T23:59:59")).isBeforeOrEqualTo(parse("2000-01-01T23:59:59"))
+   *                                         .isBeforeOrEqualTo(parse("2000-01-02T00:00:00"));</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -134,12 +125,9 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01T23:59:59")).isBeforeOrEqualTo("2000-01-01T23:59:59")
-   *                                         .isBeforeOrEqualTo("2000-01-02T00:00:00");
-   * </code></pre>
+   *                                         .isBeforeOrEqualTo("2000-01-02T00:00:00");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -157,11 +145,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Verifies that the actual {@code LocalDateTime} is after or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00")).isAfterOrEqualTo(parse("2000-01-01T00:00:00"))
-   *                                         .isAfterOrEqualTo(parse("1999-12-31T23:59:59"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00")).isAfterOrEqualTo(parse("2000-01-01T00:00:00"))
+   *                                         .isAfterOrEqualTo(parse("1999-12-31T23:59:59"));</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -185,12 +170,9 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01T00:00:00")).isAfterOrEqualTo("2000-01-01T00:00:00")
-   *                                         .isAfterOrEqualTo("1999-12-31T23:59:59");
-   * </code></pre>
+   *                                         .isAfterOrEqualTo("1999-12-31T23:59:59");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -208,10 +190,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Verifies that the actual {@code LocalDateTime} is <b>strictly</b> after the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00")).isAfter(parse("1999-12-31T23:59:59"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00")).isAfter(parse("1999-12-31T23:59:59"));</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -235,11 +214,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
-   * assertThat(parse("2000-01-01T00:00:00")).isAfter("1999-12-31T23:59:59");
-   * </code></pre>
+   * <pre><code class='java'> // use String in comparison to avoid conversion
+   * assertThat(parse("2000-01-01T00:00:00")).isAfter("1999-12-31T23:59:59");</code></pre>
    * 
    * @param localDateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -260,11 +236,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01T00:00:00")).isEqualTo("2000-01-01T00:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01T00:00:00")).isEqualTo("2000-01-01T00:00:00");</code></pre>
    * 
    * @param dateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -285,11 +258,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01T00:00:00")).isNotEqualTo("2000-01-15T00:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01T00:00:00")).isNotEqualTo("2000-01-15T00:00:00");</code></pre>
    * 
    * @param dateTimeAsString String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -310,11 +280,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String based representation of LocalDateTime
-   * assertThat(parse("2000-01-01T00:00:00")).isIn("1999-12-31T00:00:00", "2000-01-01T00:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // use String based representation of LocalDateTime
+   * assertThat(parse("2000-01-01T00:00:00")).isIn("1999-12-31T00:00:00", "2000-01-01T00:00:00");</code></pre>
    * 
    * @param dateTimesAsString String array representing {@link LocalDateTime}s.
    * @return this assertion object.
@@ -335,11 +302,8 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * >ISO LocalDateTime format</a> to allow calling {@link LocalDateTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // use String based representation of LocalDateTime
-   * assertThat(parse("2000-01-01T00:00:00")).isNotIn("1999-12-31T00:00:00", "2000-01-02T00:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // use String based representation of LocalDateTime
+   * assertThat(parse("2000-01-01T00:00:00")).isNotIn("1999-12-31T00:00:00", "2000-01-02T00:00:00");</code></pre>
    * 
    * @param dateTimesAsString Array of String representing a {@link LocalDateTime}.
    * @return this assertion object.
@@ -408,9 +372,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Assertion fails as second fields differ even if time difference is only 1ns.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * LocalDateTime localDateTime1 = LocalDateTime.of(2000, 1, 1, 0, 0, 1, 0);
    * LocalDateTime localDateTime2 = LocalDateTime.of(2000, 1, 1, 0, 0, 1, 456);
    * assertThat(localDateTime1).isEqualToIgnoringNanos(localDateTime2);
@@ -418,8 +380,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * // failing assertions (even if time difference is only 1ms)
    * LocalDateTime localDateTimeA = LocalDateTime.of(2000, 1, 1, 0, 0, 1, 0);
    * LocalDateTime localDateTimeB = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 999999999);
-   * assertThat(localDateTimeA).isEqualToIgnoringNanos(localDateTimeB);
-   * </code></pre>
+   * assertThat(localDateTimeA).isEqualToIgnoringNanos(localDateTimeB);</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -447,9 +408,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Assertion fails as minute fields differ even if time difference is only 1s.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successful assertions
+   * <pre><code class='java'> // successful assertions
    * LocalDateTime localDateTime1 = LocalDateTime.of(2000, 1, 1, 23, 50, 0, 0);
    * LocalDateTime localDateTime2 = LocalDateTime.of(2000, 1, 1, 23, 50, 10, 456);
    * assertThat(localDateTime1).isEqualToIgnoringSeconds(localDateTime2);
@@ -457,8 +416,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * // failing assertions (even if time difference is only 1ms)
    * LocalDateTime localDateTimeA = LocalDateTime.of(2000, 1, 1, 23, 50, 00, 000);
    * LocalDateTime localDateTimeB = LocalDateTime.of(2000, 1, 1, 23, 49, 59, 999);
-   * assertThat(localDateTimeA).isEqualToIgnoringSeconds(localDateTimeB);
-   * </code></pre>
+   * assertThat(localDateTimeA).isEqualToIgnoringSeconds(localDateTimeB);</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -487,9 +445,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Time difference is only 1s but hour fields differ.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successful assertions
+   * <pre><code class='java'> // successful assertions
    * LocalDateTime localDateTime1 = LocalDateTime.of(2000, 1, 1, 23, 50, 0, 0);
    * LocalDateTime localDateTime2 = LocalDateTime.of(2000, 1, 1, 23, 00, 2, 7);
    * assertThat(localDateTime1).isEqualToIgnoringMinutes(localDateTime2);
@@ -497,8 +453,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * // failing assertions (even if time difference is only 1ms)
    * LocalDateTime localDateTimeA = LocalDateTime.of(2000, 1, 1, 01, 00, 00, 000);
    * LocalDateTime localDateTimeB = LocalDateTime.of(2000, 1, 1, 00, 59, 59, 999);
-   * assertThat(localDateTimeA).isEqualToIgnoringMinutes(localDateTimeB);
-   * </code></pre>
+   * assertThat(localDateTimeA).isEqualToIgnoringMinutes(localDateTimeB);</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.
@@ -527,9 +482,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * Time difference is only 1min but day fields differ.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * LocalDateTime localDateTime1 = LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999);
    * LocalDateTime localDateTime2 = LocalDateTime.of(2000, 1, 1, 00, 00, 00, 000);
    * assertThat(localDateTime1).isEqualToIgnoringHours(localDateTime2);
@@ -537,8 +490,7 @@ public abstract class AbstractLocalDateTimeAssert<S extends AbstractLocalDateTim
    * // failing assertions (even if time difference is only 1ms)
    * LocalDateTime localDateTimeA = LocalDateTime.of(2000, 1, 2, 00, 00, 00, 000);
    * LocalDateTime localDateTimeB = LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999);
-   * assertThat(localDateTimeA).isEqualToIgnoringHours(localDateTimeB);
-   * </code></pre>
+   * assertThat(localDateTimeA).isEqualToIgnoringHours(localDateTimeB);</code></pre>
    * 
    * @param other the given {@link LocalDateTime}.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractLocalTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLocalTimeAssert.java
@@ -52,10 +52,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Verifies that the actual {@code LocalTime} is <b>strictly</b> before the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("12:00:00")).isBefore(parse("13:00:00"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("12:00:00")).isBefore(parse("13:00:00"));</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -79,11 +76,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
-   * assertThat(parse("12:59")).isBefore("13:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * assertThat(parse("12:59")).isBefore("13:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -101,11 +95,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Verifies that the actual {@code LocalTime} is before or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("12:00:00")).isBeforeOrEqualTo(parse("12:00:00"))
-   *                                        .isBeforeOrEqualTo(parse("12:00:01"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("12:00:00")).isBeforeOrEqualTo(parse("12:00:00"))
+   *                                        .isBeforeOrEqualTo(parse("12:00:01"));</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -129,12 +120,9 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
    * assertThat(parse("12:00:00")).isBeforeOrEqualTo("12:00:00")
-   *                              .isBeforeOrEqualTo("13:00:00");
-   * </code></pre>
+   *                              .isBeforeOrEqualTo("13:00:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -152,11 +140,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Verifies that the actual {@code LocalTime} is after or equals to the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("13:00:00")).isAfterOrEqualTo(parse("13:00:00"))
-   *                              .isAfterOrEqualTo(parse("12:00:00"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("13:00:00")).isAfterOrEqualTo(parse("13:00:00"))
+   *                              .isAfterOrEqualTo(parse("12:00:00"));</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -180,12 +165,9 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
    * assertThat(parse("13:00:00")).isAfterOrEqualTo("13:00:00")
-   *                              .isAfterOrEqualTo("12:00:00");
-   * </code></pre>
+   *                              .isAfterOrEqualTo("12:00:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -203,10 +185,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Verifies that the actual {@code LocalTime} is <b>strictly</b> after the given one.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * assertThat(parse("13:00:00")).isAfter(parse("12:00:00"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("13:00:00")).isAfter(parse("12:00:00"));</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -230,11 +209,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
-   * assertThat(parse("13:00:00")).isAfter("12:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * assertThat(parse("13:00:00")).isAfter("12:00:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -255,11 +231,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
-   * assertThat(parse("13:00:00")).isEqualTo("13:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * assertThat(parse("13:00:00")).isEqualTo("13:00:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -280,11 +253,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTime as String (AssertJ taking care of the conversion)
-   * assertThat(parse("13:00:00")).isNotEqualTo("12:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTime as String (AssertJ taking care of the conversion)
+   * assertThat(parse("13:00:00")).isNotEqualTo("12:00:00");</code></pre>
    * 
    * @param localTimeAsString String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -305,11 +275,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTimes as String (AssertJ taking care of the conversion)
-   * assertThat(parse("13:00:00")).isIn("12:00:00", "13:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTimes as String (AssertJ taking care of the conversion)
+   * assertThat(parse("13:00:00")).isIn("12:00:00", "13:00:00");</code></pre>
    * 
    * @param localTimesAsString String array representing {@link LocalTime}s.
    * @return this assertion object.
@@ -330,11 +297,8 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * >ISO LocalTime format</a> to allow calling {@link LocalTime#parse(CharSequence)} method.
    * <p>
    * Example :
-   * 
-   * <pre><code class='java'>
-   * // you can express expected LocalTimes as String (AssertJ taking care of the conversion)
-   * assertThat(parse("13:00:00")).isNotIn("12:00:00", "14:00:00");
-   * </code></pre>
+   * <pre><code class='java'> // you can express expected LocalTimes as String (AssertJ taking care of the conversion)
+   * assertThat(parse("13:00:00")).isNotIn("12:00:00", "14:00:00");</code></pre>
    * 
    * @param localTimesAsString Array of String representing a {@link LocalTime}.
    * @return this assertion object.
@@ -396,9 +360,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Assertion fails as second fields differ even if time difference is only 1ns.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * LocalTime localTime1 = LocalTime.of(12, 0, 1, 0);
    * LocalTime localTime2 = LocalTime.of(12, 0, 1, 456);
    * assertThat(localTime1).isEqualToIgnoringNanos(localTime2);
@@ -406,8 +368,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * // failing assertions (even if time difference is only 1ns)
    * LocalTime localTimeA = LocalTime.of(12, 0, 1, 0);
    * LocalTime localTimeB = LocalTime.of(12, 0, 0, 999999999);
-   * assertThat(localTimeA).isEqualToIgnoringNanos(localTimeB);
-   * </code></pre>
+   * assertThat(localTimeA).isEqualToIgnoringNanos(localTimeB);</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -435,9 +396,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Assertion fails as minute fields differ even if time difference is only 1s.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successful assertions
+   * <pre><code class='java'> // successful assertions
    * LocalTime localTime1 = LocalTime.of(23, 50, 0, 0);
    * LocalTime localTime2 = LocalTime.of(23, 50, 10, 456);
    * assertThat(localTime1).isEqualToIgnoringSeconds(localTime2);
@@ -445,8 +404,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * // failing assertions (even if time difference is only 1ms)
    * LocalTime localTimeA = LocalTime.of(23, 50, 00, 000);
    * LocalTime localTimeB = LocalTime.of(23, 49, 59, 999);
-   * assertThat(localTimeA).isEqualToIgnoringSeconds(localTimeB);
-   * </code></pre>
+   * assertThat(localTimeA).isEqualToIgnoringSeconds(localTimeB);</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.
@@ -475,9 +433,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * Time difference is only 1s but hour fields differ.
    * <p>
    * Code example :
-   * 
-   * <pre><code class='java'>
-   * // successful assertions
+   * <pre><code class='java'> // successful assertions
    * LocalTime localTime1 = LocalTime.of(23, 50, 0, 0);
    * LocalTime localTime2 = LocalTime.of(23, 00, 2, 7);
    * assertThat(localTime1).hasSameHourAs(localTime2);
@@ -485,8 +441,7 @@ public abstract class AbstractLocalTimeAssert<S extends AbstractLocalTimeAssert<
    * // failing assertions (even if time difference is only 1ms)
    * LocalTime localTimeA = LocalTime.of(01, 00, 00, 000);
    * LocalTime localTimeB = LocalTime.of(00, 59, 59, 999);
-   * assertThat(localTimeA).hasSameHourAs(localTimeB);
-   * </code></pre>
+   * assertThat(localTimeA).hasSameHourAs(localTimeB);</code></pre>
    * 
    * @param other the given {@link LocalTime}.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -35,16 +35,10 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * Verifies that there is a value present in the actual {@link java.util.Optional}.
    * </p>
    * Assertion will pass :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.of("something")).isPresent();
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.of("something")).isPresent() * </code></pre>
    * 
    * Assertion will fail :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.empty()).isPresent();
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.empty()).isPresent();</code></pre>
    *
    * @return this assertion object.
    */
@@ -58,16 +52,10 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * Verifies that the actual {@link java.util.Optional} is empty.
    * </p>
    * Assertion will pass :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.empty()).isEmpty();
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.empty()).isEmpty();</code></pre>
    * 
    * Assertion will fail :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.of("something")).isEmpty();
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.of("something")).isEmpty();</code></pre>
    *
    * @return this assertion object.
    */
@@ -81,18 +69,12 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
    * Verifies that the actual {@link java.util.Optional} contains the value in argument.
    * </p>
    * Assertion will pass :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.of("something")).contains("something");
-   * assertThat(Optional.of(10)).contains(10);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.of("something")).contains("something");
+   * assertThat(Optional.of(10)).contains(10);</code></pre>
    * 
    * Assertion will fail :
-   * 
-   * <pre><code class='java'>
-   * assertThat(Optional.of("something")).contains("something else");
-   * assertThat(Optional.of(20)).contains(10);
-   * </code></pre>
+   * <pre><code class='java'> assertThat(Optional.of("something")).contains("something else");
+   * assertThat(Optional.of(20)).contains(10);</code></pre>
    *
    * @param expectedValue the expected value inside the {@link java.util.Optional}.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
@@ -55,10 +55,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Comparison is done on {@code ZonedDateTime}'s instant (i.e. {@link ZonedDateTime#toEpochSecond()})
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T23:59:59Z")).isBefore(parse("2000-01-02T00:00:00Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T23:59:59Z")).isBefore(parse("2000-01-02T00:00:00Z"));</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -85,11 +82,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check..
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01T23:59:59Z")).isBefore("2000-01-02T00:00:00Z");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01T23:59:59Z")).isBefore("2000-01-02T00:00:00Z");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -109,11 +103,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Comparison is done on {@code ZonedDateTime}'s instant (i.e. {@link ZonedDateTime#toEpochSecond()})
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T23:59:59Z")).isBeforeOrEqualTo(parse("2000-01-01T23:59:59Z"))
-   *                                          .isBeforeOrEqualTo(parse("2000-01-02T00:00:00Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T23:59:59Z")).isBeforeOrEqualTo(parse("2000-01-01T23:59:59Z"))
+   *                                          .isBeforeOrEqualTo(parse("2000-01-02T00:00:00Z"));</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -140,12 +131,9 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check..
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01T23:59:59Z")).isBeforeOrEqualTo("2000-01-01T23:59:59Z")
-   *                                          .isBeforeOrEqualTo("2000-01-02T00:00:00Z");
-   * </code></pre>
+   *                                          .isBeforeOrEqualTo("2000-01-02T00:00:00Z");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -165,11 +153,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Comparison is done on {@code ZonedDateTime}'s instant (i.e. {@link ZonedDateTime#toEpochSecond()})
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00Z")).isAfterOrEqualTo(parse("2000-01-01T00:00:00Z"))
-   *                                          .isAfterOrEqualTo(parse("1999-12-31T23:59:59Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00Z")).isAfterOrEqualTo(parse("2000-01-01T00:00:00Z"))
+   *                                          .isAfterOrEqualTo(parse("1999-12-31T23:59:59Z"));</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -196,12 +181,9 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
+   * <pre><code class='java'> // use String in comparison to avoid conversion
    * assertThat(parse("2000-01-01T00:00:00Z")).isAfterOrEqualTo("2000-01-01T00:00:00Z")
-   *                                          .isAfterOrEqualTo("1999-12-31T23:59:59Z");
-   * </code></pre>
+   *                                          .isAfterOrEqualTo("1999-12-31T23:59:59Z");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -221,10 +203,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Comparison is done on {@code ZonedDateTime}'s instant (i.e. {@link ZonedDateTime#toEpochSecond()})
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00Z")).isAfter(parse("1999-12-31T23:59:59Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00Z")).isAfter(parse("1999-12-31T23:59:59Z"));</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -251,11 +230,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use String in comparison to avoid conversion
-   * assertThat(parse("2000-01-01T00:00:00Z")).isAfter("1999-12-31T23:59:59Z");
-   * </code></pre>
+   * <pre><code class='java'> // use String in comparison to avoid conversion
+   * assertThat(parse("2000-01-01T00:00:00Z")).isAfter("1999-12-31T23:59:59Z");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -282,9 +258,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Assertion fails as second fields differ even if time difference is only 1ns.
    * <p>
    * Code example :
-   *
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * ZonedDateTime dateTime1 = ZonedDateTime.of(2000, 1, 1, 0, 0, 1, 0);
    * ZonedDateTime dateTime2 = ZonedDateTime.of(2000, 1, 1, 0, 0, 1, 456);
    * assertThat(dateTime1).isEqualToIgnoringNanos(dateTime2);
@@ -292,8 +266,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * // failing assertions (even if time difference is only 1ms)
    * ZonedDateTime dateTimeA = ZonedDateTime.of(2000, 1, 1, 0, 0, 1, 0);
    * ZonedDateTime dateTimeB = ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 999999999);
-   * assertThat(dateTimeA).isEqualToIgnoringNanos(dateTimeB);
-   * </code></pre>
+   * assertThat(dateTimeA).isEqualToIgnoringNanos(dateTimeB);</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -324,9 +297,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Assertion fails as minute fields differ even if time difference is only 1ns.
    * <p>
    * Code example :
-   *
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * ZonedDateTime dateTime1 = ZonedDateTime.of(2000, 1, 1, 23, 50, 0, 0);
    * ZonedDateTime dateTime2 = ZonedDateTime.of(2000, 1, 1, 23, 50, 10, 456);
    * assertThat(dateTime1).isEqualToIgnoringSeconds(dateTime2);
@@ -334,8 +305,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * // failing assertions (even if time difference is only 1ns)
    * ZonedDateTime dateTimeA = ZonedDateTime.of(2000, 1, 1, 23, 50, 00, 0);
    * ZonedDateTime dateTimeB = ZonedDateTime.of(2000, 1, 1, 23, 49, 59, 999999999);
-   * assertThat(dateTimeA).isEqualToIgnoringSeconds(dateTimeB);
-   * </code></pre>
+   * assertThat(dateTimeA).isEqualToIgnoringSeconds(dateTimeB);</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -367,9 +337,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Time difference is only 1s but hour fields differ.
    * <p>
    * Code example :
-   *
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * ZonedDateTime dateTime1 = ZonedDateTime.of(2000, 1, 1, 23, 50, 0, 0);
    * ZonedDateTime dateTime2 = ZonedDateTime.of(2000, 1, 1, 23, 00, 2, 7);
    * assertThat(dateTime1).isEqualToIgnoringMinutes(dateTime2);
@@ -377,8 +345,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * // failing assertions (even if time difference is only 1ms)
    * ZonedDateTime dateTimeA = ZonedDateTime.of(2000, 1, 1, 01, 00, 00, 000);
    * ZonedDateTime dateTimeB = ZonedDateTime.of(2000, 1, 1, 00, 59, 59, 999);
-   * assertThat(dateTimeA).isEqualToIgnoringMinutes(dateTimeB);
-   * </code></pre>
+   * assertThat(dateTimeA).isEqualToIgnoringMinutes(dateTimeB);</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -410,9 +377,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Time difference is only 1min but day fields differ.
    * <p>
    * Code example :
-   *
-   * <pre><code class='java'>
-   * // successfull assertions
+   * <pre><code class='java'> // successfull assertions
    * ZonedDateTime dateTime1 = ZonedDateTime.of(2000, 1, 1, 23, 59, 59, 999, ZoneId.systemDefault());
    * ZonedDateTime dateTime2 = ZonedDateTime.of(2000, 1, 1, 00, 00, 00, 000, ZoneId.systemDefault());
    * assertThat(dateTime1).isEqualToIgnoringHours(dateTime2);
@@ -420,8 +385,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * // failing assertions (even if time difference is only 1ms)
    * ZonedDateTime dateTimeA = ZonedDateTime.of(2000, 1, 2, 00, 00, 00, 000, ZoneId.systemDefault());
    * ZonedDateTime dateTimeB = ZonedDateTime.of(2000, 1, 1, 23, 59, 59, 999, ZoneId.systemDefault());
-   * assertThat(dateTimeA).isEqualToIgnoringHours(dateTimeB);
-   * </code></pre>
+   * assertThat(dateTimeA).isEqualToIgnoringHours(dateTimeB);</code></pre>
    *
    * @param other the given {@link ZonedDateTime}.
    * @return this assertion object.
@@ -445,15 +409,12 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link java.time.ZoneId}</b>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * ZonedDateTime firstOfJanuary2000InUTC = ZonedDateTime.parse("2000-01-01T00:00:00Z");
+   * <pre><code class='java'> ZonedDateTime firstOfJanuary2000InUTC = ZonedDateTime.parse("2000-01-01T00:00:00Z");
    * assertThat(firstOfJanuary2000InUTC).isEqualTo(parse("2000-01-01T00:00:00Z"));
    * 
    * // the following assertion succeeds as ZonedDateTime are compared in actual's time zone
    * // 2000-01-01T01:00:00+01:00 = 2000-01-01T00:00:00 in UTC
-   * assertThat(firstOfJanuary2000InUTC).isEqualTo(parse("2000-01-01T01:00:00+01:00"));
-   * </code></pre>
+   * assertThat(firstOfJanuary2000InUTC).isEqualTo(parse("2000-01-01T01:00:00+01:00"));</code></pre>
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -474,16 +435,13 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
    * ZonedDateTime firstOfJanuary2000InUTC = ZonedDateTime.parse("2000-01-01T00:00:00Z");
    * assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T00:00:00Z");
    * 
    * // the following assertion succeeds as ZonedDateTime are compared in actual's time zone
    * // 2000-01-01T01:00:00+01:00 = 2000-01-01T00:00:00 in UTC
-   * assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T01:00:00+01:00");
-   * </code></pre>
+   * assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T01:00:00+01:00");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -501,10 +459,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * Verifies that the actual value is not equal to the given one <b>in the actual ZonedDateTime's java.time.ZoneId</b>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00Z")).isNotEqualTo(parse("2000-01-15T00:00:00Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00Z")).isNotEqualTo(parse("2000-01-15T00:00:00Z"));</code></pre>
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -525,11 +480,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * {@link ZonedDateTime} to check.. {@link ZonedDateTime}.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use directly String in comparison to avoid writing the code to perform the conversion
-   * assertThat(parse("2000-01-01T00:00:00Z")).isNotEqualTo("2000-01-15T00:00:00Z");
-   * </code></pre>
+   * <pre><code class='java'> // use directly String in comparison to avoid writing the code to perform the conversion
+   * assertThat(parse("2000-01-01T00:00:00Z")).isNotEqualTo("2000-01-15T00:00:00Z");</code></pre>
    *
    * @param dateTimeAsString String representing a {@link ZonedDateTime}.
    * @return this assertion object.
@@ -548,11 +500,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * ZonedDateTime's {@link java.time.ZoneId}</b>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00Z")).isIn(parse("1999-12-31T23:59:59Z"), 
-   *                                                parse("2000-01-01T00:00:00Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00Z")).isIn(parse("1999-12-31T23:59:59Z"),
+   *                                                parse("2000-01-01T00:00:00Z"));</code></pre>
    *
    * @param expected the given {@link ZonedDateTime}s to compare the actual value to.
    * @return {@code this} assertion object.
@@ -573,12 +522,9 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * the {@link ZonedDateTime} to check..
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use String based representation of LocalDateTime
+   * <pre><code class='java'> // use String based representation of LocalDateTime
    * assertThat(parse("2000-01-01T00:00:00Z")).isIn("1999-12-31T23:59:59Z", 
-   *                                                "2000-01-01T00:00:00Z");
-   * </code></pre>
+   *                                                "2000-01-01T00:00:00Z");</code></pre>
    *
    * @param dateTimesAsString String array representing {@link ZonedDateTime}s.
    * @return this assertion object.
@@ -597,11 +543,8 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * ZonedDateTime's {@link java.time.ZoneId}</b>.
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * assertThat(parse("2000-01-01T00:00:00Z")).isNotIn(parse("1999-12-31T23:59:59Z"), 
-   *                                                   parse("2000-01-02T00:00:00Z"));
-   * </code></pre>
+   * <pre><code class='java'> assertThat(parse("2000-01-01T00:00:00Z")).isNotIn(parse("1999-12-31T23:59:59Z"),
+   *                                                   parse("2000-01-02T00:00:00Z"));</code></pre>
    *
    * @param expected the given {@link ZonedDateTime}s to compare the actual value to.
    * @return {@code this} assertion object.
@@ -622,12 +565,9 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
    * the {@link ZonedDateTime} to check..
    * <p>
    * Example :
-   *
-   * <pre><code class='java'>
-   * // use String based representation of ZonedDateTime
+   * <pre><code class='java'> // use String based representation of ZonedDateTime
    * assertThat(parse("2000-01-01T00:00:00Z")).isNotIn("1999-12-31T23:59:59Z", 
-   *                                                   "2000-01-02T00:00:00Z");
-   * </code></pre>
+   *                                                   "2000-01-02T00:00:00Z");</code></pre>
    *
    * @param dateTimesAsString String array representing {@link ZonedDateTime}s.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/Condition.java
+++ b/src/main/java/org/assertj/core/api/Condition.java
@@ -65,24 +65,19 @@ public class Condition<T> implements Descriptable<Condition<T>> {
    * args to build the description as in {@link String#format(String, Object...)}.
    * <p>
    * Example:
-   * 
-   * <pre><code class='java'>
-   * // build condition with Predicate&lt;String&gt; and set description using String#format pattern.
+   * <pre><code class='java'> // build condition with Predicate&lt;String&gt; and set description using String#format pattern.
    * Condition&lt;String&gt; fairyTale = new Condition&lt;String&gt;(s -> s.startsWith("Once upon a time"), "a %s tale", "fairy");
    * 
    * String littleRedCap = "Once upon a time there was a dear little girl ...";
-   * assertThat(littleRedCap).is(fairyTale);
-   * </code></pre>
-   * Error message example:
+   * assertThat(littleRedCap).is(fairyTale);</code></pre>
    * 
-   * <pre><code class='java'>
-   * // unfortunately this assertion fails ... but contact me if you can make it pass :)
+   * Error message example:
+   * <pre><code class='java'> // unfortunately this assertion fails ... but contact me if you can make it pass :)
    * assertThat("life").is(fairyTale);
    * // error message
    * Expecting:
    *  &lt;"life"&gt;
-   * to be &lt;a fairy tale&gt;
-   * </code></pre>
+   * to be &lt;a fairy tale&gt;</code></pre>
    * 
    * @param predicate the {@link Predicate} used to build the condition.
    * @param description the description of this condition.


### PR DESCRIPTION
I did the for new classes on the java-8 branch only. I did not succeed merging my other pull request into this branch, so I could not easily check if new methods of existing classes also need this change. I'm willing to do this after my other pull request is merged into the java-8 branch.