### PR TITLE
Add MapEntry formatting based on `Representation.toStringOf()`.

### DIFF
--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -13,7 +13,8 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.util.Objects.*;
-import static org.assertj.core.util.Strings.quote;
+import static org.assertj.core.presentation.DefaultToString.toStringOf;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.Map;
 
@@ -62,6 +63,6 @@ public class MapEntry<K, V> {
 
   @Override
   public String toString() {
-    return String.format("%s[key=%s, value=%s]", getClass().getSimpleName(), quote(key), quote(value));
+    return toStringOf(this, STANDARD_REPRESENTATION);
   }
 }

--- a/src/main/java/org/assertj/core/presentation/DefaultToString.java
+++ b/src/main/java/org/assertj/core/presentation/DefaultToString.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 
+import org.assertj.core.data.MapEntry;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.util.Arrays;
 import org.assertj.core.util.IterableUtil;
@@ -50,11 +51,16 @@ public final class DefaultToString {
     if (o instanceof Collection<?>) return IterableUtil.smartFormat(representation, (Collection<?>) o);
     if (o instanceof Map<?, ?>) return Maps.format(representation, (Map<?, ?>) o);
     if (o instanceof Tuple) return toStringOf((Tuple) o, representation);
+    if (o instanceof MapEntry) return toStringOf((MapEntry<?, ?>) o, representation);
     return o == null ? null : o.toString();
   }
 
   public static String toStringOf(Tuple tuple, Representation representation) {
     return singleLineFormat(representation, tuple.toList(), TUPPLE_START, TUPPLE_END);
+  }
+
+  public static String toStringOf(MapEntry<?, ?> mapEntry, Representation representation) {
+    return String.format("MapEntry[key=%s, value=%s]", representation.toStringOf(mapEntry.key), representation.toStringOf(mapEntry.value));
   }
 
   private DefaultToString() {}

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -85,9 +85,9 @@ public class SoftAssertionsTest {
       assertThat(errors).contains(String.format("%nExpecting:%n"
                                   + " <{\"54\"=\"55\"}>%n"
                                   + "to contain:%n"
-                                  + " <[MapEntry[key='1', value='2']]>%n"
+                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
                                   + "but could not find:%n"
-                                  + " <[MapEntry[key='1', value='2']]>%n"));
+                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
 
     }
   }
@@ -264,9 +264,9 @@ public class SoftAssertionsTest {
       assertThat(errors.get(39)).isEqualTo(String.format("%nExpecting:%n"
                                            + " <{\"54\"=\"55\"}>%n"
                                            + "to contain:%n"
-                                           + " <[MapEntry[key='1', value='2']]>%n"
+                                           + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
                                            + "but could not find:%n"
-                                           + " <[MapEntry[key='1', value='2']]>%n"));
+                                           + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
     }
   }
 

--- a/src/test/java/org/assertj/core/data/MapEntry_toString_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_toString_Test.java
@@ -33,6 +33,6 @@ public class MapEntry_toString_Test {
 
   @Test
   public void should_implement_toString() {
-    assertThat(entry.toString()).isEqualTo("MapEntry[key='name', value='Yoda']");
+    assertThat(entry.toString()).isEqualTo("MapEntry[key=\"name\", value=\"Yoda\"]");
   }
 }


### PR DESCRIPTION
Add special  processing of `MapEntry` for pretty printing of `AssertionError` message.

````java
   /* Pull request solves this issue */
  @Test public void mapEntryIssue() {
        assertThat(Collections.singletonMap("one-two-three", new long[] {1, 2, 3}))
            .containsEntry("one-two-three", new long[] {3, 2, 1});
        /* generates
           java.lang.AssertionError: 
                Expecting:
                 <{"one-two-three"=[1L, 2L, 3L]}>
                to contain:
                 <[MapEntry[key='one-two-three', value=[J@57a4d5ee]]>
                but could not find:
                 <[MapEntry[key='one-two-three', value=[J@57a4d5ee]]>
         */
    }
````
Changes update some tests and break convention on encoding strings in `MapEntry` with a single quote - instead `StandardRepresentation` is used.