### PR TITLE
make hasBeenThrown public accessible

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -39,7 +39,7 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
     super(actual, selfType);
   }
 
-  protected S hasBeenThrown() {
+  public S hasBeenThrown() {
     if (actual == null) throw Failures.instance().failure("Expecting code to raise a throwable.");
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -64,4 +64,26 @@ public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Th
     }
     return null;
   }
+  
+  /**
+   * Catch given throwable if any was thrown
+   *
+   * @param throwableType throwable class to catch
+   * @param callable method to catch for throwable
+   * @param <T> Throwable type
+   * @return catched throwable if any was thrown
+   * @throws Exception rethrow all unexpected throwables
+   */
+  private static <T extends Throwable> T catchThrowable(Class<T> throwableType, Callable<?> callable) throws Exception {
+    try {
+      callable.call();
+    } catch (Throwable throwable) {
+      if (throwableType != null && !throwableType.isInstance(throwable)) {
+        throw throwable;
+      }
+      //noinspection unchecked
+      return (T) throwable;
+    }
+  	return null;
+  }
 }


### PR DESCRIPTION
can be public without a doubt. I need this to have a test code like this:

   @Test
    public void expectExceptionLambda() throws Exception {
        // give
        Thrower thrower = new Thrower();

        // when
        Throwable exception = catchThrowable(() -> thrower.throwNullPointerException("boom"));

        // then
        assertThat(exception).hasBeenThrown().hasMessage("boom");
    }