### PR TITLE
Add isNotEqualByComparingTo() in AbstractBigDecimalAssert.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -230,6 +230,10 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
     return isEqualByComparingTo(new BigDecimal(expected));
   }
 
+  public S isNotEqualByComparingTo(String expected) {
+    return isNotEqualByComparingTo(new BigDecimal(expected));
+  }
+
   @Override
   public S usingComparator(Comparator<? super BigDecimal> customComparator) {
     super.usingComparator(customComparator);

--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -230,6 +230,18 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
     return isEqualByComparingTo(new BigDecimal(expected));
   }
 
+  /**
+   * Same as {@link AbstractComparableAssert#isNotEqualByComparingTo(Comparable) isEqualByComparingTo(BigDecimal)} but
+   * takes care of converting given String to {@link BigDecimal} for you.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * // assertions will pass
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualByComparingTo(&quot;7.99&quot;);
+   *
+   * // assertion will fail
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualByComparingTo(&quot;8.00&quot;);</code></pre>
+   */
   public S isNotEqualByComparingTo(String expected) {
     return isNotEqualByComparingTo(new BigDecimal(expected));
   }

--- a/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isNotEqualByComparingToWithStringParameter_Test.java
+++ b/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isNotEqualByComparingToWithStringParameter_Test.java
@@ -1,0 +1,27 @@
+package org.assertj.core.api.bigdecimal;
+
+import org.assertj.core.api.BigDecimalAssert;
+import org.assertj.core.api.BigDecimalAssertBaseTest;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link BigDecimalAssert#isNotEqualByComparingTo(String)}</code>.
+ *
+ * @author Guillaume Husta
+ */
+public class BigDecimalAssert_isNotEqualByComparingToWithStringParameter_Test extends BigDecimalAssertBaseTest {
+
+  @Override
+  protected BigDecimalAssert invoke_api_method() {
+      return assertions.isNotEqualByComparingTo(ONE_AS_STRING);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertNotEqualByComparison(getInfo(assertions), getActual(assertions), new BigDecimal(ONE_AS_STRING));
+  }
+
+}


### PR DESCRIPTION
Enable to use this :
    assertThat(new BigDecimal("8.0")).isNotEqualByComparingTo("7.99999999");
In addition to :
    assertThat(new BigDecimal("8.0")).isNotEqualByComparingTo(new BigDecimal("7.99999999"));