### PR TITLE
Path's assertions should not rely on java.nio.Path.toFile() (fixes #439)

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldHaveBinaryContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveBinaryContent.java
@@ -13,12 +13,13 @@
 package org.assertj.core.error;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.assertj.core.internal.BinaryDiffResult;
 
 
 /**
- * Creates an error message indicating that an assertion that verifies that a file has a given binary content failed.
+ * Creates an error message indicating that an assertion that verifies that a file/path has a given binary content failed.
  * 
  * @author Olivier Michallat
  */
@@ -33,9 +34,24 @@ public class ShouldHaveBinaryContent extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
     return new ShouldHaveBinaryContent(actual, diff);
   }
+  
+  /**
+   * Creates a new <code>{@link ShouldHaveBinaryContent}</code>.
+   * @param actual the actual path in the failed assertion.
+   * @param diff the differences between {@code actual} and the given binary content.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveBinaryContent(Path actual, BinaryDiffResult diff) {
+    return new ShouldHaveBinaryContent(actual, diff);
+  }
 
   private ShouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
     super("%nFile:%n <%s>%ndoes not have expected binary content at offset <%s>, expecting:%n <%s>%nbut was:%n <%s>", actual,
+        diff.offset, diff.expected, diff.actual);
+  }
+  
+  private ShouldHaveBinaryContent(Path actual, BinaryDiffResult diff) {
+    super("%nPath:%n <%s>%ndoes not have expected binary content at offset <%s>, expecting:%n <%s>%nbut was:%n <%s>", actual,
         diff.offset, diff.expected, diff.actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveContent.java
@@ -14,11 +14,12 @@ package org.assertj.core.error;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.List;
 
 
 /**
- * Creates an error message indicating that an assertion that verifies that a file has a given text content failed.
+ * Creates an error message indicating that an assertion that verifies that a file/path has a given text content failed.
  * 
  * @author Olivier Michallat
  */
@@ -34,9 +35,25 @@ public class ShouldHaveContent extends AbstractShouldHaveTextContent {
   public static ErrorMessageFactory shouldHaveContent(File actual, Charset charset, List<String> diffs) {
     return new ShouldHaveContent(actual, charset, diffsAsString(diffs));
   }
+  
+  /**
+   * Creates a new <code>{@link ShouldHaveContent}</code>.
+   * @param actual the actual path in the failed assertion.
+   * @param charset the charset that was used to read the the path.
+   * @param diffs the differences between {@code actual} and the expected text that was provided in the assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveContent(Path actual, Charset charset, List<String> diffs) {
+    return new ShouldHaveContent(actual, charset, diffsAsString(diffs));
+  }
 
   private ShouldHaveContent(File actual, Charset charset, String diffs) {
     super("%nFile:%n  <%s>%nread with charset <%s> does not have the expected content:", actual, charset);
+    this.diffs = diffs;
+  }
+  
+  private ShouldHaveContent(Path actual, Charset charset, String diffs) {
+    super("%nPath:%n  <%s>%nread with charset <%s> does not have the expected content:", actual, charset);
     this.diffs = diffs;
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
@@ -15,10 +15,11 @@ package org.assertj.core.error;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
- * Creates an error message indicating that an assertion that verifies that two files/inputStreams have same content failed.
+ * Creates an error message indicating that an assertion that verifies that two files/inputStreams/paths have same content failed.
  * 
  * @author Yvonne Wang
  * @author Matthieu Baechler
@@ -40,11 +41,22 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
   /**
    * Creates a new <code>{@link ShouldHaveSameContent}</code>.
    * @param actual the actual InputStream in the failed assertion.
-   * @param expected the expected Stream in the failed assertion.
+   * @param expected the expected InputStream in the failed assertion.
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, InputStream expected, List<String> diffs) {
+    return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
+  }
+  
+  /**
+   * Creates a new <code>{@link ShouldHaveSameContent}</code>.
+   * @param actual the actual Path in the failed assertion.
+   * @param expected the expected Path in the failed assertion.
+   * @param diffs the differences between {@code actual} and {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveSameContent(Path actual, Path expected, List<String> diffs) {
     return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 
@@ -55,6 +67,11 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
 
   private ShouldHaveSameContent(InputStream actual, InputStream expected, String diffs) {
     super("%nInputStreams do not have same content:", actual, expected);
+    this.diffs = diffs;
+  }
+  
+  private ShouldHaveSameContent(Path actual, Path expected, String diffs) {
+    super("%nPath:%n  <%s>%nand path:%n  <%s>%ndo not have same content:", actual, expected);
     this.diffs = diffs;
   }
 }

--- a/src/main/java/org/assertj/core/internal/BinaryDiff.java
+++ b/src/main/java/org/assertj/core/internal/BinaryDiff.java
@@ -14,15 +14,16 @@ package org.assertj.core.internal;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.assertj.core.util.VisibleForTesting;
 
 
 /**
- * Compares the binary content of two streams.
+ * Compares the binary content of two inputStreams/paths.
  * 
  * @author Olivier Michallat
  */
@@ -31,11 +32,16 @@ public class BinaryDiff {
 
   @VisibleForTesting
   public BinaryDiffResult diff(File actual, byte[] expected) throws IOException {
+    return diff(actual.toPath(), expected);
+  }
+
+  @VisibleForTesting
+  public BinaryDiffResult diff(Path actual, byte[] expected) throws IOException {
     InputStream expectedStream = new ByteArrayInputStream(expected);
     InputStream actualStream = null;
     boolean threw = true;
     try {
-      actualStream = new FileInputStream(actual);
+      actualStream = Files.newInputStream(actual);
       BinaryDiffResult result = diff(actualStream, expectedStream);
       threw = false;
       return result;

--- a/src/main/java/org/assertj/core/internal/Diff.java
+++ b/src/main/java/org/assertj/core/internal/Diff.java
@@ -19,12 +19,13 @@ import static org.assertj.core.util.Objects.areEqual;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,7 +33,7 @@ import org.assertj.core.util.VisibleForTesting;
 
 
 /**
- * Compares the contents of two files or two streams.
+ * Compares the contents of two files, inputStreams or paths.
  * 
  * @author David DIDIER
  * @author Alex Ruiz
@@ -61,11 +62,16 @@ public class Diff {
 
   @VisibleForTesting
   public List<String> diff(File actual, File expected) throws IOException {
+    return diff(actual.toPath(), expected.toPath());
+  }
+  
+  @VisibleForTesting
+  public List<String> diff(Path actual, Path expected) throws IOException {
     BufferedReader reader1 = null;
     BufferedReader reader2 = null;
     try {
-      reader1 = readerFor(actual);
-      reader2 = readerFor(expected);
+      reader1 = Files.newBufferedReader(actual, Charset.defaultCharset());
+      reader2 = Files.newBufferedReader(expected, Charset.defaultCharset());
       return unmodifiableList(diff(reader1, reader2));
     } finally {
       closeQuietly(reader1);
@@ -75,9 +81,14 @@ public class Diff {
 
   @VisibleForTesting
   public List<String> diff(File actual, String expected, Charset charset) throws IOException {
+    return diff(actual.toPath(), expected, charset);
+  }
+  
+  @VisibleForTesting
+  public List<String> diff(Path actual, String expected, Charset charset) throws IOException {
     BufferedReader reader1 = null;
     try {
-      reader1 = readerFor(actual, charset);
+      reader1 = Files.newBufferedReader(actual, charset); 
       BufferedReader reader2 = readerFor(expected);
       return unmodifiableList(diff(reader1, reader2));
     } finally {
@@ -87,18 +98,6 @@ public class Diff {
 
   private BufferedReader readerFor(InputStream stream) {
     return new BufferedReader(new InputStreamReader(stream));
-  }
-
-  private BufferedReader readerFor(InputStream stream, Charset charset) {
-    return new BufferedReader(new InputStreamReader(stream, charset));
-  }
-
-  private BufferedReader readerFor(File file) throws IOException {
-    return readerFor(new FileInputStream(file));
-  }
-
-  private BufferedReader readerFor(File file, Charset charset) throws IOException {
-    return readerFor(new FileInputStream(file), charset);
   }
 
   private BufferedReader readerFor(String string) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -35,7 +35,6 @@ import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.LinkOption;
@@ -274,25 +273,23 @@ public class Paths {
 	if (expected == null) throw new NullPointerException("The text to compare to should not be null");
 	assertIsReadable(info, actual);
 	try {
-	  File actualAsFile = actual.toFile();
-	  List<String> diffs = diff.diff(actualAsFile, expected, charset);
+	  List<String> diffs = diff.diff(actual, expected, charset);
 	  if (diffs.isEmpty()) return;
-	  throw failures.failure(info, shouldHaveContent(actualAsFile, charset, diffs));
+	  throw failures.failure(info, shouldHaveContent(actual, charset, diffs));
 	} catch (IOException e) {
-	  throw new RuntimeIOException(format("Unable to verify text contents of file:<%s>", actual), e);
+	  throw new RuntimeIOException(format("Unable to verify text contents of path:<%s>", actual), e);
 	}
   }
 
   public void assertHasBinaryContent(AssertionInfo info, Path actual, byte[] expected) {
 	if (expected == null) throw new NullPointerException("The binary content to compare to should not be null");
 	assertIsReadable(info, actual);
-	File actualFile = actual.toFile();
 	try {
-	  BinaryDiffResult diffResult = binaryDiff.diff(actualFile, expected);
+	  BinaryDiffResult diffResult = binaryDiff.diff(actual, expected);
 	  if (diffResult.hasNoDiff()) return;
-	  throw failures.failure(info, shouldHaveBinaryContent(actualFile, diffResult));
+	  throw failures.failure(info, shouldHaveBinaryContent(actual, diffResult));
 	} catch (IOException e) {
-	  throw new RuntimeIOException(format("Unable to verify binary contents of file:<%s>", actualFile), e);
+	  throw new RuntimeIOException(format("Unable to verify binary contents of path:<%s>", actual), e);
 	}
   }
 
@@ -304,14 +301,12 @@ public class Paths {
 	  throw new IllegalArgumentException(format("The given Path <%s> to compare actual content to should be readable", expected));
 	// @format:on
 	assertIsReadable(info, actual);
-	File expectedFile = expected.toFile();
-	File actualFile = actual.toFile();
 	try {
-	  List<String> diffs = diff.diff(actualFile, expectedFile);
+	  List<String> diffs = diff.diff(actual, expected);
 	  if (diffs.isEmpty()) return;
-	  throw failures.failure(info, shouldHaveSameContent(actualFile, expectedFile, diffs));
+	  throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
 	} catch (IOException e) {
-	  throw new RuntimeIOException(format("Unable to compare contents of files:<%s> and:<%s>", actualFile, expectedFile), e);
+	  throw new RuntimeIOException(format("Unable to compare contents of paths:<%s> and:<%s>", actual, expected), e);
 	}
   }
 

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
@@ -61,7 +61,7 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
   
   @Test
   public void should_pass_if_path_has_expected_text_content() throws IOException {
-	when(binaryDiff.diff(path.toFile(), expected)).thenReturn(noDiff());
+	when(binaryDiff.diff(path, expected)).thenReturn(noDiff());
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	paths.assertHasBinaryContent(someInfo(), path, expected);
@@ -109,7 +109,7 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
 	IOException cause = new IOException();
-	when(binaryDiff.diff(path.toFile(), expected)).thenThrow(cause);
+	when(binaryDiff.diff(path, expected)).thenThrow(cause);
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	try {
@@ -123,14 +123,14 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
   @Test
   public void should_fail_if_path_does_not_have_expected_binary_content() throws IOException {
 	BinaryDiffResult binaryDiffs = new BinaryDiffResult(15, (byte) 0xCA, (byte) 0xFE);
-	when(binaryDiff.diff(path.toFile(), expected)).thenReturn(binaryDiffs);
+	when(binaryDiff.diff(path, expected)).thenReturn(binaryDiffs);
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	AssertionInfo info = someInfo();
 	try {
 	  paths.assertHasBinaryContent(info, path, expected);
 	} catch (AssertionError e) {
-	  verify(failures).failure(info, shouldHaveBinaryContent(path.toFile(), binaryDiffs));
+	  verify(failures).failure(info, shouldHaveBinaryContent(path, binaryDiffs));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
@@ -68,7 +68,7 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
   
   @Test
   public void should_pass_if_path_has_expected_text_content() throws IOException {
-	when(diff.diff(path.toFile(), expected, charset)).thenReturn(new ArrayList<String>());
+	when(diff.diff(path, expected, charset)).thenReturn(new ArrayList<String>());
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	paths.assertHasContent(someInfo(), path, expected, charset);
@@ -116,7 +116,7 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
 	IOException cause = new IOException();
-	when(diff.diff(path.toFile(), expected, charset)).thenThrow(cause);
+	when(diff.diff(path, expected, charset)).thenThrow(cause);
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	try {
@@ -130,14 +130,14 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
   @Test
   public void should_fail_if_path_does_not_have_expected_text_content() throws IOException {
 	List<String> diffs = newArrayList("line:1, expected:<line1> but was:<EOF>");
-	when(diff.diff(path.toFile(), expected, charset)).thenReturn(diffs);
+	when(diff.diff(path, expected, charset)).thenReturn(diffs);
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 	AssertionInfo info = someInfo();
 	try {
 	  paths.assertHasContent(info, path, expected, charset);
 	} catch (AssertionError e) {
-	  verify(failures).failure(info, shouldHaveContent(path.toFile(), charset, diffs));
+	  verify(failures).failure(info, shouldHaveContent(path, charset, diffs));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -42,7 +42,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_path_has_same_content_as_other() throws IOException {
-	when(diff.diff(actual.toFile(), other.toFile())).thenReturn(new ArrayList<String>());
+	when(diff.diff(actual, other)).thenReturn(new ArrayList<String>());
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
@@ -106,7 +106,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
 	IOException cause = new IOException();
-	when(diff.diff(actual.toFile(), other.toFile())).thenThrow(cause);
+	when(diff.diff(actual, other)).thenThrow(cause);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
@@ -121,7 +121,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   @Test
   public void should_fail_if_actual_and_given_path_does_not_have_the_same_content() throws IOException {
 	List<String> diffs = newArrayList("line:1, other:<line1> but was:<EOF>");
-	when(diff.diff(actual.toFile(), other.toFile())).thenReturn(diffs);
+	when(diff.diff(actual, other)).thenReturn(diffs);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
@@ -129,7 +129,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	try {
 	  paths.assertHasSameContentAs(info, actual, other);
 	} catch (AssertionError e) {
-	  verify(failures).failure(info, shouldHaveSameContent(actual.toFile(), other.toFile(), diffs));
+	  verify(failures).failure(info, shouldHaveSameContent(actual, other, diffs));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION
After these changes the memoryfilesystem dependecy can be replaced with jimfs and all tests still succeed.