### PR TITLE
fixed FindBugs warning for string concatenation in loop

### DIFF
--- a/src/main/java/org/assertj/core/internal/Failures.java
+++ b/src/main/java/org/assertj/core/internal/Failures.java
@@ -186,17 +186,17 @@ org.junit.ComparisonFailure: expected:<'[Ronaldo]'> but was:<'[Messi]'>
   }
 
   private String threadDumpDescription() {
-	String threadDumpDescription = "";
+	StringBuilder threadDumpDescription = new StringBuilder();
 	ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 	ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
 	for (ThreadInfo threadInfo : threadInfos) {
-	  threadDumpDescription += format("\"%s\"%n\tjava.lang.Thread.State: %s",
-		                              threadInfo.getThreadName(), threadInfo.getThreadState());
+	  threadDumpDescription.append(format("\"%s\"%n\tjava.lang.Thread.State: %s",
+		                              threadInfo.getThreadName(), threadInfo.getThreadState()));
 	  for (StackTraceElement stackTraceElement : threadInfo.getStackTrace()) {
-		threadDumpDescription += LINE_SEPARATOR + "\t\tat " + stackTraceElement;
+		threadDumpDescription.append(LINE_SEPARATOR + "\t\tat " + stackTraceElement);
 	  }
-	  threadDumpDescription += LINE_SEPARATOR + LINE_SEPARATOR;
+	  threadDumpDescription.append(LINE_SEPARATOR + LINE_SEPARATOR);
 	}
-	return threadDumpDescription;
+	return threadDumpDescription.toString();
   }
 }


### PR DESCRIPTION
of course performance is not a focus of AssertJ, but this fix does not make the code less readable imho