### PR TITLE
Fixes #312: To be OS agnostic, replace \n by %n in error messages

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringHours.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringHours.java
@@ -37,6 +37,6 @@ public class ShouldBeEqualIgnoringHours extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringHours(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month and day as:\n  <%s>\nbut had not.", actual, other);
+    super("%nExpecting:%n  <%s>%nto have same year, month and day as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes.java
@@ -65,14 +65,14 @@ public class ShouldBeEqualIgnoringMinutes extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringMinutes(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month, day and hour as:\n  <%s>\nbut had not.", actual, other);
+    super("%nExpecting:%n  <%s>%nto have same year, month, day and hour as:%n  <%s>%nbut had not.", actual, other);
   }
 
   private ShouldBeEqualIgnoringMinutes(LocalTime actual, LocalTime other) {
-      super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
+      super("%nExpecting:%n  <%s>%nto have same hour as:%n  <%s>%nbut had not.", actual, other);
   }
 
   private ShouldBeEqualIgnoringMinutes(OffsetTime actual, OffsetTime other) {
-      super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
+      super("%nExpecting:%n  <%s>%nto have same hour as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos.java
@@ -66,15 +66,15 @@ public class ShouldBeEqualIgnoringNanos extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringNanos(Object actual, Object other) {
-	super("\nExpecting:\n  <%s>\nto have same year, month, day, hour, minute and second as:\n  <%s>\nbut had not.",
+	super("%nExpecting:%n  <%s>%nto have same year, month, day, hour, minute and second as:%n  <%s>%nbut had not.",
 	      actual, other);
   }
 
   private ShouldBeEqualIgnoringNanos(LocalTime actual, LocalTime other) {
-	super("\nExpecting:\n  <%s>\nto have same hour, minute and second as:\n  <%s>\nbut had not.", actual, other);
+	super("%nExpecting:%n  <%s>%nto have same hour, minute and second as:%n  <%s>%nbut had not.", actual, other);
   }
 
   private ShouldBeEqualIgnoringNanos(OffsetTime actual, OffsetTime other) {
-      super("\nExpecting:\n  <%s>\nto have same hour, minute and second as:\n  <%s>\nbut had not.", actual, other);
+      super("%nExpecting:%n  <%s>%nto have same hour, minute and second as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds.java
@@ -43,7 +43,7 @@ public class ShouldBeEqualIgnoringSeconds extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringSeconds(Object actual, Object other) {
-	super("\nExpecting:\n  <%s>\nto have same year, month, day, hour and minute as:\n  <%s>\nbut had not.", actual,
+	super("%nExpecting:%n  <%s>%nto have same year, month, day, hour and minute as:%n  <%s>%nbut had not.", actual,
 	      other);
   }
 
@@ -70,10 +70,10 @@ public class ShouldBeEqualIgnoringSeconds extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringSeconds(LocalTime actual, LocalTime other) {
-	super("\nExpecting:\n  <%s>\nto have same hour and minute as:\n  <%s>\nbut had not.", actual, other);
+	super("%nExpecting:%n  <%s>%nto have same hour and minute as:%n  <%s>%nbut had not.", actual, other);
   }
 
   private ShouldBeEqualIgnoringSeconds(OffsetTime actual, OffsetTime other) {
-      super("\nExpecting:\n  <%s>\nto have same hour and minute as:\n  <%s>\nbut had not.", actual, other);
+      super("%nExpecting:%n  <%s>%nto have same hour and minute as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone.java
@@ -46,6 +46,6 @@ public class ShouldBeEqualIgnoringTimezone extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringTimezone(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same time fields except timezone as:\n  <%s>\nbut had not.", actual, other);
+    super("%nExpecting:%n  <%s>%nto have same time fields except timezone as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSameHourAs.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSameHourAs.java
@@ -35,6 +35,6 @@ public class ShouldHaveSameHourAs extends BasicErrorMessageFactory {
     }
 
     private ShouldHaveSameHourAs(Temporal actual, Temporal other) {
-        super("\nExpecting:\n  <%s>\nto have same hour as:\n  <%s>\nbut had not.", actual, other);
+        super("%nExpecting:%n  <%s>%nto have same hour as:%n  <%s>%nbut had not.", actual, other);
     }
 }

--- a/src/main/java/org/assertj/core/error/ShouldMatch.java
+++ b/src/main/java/org/assertj/core/error/ShouldMatch.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Predicate;
@@ -25,15 +26,15 @@ import org.assertj.core.presentation.PredicateDescription;
 public class ShouldMatch extends BasicErrorMessageFactory {
 
   // @format:off
-  public static final String ADVICE = "\n\n"+
-	                                  "You can use 'matches(Predicate p, String description)' to have a better error message\n" +
-	                                  "For example:\n" +
-	                                  "  assertThat(player).matches(p -> p.isRookie(), \"is rookie\");\n" +
-	                                  "will give an error message looking like:\n" +
-	                                  "\n" +
-	                                  "Expecting:\n" +
-	                                  "  <player>\n" +
-	                                  "to match 'is rookie' predicate";
+  public static final String ADVICE = format("%n%n"+
+	                                         "You can use 'matches(Predicate p, String description)' to have a better error message%n" +
+	                                         "For example:%n" +
+	                                         "  assertThat(player).matches(p -> p.isRookie(), \"is rookie\");%n" +
+	                                         "will give an error message looking like:%n" +
+	                                         "%n" +
+	                                         "Expecting:%n" +
+	                                         "  <player>%n" +
+	                                         "to match 'is rookie' predicate");
   // @format:on
 
   /**
@@ -52,6 +53,6 @@ public class ShouldMatch extends BasicErrorMessageFactory {
   }
 
   private ShouldMatch(Object actual, Predicate<?> predicate, PredicateDescription description) {
-	super("\nExpecting:\n  <%s>\nto match %s predicate." + (description.isDefault() ? ADVICE : ""), actual, description);
+	super("%nExpecting:%n  <%s>%nto match %s predicate." + (description.isDefault() ? ADVICE : ""), actual, description);
   }
 }

--- a/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -190,7 +191,7 @@ public class AutoCloseableSoftAssertionsTest {
 	  assertThat(errors.get(18)).isEqualTo("expected:<1[5].0f> but was:<1[4].0f>");
 	  assertThat(errors.get(19)).isEqualTo("expected:<[1[7].0f]> but was:<[1[6].0f]>");
 
-	  assertThat(errors.get(20)).isEqualTo(String.format("%nInputStreams do not have same content:"
+	  assertThat(errors.get(20)).isEqualTo(format("%nInputStreams do not have same content:"
 		                                   + System.getProperty("line.separator")
 		                                   + "line:<1>, expected:<B> but was:<A>"));
 
@@ -199,7 +200,7 @@ public class AutoCloseableSoftAssertionsTest {
 	  assertThat(errors.get(23)).isEqualTo("expected:<[2[5]]> but was:<[2[4]]>");
 
 	  assertThat(errors.get(24)).isEqualTo("expected:<[\"2[7]\"]> but was:<[\"2[6]\"]>");
-	  assertThat(errors.get(25)).isEqualTo(String.format("%nExpecting:%n" +
+	  assertThat(errors.get(25)).isEqualTo(format("%nExpecting:%n" +
 		                                   " <[\"28\"]>%n" +
 		                                   "to contain:%n" +
 		                                   " <[\"29\"]>%n" +
@@ -221,14 +222,14 @@ public class AutoCloseableSoftAssertionsTest {
 
 	  assertThat(errors.get(35)).isEqualTo("expected:<5[1]> but was:<5[0]>");
 	  assertThat(errors.get(36)).isEqualTo("expected:<[5[3]]> but was:<[5[2]]>");
-	  assertThat(errors.get(37)).isEqualTo(String.format("%nExpecting message:%n"
+	  assertThat(errors.get(37)).isEqualTo(format("%nExpecting message:%n"
 		                                   + " <\"NullPointerException message\">%n"
 		                                   + "but was:%n"
 		                                   + " <\"IllegalArgumentException message\">"));
-	  assertThat(errors.get(38)).isEqualTo("\nExpecting message:\n"
-		                                   + " <\"something was good\">\n"
-		                                   + "but was:\n"
-		                                   + " <\"something was wrong\">");
+	  assertThat(errors.get(38)).isEqualTo(format("%nExpecting message:%n"
+		                                   + " <\"something was good\">%n"
+		                                   + "but was:%n"
+		                                   + " <\"something was wrong\">"));
 	  assertThat(errors.get(39)).isEqualTo("expected:<Optional[[goo]d option]> but was:<Optional[[ba]d option]>");
 	  assertThat(errors.get(40)).isEqualTo("expected:<2015-01-0[2]> but was:<2015-01-0[1]>");
 	  assertThat(errors.get(41)).isEqualTo("expected:<2015-01-01T23:59[]> but was:<2015-01-01T23:59[:59]>");

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailedWithThrowableThat_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailedWithThrowableThat_Test.java
@@ -46,10 +46,10 @@ public class CompletableFutureAssert_hasFailedWithThrowableThat_Test extends Bas
     // @format:off
     assertThatThrownBy(() -> assertThat(future).hasFailedWithThrowableThat().isInstanceOf(IllegalArgumentException.class))
                .isInstanceOf(AssertionError.class)
-               .hasMessageContaining("Expecting:\n" +
-                                     " <java.lang.RuntimeException: some random error>\n" +
-                                     "to be an instance of:\n" +
-                                     " <java.lang.IllegalArgumentException>\n");
+               .hasMessageContaining(format("Expecting:%n" +
+                                            " <java.lang.RuntimeException: some random error>%n" +
+                                            "to be an instance of:%n" +
+                                            " <java.lang.IllegalArgumentException>%n"));
     // @format:on
   }
 

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfterOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,11 +49,11 @@ public class LocalDateAssert_isAfterOrEqualTo_Test extends LocalDateAssertBaseTe
 	try {
 	  assertThat(LocalDate.of(2000, 1, 5)).isAfterOrEqualTo(LocalDate.of(2012, 1, 1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <2000-01-05>\n" +
-		                       "to be after or equals to:\n" +
-		                       "  <2012-01-01>");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       "  <2000-01-05>%n" +
+		                       "to be after or equals to:%n" +
+		                       "  <2012-01-01>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfter_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static java.time.LocalDate.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -44,11 +45,11 @@ public class LocalDateAssert_isAfter_Test extends LocalDateAssertBaseTest {
 	try {
 	  assertThat(parse("2000-01-01")).isAfter(parse("2000-01-01"));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <2000-01-01>\n" +
-		                       "to be strictly after:\n" +
-		                       "  <2000-01-01>");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <2000-01-01>%n" +
+		                              "to be strictly after:%n" +
+		                              "  <2000-01-01>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBeforeOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,7 +49,7 @@ public class LocalDateAssert_isBeforeOrEqualTo_Test extends LocalDateAssertBaseT
     try {
       assertThat(LocalDate.of(2000, 1, 5)).isBeforeOrEqualTo(LocalDate.of(1998, 1, 1));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05>\nto be before or equals to:\n  <1998-01-01>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05>%nto be before or equals to:%n  <1998-01-01>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBefore_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -47,7 +48,7 @@ public class LocalDateAssert_isBefore_Test extends LocalDateAssertBaseTest {
     try {
       assertThat(LocalDate.of(2000, 1, 5)).isBefore(LocalDate.of(1998, 1, 1));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05>\nto be strictly before:\n  <1998-01-01>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05>%nto be strictly before:%n  <1998-01-01>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,7 +45,7 @@ public class LocalDateAssert_isIn_Test extends LocalDateAssertBaseTest {
     try {
       assertThat(LocalDate.of(2000, 1, 5)).isIn(LocalDate.of(2012, 1, 1).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05>\nto be in:\n <[2012-01-01]>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05>%nto be in:%n <[2012-01-01]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -41,7 +42,7 @@ public class LocalDateAssert_isNotEqualTo_Test extends LocalDateAssertBaseTest {
 	try {
 	  assertThat(LocalDate.of(2000, 1, 5)).isNotEqualTo(LocalDate.of(2000, 1, 5).toString());
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n <2000-01-05>\nnot to be equal to:\n <2000-01-05>\n");
+	  assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05>%nnot to be equal to:%n <2000-01-05>%n"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdate;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -42,7 +43,7 @@ public class LocalDateAssert_isNotIn_Test extends LocalDateAssertBaseTest {
 	  assertThat(LocalDate.of(2000, 1, 5)).isNotIn(LocalDate.of(2000, 1, 5).toString(),
 		                                           LocalDate.of(2012, 1, 1).toString());
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n <2000-01-05>\nnot to be in:\n <[2000-01-05, 2012-01-01]>\n");
+	  assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05>%nnot to be in:%n <[2000-01-05, 2012-01-01]>%n"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,11 +49,11 @@ public class LocalDateTimeAssert_isAfterOrEqualTo_Test extends LocalDateTimeAsse
 	try {
 	  assertThat(LocalDateTime.of(2000, 1, 5, 3, 0, 5)).isAfterOrEqualTo(LocalDateTime.of(2012, 1, 1, 3, 3, 3));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <2000-01-05T03:00:05>\n" +
-		                       "to be after or equals to:\n" +
-		                       "  <2012-01-01T03:03:03>");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       "  <2000-01-05T03:00:05>%n" +
+		                       "to be after or equals to:%n" +
+		                       "  <2012-01-01T03:03:03>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
@@ -49,11 +49,11 @@ public class LocalDateTimeAssert_isAfter_Test extends LocalDateTimeAssertBaseTes
 	try {
 	  assertThat(parse("2000-01-01T03:00:05.123")).isAfter(parse("2000-01-01T03:00:05.123456789"));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <2000-01-01T03:00:05.123>\n" +
-		                       "to be strictly after:\n" +
-		                       "  <2000-01-01T03:00:05.123456789>");
+	  assertThat(e).hasMessage(String.format("%n" +
+		                       "Expecting:%n" +
+		                       "  <2000-01-01T03:00:05.123>%n" +
+		                       "to be strictly after:%n" +
+		                       "  <2000-01-01T03:00:05.123456789>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,7 +49,7 @@ public class LocalDateTimeAssert_isBeforeOrEqualTo_Test extends LocalDateTimeAss
     try {
       assertThat(LocalDateTime.of(2000, 1, 5, 3, 0, 5)).isBeforeOrEqualTo(LocalDateTime.of(1998, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05>\nto be before or equals to:\n  <1998-01-01T03:03:03>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05>%nto be before or equals to:%n  <1998-01-01T03:03:03>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -47,7 +48,7 @@ public class LocalDateTimeAssert_isBefore_Test extends LocalDateTimeAssertBaseTe
     try {
       assertThat(LocalDateTime.of(2000, 1, 5, 3, 0, 5)).isBefore(LocalDateTime.of(1998, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05>\nto be strictly before:\n  <1998-01-01T03:03:03>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05>%nto be strictly before:%n  <1998-01-01T03:03:03>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalDateTimeAssert.NULL_LOCAL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -36,8 +37,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
       assertThat(refLocalDateTime).isEqualToIgnoringHours(refLocalDateTime.minusHours(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00>\nto have same year, month and day as:\n  <2000-01-01T23:00>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00>%nto have same year, month and day as:%n  <2000-01-01T23:00>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -49,8 +50,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
       assertThat(refLocalDateTime).isEqualToIgnoringHours(refLocalDateTime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00>\nto have same year, month and day as:\n  <2000-01-01T23:59:59.999999999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00>%nto have same year, month and day as:%n  <2000-01-01T23:59:59.999999999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMinutes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalDateTimeAssert.NULL_LOCAL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -37,8 +38,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMinutes_Test extends BaseTest 
       assertThat(refLocalDateTime).isEqualToIgnoringMinutes(refLocalDateTime.minusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -50,8 +51,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMinutes_Test extends BaseTest 
       assertThat(refLocalDateTime).isEqualToIgnoringMinutes(refLocalDateTime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:59.999999999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:59.999999999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalDateTimeAssert.NULL_LOCAL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -38,8 +39,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseT
       assertThat(refLocalDateTime).isEqualToIgnoringNanos(refLocalDateTime.plusSeconds(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:02>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:02>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseT
       assertThat(refLocalDateTime).isEqualToIgnoringNanos(refLocalDateTime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:00.999999999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:00.999999999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalDateTimeAssert.NULL_LOCAL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -37,8 +38,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest 
       assertThat(refLocalDateTime).isEqualToIgnoringSeconds(refLocalDateTime.plusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:52>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:52>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -50,8 +51,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest 
       assertThat(refLocalDateTime).isEqualToIgnoringSeconds(refLocalDateTime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:50:59.999999999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:50:59.999999999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,7 +45,7 @@ public class LocalDateTimeAssert_isIn_Test extends LocalDateTimeAssertBaseTest {
     try {
       assertThat(LocalDateTime.of(2000, 1, 5, 3, 0, 5)).isIn(LocalDateTime.of(2012, 1, 1, 3, 3, 3).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05>\nto be in:\n <[2012-01-01T03:03:03]>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05>%nto be in:%n <[2012-01-01T03:03:03]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -45,7 +46,7 @@ public class LocalDateTimeAssert_isNotEqualTo_Test extends LocalDateTimeAssertBa
       assertThat(LocalDateTime.of(2000, 1, 5, 3, 0, 5))
           .isNotEqualTo(LocalDateTime.of(2000, 1, 5, 3, 0, 5).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05>\nnot to be equal to:\n <2000-01-05T03:00:05>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05>%nnot to be equal to:%n <2000-01-05T03:00:05>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -46,8 +47,8 @@ public class LocalDateTimeAssert_isNotIn_Test extends LocalDateTimeAssertBaseTes
           LocalDateTime.of(2012, 1, 1, 3, 3, 3).toString());
     } catch (AssertionError e) {
       assertThat(e)
-          .hasMessage(
-              "\nExpecting:\n <2000-01-05T03:00:05>\nnot to be in:\n <[2000-01-05T03:00:05, 2012-01-01T03:03:03]>\n");
+          .hasMessage(format(
+              "%nExpecting:%n <2000-01-05T03:00:05>%nnot to be in:%n <[2000-01-05T03:00:05, 2012-01-01T03:03:03]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasSameHourAs_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasSameHourAs_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalTimeAssert.NULL_LOCAL_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -35,12 +36,12 @@ public class LocalTimeAssert_hasSameHourAs_Test extends BaseTest {
 	try {
 	  assertThat(refLocalTime).hasSameHourAs(refLocalTime.minusMinutes(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <23:00>\n" +
-		                       "to have same hour as:\n" +
-		                       "  <22:59>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <23:00>%n" +
+		                              "to have same hour as:%n" +
+		                              "  <22:59>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,12 +52,12 @@ public class LocalTimeAssert_hasSameHourAs_Test extends BaseTest {
 	try {
 	  assertThat(refLocalTime).hasSameHourAs(refLocalTime.minusNanos(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <23:00>\n" +
-		                       "to have same hour as:\n" +
-		                       "  <22:59:59.999999999>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <23:00>%n" +
+		                              "to have same hour as:%n" +
+		                              "  <22:59:59.999999999>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfterOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,11 +49,11 @@ public class LocalTimeAssert_isAfterOrEqualTo_Test extends LocalTimeAssertBaseTe
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isAfterOrEqualTo(LocalTime.of(3, 3, 3));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <03:00:05>\n" +
-		                       "to be after or equals to:\n" +
-		                       "  <03:03:03>");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       "  <03:00:05>%n" +
+		                       "to be after or equals to:%n" +
+		                       "  <03:03:03>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfter_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static java.time.LocalTime.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -44,11 +45,11 @@ public class LocalTimeAssert_isAfter_Test extends LocalTimeAssertBaseTest {
 	try {
 	  assertThat(parse("03:00:05.123")).isAfter(parse("03:00:05.123456789"));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <03:00:05.123>\n" +
-		                       "to be strictly after:\n" +
-		                       "  <03:00:05.123456789>");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <03:00:05.123>%n" +
+		                              "to be strictly after:%n" +
+		                              "  <03:00:05.123456789>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBeforeOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,11 +49,11 @@ public class LocalTimeAssert_isBeforeOrEqualTo_Test extends LocalTimeAssertBaseT
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isBeforeOrEqualTo(LocalTime.of(3, 0, 4));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <03:00:05>\n" +
-		                       "to be before or equals to:\n" +
-		                       "  <03:00:04>");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <03:00:05>%n" +
+		                              "to be before or equals to:%n" +
+		                              "  <03:00:04>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBefore_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -47,11 +48,11 @@ public class LocalTimeAssert_isBefore_Test extends LocalTimeAssertBaseTest {
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isBefore(LocalTime.of(3, 0, 4));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <03:00:05>\n" +
-		                       "to be strictly before:\n" +
-		                       "  <03:00:04>");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       "  <03:00:05>%n" +
+		                       "to be strictly before:%n" +
+		                       "  <03:00:04>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualToIgnoringNanoseconds_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualToIgnoringNanoseconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalTimeAssert.NULL_LOCAL_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -36,11 +37,11 @@ public class LocalTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseTest 
 	try {
 	  assertThat(refLocalTime).isEqualToIgnoringNanos(refLocalTime.plusSeconds(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n  " +
-		                       "<00:00:01>\n" +
-		                       "to have same hour, minute and second as:\n" +
-		                       "  <00:00:02>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%nExpecting:%n  " +
+		                              "<00:00:01>%n" +
+		                              "to have same hour, minute and second as:%n" +
+		                              "  <00:00:02>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,11 +52,11 @@ public class LocalTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseTest 
 	try {
 	  assertThat(refLocalTime).isEqualToIgnoringNanos(refLocalTime.minusNanos(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n" +
-		                       "  <00:00:01>\n" +
-		                       "to have same hour, minute and second as:\n" +
-		                       "  <00:00:00.999999999>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%nExpecting:%n" +
+		                              "  <00:00:01>%n" +
+		                              "to have same hour, minute and second as:%n" +
+		                              "  <00:00:00.999999999>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.AbstractLocalTimeAssert.NULL_LOCAL_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -35,11 +36,11 @@ public class LocalTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest {
 	try {
 	  assertThat(refLocalTime).isEqualToIgnoringSeconds(refLocalTime.plusMinutes(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n" +
-		                       "  <23:51>\n" +
-		                       "to have same hour and minute as:\n" +
-		                       "  <23:52>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%nExpecting:%n" +
+		                              "  <23:51>%n" +
+		                              "to have same hour and minute as:%n" +
+		                              "  <23:52>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();
@@ -50,11 +51,11 @@ public class LocalTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest {
 	try {
 	  assertThat(refLocalTime).isEqualToIgnoringSeconds(refLocalTime.minusNanos(1));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\nExpecting:\n" +
-		                       "  <23:51>\n" +
-		                       "to have same hour and minute as:\n" +
-		                       "  <23:50:59.999999999>\n" +
-		                       "but had not.");
+	  assertThat(e).hasMessage(format("%nExpecting:%n" +
+		                              "  <23:51>%n" +
+		                              "to have same hour and minute as:%n" +
+		                              "  <23:50:59.999999999>%n" +
+		                              "but had not."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,11 +45,11 @@ public class LocalTimeAssert_isIn_Test extends LocalTimeAssertBaseTest {
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isIn("03:03:03");
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       " <03:00:05>\n" +
-		                       "to be in:\n" +
-		                       " <[03:03:03]>\n");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              " <03:00:05>%n" +
+		                              "to be in:%n" +
+		                              " <[03:03:03]>%n"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,11 +45,11 @@ public class LocalTimeAssert_isNotEqualTo_Test extends LocalTimeAssertBaseTest {
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isNotEqualTo("03:00:05");
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       " <03:00:05>\n" +
-		                       "not to be equal to:\n" +
-		                       " <03:00:05>\n");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       " <03:00:05>%n" +
+		                       "not to be equal to:%n" +
+		                       " <03:00:05>%n"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.localtime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,11 +45,11 @@ public class LocalTimeAssert_isNotIn_Test extends LocalTimeAssertBaseTest {
 	try {
 	  assertThat(LocalTime.of(3, 0, 5)).isNotIn("03:00:05", "03:03:03");
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       " <03:00:05>\n" +
-		                       "not to be in:\n" +
-		                       " <[03:00:05, 03:03:03]>\n");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       " <03:00:05>%n" +
+		                       "not to be in:%n" +
+		                       " <[03:00:05, 03:03:03]>%n"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -63,7 +64,7 @@ public class ZonedDateTimeAssert_isAfterOrEqualTo_Test extends ZonedDateTimeAsse
     try {
       assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC)).isAfterOrEqualTo(ZonedDateTime.of(2012, 1, 1, 3, 3, 3, 0, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05Z>\nto be after or equals to:\n  <2012-01-01T03:03:03Z>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05Z>%nto be after or equals to:%n  <2012-01-01T03:03:03Z>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfter_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -67,7 +68,7 @@ public class ZonedDateTimeAssert_isAfter_Test extends ZonedDateTimeAssertBaseTes
     try {
       assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC)).isAfter(ZonedDateTime.of(2012, 1, 1, 3, 3, 3, 0, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05Z>\nto be strictly after:\n  <2012-01-01T03:03:03Z>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05Z>%nto be strictly after:%n  <2012-01-01T03:03:03Z>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -66,11 +67,11 @@ public class ZonedDateTimeAssert_isBeforeOrEqualTo_Test extends ZonedDateTimeAss
 	  assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC)).isBeforeOrEqualTo(ZonedDateTime.of(1998, 1, 1, 3, 3, 3,
 		                                                                                           0, UTC));
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <2000-01-05T03:00:05Z>\n" +
-		                       "to be before or equals to:\n" +
-		                       "  <1998-01-01T03:03:03Z>");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <2000-01-05T03:00:05Z>%n" +
+		                              "to be before or equals to:%n" +
+		                              "  <1998-01-01T03:03:03Z>"));
 	  return;
 	}
 	fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBefore_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -67,7 +68,7 @@ public class ZonedDateTimeAssert_isBefore_Test extends ZonedDateTimeAssertBaseTe
     try {
       assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 0, 0, UTC)).isBefore(ZonedDateTime.of(1998, 1, 1, 3, 3, 0, 0, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00Z>\nto be strictly before:\n  <1998-01-01T03:03Z>");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00Z>%nto be strictly before:%n  <1998-01-01T03:03Z>"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.AbstractZonedDateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,7 +45,7 @@ public class ZonedDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
       // DateTime(2013, 6, 10, 0, 0, cestTimeZone) = DateTime(2013, 6, 9, 22, 0, DateTimeZone.UTC)
       assertThat(utcDateTime).isEqualToIgnoringHours(ZonedDateTime.of(2013, 6, 10, 0, 0, 0, 0, cestTimeZone));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2013-06-10T00:00Z>\nto have same year, month and day as:\n  <2013-06-09T22:00Z>\nbut had not.");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2013-06-10T00:00Z>%nto have same year, month and day as:%n  <2013-06-09T22:00Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -55,7 +56,7 @@ public class ZonedDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
     try {
       assertThat(refDatetime).isEqualToIgnoringHours(refDatetime.minusHours(1));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-02T00:00Z>\nto have same year, month and day as:\n  <2000-01-01T23:00Z>\nbut had not.");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-02T00:00Z>%nto have same year, month and day as:%n  <2000-01-01T23:00Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -67,8 +68,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
       assertThat(refDatetime).isEqualToIgnoringHours(refDatetime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-                                .isEqualTo(
-                                           "\nExpecting:\n  <2000-01-02T00:00Z>\nto have same year, month and day as:\n  <2000-01-01T23:59:59.999999999Z>\nbut had not.");
+                                .isEqualTo(format(
+                                           "%nExpecting:%n  <2000-01-02T00:00Z>%nto have same year, month and day as:%n  <2000-01-01T23:59:59.999999999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ZonedDateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -38,8 +39,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test extends BaseTest 
       assertThat(refDatetime).isEqualToIgnoringMinutes(refDatetime.minusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00Z>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test extends BaseTest 
       assertThat(refDatetime).isEqualToIgnoringMinutes(refDatetime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:59.999999999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00Z>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:59.999999999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ZonedDateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -38,8 +39,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseT
       assertThat(refDatetime).isEqualToIgnoringNanos(refDatetime.plusSeconds(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:02Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01Z>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:02Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test extends BaseT
       assertThat(refDatetime).isEqualToIgnoringNanos(refDatetime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:00.999999999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01Z>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:00.999999999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ZonedDateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -38,8 +39,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest 
       assertThat(refDatetime).isEqualToIgnoringSeconds(refDatetime.plusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:52Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51Z>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:52Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test extends BaseTest 
       assertThat(refDatetime).isEqualToIgnoringSeconds(refDatetime.minusNanos(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:50:59.999999999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51Z>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:50:59.999999999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isIn_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isIn_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -46,8 +47,8 @@ public class ZonedDateTimeAssert_isIn_errors_Test extends ZonedDateTimeAssertBas
       assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC))
           .isIn(ZonedDateTime.of(2012, 1, 1, 3, 3, 3, 0, UTC).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage(
-          "\nExpecting:\n <2000-01-05T03:00:05Z>\nto be in:\n <[2012-01-01T03:03:03Z]>\n");
+      assertThat(e).hasMessage(format(
+          "%nExpecting:%n <2000-01-05T03:00:05Z>%nto be in:%n <[2012-01-01T03:03:03Z]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -46,7 +47,7 @@ public class ZonedDateTimeAssert_isNotEqualTo_errors_Test extends ZonedDateTimeA
       ZonedDateTime date = ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC);
       assertThat(date).isNotEqualTo(date.toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05Z>\nnot to be equal to:\n <2000-01-05T03:00:05Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05Z>%nnot to be equal to:%n <2000-01-05T03:00:05Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotIn_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotIn_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -47,10 +48,10 @@ public class ZonedDateTimeAssert_isNotIn_errors_Test extends ZonedDateTimeAssert
           ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC).toString(),
           ZonedDateTime.of(2012, 1, 1, 3, 3, 3, 0, UTC).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage(
-          "\nExpecting:\n <2000-01-05T03:00:05Z>\nnot to be in:\n"
-              + " <[2000-01-05T03:00:05Z, 2012-01-01T03:03:03Z]>\n"
-      );
+      assertThat(e).hasMessage(format(
+          "%nExpecting:%n <2000-01-05T03:00:05Z>%nnot to be in:%n"
+              + " <[2000-01-05T03:00:05Z, 2012-01-01T03:03:03Z]>%n"
+      ));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/core/condition/ConditionBuiltWithPredicateTest.java
+++ b/src/test/java/org/assertj/core/condition/ConditionBuiltWithPredicateTest.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.condition;
 
+import static java.lang.String.format;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -67,10 +68,10 @@ public class ConditionBuiltWithPredicateTest implements WithAssertions {
 	try {
 	  assertThat("Vader").is(jedi);
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       " <\"Vader\">\n" +
-		                       "to be <a jedi>");
+	  assertThat(e).hasMessage(format("%n" +
+		                       "Expecting:%n" +
+		                       " <\"Vader\">%n" +
+		                       "to be <a jedi>"));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/condition/MatchPredicateTest.java
+++ b/src/test/java/org/assertj/core/condition/MatchPredicateTest.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.condition;
 
+import static java.lang.String.format;
 import static org.assertj.core.test.ErrorMessages.predicateIsNull;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -50,19 +51,19 @@ public class MatchPredicateTest implements WithAssertions {
 	  assertThat(yoda).matches(x -> x.lightSaberColor.equals("Red"));
 	} catch (AssertionError e) {
 	  // @format:off
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <Yoda the Jedi>\n" +
-		                       "to match given predicate.\n" +
-		                       "\n" +
-		                       "You can use 'matches(Predicate p, String description)' to have a better error message\n" +
-		                       "For example:\n" +
-		                       "  assertThat(player).matches(p -> p.isRookie(), \"is rookie\");\n" +
-		                       "will give an error message looking like:\n" +
-		                       "\n" +
-		                       "Expecting:\n" +
-		                       "  <player>\n" +
-		                       "to match 'is rookie' predicate");
+	  assertThat(e).hasMessage(format("%n" +
+		                              "Expecting:%n" +
+		                              "  <Yoda the Jedi>%n" +
+		                              "to match given predicate.%n" +
+		                              "%n" +
+		                              "You can use 'matches(Predicate p, String description)' to have a better error message%n" +
+		                              "For example:%n" +
+		                              "  assertThat(player).matches(p -> p.isRookie(), \"is rookie\");%n" +
+		                              "will give an error message looking like:%n" +
+		                              "%n" +
+		                              "Expecting:%n" +
+		                              "  <player>%n" +
+		                              "to match 'is rookie' predicate"));
 	  //@format:on
 	  return;
 	}
@@ -74,10 +75,10 @@ public class MatchPredicateTest implements WithAssertions {
 	try {
 	  assertThat(yoda).as("check light saber").matches(x -> x.lightSaberColor.equals("Red"), "has red light saber");
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("[check light saber] \n" +
-		                       "Expecting:\n" +
-		                       "  <Yoda the Jedi>\n" +
-		                       "to match 'has red light saber' predicate.");
+	  assertThat(e).hasMessage(format("[check light saber] %n" +
+		                              "Expecting:%n" +
+		                              "  <Yoda the Jedi>%n" +
+		                              "to match 'has red light saber' predicate."));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/error/OptionalDoubleShouldHaveValueCloseTo_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalDoubleShouldHaveValueCloseTo_create_Test.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import java.util.OptionalDouble;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.OptionalDoubleShouldHaveValueCloseTo.shouldHaveValueCloseTo;
@@ -25,16 +26,16 @@ public class OptionalDoubleShouldHaveValueCloseTo_create_Test {
     @Test
     public void should_create_error_message_when_optionaldouble_is_empty() throws Exception {
         String errorMessage = shouldHaveValueCloseTo(10.0).create();
-        assertThat(errorMessage).isEqualTo("\nExpecting an OptionalDouble with value:\n" +
-                                           "  <10.0>\n" +
-                                           "but was empty.");
+        assertThat(errorMessage).isEqualTo(format("%nExpecting an OptionalDouble with value:%n" +
+                                                  "  <10.0>%n" +
+                                                  "but was empty."));
     }
 
     @Test
     public void should_create_error_message() throws Exception {
         String errorMessage = shouldHaveValueCloseTo(OptionalDouble.of(20.0), 10.0, within(2.0), 3).create();
-        assertThat(errorMessage).isEqualTo("\nExpecting:\n  <OptionalDouble[20.0]>\nto be close to:\n  <10.0>\n" +
-                                           "by less than <2.0> but difference was <3.0>.\n" +
-                                           "(a difference of exactly <2.0> being considered valid)");
+        assertThat(errorMessage).isEqualTo(format("%nExpecting:%n  <OptionalDouble[20.0]>%nto be close to:%n  <10.0>%n" +
+                                                  "by less than <2.0> but difference was <3.0>.%n" +
+                                                  "(a difference of exactly <2.0> being considered valid)"));
     }
 }

--- a/src/test/java/org/assertj/core/error/OptionalShouldBeEmpty_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldBeEmpty_create_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 
@@ -28,7 +29,7 @@ public class OptionalShouldBeEmpty_create_Test {
   @Test
   public void should_create_error_message_for_optional() {
     String errorMessage = shouldBeEmpty(Optional.of("not-empty")).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting an empty Optional but was containing value: <\"not-empty\">.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting an empty Optional but was containing value: <\"not-empty\">."));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -39,18 +40,18 @@ public class OptionalShouldBeEmpty_create_Test {
   @Test
   public void should_create_error_message_for_optionaldouble() {
     String errorMessage = shouldBeEmpty(OptionalDouble.of(1)).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting an empty OptionalDouble but was containing value: <1.0>.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting an empty OptionalDouble but was containing value: <1.0>."));
   }
 
   @Test
   public void should_create_error_message_for_optionalint() {
     String errorMessage = shouldBeEmpty(OptionalInt.of(1)).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting an empty OptionalInt but was containing value: <1>.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting an empty OptionalInt but was containing value: <1>."));
   }
 
   @Test
   public void should_create_error_message_for_optionallong() {
     String errorMessage = shouldBeEmpty(OptionalLong.of(1L)).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting an empty OptionalLong but was containing value: <1L>.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting an empty OptionalLong but was containing value: <1L>."));
   }
 }

--- a/src/test/java/org/assertj/core/error/OptionalShouldBePresent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldBePresent_create_Test.java
@@ -1,5 +1,5 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * Licensed under the Apache License, Version 2.0 (the "License")); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 
@@ -27,24 +28,24 @@ public class OptionalShouldBePresent_create_Test {
   @Test
   public void should_create_error_message_with_optional() throws Exception {
     String errorMessage = shouldBePresent(Optional.empty()).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting Optional to contain a value but was empty.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain a value but was empty."));
   }
 
   @Test
   public void should_create_error_message_with_optionaldouble() throws Exception {
     String errorMessage = shouldBePresent(OptionalDouble.empty()).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting OptionalDouble to contain a value but was empty.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting OptionalDouble to contain a value but was empty."));
   }
 
   @Test
   public void should_create_error_message_with_optionalint() throws Exception {
     String errorMessage = shouldBePresent(OptionalInt.empty()).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting OptionalInt to contain a value but was empty.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting OptionalInt to contain a value but was empty."));
   }
 
   @Test
   public void should_create_error_message_with_optionallong() throws Exception {
     String errorMessage = shouldBePresent(OptionalLong.empty()).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting OptionalLong to contain a value but was empty.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting OptionalLong to contain a value but was empty."));
   }
 }

--- a/src/test/java/org/assertj/core/error/OptionalShouldContainInstanceOf_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldContainInstanceOf_create_Test.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
 
@@ -12,6 +13,6 @@ public class OptionalShouldContainInstanceOf_create_Test {
   @Test
   public void should_create_error_message_with_expected_type() {
     String errorMessage = shouldContainInstanceOf(Optional.empty(), Object.class).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting Optional to contain a value of type java.lang.Object.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain a value of type java.lang.Object."));
   }
 }

--- a/src/test/java/org/assertj/core/error/OptionalShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldContain_create_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
 import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
@@ -28,58 +29,58 @@ public class OptionalShouldContain_create_Test {
   @Test
   public void should_create_error_message_when_optional_is_empty() {
     String errorMessage = shouldContain(10).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting Optional to contain:\n" +
-                                       "  <10>\n" +
-                                       "but was empty.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
+                                              "  <10>%n" +
+                                              "but was empty."));
   }
 
   @Test
   public void should_create_error_message() {
     String errorMessage = shouldContain(Optional.of(20), 10).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting:\n" +
-                                       "  <Optional[20]>\n" +
-                                       "to contain:\n" +
-                                       "  <10>\n" +
-                                       "but did not.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
+                                              "  <Optional[20]>%n" +
+                                              "to contain:%n" +
+                                              "  <10>%n" +
+                                              "but did not."));
   }
 
   @Test
   public void should_create_error_message_with_optionaldouble() {
     String errorMessage = shouldContain(OptionalDouble.of(20.0), 10.0).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting:\n" +
-                                       "  <OptionalDouble[20.0]>\n" +
-                                       "to contain:\n" +
-                                       "  <10.0>\n" +
-                                       "but did not.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
+                                              "  <OptionalDouble[20.0]>%n" +
+                                              "to contain:%n" +
+                                              "  <10.0>%n" +
+                                              "but did not."));
   }
 
   @Test
   public void should_create_error_message_with_optionalint() {
     String errorMessage = shouldContain(OptionalInt.of(20), 10).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting:\n" +
-                                       "  <OptionalInt[20]>\n" +
-                                       "to contain:\n" +
-                                       "  <10>\n" +
-                                       "but did not.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
+                                              "  <OptionalInt[20]>%n" +
+                                              "to contain:%n" +
+                                              "  <10>%n" +
+                                              "but did not."));
   }
 
   @Test
   public void should_create_error_message_with_optionallong() {
     String errorMessage = shouldContain(OptionalLong.of(20L), 10L).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting:\n" +
-                                       "  <OptionalLong[20]>\n" +
-                                       "to contain:\n" +
-                                       "  <10L>\n" +
-                                       "but did not.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
+                                              "  <OptionalLong[20]>%n" +
+                                              "to contain:%n" +
+                                              "  <10L>%n" +
+                                              "but did not."));
   }
 
   @Test
   public void should_create_error_message_for_different_instances() {
     String errorMessage = shouldContainSame(Optional.of(new Integer(10)), new Integer(10)).create();
-    assertThat(errorMessage).isEqualTo("\nExpecting:\n" +
-                                       "  <Optional[10]>\n" +
-                                       "to contain the instance (i.e. compared with ==):\n" +
-                                       "  <10>\n" +
-                                       "but did not.");
+    assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
+                                       "  <Optional[10]>%n" +
+                                       "to contain the instance (i.e. compared with ==):%n" +
+                                       "  <10>%n" +
+                                       "but did not."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringMinutes_create_Test.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualIgnoringMinutes;
 
@@ -38,12 +39,12 @@ public class ShouldBeEqualIgnoringMinutes_create_Test {
       factory = shouldBeEqualIgnoringMinutes(LocalTime.of(12, 0), LocalTime.of(12, 1));
 
       String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-      assertThat(message).isEqualTo("[Test] \n" +
-                                    "Expecting:\n" +
-                                    "  <12:00>\n" +
-                                    "to have same hour as:\n" +
-                                    "  <12:01>\n" +
-                                    "but had not.");
+      assertThat(message).isEqualTo(format("[Test] %n" +
+                                           "Expecting:%n" +
+                                           "  <12:00>%n" +
+                                           "to have same hour as:%n" +
+                                           "  <12:01>%n" +
+                                           "but had not."));
   }
 
   @Test
@@ -52,11 +53,11 @@ public class ShouldBeEqualIgnoringMinutes_create_Test {
     factory = shouldBeEqualIgnoringMinutes(OffsetTime.of(12,0,0,0, ZoneOffset.UTC),OffsetTime.of(12,1,0,0, ZoneOffset.UTC));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo("[Test] \n" +
-                                  "Expecting:\n" +
-                                  "  <12:00Z>\n" +
-                                  "to have same hour as:\n" +
-                                  "  <12:01Z>\n" +
-                                  "but had not.");
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <12:00Z>%n" +
+                                         "to have same hour as:%n" +
+                                         "  <12:01Z>%n" +
+                                         "but had not."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNanos_create_Test.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
 
@@ -38,12 +39,12 @@ public class ShouldBeEqualIgnoringNanos_create_Test {
       factory = shouldBeEqualIgnoringNanos(LocalTime.of(12, 0),LocalTime.of(13,0));
 
       String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-      assertThat(message).isEqualTo("[Test] \n" +
-                                    "Expecting:\n" +
-                                    "  <12:00>\n" +
-                                    "to have same hour, minute and second as:\n" +
-                                    "  <13:00>\n" +
-                                    "but had not.");
+      assertThat(message).isEqualTo(format("[Test] %n" +
+                                    "Expecting:%n" +
+                                    "  <12:00>%n" +
+                                    "to have same hour, minute and second as:%n" +
+                                    "  <13:00>%n" +
+                                    "but had not."));
   }
 
   @Test
@@ -52,11 +53,11 @@ public class ShouldBeEqualIgnoringNanos_create_Test {
     factory = shouldBeEqualIgnoringNanos(OffsetTime.of(12,0,0,0, ZoneOffset.UTC),OffsetTime.of(13,0,0,0, ZoneOffset.UTC));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo("[Test] \n" +
-                                  "Expecting:\n" +
-                                  "  <12:00Z>\n" +
-                                  "to have same hour, minute and second as:\n" +
-                                  "  <13:00Z>\n" +
-                                  "but had not.");
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                  "Expecting:%n" +
+                                  "  <12:00Z>%n" +
+                                  "to have same hour, minute and second as:%n" +
+                                  "  <13:00Z>%n" +
+                                  "but had not."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringSeconds_create_Test.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
 
@@ -38,12 +39,12 @@ public class ShouldBeEqualIgnoringSeconds_create_Test {
       factory = shouldBeEqualIgnoringSeconds(LocalTime.of(12, 0, 1),LocalTime.of(12, 0, 2));
 
       String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-      assertThat(message).isEqualTo("[Test] \n" +
-                                    "Expecting:\n" +
-                                    "  <12:00:01>\n" +
-                                    "to have same hour and minute as:\n" +
-                                    "  <12:00:02>\n" +
-                                    "but had not.");
+      assertThat(message).isEqualTo(format("[Test] %n" +
+                                           "Expecting:%n" +
+                                           "  <12:00:01>%n" +
+                                           "to have same hour and minute as:%n" +
+                                           "  <12:00:02>%n" +
+                                           "but had not."));
   }
 
   @Test
@@ -52,11 +53,11 @@ public class ShouldBeEqualIgnoringSeconds_create_Test {
     factory = shouldBeEqualIgnoringSeconds(OffsetTime.of(12,0,1,0, ZoneOffset.UTC),OffsetTime.of(12,0,2,0, ZoneOffset.UTC));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo("[Test] \n" +
-                                  "Expecting:\n" +
-                                  "  <12:00:01Z>\n" +
-                                  "to have same hour and minute as:\n" +
-                                  "  <12:00:02Z>\n" +
-                                  "but had not.");
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <12:00:01Z>%n" +
+                                         "to have same hour and minute as:%n" +
+                                         "  <12:00:02Z>%n" +
+                                         "but had not."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringTimezone_create_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.MIN;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,12 +43,12 @@ public class ShouldBeEqualIgnoringTimezone_create_Test {
                                             OffsetTime.of(12, 0, 0, 0, MIN));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo("[Test] \n" +
-                                  "Expecting:\n" +
-                                  "  <12:00Z>\n" +
-                                  "to have same time fields except timezone as:\n" +
-                                  "  <12:00-18:00>\n" +
-                                  "but had not.");
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <12:00Z>%n" +
+                                         "to have same time fields except timezone as:%n" +
+                                         "  <12:00-18:00>%n" +
+                                         "but had not."));
   }
 
   @Test
@@ -57,11 +58,11 @@ public class ShouldBeEqualIgnoringTimezone_create_Test {
                                             OffsetDateTime.of(2000, 5, 13, 12, 0, 0, 0, MIN));
 
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo("[Test] \n" +
-                                  "Expecting:\n" +
-                                  "  <2000-05-13T12:00Z>\n" +
-                                  "to have same time fields except timezone as:\n" +
-                                  "  <2000-05-13T12:00-18:00>\n" +
-                                  "but had not.");
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <2000-05-13T12:00Z>%n" +
+                                         "to have same time fields except timezone as:%n" +
+                                         "  <2000-05-13T12:00-18:00>%n" +
+                                         "but had not."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveSameHourAs_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSameHourAs_create_Test.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldHaveSameHourAs.shouldHaveSameHourAs;
 
@@ -36,7 +37,7 @@ public class ShouldHaveSameHourAs_create_Test {
     public void should_create_error_message_localtime() {
         factory = shouldHaveSameHourAs(LocalTime.of(12, 0), LocalTime.of(13, 0));
         assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation()))
-            .isEqualTo("[Test] \nExpecting:\n  <12:00>\nto have same hour as:\n  <13:00>\nbut had not.");
+            .isEqualTo(format("[Test] %nExpecting:%n  <12:00>%nto have same hour as:%n  <13:00>%nbut had not."));
     }
 
     @Test
@@ -44,6 +45,6 @@ public class ShouldHaveSameHourAs_create_Test {
         factory = shouldHaveSameHourAs(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC),
                                        OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
         assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation()))
-            .isEqualTo("[Test] \nExpecting:\n  <12:00Z>\nto have same hour as:\n  <13:00Z>\nbut had not.");
+            .isEqualTo(format("[Test] %nExpecting:%n  <12:00Z>%nto have same hour as:%n  <13:00Z>%nbut had not."));
     }
 }

--- a/src/test/java/org/assertj/core/error/ShouldMatch_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldMatch_create_Test.java
@@ -1,5 +1,6 @@
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldMatch.shouldMatch;
 import static org.assertj.core.test.ExpectedException.none;
@@ -20,7 +21,7 @@ public class ShouldMatch_create_Test {
   public void should_create_error_message_with_default_predicate_description() {
 	ErrorMessageFactory factory = shouldMatch("Yoda", color -> color.equals("green"), PredicateDescription.GIVEN);
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \nExpecting:\n  <\"Yoda\">\nto match given predicate." + ShouldMatch.ADVICE);
+	assertThat(message).isEqualTo(format("[Test] %nExpecting:%n  <\"Yoda\">%nto match given predicate." + ShouldMatch.ADVICE));
   }
 
   @Test
@@ -28,7 +29,7 @@ public class ShouldMatch_create_Test {
 	ErrorMessageFactory factory = shouldMatch("Yoda", (String color) -> color.equals("green"),
 	                                          new PredicateDescription("green light saber"));
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \nExpecting:\n  <\"Yoda\">\nto match 'green light saber' predicate.");
+	assertThat(message).isEqualTo(format("[Test] %nExpecting:%n  <\"Yoda\">%nto match 'green light saber' predicate."));
   }
   
   @Test

--- a/src/test/java/org/assertj/core/error/future/ShouldBeCancelled_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldBeCancelled_create_Test.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldBeCancelled.shouldBeCancelled;
 
@@ -23,10 +24,10 @@ public class ShouldBeCancelled_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldBeCancelled(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to be cancelled");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "to be cancelled"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldBeCompleted_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldBeCompleted_create_Test.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 
@@ -23,10 +24,10 @@ public class ShouldBeCompleted_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldBeCompleted(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to be completed");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "to be completed"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldBeDone_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldBeDone_create_Test.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldBeDone.shouldBeDone;
 
@@ -23,10 +24,10 @@ public class ShouldBeDone_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldBeDone(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to be done");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "to be done"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldHaveCompletedExceptionally_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldHaveCompletedExceptionally_create_Test.java
@@ -9,6 +9,7 @@
  */
 package org.assertj.core.error.future;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldBeCompletedExceptionally.shouldHaveCompletedExceptionally;
 
@@ -23,10 +24,10 @@ public class ShouldHaveCompletedExceptionally_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldHaveCompletedExceptionally(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to be completed exceptionally");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "to be completed exceptionally"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldHaveFailed_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldHaveFailed_create_Test.java
@@ -9,6 +9,7 @@
  */
 package org.assertj.core.error.future;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldHaveFailed.shouldHaveFailed;
 
@@ -23,10 +24,10 @@ public class ShouldHaveFailed_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldHaveFailed(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to have failed (i.e. completed exceptionally and not cancelled)");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                "Expecting%n" +
+                                "  <CompletableFuture[Incomplete]>%n" +
+                                "to have failed (i.e. completed exceptionally and not cancelled)"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldNotBeCancelled_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldNotBeCancelled_create_Test.java
@@ -9,6 +9,7 @@
  */
 package org.assertj.core.error.future;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldNotBeCancelled.shouldNotBeCancelled;
 
@@ -26,10 +27,10 @@ public class ShouldNotBeCancelled_create_Test {
 
     String error = shouldNotBeCancelled(future).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Cancelled]>\n" +
-                                "not to be cancelled");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                "Expecting%n" +
+                                "  <CompletableFuture[Cancelled]>%n" +
+                                "not to be cancelled"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldNotBeCompleted_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldNotBeCompleted_create_Test.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldNotBeCompleted.shouldNotBeCompleted;
 
@@ -23,10 +24,10 @@ public class ShouldNotBeCompleted_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldNotBeCompleted(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "not to be completed");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "not to be completed"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldNotBeDone_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldNotBeDone_create_Test.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldNotBeDone.shouldNotBeDone;
 
@@ -23,10 +24,10 @@ public class ShouldNotBeDone_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldNotBeDone(CompletableFuture.completedFuture("done")).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Completed: \"done\"]>\n" +
-                                "not to be done");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Completed: \"done\"]>%n" +
+                                       "not to be done"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldNotHaveCompletedExceptionally_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldNotHaveCompletedExceptionally_create_Test.java
@@ -9,6 +9,7 @@
  */
 package org.assertj.core.error.future;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldNotBeCompletedExceptionally.shouldNotHaveCompletedExceptionally;
 
@@ -23,10 +24,10 @@ public class ShouldNotHaveCompletedExceptionally_create_Test {
   public void should_create_error_message() throws Exception {
     String error = shouldNotHaveCompletedExceptionally(new CompletableFuture<Object>()).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Incomplete]>\n" +
-                                "to not be completed exceptionally");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                       "Expecting%n" +
+                                       "  <CompletableFuture[Incomplete]>%n" +
+                                       "to not be completed exceptionally"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/future/ShouldNotHaveFailed_create_Test.java
+++ b/src/test/java/org/assertj/core/error/future/ShouldNotHaveFailed_create_Test.java
@@ -9,6 +9,7 @@
  */
 package org.assertj.core.error.future;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldNotHaveFailed.shouldNotHaveFailed;
 
@@ -26,10 +27,10 @@ public class ShouldNotHaveFailed_create_Test {
 
     String error = shouldNotHaveFailed(future).create(new TestDescription("TEST"));
 
-    assertThat(error).isEqualTo("[TEST] \n" +
-                                "Expecting\n" +
-                                "  <CompletableFuture[Failed: java.lang.RuntimeException]>\n" +
-                                "to not have failed");
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+                                "Expecting%n" +
+                                "  <CompletableFuture[Failed: java.lang.RuntimeException]>%n" +
+                                "to not have failed"));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objects;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeEqualByComparingOnlyGivenFields.shouldBeEqualComparingOnlyGivenFields;
@@ -144,11 +145,11 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
 
   @Test
   public void should_fail_when_selected_field_does_not_exist() {
-    thrown.expect(IntrospectionError.class, "\nCan't find any field or property with name 'age'.\n" +
-                                            "Error when introspecting properties was :\n" +
-                                            "- No getter for property 'age' in org.assertj.core.test.Jedi \n" +
-                                            "Error when introspecting fields was :\n" +
-                                            "- Unable to obtain the value of the field <'age'> from <Yoda the Jedi>");
+    thrown.expect(IntrospectionError.class, format("%nCan't find any field or property with name 'age'.%n" +
+                                                   "Error when introspecting properties was :%n" +
+                                                   "- No getter for property 'age' in org.assertj.core.test.Jedi %n" +
+                                                   "Error when introspecting fields was :%n" +
+                                                   "- Unable to obtain the value of the field <'age'> from <Yoda the Jedi>"));
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Yoda", "Blue");
     objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, "age");


### PR DESCRIPTION
apply this fix to java 8 assertions