### PR TITLE
Backport assertThatThrownBy() and catchThrowable() methods

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -14,6 +14,7 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Throwables;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -37,6 +38,11 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
 
 	protected AbstractThrowableAssert(A actual, Class<?> selfType) {
 		super(actual, selfType);
+	}
+
+	protected S hasBeenThrown() {
+		if (actual == null) throw Failures.instance().failure("Expecting code to raise a throwable.");
+		return myself;
 	}
 
 	/**

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.AllOf;
 import org.assertj.core.condition.AnyOf;
@@ -523,6 +524,54 @@ public class Assertions {
    */
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
+  }
+
+  /**
+   * Allows to capture and then assert on a {@link Throwable} more easily when used with lambdas.
+   *
+   * <p>
+   * Example :
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   assertThatThrownBy(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+   *                                                              .hasMessageContaining("boom");
+   * }</code></pre>
+   *
+   * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+    return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to catch an {@link Throwable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * This caught {@link Throwable} can then be asserted.
+   * </p>
+   *
+   * <p>
+   * Example:
+   * </p>
+   *
+   * <pre><code class='java'> {@literal @}Test
+   * public void testException() {
+   *   // when
+   *   Throwable thrown = catchThrowable(() -> { throw new Exception("boom!"); });
+   *
+   *   // then
+   *   assertThat(thrown).isInstanceOf(Exception.class)
+   *                     .hasMessageContaining("boom");
+   * } </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
+    return ThrowableAssert.catchThrowable(shouldRaiseThrowable);
   }
 
   // -------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -27,7 +27,20 @@ package org.assertj.core.api;
  */
 public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Throwable> {
 
+  public interface ThrowingCallable {
+    void call() throws Throwable;
+  }
+
   protected ThrowableAssert(Throwable actual) {
     super(actual, ThrowableAssert.class);
+  }
+
+  public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
+    try {
+      shouldRaiseThrowable.call();
+    } catch (Throwable throwable) {
+      return throwable;
+    }
+    return null;
   }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
+
+public class Assertions_assertThat_with_Throwable_Test {
+
+  @Test
+  public void should_build_ThrowableAssert_with_runtime_exception_thrown() {
+    assertThatThrownBy(new ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        throw new IllegalArgumentException("something was wrong");
+      }
+    }).isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("something was wrong");
+  }
+
+  @Test
+  public void should_build_ThrowableAssert_with_throwable_thrown() {
+    assertThatThrownBy(new ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        throw new Throwable("something was wrong");
+      }
+    }).isInstanceOf(Throwable.class)
+      .hasMessage("something was wrong");
+  }
+
+  @Test
+  public void should_fail_if_no_throwable_was_thrown() {
+    try {
+      assertThatThrownBy(new ThrowingCallable() {
+        @Override
+        public void call() throws Throwable {
+          // noop
+        }
+      }).hasMessage("yo");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("Expecting code to raise a throwable.");
+      return;
+    }
+    failBecauseExceptionWasNotThrown(AssertionError.class);
+  }
+
+  @Test
+  public void can_capture_exception_and_then_assert_following_AAA_or_BDD_style() {
+    // given
+    // some preconditions
+
+    // when
+    Throwable boom = catchThrowable(raisingException("boom!!!!"));
+
+    // then
+    assertThat(boom).isInstanceOf(Exception.class)
+                    .hasMessageContaining("boom");
+  }
+
+  @Test
+  public void fail_with_good_message_when_assertion_is_failing() {
+    try {
+      assertThatThrownBy(raisingException("boom")).hasMessage("yo");
+    } catch (AssertionError ae) {
+      assertThat(ae).hasMessageContaining("Expecting message:")
+                    .hasMessageContaining("<\"yo\">")
+                    .hasMessageContaining("but was:")
+                    .hasMessageContaining("<\"boom\">");
+      return;
+    }
+    failBecauseExceptionWasNotThrown(AssertionError.class);
+  }
+
+  private ThrowingCallable raisingException(final String reason) {
+    return new ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        throw new Exception(reason);
+      }
+    };
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_from_ThrowingCallable_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_from_ThrowingCallable_Test.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
+
+public class ThrowableAssert_built_from_ThrowingCallable_Test {
+
+  @Test
+  public void should_build_ThrowableAssert_with_runtime_exception_thrown_by_callable_code() {
+		// check that actual exception is the one thrown by ThrowingCallable()#run
+		assertThatThrownBy(new ThrowingCallable() {
+			@Override
+			public void call() {
+				throw new IllegalArgumentException("something was wrong");
+			}
+		}).isInstanceOf(IllegalArgumentException.class).hasMessage("something was wrong");
+  }
+
+  @Test
+  public void should_build_ThrowableAssert_with_throwable_thrown_by_callable_code() {
+		assertThatThrownBy(new ThrowingCallable() {
+			@Override
+			public void call() throws Exception {
+				throw new Exception("something was wrong");
+			}
+		}).isInstanceOf(Exception.class).hasMessage("something was wrong");
+  }
+
+  @Test
+  public void should_fail_if_nothing_is_thrown_by_callable_code() {
+		try {
+			assertThatThrownBy(new ThrowingCallable() {
+				@Override
+				public void call() {
+					// no exception
+				}
+			});
+		} catch (AssertionError e) {
+			assertThat(e).hasMessage("Expecting code to raise a throwable.");
+			return;
+		}
+		failBecauseExceptionWasNotThrown(AssertionError.class);
+  }
+}


### PR DESCRIPTION
resolves #486 