### PR TITLE
Fix build status: s/CloudBees/Travis CI/.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # AssertJ - Fluent assertions for java
 
-[![Build Status](https://assertj.ci.cloudbees.com/buildStatus/icon?job=assertj-core)](https://assertj.ci.cloudbees.com/job/assertj-core/)
+Build status:
+
+* master: [![Build Status (master)](https://travis-ci.org/joel-costigliola/assertj-core.svg?branch=master)](https://travis-ci.org/joel-costigliola/assertj-core)
+* 2.x: [![Build Status (2.x)](https://travis-ci.org/joel-costigliola/assertj-core.svg?branch=2.x)](https://travis-ci.org/joel-costigliola/assertj-core/branches)
+* 1.x: [![Build Status (1.x)](https://travis-ci.org/joel-costigliola/assertj-core.svg?branch=1.x)](https://travis-ci.org/joel-costigliola/assertj-core/branches)
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-core)
 


### PR DESCRIPTION
The CloudBees build server for AssertJ appears to have been turned down but
there's an up-to-date Travis CI build is configured and running, so let's use
that.

This change adds per-branch build status images for `master`, `2.x`, and `1.x`.

To see how the new README looks, take a look at [my branch](https://github.com/mbrukman/assertj-core/tree/readme-build-status).