### PR TITLE
Added assertThatException 

### DIFF
--- a/src/main/java/org/assertj/core/api/ChainedThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ChainedThrowableAssert.java
@@ -1,0 +1,30 @@
+package org.assertj.core.api;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+/**
+ * Assertion methods for {@link java.lang.Throwable}.
+ * <p>
+ * This class is linked with the {@link ExpectThrowableAssert} and allow to check that an exception
+ * type is thrown by several lambda.
+ */
+public class ChainedThrowableAssert<T extends Throwable>
+    extends AbstractThrowableAssert<ChainedThrowableAssert<T>, T> {
+  private final ExpectThrowableAssert<T> parent;
+
+  ChainedThrowableAssert(final ExpectThrowableAssert<T> parent, final T actual) {
+    super(actual, ChainedThrowableAssert.class);
+    this.parent = parent;
+  }
+
+  /**
+   * Assert that an exception of type T is actually thrown by the {@code throwingCallable}.
+   *
+   * @param throwingCallable
+   * @return return a {@link ChainedThrowableAssert}.
+   * @see ExpectThrowableAssert#isThrownBy(ThrowingCallable)
+   */
+  public ChainedThrowableAssert<T> isThrownBy(final ThrowingCallable throwingCallable) {
+    return parent.isThrownBy(throwingCallable);
+  }
+}

--- a/src/main/java/org/assertj/core/api/ChainedThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ChainedThrowableAssert.java
@@ -27,4 +27,350 @@ public class ChainedThrowableAssert<T extends Throwable>
   public ChainedThrowableAssert<T> isThrownBy(final ThrowingCallable throwingCallable) {
     return parent.isThrownBy(throwingCallable);
   }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withMessage(String)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasMessage(String message) {
+    return super.hasMessage(message);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withCause(Throwable)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasCause(Throwable cause) {
+    return super.hasCause(cause);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withNoCause()}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasNoCause() {
+    return super.hasNoCause();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withMessageStartingWith(String)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasMessageStartingWith(String description) {
+    return super.hasMessageStartingWith(description);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withMessageContaining(String)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasMessageContaining(String description) {
+    return super.hasMessageContaining(description);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withMessageMatching(String)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasMessageMatching(String regex) {
+    return super.hasMessageMatching(regex);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withMessageEndingWith(String)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasMessageEndingWith(String description) {
+    return super.hasMessageEndingWith(description);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withCauseInstanceOf(Class)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasCauseInstanceOf(Class<? extends Throwable> type) {
+    return super.hasCauseInstanceOf(type);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withCauseExactlyInstanceOf(Class)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasCauseExactlyInstanceOf(Class<? extends Throwable> type) {
+    return super.hasCauseExactlyInstanceOf(type);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withRootCauseInstanceOf(Class)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasRootCauseInstanceOf(Class<? extends Throwable> type) {
+    return super.hasRootCauseInstanceOf(type);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @deprecated in this context, prefer {@link #withRootCauseExactlyInstanceOf(Class)}.
+   */
+  @Override
+  @Deprecated
+  public ChainedThrowableAssert<T> hasRootCauseExactlyInstanceOf(Class<? extends Throwable> type) {
+    return super.hasRootCauseExactlyInstanceOf(type);
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} is equal to the given one.
+   *
+   * @param message the expected message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} is not equal to the given one.
+   * @see AbstractThrowableAssert#hasMessage(String)
+   */
+  public ChainedThrowableAssert<T> withMessage(String message) {
+    return super.hasMessage(message);
+  }
+
+  /**
+   * Verifies that the actual {@code Throwable} has a cause similar to the given one, that is with same type and message
+   * (it does not use {@link Throwable#equals(Object) equals} method for comparison).
+   *
+   * Example:
+   * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("invalid arg");
+   * Throwable throwable = new Throwable(invalidArgException);
+   *
+   * // This assertion succeeds:
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCause(invalidArgException);
+   *
+   * // These assertions fail:
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCause(new IllegalArgumentException("bad arg"));
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCause(new NullPointerException());
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCause(null); // prefer withNoCause()</code>
+   * </pre>
+   * 
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has not the given cause.
+   * @see AbstractThrowableAssert#hasCause(Throwable)
+   */
+  public ChainedThrowableAssert<T> withCause(Throwable cause) {
+    return super.hasCause(cause);
+  }
+
+  /**
+   * Verifies that the actual {@code Throwable} does not have a cause.
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has a cause.
+   * @see AbstractThrowableAssert#hasNoCause()
+   */
+  public ChainedThrowableAssert<T> withNoCause() {
+    return super.hasNoCause();
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} starts with the given description.
+   *
+   * @param description the description expected to start the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not start with the given description.
+   * @see AbstractThrowableAssert#hasMessageStartingWith(String)
+   */
+  public ChainedThrowableAssert<T> withMessageStartingWith(String description) {
+    return super.hasMessageStartingWith(description);
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} contains with the given description.
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not contain the given description.
+   * @see AbstractThrowableAssert#hasMessageContaining(String)
+   */
+  public ChainedThrowableAssert<T> withMessageContaining(String description) {
+    return super.hasMessageContaining(description);
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} matches with the given regular expression.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwable = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withMessageMatching("wrong amount [0-9]*");
+   *
+   * // assertion will fail
+   * ssertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withMessageMatching("wrong amount [0-9]* euros");</code>
+   * </pre>
+   *
+   * @param regex the regular expression of value expected to be matched the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not match the given regular expression.
+   * @throws NullPointerException if the regex is null
+   * @see AbstractThrowableAssert#hasMessageMatching(String)
+   */
+  public ChainedThrowableAssert<T> withMessageMatching(String regex) {
+    return super.hasMessageMatching(regex);
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} ends with the given description.
+   *
+   * @param description the description expected to end the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not end with the given description.
+   * @see AbstractThrowableAssert#hasMessageEndingWith(String)
+   */
+  public ChainedThrowableAssert<T> withMessageEndingWith(String description) {
+    return super.hasMessageEndingWith(description);
+  }
+
+  /**
+   * Verifies that the cause of the actual {@code Throwable} is an instance of the given type.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable throwable = new Throwable(new NullPointerException());
+   *
+   * // assertion will pass
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseInstanceOf(NullPointerException.class);
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseInstanceOf(RuntimeException.class);
+   *
+   * // assertion will fail
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseInstanceOf(IllegalArgumentException.class);</code></pre>
+   *
+   * @param type the expected cause type.
+   * @return this assertion object.
+   * @throws NullPointerException if given type is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no cause.
+   * @throws AssertionError if the cause of the actual {@code Throwable} is not an instance of the given type.
+   * @see AbstractThrowableAssert#hasCauseInstanceOf(Class)
+   */
+  public ChainedThrowableAssert<T> withCauseInstanceOf(Class<? extends Throwable> type) {
+    return super.hasCauseInstanceOf(type);
+  }
+
+  /**
+   * Verifies that the cause of the actual {@code Throwable} is <b>exactly</b> an instance of the given type.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable throwable = new Throwable(new NullPointerException());
+   *
+   * // assertion will pass
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseExactlyInstanceOf(NullPointerException.class);
+   *
+   * // assertions will fail (even if NullPointerException is a RuntimeException since we want an exact match)
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseExactlyInstanceOf(RuntimeException.class);
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withCauseExactlyInstanceOf(IllegalArgumentException.class);</code></pre>
+   *
+   * </p>
+   *
+   * @param type the expected cause type.
+   * @return this assertion object.
+   * @throws NullPointerException if given type is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no cause.
+   * @throws AssertionError if the cause of the actual {@code Throwable} is not <b>exactly</b> an instance of the given
+   *           type.
+   * @see AbstractThrowableAssert#hasCauseExactlyInstanceOf(Class)          
+   */
+  public ChainedThrowableAssert<T> withCauseExactlyInstanceOf(Class<? extends Throwable> type) {
+    return super.hasCauseExactlyInstanceOf(type);
+  }
+
+  /**
+   * Verifies that the root cause of the actual {@code Throwable} is an instance of the given type.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable throwable = new Throwable(new IllegalStateException(new
+   * NullPointerException()));
+   *
+   * // assertion will pass
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseInstanceOf(NullPointerException.class);
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseInstanceOf(RuntimeException.class);
+   *
+   * // assertion will fail
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseInstanceOf(IllegalStateException.class);</code></pre>
+   *
+   * </p>
+   *
+   * @param type the expected cause type.
+   * @return this assertion object.
+   * @throws NullPointerException if given type is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no cause.
+   * @throws AssertionError if the cause of the actual {@code Throwable} is not an instance of the given type.
+   * @see AbstractThrowableAssert#hasRootCauseInstanceOf(Class)
+   */
+  public ChainedThrowableAssert<T> withRootCauseInstanceOf(Class<? extends Throwable> type) {
+    return super.hasRootCauseInstanceOf(type);
+  }
+
+  /**
+   * Verifies that the root cause of the actual {@code Throwable} is <b>exactly</b> an instance of the given type.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable throwable = new Throwable(new IllegalStateException(new
+   * NullPointerException()));
+   *
+   * // assertion will pass
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseExactlyInstanceOf(NullPointerException.class);
+   *
+   * // assertion will fail (even if NullPointerException is a RuntimeException since we want an exact match)
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseExactlyInstanceOf(RuntimeException.class);
+   * assertThatException(Throwable.class).isThrownBy(() -> {throw throwable;}).withRootCauseExactlyInstanceOf(IllegalStateException.class);</code></pre>
+   *
+   * </p>
+   *
+   * @param type the expected cause type.
+   * @return this assertion object.
+   * @throws NullPointerException if given type is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no cause.
+   * @throws AssertionError if the root cause of the actual {@code Throwable} is not <b>exactly</b> an instance of the
+   *           given type.
+   * @see AbstractThrowableAssert#hasRootCauseExactlyInstanceOf(Class)
+   */  
+  public ChainedThrowableAssert<T> withRootCauseExactlyInstanceOf(Class<? extends Throwable> type) {
+    return super.hasRootCauseExactlyInstanceOf(type);
+  }
+
 }

--- a/src/main/java/org/assertj/core/api/ExpectThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ExpectThrowableAssert.java
@@ -1,0 +1,40 @@
+package org.assertj.core.api;
+
+import static java.util.Objects.requireNonNull;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+/**
+ * Assertion methods for exception.
+ * <p>
+ * The class itself does not do much, it delegates it work to {@link #isThrownBy(ThrowingCallable)}.
+ *
+ * @param <T> type of throwable to be thrown.
+ */
+public class ExpectThrowableAssert<T extends Throwable> {
+  private final Class<? extends T> expectedExceptionType;
+
+  /**
+   * Default constructor.
+   *
+   * @param exceptionType class representing the target (expected) exception.
+   */
+  ExpectThrowableAssert(final Class<? extends T> exceptionType) {
+    this.expectedExceptionType = requireNonNull(exceptionType, "exceptionType");
+  }
+
+  /**
+   * Assert that an exception of type T is actually thrown by the {@code throwingCallable}.
+   *
+   * @param throwingCallable
+   * @return return a {@link ChainedThrowableAssert}.
+   */
+  public ChainedThrowableAssert<T> isThrownBy(final ThrowingCallable throwingCallable) {
+    Throwable throwable = ThrowableAssert.catchThrowable(throwingCallable);
+    StrictAssertions.assertThat(throwable).hasBeenThrown().isInstanceOf(expectedExceptionType);
+    @SuppressWarnings("unchecked")
+    T c = (T) throwable;
+    return new ChainedThrowableAssert<>(this, c);
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/StrictAssertions.java
+++ b/src/main/java/org/assertj/core/api/StrictAssertions.java
@@ -561,6 +561,36 @@ public class StrictAssertions {
   }
 
   /**
+   * Check for thrown exception.
+   * <p>
+   * This method is more or less the same of {@link #assertThatThrownBy(ThrowingCallable)} but in a more natural way:
+   * 
+   * <pre>
+   * <code class='java'>
+   * // create a function that takes the exception message as parameter.
+   * Function&lt;String, ThrowingCallable&gt; lambda = message -&gt; {
+   *   throw new IllegalArgumentException(message);
+   * };
+   * assertThatException(IllegalArgumentException.class)
+   *   .isThrownBy(lambda.apply("this is illegal"))
+   *     .hasMessage("this is illegal")
+   *   .isThrownBy(lambda.apply("this is also illegal"))
+   *     .hasMessage("this is also illegal") 
+   * ;
+   * </code>
+   * </pre>
+   * 
+   * @implNotes the name differs from other method (assertThat) because there already exists an
+   *            {@link #assertThat(Class)} method.
+   * @param exceptionType the expected exception type.
+   * @return the created {@link ExpectThrowableAssert}.
+   */
+  public static <T extends Throwable> ExpectThrowableAssert<T> assertThatException(final Class<? extends T> exceptionType) {
+    return new ExpectThrowableAssert<>(exceptionType);
+  }
+  
+
+  /**
    * Allows to catch an {@link Throwable} more easily when used with Java 8 lambdas.
    *
    * <p>

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -607,6 +607,13 @@ public interface WithAssertions {
   default public AbstractOffsetDateTimeAssert<?> assertThat(final OffsetDateTime offsetDateTime) {
       return Assertions.assertThat(offsetDateTime);
   }
+  
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThatException(Class)}
+   */
+  default public <T extends Throwable> ExpectThrowableAssert<T> assertThatException(final Class<? extends T> exceptionType) {
+      return Assertions.assertThatException(exceptionType);
+  }
 
   // --------------------------------------------------------------------------------------------------
   // Filter methods : not assertions but here to have a complete entry point to all AssertJ features.

--- a/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssertTest.java
+++ b/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssertTest.java
@@ -3,7 +3,6 @@ package org.assertj.core.api.throwable;
 import static org.assertj.core.api.Fail.shouldHaveThrown;
 import static org.assertj.core.api.StrictAssertions.assertThat;
 import static org.assertj.core.api.StrictAssertions.assertThatException;
-import static org.assertj.core.api.StrictAssertions.assertThatThrownBy;
 
 import java.util.NoSuchElementException;
 
@@ -18,8 +17,10 @@ public class ExpectThrowableAssertTest {
     assertThatException(NoSuchElementException.class)
       .isThrownBy(() -> {throw ex;})
         .isSameAs(ex)
-      .isThrownBy(() -> {throw new NoSuchElementException("this too");})
-        .hasMessage("this too")
+        .withNoCause()
+      .isThrownBy(() -> {throw new NoSuchElementException("this too").initCause(new IllegalArgumentException("The cause"));})
+        .withMessage("this too")
+        .withCauseInstanceOf(IllegalArgumentException.class)
     ;
     // @format:on
   }

--- a/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssertTest.java
+++ b/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssertTest.java
@@ -1,0 +1,37 @@
+package org.assertj.core.api.throwable;
+
+import static org.assertj.core.api.Fail.shouldHaveThrown;
+import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.StrictAssertions.assertThatException;
+import static org.assertj.core.api.StrictAssertions.assertThatThrownBy;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+public class ExpectThrowableAssertTest {
+
+  @Test
+  public void should_build_ExpectThrowableAssert_with_exception_thrown_by_lambda() {
+    NoSuchElementException ex = new NoSuchElementException("no such element!");
+    // @format:off
+    assertThatException(NoSuchElementException.class)
+      .isThrownBy(() -> {throw ex;})
+        .isSameAs(ex)
+      .isThrownBy(() -> {throw new NoSuchElementException("this too");})
+        .hasMessage("this too")
+    ;
+    // @format:on
+  }
+  
+  @Test
+  public void should_fail_if_nothing_is_thrown_by_lambda() {
+    try {
+      assertThatException(NoSuchElementException.class).isThrownBy(() -> {});
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("Expecting code to raise a throwable.");
+      return;
+    }
+    shouldHaveThrown(AssertionError.class);
+  }
+}


### PR DESCRIPTION
Add `assertThatException` in complement of `assertThatThrownBy`.

This patches add two classes: `ExpectThrowableAssert` and `ChainedThrowableAssert`. The first delegate to the second and will check that the lambda actually throw an exception of expected type.

Also, this allow for chaining:

```
IntConsumer lambda = int n -> {
  if (n < 0) throw new IllegalArgumentException(n + " is negative");
  if (n > 100) throw new IllegalArgumentException(n + " must be less or equals to 100");
}
assertThatException(IllegalArgumentException.class)
  .isThrownBy(() -> lambda.accept(-1))
    .hasMessage("-1 is negative")
  .isThrownBy(() -> lambda.accept(101))
    .hasMessage("101 must be less or equals to 100")
;
```

To be compared with the existing `assertThatThrownBy`:

```
assertThatThrownBy(() -> lambda.accept(-1))
  .isInstanceOf(IllegalArgumentException.class)
  .hasMessage("-1 is negative")
;
assertThatThrownBy(() -> lambda.accept(101))
  .isInstanceOf(IllegalArgumentException.class)
  .hasMessage("101 must be less or equals to 100")
;
```

As said in the javadoc, `assertThatException` is named like that because of `assertThat(Class)` and type erasure.