### PR TITLE
Support Hamcrest matchers as conditions (#556)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/src/main/java/org/assertj/core/api/HamcrestCondition.java
+++ b/src/main/java/org/assertj/core/api/HamcrestCondition.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+/**
+ * Allows to use a Hamcrest matcher as a condition.
+ * 
+ * Example:
+ * <pre><code class='java'> Condition&lt;String&gt; aStringContainingA = new HamcrestCondition&lt;&gt;(containsString(&quot;a&quot;));
+ * 
+ * // assertions will pass
+ * assertThat(&quot;abc&quot;).is(aStringContainingA);
+ * assertThat(&quot;bc&quot;).isNot(aStringContainingA);
+ * 
+ * // assertion will fail
+ * assertThat(&quot;bc&quot;).is(aStringContainingA);</code></pre>
+*/
+public class HamcrestCondition<T> extends Condition<T> {
+
+  private Matcher<T> matcher;
+
+  /**
+   * Constructs a {@link Condition} using the matcher given as a parameter.
+   * 
+   * @param matcher the Hamcrest matcher to use as a condition
+   */
+ public HamcrestCondition(Matcher<T> matcher) {
+    this.matcher = matcher;
+    as(describeMatcher());
+  }
+
+ /**
+  * {@inheritDoc}
+  */
+  @Override
+  public boolean matches(T value) {
+    return matcher.matches(value);
+  }
+
+  private String describeMatcher() {
+    Description d = new StringDescription();
+    matcher.describeTo(d);
+    return d.toString();
+  }
+}

--- a/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
+++ b/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.HamcrestCondition;
+import org.junit.Test;
+
+public class HamcrestConditionTest {
+
+  @Test
+  public void should_be_able_to_use_a_hamcrest_matcher_as_a_condition() {
+    Condition<String> aStringContainingA = new HamcrestCondition<>(containsString("a"));
+
+    assertThat("abc").is(aStringContainingA);
+    assertThat("bc").isNot(aStringContainingA);
+  }
+}


### PR DESCRIPTION
I think the result is impressive for so little effort.

Error messages are surprisingly readable:

> java.lang.AssertionError: 
> Expecting:
> <"bc">
> to be <a string containing "a">
