### PR TITLE
Added hasValidEqualsAndHashCode to do some common tests with hashCode/equals…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -12,6 +12,13 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.assertj.core.util.introspection.IntrospectionError;
 
 /**
@@ -173,4 +180,67 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
     objects.assertIsEqualToIgnoringGivenFields(info, actual, other);
     return myself;
   }
+  
+  /**
+   * This method will check that {@link Object#equals(Object)} and {@link #hashCode()} follows the
+   * rules described in javadoc of {@link Object#equals(Object)} and {@link Object#hashCode()}.
+   *
+   * @param supplierOfTThatAreEqualsTo provide a set of object that should be equals to the actual
+   *          value. The actual value is always checked!
+   * @param supplierOfTThatAreNotEqualsTo a set of object that are not equals to the actual value.
+   * @return this object for chaining purpose.
+   */
+  public final S hasValidEqualsAndHashCode(final Supplier<List<? extends A>> supplierOfTThatAreEqualsTo,
+                                           final Supplier<List<?>> supplierOfTThatAreNotEqualsTo) {
+    // @formatter:off
+    this.isNotNull()
+        .isEqualTo(actual)
+        .isNotEqualTo(null);
+    // @formatter:on
+
+    final List<A> equalToList = new ArrayList<>();
+    equalToList.add(actual);
+    equalToList.addAll(supplierOfTThatAreEqualsTo.get());
+    final List<Object> notEqualToList = new ArrayList<>();
+    notEqualToList.add(new Object());
+    notEqualToList.addAll(supplierOfTThatAreNotEqualsTo.get());
+
+    // the object should not have changed its value, the hashCode should remain the
+    // same.
+    final AbstractIntegerAssert<?> assertThatActualHashCode = assertThat(actual.hashCode()).as("%s hashCode()", this.info.descriptionText());
+
+    equalToList.forEach(other -> {
+      this.isEqualTo(other);
+      assertThatActualHashCode.isEqualTo(other.hashCode());
+    });
+
+    notEqualToList.forEach(other -> {
+      this.isNotEqualTo(other);
+    });
+
+    return myself;
+  }
+
+  /**
+   * This method will check that {@link Object#equals(Object)} and {@link #hashCode()} follows the
+   * rules described in javadoc of {@link Object#equals(Object)} and {@link Object#hashCode()}.
+   *
+   * @param supplierOfTThatAreNotEqualsTo a set of object that are not equals to the actual value.
+   * @return this object for chaining purpose.
+   * @see #hasValidEqualsAndHashCode(Supplier, Supplier)
+   */
+  public final S hasValidEqualsAndHashCode(final Supplier<List<?>> supplierOfTThatAreNotEqualsTo) {
+    return hasValidEqualsAndHashCode(Collections::emptyList, supplierOfTThatAreNotEqualsTo);
+  }
+
+  /**
+   * This method will check that {@link Object#equals(Object)} and {@link #hashCode()} follows the
+   * rules described in javadoc of {@link Object#equals(Object)} and {@link Object#hashCode()}.
+   *
+   * @return this object for chaining purpose.
+   * @see #hasValidEqualsAndHashCode(Supplier, Supplier)
+   */
+  public final S hasValidEqualsAndHashCode() {
+    return hasValidEqualsAndHashCode(Collections::emptyList, Collections::emptyList);
+  }  
 }

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_hasValidEqualsAndHashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_hasValidEqualsAndHashCode_Test.java
@@ -1,0 +1,21 @@
+package org.assertj.core.api.object;
+
+import static java.util.Arrays.asList;
+
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ObjectAssertBaseTest;
+import org.assertj.core.test.Jedi;
+
+public class ObjectAssert_hasValidEqualsAndHashCode_Test extends ObjectAssertBaseTest {
+
+  private Jedi other = new Jedi("Yoda", "Blue");
+
+  @Override
+  protected ObjectAssert<Jedi> invoke_api_method() {
+    return assertions.hasValidEqualsAndHashCode(() -> asList(new Jedi("Yoda", "Green")), () -> asList(other));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  }
+}


### PR DESCRIPTION
I added this method to check that `hashCode()` and `equals()` behave correctly for classic value (like: null, this, and value provided by the user). It also checks that if *a == b* then *hash(a) == hash(b)*.

I don't know where I can plug a test that fail, but this is an example: https://gist.github.com/glhez/3596211453d2e74c9a54#file-hasvalidequalsandhashcode-java