### PR TITLE
Fixes #440: Assertions related to entries on AbstractMapAssert should…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -18,7 +18,6 @@ import static org.assertj.core.util.Arrays.array;
 import java.util.Comparator;
 import java.util.Map;
 
-import org.assertj.core.data.MapEntry;
 import org.assertj.core.internal.Maps;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -40,7 +39,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author dorzey
  */
 public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>, A extends Map<K, V>, K, V>
-    extends AbstractAssert<S, A> implements EnumerableAssert<S, MapEntry<? extends K, ? extends V>> {
+    extends AbstractAssert<S, A> implements EnumerableAssert<S, Map.Entry<? extends K, ? extends V>> {
 
   @VisibleForTesting
   Maps maps = Maps.instance();
@@ -126,7 +125,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map does not contain the given entries.
    */
-  public S contains(@SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+  public S contains(@SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     maps.assertContains(info, actual, entries);
     return myself;
   }
@@ -167,7 +166,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map contains any of the given entries.
    */
-  public S doesNotContain(@SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+  public S doesNotContain(@SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     maps.assertDoesNotContain(info, actual, entries);
     return myself;
   }
@@ -361,7 +360,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map does not contain the given entries, i.e. the actual map contains some or
    *           none of the given entries, or the actual map contains more entries than the given ones.
    */
-  public S containsOnly(@SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+  public S containsOnly(@SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     maps.assertContainsOnly(info, actual, entries);
     return myself;
   }
@@ -389,7 +388,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    *           contains some or none of the given entries, or the actual map contains more entries than the given ones
    *           or entries are the same but the order is not.
    */
-  public S containsExactly(@SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+  public S containsExactly(@SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     maps.assertContainsExactly(info, actual, entries);
     return myself;
   }
@@ -402,7 +401,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    */
   @Override
   @Deprecated
-  public S usingElementComparator(Comparator<? super MapEntry<? extends K, ? extends V>> customComparator) {
+  public S usingElementComparator(Comparator<? super Map.Entry<? extends K, ? extends V>> customComparator) {
     throw new UnsupportedOperationException("custom element Comparator is not supported for MapEntry comparison");
   }
 

--- a/src/main/java/org/assertj/core/api/MapAssert.java
+++ b/src/main/java/org/assertj/core/api/MapAssert.java
@@ -14,8 +14,6 @@ package org.assertj.core.api;
 
 import java.util.Map;
 
-import org.assertj.core.data.MapEntry;
-
 /**
  * Assertions for {@link Map}s.
  * <p>
@@ -40,19 +38,19 @@ public class MapAssert<K, V> extends AbstractMapAssert<MapAssert<K, V>, Map<K, V
 
   @SafeVarargs
   @Override
-  public final MapAssert<K, V> contains(MapEntry<? extends K, ? extends V>... entries) {
+  public final MapAssert<K, V> contains(Map.Entry<? extends K, ? extends V>... entries) {
     return super.contains(entries);
   }
 
   @SafeVarargs
   @Override
-  public final MapAssert<K, V> containsOnly(MapEntry<? extends K, ? extends V>... entries) {
+  public final MapAssert<K, V> containsOnly(Map.Entry<? extends K, ? extends V>... entries) {
     return super.containsOnly(entries);
   }
   
   @SafeVarargs
   @Override
-  public final MapAssert<K, V> containsExactly(MapEntry<? extends K, ? extends V>... entries) {
+  public final MapAssert<K, V> containsExactly(Map.Entry<? extends K, ? extends V>... entries) {
     return super.containsExactly(entries);
   }
   
@@ -82,7 +80,7 @@ public class MapAssert<K, V> extends AbstractMapAssert<MapAssert<K, V>, Map<K, V
   
   @SafeVarargs
   @Override
-  public final MapAssert<K, V> doesNotContain(MapEntry<? extends K, ? extends V>... entries) {
+  public final MapAssert<K, V> doesNotContain(Map.Entry<? extends K, ? extends V>... entries) {
     return super.doesNotContain(entries);
   }
 }

--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -23,7 +23,7 @@ import java.util.Map;
  *
  * @author Yvonne Wang
  */
-public class MapEntry<K, V> {
+public class MapEntry<K, V> implements Map.Entry<K, V>{
   
   public final K key;
   public final V value;
@@ -64,5 +64,28 @@ public class MapEntry<K, V> {
   @Override
   public String toString() {
     return toStringOf(this, STANDARD_REPRESENTATION);
+  }
+
+  @Override
+  public K getKey() {
+    return key;
+  }
+
+  @Override
+  public V getValue() {
+    return value;
+  }
+  
+  /**
+   * Always throws <tt>UnsupportedOperationException</tt>,
+   * as this class represents an <i>immutable</i> map entry.
+   *
+   * @param value ignored
+   * @return (Does not return)
+   * @throws UnsupportedOperationException always
+   */
+  @Override
+  public V setValue(V value) {
+      throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.data.MapEntry;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -177,15 +176,15 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} is {@code null}.
    * @throws AssertionError if the given {@code Map} does not contain the given entries.
    */
-  public <K, V> void assertContains(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>[] entries) {
+  public <K, V> void assertContains(AssertionInfo info, Map<K, V> actual, Map.Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     assertNotNull(info, actual);
     // if both actual and values are empty, then assertion passes.
     if (actual.isEmpty() && entries.length == 0)
       return;
     failIfEmptySinceActualIsNotEmpty(entries);
-    Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    for (MapEntry<? extends K, ? extends V> entry : entries) {
+    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
+    for (Map.Entry<? extends K, ? extends V> entry : entries) {
       if (!containsEntry(actual, entry)) {
         notFound.add(entry);
       }
@@ -207,11 +206,11 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} contains any of the given entries.
    */
   public <K, V> void assertDoesNotContain(AssertionInfo info, Map<K, V> actual,
-                                          MapEntry<? extends K, ? extends V>[] entries) {
+                                          Map.Entry<? extends K, ? extends V>[] entries) {
     failIfNullOrEmpty(entries);
     assertNotNull(info, actual);
-    Set<MapEntry<? extends K, ? extends V>> found = new LinkedHashSet<>();
-    for (MapEntry<? extends K, ? extends V> entry : entries) {
+    Set<Map.Entry<? extends K, ? extends V>> found = new LinkedHashSet<>();
+    for (Map.Entry<? extends K, ? extends V> entry : entries) {
       if (containsEntry(actual, entry)) {
         found.add(entry);
       }
@@ -370,15 +369,15 @@ public class Maps {
    *           none of the given entries, or the actual map contains more entries than the given ones.
    */
   public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual,
-                                        @SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+                                        @SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) {
       return;
     }
     failIfEmpty(entries);
 
-    Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    Set<MapEntry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
+    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
+    Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
 
     compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
@@ -402,14 +401,14 @@ public class Maps {
    *           or entries are the same but the order is not.
    */
   public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual,
-                                           @SuppressWarnings("unchecked") MapEntry<? extends K, ? extends V>... entries) {
+                                           @SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
     failIfEmpty(entries);
     assertHasSameSizeAs(info, actual, entries);
 
-    Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    Set<MapEntry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
+    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
+    Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
 
     compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
@@ -417,8 +416,8 @@ public class Maps {
       // check entries order
       int index = 0;
       for (K keyFromActual : actual.keySet()) {
-        if (!areEqual(keyFromActual, entries[index].key)) {
-          MapEntry<K, V> actualEntry = entry(keyFromActual, actual.get(keyFromActual));
+        if (!areEqual(keyFromActual, entries[index].getKey())) {
+          Map.Entry<K, V> actualEntry = entry(keyFromActual, actual.get(keyFromActual));
           throw failures.failure(info, elementsDifferAtIndex(actualEntry, entries[index], index));
         }
         index++;
@@ -449,9 +448,9 @@ public class Maps {
   }
 
   private <K, V> void compareActualMapAndExpectedEntries(Map<K, V> actual,
-                                                         MapEntry<? extends K, ? extends V>[] entries,
-                                                         Set<MapEntry<? extends K, ? extends V>> notExpected,
-                                                         Set<MapEntry<? extends K, ? extends V>> notFound) {
+                                                         Map.Entry<? extends K, ? extends V>[] entries,
+                                                         Set<Map.Entry<? extends K, ? extends V>> notExpected,
+                                                         Set<Map.Entry<? extends K, ? extends V>> notFound) {
     Map<K, V> expectedEntries = entriesToMap(entries);
     Map<K, V> actualEntries = new LinkedHashMap<>(actual);
     for (Map.Entry<K, V> entry : expectedEntries.entrySet()) {
@@ -470,15 +469,15 @@ public class Maps {
   }
 
   private <K, V> void doCommonContainsCheck(AssertionInfo info, Map<K, V> actual,
-                                            MapEntry<? extends K, ? extends V>[] entries) {
+                                            Map.Entry<? extends K, ? extends V>[] entries) {
     assertNotNull(info, actual);
     failIfNull(entries);
   }
 
-  private static <K, V> Map<K, V> entriesToMap(MapEntry<? extends K, ? extends V>[] entries) {
+  private static <K, V> Map<K, V> entriesToMap(Map.Entry<? extends K, ? extends V>[] entries) {
     Map<K, V> expectedEntries = new LinkedHashMap<>();
-    for (MapEntry<? extends K, ? extends V> entry : entries) {
-      expectedEntries.put(entry.key, entry.value);
+    for (Map.Entry<? extends K, ? extends V> entry : entries) {
+      expectedEntries.put(entry.getKey(), entry.getValue());
     }
     return expectedEntries;
   }
@@ -487,12 +486,12 @@ public class Maps {
     if (keys.length == 0) throw new IllegalArgumentException("The array of keys to look for should not be empty");
   }
 
-  private static <K, V> void failIfEmpty(MapEntry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfEmpty(Map.Entry<? extends K, ? extends V>[] entries) {
     if (entries.length == 0)
       throw new IllegalArgumentException("The array of entries to look for should not be empty");
   }
 
-  private static <K, V> void failIfNullOrEmpty(MapEntry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfNullOrEmpty(Map.Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     failIfEmpty(entries);
   }
@@ -501,20 +500,20 @@ public class Maps {
     if (keys == null) throw new NullPointerException("The array of keys to look for should not be null");
   }
 
-  private static <K, V> void failIfNull(MapEntry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfNull(Map.Entry<? extends K, ? extends V>[] entries) {
     if (entries == null) throw new NullPointerException("The array of entries to look for should not be null");
   }
 
-  private <K, V> boolean containsEntry(Map<K, V> actual, MapEntry<? extends K, ? extends V> entry) {
+  private <K, V> boolean containsEntry(Map<K, V> actual, Map.Entry<? extends K, ? extends V> entry) {
     if (entry == null) throw new NullPointerException("Entries to look for should not be null");
-    return actual.containsKey(entry.key) ? areEqual(actual.get(entry.key), entry.value) : false;
+    return actual.containsKey(entry.getKey()) ? areEqual(actual.get(entry.getKey()), entry.getValue()) : false;
   }
 
   private void assertNotNull(AssertionInfo info, Map<?, ?> actual) {
     Objects.instance().assertNotNull(info, actual);
   }
 
-  private static <K, V> void failIfEmptySinceActualIsNotEmpty(MapEntry<? extends K, ? extends V>[] values) {
+  private static <K, V> void failIfEmptySinceActualIsNotEmpty(Map.Entry<? extends K, ? extends V>[] values) {
     if (values.length == 0) throw new AssertionError("actual is not empty");
   }
 }

--- a/src/test/java/org/assertj/core/api/MapAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/MapAssertBaseTest.java
@@ -15,6 +15,9 @@ package org.assertj.core.api;
 import static java.util.Collections.emptyMap;
 import static org.mockito.Mockito.mock;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.assertj.core.internal.Maps;
@@ -38,5 +41,20 @@ public abstract class MapAssertBaseTest extends BaseTestTemplate<MapAssert<Objec
     super.inject_internal_objects();
     maps = mock(Maps.class);
     assertions.maps = maps;
+  }
+  
+  protected <K,V> Map.Entry<K, V> javaMapEntry(K key, V value) {
+    return new SimpleImmutableEntry<K, V>(key, value);
+  }
+  
+  protected <K, V> Map<K, V> map(K key, V value) {
+    return Collections.singletonMap(key, value);
+  }
+  
+  protected <K, V> Map<K, V> map(K k1, V v1, K k2, V v2) {
+    Map<K, V> map = new LinkedHashMap<K, V>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    return map;
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 import org.assertj.core.data.MapEntry;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.MapAssert#containsExactly(org.assertj.core.data.MapEntry...)}</code>.
@@ -37,5 +39,10 @@ public class MapAssert_containsExactly_Test extends MapAssertBaseTest {
   @Override
   protected void verify_internal_effects() {
     verify(maps).assertContainsExactly(getInfo(assertions), getActual(assertions), entries);
+  }
+  
+  @Test
+  public void invoke_api_like_user() {
+     assertThat(map("key1", "value1", "key2", "value2")).containsExactly(entry("key1", "value1"), entry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_with_Java_Util_MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_with_Java_Util_MapEntry_Test.java
@@ -13,37 +13,31 @@
 package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
-import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 
+public class MapAssert_containsExactly_with_Java_Util_MapEntry_Test extends MapAssertBaseTest {
 
-/**
- * Tests for <code>{@link MapAssert#doesNotContain(MapEntry...)}</code>.
- * 
- * @author Alex Ruiz
- * @author Nicolas François
- */
-public class MapAssert_doesNotContain_Test extends MapAssertBaseTest {
+  final Map.Entry<String, String>[] entries = array(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.doesNotContain(entry("key1", "value1"), entry("key2", "value2"));
+    return assertions.containsExactly(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 
   @Override
   protected void verify_internal_effects() {
-    MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
-    verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
+    verify(maps).assertContainsExactly(getInfo(assertions), getActual(assertions), entries);
   }
   
   @Test
   public void invoke_api_like_user() {
-     assertThat(map("key1", "value1")).doesNotContain(entry("key2", "value2"), entry("key3", "value3"));
+     assertThat(map("key1", "value1", "key2", "value2")).containsExactly(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 import org.assertj.core.data.MapEntry;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.MapAssert#containsOnly(org.assertj.core.data.MapEntry...)}</code>.
@@ -37,5 +39,10 @@ public class MapAssert_containsOnly_Test extends MapAssertBaseTest {
   @Override
   protected void verify_internal_effects() {
     verify(maps).assertContainsOnly(getInfo(assertions), getActual(assertions), entries);
+  }
+  
+  @Test
+  public void invoke_api_like_user() {
+     assertThat(map("key1", "value1", "key2", "value2")).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_with_Java_Util_MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_with_Java_Util_MapEntry_Test.java
@@ -13,37 +13,31 @@
 package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
-import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 
+public class MapAssert_containsOnly_with_Java_Util_MapEntry_Test extends MapAssertBaseTest {
 
-/**
- * Tests for <code>{@link MapAssert#doesNotContain(MapEntry...)}</code>.
- * 
- * @author Alex Ruiz
- * @author Nicolas François
- */
-public class MapAssert_doesNotContain_Test extends MapAssertBaseTest {
+  final Map.Entry<String, String>[] entries = array(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.doesNotContain(entry("key1", "value1"), entry("key2", "value2"));
+    return assertions.containsOnly(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 
   @Override
   protected void verify_internal_effects() {
-    MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
-    verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
+    verify(maps).assertContainsOnly(getInfo(assertions), getActual(assertions), entries);
   }
   
   @Test
   public void invoke_api_like_user() {
-     assertThat(map("key1", "value1")).doesNotContain(entry("key2", "value2"), entry("key3", "value3"));
+     assertThat(map("key1", "value1", "key2", "value2")).containsOnly(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_contains_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_contains_Test.java
@@ -12,12 +12,14 @@
  */
 package org.assertj.core.api.map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 import org.assertj.core.data.MapEntry;
+import org.junit.Test;
 
 import static org.mockito.Mockito.verify;
 
@@ -40,5 +42,10 @@ public class MapAssert_contains_Test extends MapAssertBaseTest {
   @Override
   protected void verify_internal_effects() {
     verify(maps).assertContains(getInfo(assertions), getActual(assertions), entries);
+  }
+  
+  @Test
+  public void invoke_api_like_user() {
+     assertThat(map("key1", "value1", "key2", "value2")).contains(entry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_contains_with_Java_Util_MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_contains_with_Java_Util_MapEntry_Test.java
@@ -13,37 +13,31 @@
 package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
-import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 
+public class MapAssert_contains_with_Java_Util_MapEntry_Test extends MapAssertBaseTest {
 
-/**
- * Tests for <code>{@link MapAssert#doesNotContain(MapEntry...)}</code>.
- * 
- * @author Alex Ruiz
- * @author Nicolas François
- */
-public class MapAssert_doesNotContain_Test extends MapAssertBaseTest {
+  final Map.Entry<String, String>[] entries = array(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.doesNotContain(entry("key1", "value1"), entry("key2", "value2"));
+    return assertions.contains(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 
   @Override
   protected void verify_internal_effects() {
-    MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
-    verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
+    verify(maps).assertContains(getInfo(assertions), getActual(assertions), entries);
   }
   
   @Test
   public void invoke_api_like_user() {
-     assertThat(map("key1", "value1")).doesNotContain(entry("key2", "value2"), entry("key3", "value3"));
+     assertThat(map("key1", "value1", "key2", "value2")).contains(javaMapEntry("key2", "value2"));
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContain_with_Java_Util_MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContain_with_Java_Util_MapEntry_Test.java
@@ -13,37 +13,30 @@
 package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
-import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 
-
-/**
- * Tests for <code>{@link MapAssert#doesNotContain(MapEntry...)}</code>.
- * 
- * @author Alex Ruiz
- * @author Nicolas François
- */
-public class MapAssert_doesNotContain_Test extends MapAssertBaseTest {
+public class MapAssert_doesNotContain_with_Java_Util_MapEntry_Test extends MapAssertBaseTest {
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.doesNotContain(entry("key1", "value1"), entry("key2", "value2"));
+    return assertions.doesNotContain(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
   }
 
   @Override
   protected void verify_internal_effects() {
-    MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+    Map.Entry<String, String>[] entries = array(javaMapEntry("key1", "value1"), javaMapEntry("key2", "value2"));
     verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
   }
   
   @Test
   public void invoke_api_like_user() {
-     assertThat(map("key1", "value1")).doesNotContain(entry("key2", "value2"), entry("key3", "value3"));
+     assertThat(map("key1", "value1")).doesNotContain(javaMapEntry("key2", "value2"), javaMapEntry("key3", "value3"));
   }
 }


### PR DESCRIPTION
… support java.util.Map.Entry as arguments

Enhancement seems to work fine. :)

I guess the test are wrong (especially the new test classes I added). Please give me some pointers what kind of test should be added where? And of course any other feedback. I will update the pull request accordingly.

Thanks!