### PR TITLE
Support Java 1.6 and thus Android applications under test.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -131,7 +131,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * Path xFileTurkish = Files.write(Paths.get("xfile.turk"), Collections.singleton("Gerçek Başka bir yerde mi"), turkishCharset);
    * 
    * // The following assertion succeeds:
-   * String expectedContent = "Gerçek Başka bir yerde mi" + System.lineSeparator();
+   * String expectedContent = "Gerçek Başka bir yerde mi" + org.assertj.core.util.Compatibility.System.lineSeparator();
    * byte[] binaryContent = expectedContent.getBytes(turkishCharset.name());
    * assertThat(xFileTurkish).hasBinaryContent(binaryContent);
    * 

--- a/src/main/java/org/assertj/core/error/AbstractShouldHaveTextContent.java
+++ b/src/main/java/org/assertj/core/error/AbstractShouldHaveTextContent.java
@@ -54,7 +54,7 @@ public class AbstractShouldHaveTextContent extends BasicErrorMessageFactory {
   protected static String diffsAsString(List<String> diffsList) {
     StringBuilder stringBuilder = new StringBuilder();
     for (String diff : diffsList)
-      stringBuilder.append(System.lineSeparator()).append(diff);
+      stringBuilder.append(org.assertj.core.util.Compatibility.System.lineSeparator()).append(diff);
     return stringBuilder.toString();
   }
 

--- a/src/main/java/org/assertj/core/internal/Failures.java
+++ b/src/main/java/org/assertj/core/internal/Failures.java
@@ -36,7 +36,7 @@ import org.assertj.core.util.VisibleForTesting;
  */
 public class Failures {
 
-  private static final String LINE_SEPARATOR = System.lineSeparator();
+  private static final String LINE_SEPARATOR = org.assertj.core.util.Compatibility.System.lineSeparator();
 
   private static final Failures INSTANCE = new Failures();
 

--- a/src/main/java/org/assertj/core/util/Compatibility.java
+++ b/src/main/java/org/assertj/core/util/Compatibility.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.util;
+
+/**
+ * Compatibility with older Android (Java 1.6)
+ *
+ * @author Felix von Ferey
+ */
+public final class Compatibility {
+  
+  public final static class System {
+    static String lineSeparator = java.lang.System.getProperty("line.separator");
+    
+    public static String lineSeparator() {
+      return lineSeparator;
+    }
+  
+    private System() {} // override public constructor
+  }
+  
+  private Compatibility() {} // override public constructor
+}
+

--- a/src/main/java/org/assertj/core/util/GroupFormatUtil.java
+++ b/src/main/java/org/assertj/core/util/GroupFormatUtil.java
@@ -15,7 +15,7 @@ package org.assertj.core.util;
 public class GroupFormatUtil {
 
   static final String ELEMENT_SEPARATOR = ",";
-  static final String ELEMENT_SEPARATOR_WITH_NEWLINE = ELEMENT_SEPARATOR + System.lineSeparator();
+  static final String ELEMENT_SEPARATOR_WITH_NEWLINE = ELEMENT_SEPARATOR + org.assertj.core.util.Compatibility.System.lineSeparator();
   static final String DEFAULT_END = "]";
   static final String DEFAULT_START = "[";
   // 4 spaces indentation : 2 space indentation after new line + '<' + '['

--- a/src/test/java/org/assertj/core/error/ShouldHaveSameContent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSameContent_create_Test.java
@@ -48,7 +48,7 @@ public class ShouldHaveSameContent_create_Test {
     ErrorMessageFactory factory = shouldHaveSameContent(new FakeFile("abc"), new FakeFile("xyz"), diffs);
 	StringBuilder b = new StringBuilder(String.format("[Test] %nFile:%n  <abc>%nand file:%n  <xyz>%ndo not have same content:"));
 	for (String diff : diffs)
-      b.append(System.lineSeparator()).append(diff);
+      b.append(org.assertj.core.util.Compatibility.System.lineSeparator()).append(diff);
 	assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation())).isEqualTo(b.toString());
   }
 
@@ -59,7 +59,7 @@ public class ShouldHaveSameContent_create_Test {
                                                       diffs);
 	StringBuilder b = new StringBuilder(String.format("[Test] %nInputStreams do not have same content:"));
 	for (String diff : diffs)
-      b.append(System.lineSeparator()).append(diff);
+      b.append(org.assertj.core.util.Compatibility.System.lineSeparator()).append(diff);
 	assertThat(factory.create(new TextDescription("Test"), new StandardRepresentation())).isEqualTo(b.toString());
   }
 

--- a/src/test/java/org/assertj/core/util/IterableUtil_format_Test.java
+++ b/src/test/java/org/assertj/core/util/IterableUtil_format_Test.java
@@ -62,7 +62,7 @@ public class IterableUtil_format_Test {
   @Test
   public void should_format_iterable_with_an_element_per_line() {
     String formatted = multiLineFormat(STANDARD_REPRESENTATION, asList("First", 3, "foo", "bar"));
-    String formattedAfterNewLine = System.lineSeparator() + "  <" + formatted + ">";
+    String formattedAfterNewLine = org.assertj.core.util.Compatibility.System.lineSeparator() + "  <" + formatted + ">";
     assertThat(formattedAfterNewLine).isEqualTo(format("%n" +
                                                        "  <[\"First\",%n" +
                                                        "    3,%n" +
@@ -73,7 +73,7 @@ public class IterableUtil_format_Test {
   @Test
   public void should_format_iterable_with_an_element_per_line_according_the_given_representation() {
     String formatted = multiLineFormat(HEXA_REPRESENTATION, asList(1, 2, 3));
-    String formattedAfterNewLine = System.lineSeparator() + "  <" + formatted + ">";
+    String formattedAfterNewLine = org.assertj.core.util.Compatibility.System.lineSeparator() + "  <" + formatted + ">";
     assertThat(formattedAfterNewLine).isEqualTo(format("%n" +
                                                        "  <[0x0000_0001,%n" +
                                                        "    0x0000_0002,%n" +


### PR DESCRIPTION
The current assertj-core 2.x code is nearly Java 1.6 compliant. 

Being Java 1.6 compliant is necessary for using assert-core 2.x to test Android apps which in turn may both target newer and older Android devices. Currently, testing under older Android devices (e.g. Android Gingerbread) fails due to the Java 1.6 incompatibilities.

This code makes the assertj-core 2.x code Java 1.6 compliant.
