### PR TITLE
+ catchThrowable for expected Exceptions only

### DIFF
--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -64,4 +64,26 @@ public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Th
     }
     return null;
   }
+  
+  /**
+   * Catch given throwable if any was thrown
+   *
+   * @param throwableType throwable class to catch
+   * @param callable method to catch for throwable
+   * @param <T> Throwable type
+   * @return catched throwable if any was thrown
+   * @throws Exception rethrow all unexpected throwables
+   */
+  private static <T extends Throwable> T catchThrowable(Class<T> throwableType, Callable<?> callable) throws Exception {
+    try {
+      callable.call();
+    } catch (Throwable throwable) {
+      if (throwableType != null && !throwableType.isInstance(throwable)) {
+        throw throwable;
+      }
+      //noinspection unchecked
+      return (T) throwable;
+    }
+  	return null;
+  }
 }


### PR DESCRIPTION
so you can differ between test who have unexpected exception (Test Flag is typically Red) and those who throws normal assertionsErrors  (Test Flag is typically Yellow/Orange)