### PR TITLE
Added containing-semantics for asserting content in OptionalAsserter

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldConta
 
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ComparisonStrategy;
@@ -96,6 +97,28 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
     checkNotNull(expectedValue);
     if (!actual.isPresent()) throwAssertionError(shouldContain(expectedValue));
     if (!optionalValueComparisonStrategy.areEqual(actual.get(), expectedValue)) throwAssertionError(shouldContain(actual, expectedValue));
+    return myself;
+  }
+
+	/**
+     * Verifies that the actual {@link java.util.Optional} contains a value and gives this value to the given
+     * {@link java.util.function.Consumer} for further assertions.
+     * </p>
+     * Assertion will pass :
+     * <pre><code class='java'> assertThat(Optional.of("something")).containing(s -> {assertThat(s).isEqualTo("something");});
+     * assertThat(Optional.of(10)).containing(i -> {assertThat(i).isGreaterThan(9);});</code></pre>
+     *
+     * Assertion will fail :
+     * <pre><code class='java'> assertThat(Optional.of("something")).containing(s -> {assertThat(s).isEqualTo("something else");});
+     * assertThat(Optional.empty()).containing(o -> {});</code></pre>
+     *
+     * @param consumer to further assert on the object contained inside the {@link java.util.Optional}.
+     * @return this assertion object.
+     */
+  public S containing(Consumer<T> consumer) {
+    isNotNull();
+    if (!actual.isPresent()) throwAssertionError(shouldBePresent(actual));
+    consumer.accept(actual.get());
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -101,24 +101,25 @@ public abstract class AbstractOptionalAssert<S extends AbstractOptionalAssert<S,
   }
 
 	/**
-     * Verifies that the actual {@link java.util.Optional} contains a value and gives this value to the given
-     * {@link java.util.function.Consumer} for further assertions.
-     * </p>
-     * Assertion will pass :
-     * <pre><code class='java'> assertThat(Optional.of("something")).containing(s -> {assertThat(s).isEqualTo("something");});
-     * assertThat(Optional.of(10)).containing(i -> {assertThat(i).isGreaterThan(9);});</code></pre>
-     *
-     * Assertion will fail :
-     * <pre><code class='java'> assertThat(Optional.of("something")).containing(s -> {assertThat(s).isEqualTo("something else");});
-     * assertThat(Optional.empty()).containing(o -> {});</code></pre>
-     *
-     * @param consumer to further assert on the object contained inside the {@link java.util.Optional}.
-     * @return this assertion object.
-     */
-  public S containing(Consumer<T> consumer) {
+   * Verifies that the actual {@link java.util.Optional} contains a value and gives this value to the given
+   * {@link java.util.function.Consumer} for further assertions. Should be used as a way of deeper asserting on the
+   * containing object, as further requirement(s) for the value.
+   * </p>
+   * Assertion will pass :
+   * <pre><code class='java'> assertThat(Optional.of("something")).satisfies(s -> {assertThat(s).isEqualTo("something");});
+   * assertThat(Optional.of(10)).satisfies(i -> {assertThat(i).isGreaterThan(9);});</code></pre>
+   *
+   * Assertion will fail :
+   * <pre><code class='java'> assertThat(Optional.of("something")).satisfies(s -> {assertThat(s).isEqualTo("something else");});
+   * assertThat(Optional.empty()).satisfies(o -> {});</code></pre>
+   *
+   * @param requirement to further assert on the object contained inside the {@link java.util.Optional}.
+   * @return this assertion object.
+   */
+  public S satisfies(Consumer<T> requirement) {
     isNotNull();
     if (!actual.isPresent()) throwAssertionError(shouldBePresent(actual));
-    consumer.accept(actual.get());
+    requirement.accept(actual.get());
     return myself;
   }
 

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_containing_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_containing_Test.java
@@ -1,0 +1,45 @@
+package org.assertj.core.api.optional;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.util.Optional;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.Test;
+
+public class OptionalAssert_containing_Test extends BaseTest {
+  @Test
+  public void should_fail_when_optional_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    assertThat((Optional<String>) null).containing(s -> {
+    });
+  }
+
+  @Test
+  public void should_fail_when_optional_is_empty() {
+    thrown.expectAssertionError(shouldBePresent(Optional.empty()).create());
+    assertThat(Optional.empty()).containing(o -> {
+    });
+  }
+
+  @Test
+  public void should_pass_when_consumer_passes() {
+    assertThat(Optional.of("something")).containing(s -> {
+      assertThat(s).isEqualTo("something");
+    });
+    assertThat(Optional.of(10)).containing(i -> {
+      assertThat(i).isGreaterThan(9);
+    });
+  }
+
+  @Test
+  public void should_fail_from_consumer() {
+    thrown.expectAssertionError("expected:<\"something[]\"> but was:<\"something[ else]\">");
+    assertThat(Optional.of("something else")).containing(s -> {
+      assertThat(s).isEqualTo("something");
+    });
+  }
+}

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_satisfies_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_satisfies_Test.java
@@ -10,27 +10,29 @@ import java.util.Optional;
 import org.assertj.core.api.BaseTest;
 import org.junit.Test;
 
-public class OptionalAssert_containing_Test extends BaseTest {
+public class OptionalAssert_satisfies_Test extends BaseTest {
   @Test
   public void should_fail_when_optional_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    assertThat((Optional<String>) null).containing(s -> {
+    assertThat((Optional<String>) null).satisfies(s -> {
     });
   }
 
   @Test
   public void should_fail_when_optional_is_empty() {
     thrown.expectAssertionError(shouldBePresent(Optional.empty()).create());
-    assertThat(Optional.empty()).containing(o -> {
+    assertThat(Optional.empty()).satisfies(o -> {
     });
   }
 
   @Test
   public void should_pass_when_consumer_passes() {
-    assertThat(Optional.of("something")).containing(s -> {
-      assertThat(s).isEqualTo("something");
+    assertThat(Optional.of("something")).satisfies(s -> {
+      assertThat(s).isEqualTo("something")
+                   .startsWith("some")
+                   .endsWith("thing");
     });
-    assertThat(Optional.of(10)).containing(i -> {
+    assertThat(Optional.of(10)).satisfies(i -> {
       assertThat(i).isGreaterThan(9);
     });
   }
@@ -38,7 +40,7 @@ public class OptionalAssert_containing_Test extends BaseTest {
   @Test
   public void should_fail_from_consumer() {
     thrown.expectAssertionError("expected:<\"something[]\"> but was:<\"something[ else]\">");
-    assertThat(Optional.of("something else")).containing(s -> {
+    assertThat(Optional.of("something else")).satisfies(s -> {
       assertThat(s).isEqualTo("something");
     });
   }


### PR DESCRIPTION
I wish to do a more functional style for deeper asserting on the content of an optional. The implementation allows the following style for asserting on Optionals:
```java
assertThat(Optional.of(someString)).containing(s -> {
  assertThat(s).isEqualTo("something");
  assertThat(s).startsWith("some");
  assertThat(s).endsWith("thing");
});
```

Above will fail for any ```Optional.empty```.