### PR TITLE
Added support for specifying a precision with which to compare elements of AbstractDoubleArrays

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
@@ -107,6 +107,34 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
     return myself;
   }
 
+ /**
+   * Verifies that the actual array contains the given values, in any order.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(new double[] {1.01, 3.01, 2.0}, 0.02);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(new double[] {3.0, 1.3}, 0.5);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(new double[] {1.1, 2.0}, 0.2);
+   *
+   * // assertions will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(new double[] {1.0, 4.0}, 0.5);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(new double[] {4.0, 7.0}, 2);</code></pre>
+   *
+   * @param values the given values.
+   * @param precision the precision under which the value may vary
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given values.
+   */
+  public S contains(double[] values, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContains(info, actual, values);
+    return myself;
+  }
+
   /**
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
@@ -135,6 +163,36 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
   }
 
   /**
+   * Verifies that the actual array contains only the given values and nothing else, in any order.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(new double[] {1.0, 2.0, 3.0}, 0.00001);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(new double[] {2.0, 3.0, 0.7}, 0.5);
+   *
+   * // assertions will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(new double[] {1.0, 4.0, 2.0, 3.0}, 0.5);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnly(new double[] {4.0, 7.0}, 0.2);</code></pre>
+   *
+   * </p>
+   *
+   * @param values the given values.
+   * @param precision the precision under which the value may vary
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given values, i.e. the actual array contains some
+   *           or none of the given values, or the actual array contains more values than the given ones.
+   */
+  public S containsOnly(double[] values, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContainsOnly(info, actual, values);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array contains the given values only once.
    * <p>
    * Examples :
@@ -155,6 +213,34 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    *           or none of the given values, or the actual group contains more than once these values.
    */
   public S containsOnlyOnce(double... values) {
+    arrays.assertContainsOnlyOnce(info, actual, values);
+    return myself;
+  }
+
+   /**
+   * Verifies that the actual array contains the given values only once.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnlyOnce(new double[] {1.1, 2.0}, 0.2);
+   *
+   * // assertions will fail
+   * assertThat(new double[] { 1.0, 2.0, 1.0 }).containsOnlyOnce(new double[] {1.05}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsOnlyOnce(new double[] {4.0}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0, 3.0 }).containsOnlyOnce(new double[] {0.1, 0.9, 2.0, 3.11, 4.0, 5.0}, 0.2);</code></pre>
+   *
+   * @param values the given values.
+   * @param precision the precision under which the value may vary
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group contains some
+   *           or none of the given values, or the actual group contains more than once these values.
+   */
+  public S containsOnlyOnce(double[] values, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
     arrays.assertContainsOnlyOnce(info, actual, values);
     return myself;
   }
@@ -185,6 +271,36 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
     return myself;
   }
 
+
+  /**
+   * Verifies that the actual array contains the given sequence, without any other values between them.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(new double[] {1.07, 2.0}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(new double[] {1.1, 2.1, 3.0}, 0.2);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(new double[] {2.2, 3.0}, 0.3);
+   *
+   * // assertions will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(new double[] {1.0, 3.0}, 0.2);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSequence(new double[] {4.0, 7.0}, 0.1);</code></pre>
+   *
+   * </p>
+   *
+   * @param sequence the sequence of values to look for.
+   * @param precision the precision under which the value may vary
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the given array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given sequence.
+   */
+  public S containsSequence(double[] sequence, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContainsSequence(info, actual, sequence);
+    return myself;
+  }
+
   /**
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
@@ -210,6 +326,36 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
     arrays.assertContainsSubsequence(info, actual, subsequence);
     return myself;
   }
+
+  /**
+   * Verifies that the actual array contains the given subsequence (possibly with other values between them).
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(new double[] {1.0, 2.0}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(new double[] {1.0, 2.07, 3.0}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(new double[] {2.1, 2.9}, 0.2);
+   *
+   * // assertions will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(new double[] {1.0, 3.0}, 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsSubsequence(new double[] {4.0, 7.0}, 0.1);</code></pre>
+   *
+   * </p>
+   *
+   * @param subsequence the subsequence of values to look for.
+   * @param precision the precision under which the value may vary
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the given array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given subsequence.
+   */
+  public S containsSubsequence(double[] subsequence, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContainsSubsequence(info, actual, subsequence);
+    return myself;
+  }
+
   /**
    * Verifies that the actual array contains the given value at the given index.
    * <p>
@@ -239,6 +385,37 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
   }
 
   /**
+   * Verifies that the actual array contains the given value at the given index.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, atIndex(O), 0.01);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(3.3, atIndex(2), 0.5);
+   *
+   * // assertion will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(1.0, atIndex(1), 0.2);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).contains(4.5, atIndex(2), 0.1);</code></pre>
+   *
+   * </p>
+   *
+   * @param value the value to look for.
+   * @param index the index where the value should be stored in the actual array.
+   * @param precision the precision under which the value may vary
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null} or empty.
+   * @throws NullPointerException if the given {@code Index} is {@code null}.
+   * @throws IndexOutOfBoundsException if the value of the given {@code Index} is equal to or greater than the size of
+   *           the actual array.
+   * @throws AssertionError if the actual array does not contain the given value at the given index.
+   */
+  public S contains(double value, Index index, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContains(info, actual, value, index);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array does not contain the given values.
    * <p>
    * Example:
@@ -259,6 +436,34 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
    * @throws AssertionError if the actual array contains any of the given values.
    */
   public S doesNotContain(double... values) {
+      arrays.assertDoesNotContain(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array does not contain the given values.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(new double[] {4.01, 8.0001}, 0.04);
+   *
+   * // assertion will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(new double[] {1.0, 2.0, 3.0}, 0.2);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(new double[] {3.0, 1.05}, 0.1);</code></pre>
+   *
+   * </p>
+   *
+   * @param values the given values.
+   * @param precision the precision under which the values may vary
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array contains any of the given values.
+   */
+  public S doesNotContain(double[] values, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
     arrays.assertDoesNotContain(info, actual, values);
     return myself;
   }
@@ -288,6 +493,37 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
     arrays.assertDoesNotContain(info, actual, value, index);
     return myself;
   }
+
+  /**
+   * Verifies that the actual array does not contain the given value at the given index.
+   * The check is made by taking a certain precision into consideration.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(1.01, atIndex(1), 0.0001);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(2.05, atIndex(0), 0.1);
+   *
+   * // assertion will fail
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(1.0, atIndex(0), 0.1);
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).doesNotContain(2.0, atIndex(1), 0.1);</code></pre>
+   *
+   * </p>
+   *
+   * @param value the value to look for.
+   * @param index the index where the value should be stored in the actual array.
+   * @param precision the precision under which the values may vary
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws NullPointerException if the given {@code Index} is {@code null}.
+   * @throws AssertionError if the actual array contains the given value at the given index.
+   */
+  public S doesNotContain(double value, Index index, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertDoesNotContain(info, actual, value, index);
+    return myself;
+  }
+
+
 
   /**
    * Verifies that the actual array does not contain duplicates.
@@ -411,6 +647,45 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
   public S containsExactly(double... values) {
 	arrays.assertContainsExactly(info, actual, values);
     return myself;
+  }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * The values may vary with a specified precision
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsExactly(new double[] {1.0, 1.98, 3.01}, 0.05);
+   *
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(new double[] { 1.0, 2.0, 3.0 }).containsExactly(new double[] {1.98, 1.0, 3.01}, 0.05);</code></pre>
+   *
+   * @param values the given values.
+   * @param precision the precision under which the values may vary
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public S containsExactly(double[] values, double precision) {
+    usingElementComparator(getComparatorWithPrecision(precision));
+    arrays.assertContainsExactly(info, actual, values);
+    return myself;
+  }
+
+
+  public Comparator<Double> getComparatorWithPrecision(double precision) {
+    Comparator<Double> closeToComparator = new Comparator<Double>() {
+        @Override
+        public int compare(Double o1, Double o2) {
+            if((o1.doubleValue() - o2.doubleValue()) < precision)
+                return 0;
+            return o1.doubleValue() - o2.doubleValue() > 0 ? 1 : -1;
+        }
+    };
+    return closeToComparator;
   }
 
 }


### PR DESCRIPTION
This request is in relation with issue #505 . I attempted modify the containXXX and doesNotContainXXX methods from AbstractDoubleArrays.
Awaiting a review and possible recommendations on how to write the tests.