### PR TITLE
add EditorConfig styles for java, xml and yml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 2 space indentation for java, xml and yml files
+[*.{java,xml,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I dont know if you are interested by: http://editorconfig.org/ but I find it very useful for collaborative projects.

It's not as thorough as https://github.com/joel-costigliola/assertj-core/blob/master/src/ide-support/assertj-eclipse-formatter.xml because EditorConfig works on raw files, but it allows developer to start working on projects without having to import specific settings.

It's enabled by default on many editors (jetbrains suite, GitHub web editor) and plugins are available for almost every other IDE: http://editorconfig.org/#download