### PR TITLE
#assertHasSameContentAs should use the charset set by #usingCharset t…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -122,6 +122,25 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the content of the actual {@code File} is equal to the content of the given one.
+   * The charset to use when reading the actual file can be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
+   * 
+   * Examples:
+   * <pre><code class="java"> // use the default charset
+   * File xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes()).toFile();
+   * File xFileClone = Files.write(Paths.get("xfile-clone.txt"), "The Truth Is Out There".getBytes()).toFile();
+   * File xFileFrench = Files.write(Paths.get("xfile-french.txt"), "La Vérité Est Ailleurs".getBytes()).toFile();
+   * // use UTF-8 charsest
+   * File xFileUTF8 = Files.write(Paths.get("xfile-clone.txt"), Arrays.asList("The Truth Is Out There"), Charset.forName("UTF-8")).toFile();
+   * 
+   * // The following assertion succeeds (default charset is used):
+   * assertThat(xFile).hasSameContentAs(xFileClone);
+   * // The following assertion succeeds (UTF-8 charset is used to read xFile):
+   * assertThat(xFileUTF8).usingCharset("UTF-8").hasContent(xFileClone);
+   * 
+   * // The following assertion fails:
+   * assertThat(xFile).hasSameContentAs(xFileFrench);</code></pre>
    * 
    * @param expected the given {@code File} to compare the actual {@code File} to.
    * @return {@code this} assertion object.
@@ -136,13 +155,32 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    */
   @Deprecated
   public S hasContentEqualTo(File expected) {
-    files.assertSameContentAs(info, actual, expected);
+    files.assertSameContentAs(info, actual, charset, expected);
     return myself;
   }
 
   /**
    * Verifies that the content of the actual {@code File} is equal to the content of the given one.
-   *
+   * The charset to use when reading the actual file can be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
+   * 
+   * Examples:
+   * <pre><code class="java"> // use the default charset
+   * File xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes()).toFile();
+   * File xFileClone = Files.write(Paths.get("xfile-clone.txt"), "The Truth Is Out There".getBytes()).toFile();
+   * File xFileFrench = Files.write(Paths.get("xfile-french.txt"), "La Vérité Est Ailleurs".getBytes()).toFile();
+   * // use UTF-8 charsest
+   * File xFileUTF8 = Files.write(Paths.get("xfile-clone.txt"), Arrays.asList("The Truth Is Out There"), Charset.forName("UTF-8")).toFile();
+   * 
+   * // The following assertion succeeds (default charset is used):
+   * assertThat(xFile).hasSameContentAs(xFileClone);
+   * // The following assertion succeeds (UTF-8 charset is used to read xFile):
+   * assertThat(xFileUTF8).usingCharset("UTF-8").hasContent(xFileClone);
+   * 
+   * // The following assertion fails:
+   * assertThat(xFile).hasSameContentAs(xFileFrench);</code></pre>
+   * 
    * @param expected the given {@code File} to compare the actual {@code File} to.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given {@code File} is {@code null}.
@@ -153,7 +191,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
    */
   public S hasSameContentAs(File expected) {
-      files.assertSameContentAs(info, actual, expected);
+      files.assertSameContentAs(info, actual, charset, expected);
       return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -155,7 +155,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    */
   @Deprecated
   public S hasContentEqualTo(File expected) {
-    files.assertSameContentAs(info, actual, charset, expected);
+    files.assertSameContentAs(info, actual, charset, expected, Charset.defaultCharset());
     return myself;
   }
 
@@ -191,7 +191,39 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
    */
   public S hasSameContentAs(File expected) {
-      files.assertSameContentAs(info, actual, charset, expected);
+      files.assertSameContentAs(info, actual, charset, expected, Charset.defaultCharset());
+      return myself;
+  }
+
+  /**
+   * Verifies that the content of the actual {@code File} is equal to the content of the given one.
+   * The charset to use when reading the actual file can be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
+   * 
+   * Examples:
+   * <pre><code class="java"> File fileUTF8 = Files.write(Paths.get("actual"), Collections.singleton("Gerçek"), StandardCharsets.UTF_8).toFile();
+   * Charset turkishCharset = Charset.forName("windows-1254");
+   * File fileTurkischCharset = Files.write(Paths.get("expected"), Collections.singleton("Gerçek"), turkishCharset).toFile();
+   * 
+   * // The following assertion succeeds:
+   * assertThat(fileUTF8).usingCharset(StandardCharsets.UTF_8).hasSameContentAs(fileTurkischCharset, turkishCharset);
+   * 
+   * // The following assertion fails:
+   * assertThat(fileUTF8).usingCharset(StandardCharsets.UTF_8).hasSameContentAs(fileTurkischCharset, StandardCharsets.UTF_8);</code></pre>
+   * 
+   * @param expected the given {@code File} to compare the actual {@code File} to.
+   * @param expectedCharset the {@Charset} used to read the content of the expected file.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code File} is {@code null}.
+   * @throws IllegalArgumentException if the given {@code File} is not an existing file.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws RuntimeIOException if an I/O error occurs.
+   * @throws AssertionError if the content of the actual {@code File} is not equal to the content of the given one.
+   */
+  public S hasSameContentAs(File expected, Charset expectedCharset) {
+      files.assertSameContentAs(info, actual, charset, expected, expectedCharset);
       return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -121,9 +121,41 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * @throws PathsException if an I/O error occurs.
    */
   public S hasSameContentAs(Path expected) {
-	paths.assertHasSameContentAs(info, actual, charset, expected);
+	paths.assertHasSameContentAs(info, actual, charset, expected, Charset.defaultCharset());
 	return myself;
   }
+
+  /**
+   * Verifies that the content of the actual {@code Path} is the same as the given one (both paths must be a readable
+   * files).
+   * The charset to use when reading the actual path can be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
+   * 
+   * Examples:
+   * <pre><code class="java"> Path fileUTF8Charset = Files.write(Paths.get("actual"), Collections.singleton("Gerçek"), StandardCharsets.UTF_8);
+   * Charset turkishCharset = Charset.forName("windows-1254");
+   * Path fileTurkischCharset = Files.write(Paths.get("expected"), Collections.singleton("Gerçek"), turkishCharset);
+   * 
+   * // The following assertion succeeds:
+   * assertThat(fileUTF8Charset).usingCharset(StandardCharsets.UTF_8).hasSameContentAs(fileTurkischCharset, turkishCharset);
+   * 
+   * // The following assertion fails:
+   * assertThat(fileUTF8Charset).usingCharset(StandardCharsets.UTF_8).hasSameContentAs(fileTurkischCharset, StandardCharsets.UTF_8);</code></pre>
+   * 
+   * @param expected the given {@code Path} to compare the actual {@code Path} to.
+   * @param expectedCharset the {@Charset} used to read the content of the expected Path.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Path} is {@code null}.
+   * @throws AssertionError if the actual or given {@code Path} is not an existing readable file.
+   * @throws AssertionError if the actual {@code Path} is {@code null}.
+   * @throws AssertionError if the content of the actual {@code Path} is not equal to the content of the given one.
+   * @throws PathsException if an I/O error occurs.
+   */
+  public S hasSameContentAs(Path expected, Charset expectedCharset) {
+      paths.assertHasSameContentAs(info, actual, charset, expected, expectedCharset);
+      return myself;
+    }
 
   /**
    * Verifies that the binary content of the actual {@code Path} is <b>exactly</b> equal to the given one.

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -92,16 +92,22 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
 
   /**
    * Verifies that the content of the actual {@code Path} is the same as the given one (both paths must be a readable
-   * files). The default charset is used to read each files.
+   * files).
+   * The charset to use when reading the actual path can be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
    * 
    * Examples:
    * <pre><code class="java"> // use the default charset
    * Path xFile = Files.write(Paths.get("xfile.txt"), "The Truth Is Out There".getBytes());
+   * Path xFileUTF8 = Files.write(Paths.get("xfile-clone.txt"), "The Truth Is Out There".getBytes("UTF-8"));
    * Path xFileClone = Files.write(Paths.get("xfile-clone.txt"), "The Truth Is Out There".getBytes());
    * Path xFileFrench = Files.write(Paths.get("xfile-french.txt"), "La Vérité Est Ailleurs".getBytes());
    * 
    * // The following assertion succeeds (default charset is used):
    * assertThat(xFile).hasSameContentAs(xFileClone);
+   * // The following assertion succeeds (UTF-8 charset is used to read xFile):
+   * assertThat(xFileUTF8).usingCharset("UTF-8").hasContent(xFileClone);
    * 
    * // The following assertion fails:
    * assertThat(xFile).hasSameContentAs(xFileFrench);</code></pre>
@@ -115,7 +121,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
    * @throws PathsException if an I/O error occurs.
    */
   public S hasSameContentAs(Path expected) {
-	paths.assertHasSameContentAs(info, actual, expected);
+	paths.assertHasSameContentAs(info, actual, charset, expected);
 	return myself;
   }
 
@@ -195,7 +201,7 @@ public abstract class AbstractPathAssert<S extends AbstractPathAssert<S>> extend
   /**
    * Verifies that the text content of the actual {@code Path} (which must be a readable file) is <b>exactly</b> equal
    * to the given one.<br/>
-   * The charset to use when reading the file should be provided with {@link #usingCharset(Charset)} or
+   * The charset to use when reading the actual path should be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
    * {@link Charset#defaultCharset()}) will be used.
    * 

--- a/src/main/java/org/assertj/core/internal/Diff.java
+++ b/src/main/java/org/assertj/core/internal/Diff.java
@@ -52,14 +52,13 @@ public class Diff {
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(File actual, File expected) throws IOException {
-    return diff(actual.toPath(), expected.toPath());
+  public List<Delta<String>> diff(File actual, Charset actualCharset, File expected) throws IOException {
+    return diff(actual.toPath(), actualCharset, expected.toPath());
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(Path actual, Path expected) throws IOException {
-    Charset defaultCharset = Charset.defaultCharset();
-    return diff(newBufferedReader(actual, defaultCharset), newBufferedReader(expected, defaultCharset));
+  public List<Delta<String>> diff(Path actual, Charset actualCharset, Path expected) throws IOException {
+    return diff(newBufferedReader(actual, actualCharset), newBufferedReader(expected, Charset.defaultCharset()));
   }
 
   @VisibleForTesting

--- a/src/main/java/org/assertj/core/internal/Diff.java
+++ b/src/main/java/org/assertj/core/internal/Diff.java
@@ -52,13 +52,13 @@ public class Diff {
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(File actual, Charset actualCharset, File expected) throws IOException {
-    return diff(actual.toPath(), actualCharset, expected.toPath());
+  public List<Delta<String>> diff(File actual, Charset actualCharset, File expected, Charset expectedCharset) throws IOException {
+    return diff(actual.toPath(), actualCharset, expected.toPath(), expectedCharset);
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(Path actual, Charset actualCharset, Path expected) throws IOException {
-    return diff(newBufferedReader(actual, actualCharset), newBufferedReader(expected, Charset.defaultCharset()));
+  public List<Delta<String>> diff(Path actual, Charset actualCharset, Path expected, Charset expectedCharset) throws IOException {
+    return diff(newBufferedReader(actual, actualCharset), newBufferedReader(expected, expectedCharset));
   }
 
   @VisibleForTesting

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -86,11 +86,11 @@ public class Files {
    * @throws RuntimeIOException if an I/O error occurs.
    * @throws AssertionError if the given files do not have same content.
    */
-  public void assertSameContentAs(AssertionInfo info, File actual, Charset actualCharset, File expected) {
+  public void assertSameContentAs(AssertionInfo info, File actual, Charset actualCharset, File expected, Charset expectedCharset) {
     verifyIsFile(expected);
     assertIsFile(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected);
+      List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -77,6 +77,7 @@ public class Files {
    * href="http://sourceforge.net/projects/junit-addons">JUnit-addons</a>.)
    * @param info contains information about the assertion.
    * @param actual the "actual" file.
+   * @param charset of the "actual" file.
    * @param expected the "expected" file.
    * @throws NullPointerException if {@code expected} is {@code null}.
    * @throws IllegalArgumentException if {@code expected} is not an existing file.
@@ -85,11 +86,11 @@ public class Files {
    * @throws RuntimeIOException if an I/O error occurs.
    * @throws AssertionError if the given files do not have same content.
    */
-  public void assertSameContentAs(AssertionInfo info, File actual, File expected) {
+  public void assertSameContentAs(AssertionInfo info, File actual, Charset actualCharset, File expected) {
     verifyIsFile(expected);
     assertIsFile(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, expected);
+      List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -295,7 +295,7 @@ public class Paths {
 	}
   }
 
-  public void assertHasSameContentAs(AssertionInfo info, Path actual, Path expected) {
+  public void assertHasSameContentAs(AssertionInfo info, Path actual, Charset actualCharset, Path expected) {
 	// @format:off
     checkNotNull(expected, "The given Path to compare actual content to should not be null");
 	if (!nioFilesWrapper.isReadable(expected))
@@ -303,7 +303,7 @@ public class Paths {
 	// @format:on
 	assertIsReadable(info, actual);
 	try {
-	  List<Delta<String>> diffs = diff.diff(actual, expected);
+	  List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected);
 	  if (diffs.isEmpty()) return;
 	  throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
 	} catch (IOException e) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -295,7 +295,7 @@ public class Paths {
 	}
   }
 
-  public void assertHasSameContentAs(AssertionInfo info, Path actual, Charset actualCharset, Path expected) {
+  public void assertHasSameContentAs(AssertionInfo info, Path actual, Charset actualCharset, Path expected, Charset expectedCharset) {
 	// @format:off
     checkNotNull(expected, "The given Path to compare actual content to should not be null");
 	if (!nioFilesWrapper.isReadable(expected))
@@ -303,7 +303,7 @@ public class Paths {
 	// @format:on
 	assertIsReadable(info, actual);
 	try {
-	  List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected);
+	  List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
 	  if (diffs.isEmpty()) return;
 	  throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
 	} catch (IOException e) {

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
@@ -12,14 +12,21 @@
  */
 package org.assertj.core.api.file;
 
+import static java.nio.charset.Charset.defaultCharset;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
-
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link FileAssert#hasSameContentAs(java.io.File)}</code>.
@@ -42,6 +49,25 @@ public class FileAssert_hasSameContentAs_Test extends FileAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(files).assertSameContentAs(getInfo(assertions), getActual(assertions), expected);
+    verify(files).assertSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected);
+  }
+
+  @Test
+  public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
+    Charset turkishCharset = Charset.forName("windows-1254");
+
+    Path actual = createDeleteOnExitTempFile();
+    Files.write(actual, asList("Gerçek"), turkishCharset);
+
+    Path expected = createDeleteOnExitTempFile();
+    Files.write(expected, "Gerçek".getBytes());
+
+    assertThat(actual.toFile()).usingCharset(turkishCharset).hasSameContentAs(expected.toFile());
+  }
+
+  private Path createDeleteOnExitTempFile() throws IOException {
+    Path expected = Files.createTempFile("test", "test");
+    expected.toFile().deleteOnExit();
+    return expected;
   }
 }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasSameContentAs_Test.java
@@ -49,25 +49,31 @@ public class FileAssert_hasSameContentAs_Test extends FileAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(files).assertSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected);
+    verify(files).assertSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected, defaultCharset());
   }
 
   @Test
   public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
     Charset turkishCharset = Charset.forName("windows-1254");
+    File actual = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
+    File expected = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
 
-    Path actual = createDeleteOnExitTempFile();
-    Files.write(actual, asList("Gerçek"), turkishCharset);
-
-    Path expected = createDeleteOnExitTempFile();
-    Files.write(expected, "Gerçek".getBytes());
-
-    assertThat(actual.toFile()).usingCharset(turkishCharset).hasSameContentAs(expected.toFile());
+    assertThat(actual).usingCharset(turkishCharset).hasSameContentAs(expected);
   }
 
-  private Path createDeleteOnExitTempFile() throws IOException {
-    Path expected = Files.createTempFile("test", "test");
-    expected.toFile().deleteOnExit();
-    return expected;
+  @Test
+  public void should_allow_charset_to_be_specified_for_reading_expected_file_content() throws Exception {
+    Charset turkishCharset = Charset.forName("windows-1254");
+    File actual = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
+    File expected = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
+
+    assertThat(actual).hasSameContentAs(expected, turkishCharset);
+  }
+
+  private File createDeleteOnExitTempFileWithContent(String content, Charset charset) throws IOException {
+    Path tempFile = Files.createTempFile("test", "test");
+    tempFile.toFile().deleteOnExit();
+    Files.write(tempFile, asList(content), charset);
+    return tempFile.toFile();
   }
 }

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
@@ -47,25 +47,31 @@ public class PathAssert_hasSameContentAs_Test extends PathAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-	verify(paths).assertHasSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected);
+	verify(paths).assertHasSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected, defaultCharset());
   }
   
   @Test
-  public void should_use_charset_specified_by_usingCharset_to_read_actual_path_content() throws Exception {
+  public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
     Charset turkishCharset = Charset.forName("windows-1254");
-
-    Path actual = createDeleteOnExitTempFile();
-    Files.write(actual, asList("Gerçek"), turkishCharset);
-
-    Path expected = createDeleteOnExitTempFile();
-    Files.write(expected, "Gerçek".getBytes());
+    Path actual = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
+    Path expected = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
 
     assertThat(actual).usingCharset(turkishCharset).hasSameContentAs(expected);
   }
 
-  private Path createDeleteOnExitTempFile() throws IOException {
-    Path expected = Files.createTempFile("test", "test");
-    expected.toFile().deleteOnExit();
-    return expected;
+  @Test
+  public void should_allow_charset_to_be_specified_for_reading_expected_file_content() throws Exception {
+    Charset turkishCharset = Charset.forName("windows-1254");
+    Path actual = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
+    Path expected = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
+
+    assertThat(actual).hasSameContentAs(expected, turkishCharset);
+  }
+
+  private Path createDeleteOnExitTempFileWithContent(String content, Charset charset) throws IOException {
+    Path tempFile = Files.createTempFile("test", "test");
+    tempFile.toFile().deleteOnExit();
+    Files.write(tempFile, asList(content), charset);
+    return tempFile;
   }
 }

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
@@ -12,14 +12,21 @@
  */
 package org.assertj.core.api.path;
 
+import static java.nio.charset.Charset.defaultCharset;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.assertj.core.api.PathAssert;
 import org.assertj.core.api.PathAssertBaseTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link PathAssert#hasSameContentAs(java.nio.file.Path)}</code>.
@@ -40,6 +47,25 @@ public class PathAssert_hasSameContentAs_Test extends PathAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-	verify(paths).assertHasSameContentAs(getInfo(assertions), getActual(assertions), expected);
+	verify(paths).assertHasSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected);
+  }
+  
+  @Test
+  public void should_use_charset_specified_by_usingCharset_to_read_actual_path_content() throws Exception {
+    Charset turkishCharset = Charset.forName("windows-1254");
+
+    Path actual = createDeleteOnExitTempFile();
+    Files.write(actual, asList("Gerçek"), turkishCharset);
+
+    Path expected = createDeleteOnExitTempFile();
+    Files.write(expected, "Gerçek".getBytes());
+
+    assertThat(actual).usingCharset(turkishCharset).hasSameContentAs(expected);
+  }
+
+  private Path createDeleteOnExitTempFile() throws IOException {
+    Path expected = Files.createTempFile("test", "test");
+    expected.toFile().deleteOnExit();
+    return expected;
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.files;
 
 import static java.lang.String.format;
+import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.assertj.core.util.Arrays.array;
@@ -63,7 +64,7 @@ public class Diff_diff_File_Test {
     String[] content = array("line0", "line1");
     writer.write(actual, content);
     writer.write(expected, content);
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).isEmpty();
   }
 
@@ -71,7 +72,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_files_do_not_have_equal_content() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line0", "line1");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -86,7 +87,7 @@ public class Diff_diff_File_Test {
   public void should_return_multiple_diffs_if_files_contain_multiple_differences() throws IOException {
     writer.write(actual, "line_0", "line1", "line_2");
     writer.write(expected, "line0", "line1", "line2");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).hasSize(2);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -106,7 +107,7 @@ public class Diff_diff_File_Test {
     writer.write(actual,   "line1",                     "line2", "line3", "line4", "line5", "line 9", "line 10", "line 11");
     writer.write(expected, "line1", "line1a", "line1b", "line2", "line3", "line7", "line5");
     // @format:on
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).hasSize(3);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line1a\",%n"
@@ -126,7 +127,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0");
     writer.write(expected, "line_0", "line_1");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -136,7 +137,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line_0");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
@@ -64,7 +64,7 @@ public class Diff_diff_File_Test {
     String[] content = array("line0", "line1");
     writer.write(actual, content);
     writer.write(expected, content);
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).isEmpty();
   }
 
@@ -72,7 +72,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_files_do_not_have_equal_content() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line0", "line1");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -87,7 +87,7 @@ public class Diff_diff_File_Test {
   public void should_return_multiple_diffs_if_files_contain_multiple_differences() throws IOException {
     writer.write(actual, "line_0", "line1", "line_2");
     writer.write(expected, "line0", "line1", "line2");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(2);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -107,7 +107,7 @@ public class Diff_diff_File_Test {
     writer.write(actual,   "line1",                     "line2", "line3", "line4", "line5", "line 9", "line 10", "line 11");
     writer.write(expected, "line1", "line1a", "line1b", "line2", "line3", "line7", "line5");
     // @format:on
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(3);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line1a\",%n"
@@ -127,7 +127,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0");
     writer.write(expected, "line_0", "line_1");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -137,7 +137,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line_0");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected);
+    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));

--- a/src/test/java/org/assertj/core/internal/files/Files_assertEqualContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertEqualContent_Test.java
@@ -58,20 +58,20 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
   @Test
   public void should_throw_error_if_expected_is_null() {
     thrown.expectNullPointerException("The file to compare to should not be null");
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null, defaultCharset());
   }
 
   @Test
   public void should_throw_error_if_expected_is_not_file() {
     thrown.expectIllegalArgumentException("Expected file:<'xyz'> should be an existing file");
     File notAFile = new File("xyz");
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile, defaultCharset());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected);
+    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected, defaultCharset());
   }
 
   @Test
@@ -79,7 +79,7 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
     try {
-      files.assertSameContentAs(info, notAFile, defaultCharset(), expected);
+      files.assertSameContentAs(info, notAFile, defaultCharset(), expected, defaultCharset());
     } catch (AssertionError e) {
       verify(failures).failure(info, shouldBeFile(notAFile));
       return;
@@ -89,16 +89,16 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
 
   @Test
   public void should_pass_if_files_have_equal_content() throws IOException {
-    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(new ArrayList<Delta<String>>());
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(new ArrayList<Delta<String>>());
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected, defaultCharset());
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
     IOException cause = new IOException();
-    when(diff.diff(actual, defaultCharset(), expected)).thenThrow(cause);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenThrow(cause);
     try {
-      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
+      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected, defaultCharset());
       fail("Expected a RuntimeIOException to be thrown");
     } catch (RuntimeIOException e) {
       assertThat(e.getCause()).isSameAs(cause);
@@ -108,10 +108,10 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
   @Test
   public void should_fail_if_files_do_not_have_equal_content() throws IOException {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
-    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(diffs);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(diffs);
     AssertionInfo info = someInfo();
     try {
-      files.assertSameContentAs(info, actual, defaultCharset(), expected);
+      files.assertSameContentAs(info, actual, defaultCharset(), expected, defaultCharset());
     } catch (AssertionError e) {
       verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
       return;

--- a/src/test/java/org/assertj/core/internal/files/Files_assertEqualContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertEqualContent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.files;
 
+import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
@@ -57,20 +58,20 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
   @Test
   public void should_throw_error_if_expected_is_null() {
     thrown.expectNullPointerException("The file to compare to should not be null");
-    files.assertSameContentAs(someInfo(), actual, null);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null);
   }
 
   @Test
   public void should_throw_error_if_expected_is_not_file() {
     thrown.expectIllegalArgumentException("Expected file:<'xyz'> should be an existing file");
     File notAFile = new File("xyz");
-    files.assertSameContentAs(someInfo(), actual, notAFile);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    files.assertSameContentAs(someInfo(), null, expected);
+    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected);
   }
 
   @Test
@@ -78,7 +79,7 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
     try {
-      files.assertSameContentAs(info, notAFile, expected);
+      files.assertSameContentAs(info, notAFile, defaultCharset(), expected);
     } catch (AssertionError e) {
       verify(failures).failure(info, shouldBeFile(notAFile));
       return;
@@ -88,16 +89,16 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
 
   @Test
   public void should_pass_if_files_have_equal_content() throws IOException {
-    when(diff.diff(actual, expected)).thenReturn(new ArrayList<Delta<String>>());
-    files.assertSameContentAs(someInfo(), actual, expected);
+    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(new ArrayList<Delta<String>>());
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
     IOException cause = new IOException();
-    when(diff.diff(actual, expected)).thenThrow(cause);
+    when(diff.diff(actual, defaultCharset(), expected)).thenThrow(cause);
     try {
-      files.assertSameContentAs(someInfo(), actual, expected);
+      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
       fail("Expected a RuntimeIOException to be thrown");
     } catch (RuntimeIOException e) {
       assertThat(e.getCause()).isSameAs(cause);
@@ -107,10 +108,10 @@ public class Files_assertEqualContent_Test extends FilesBaseTest {
   @Test
   public void should_fail_if_files_do_not_have_equal_content() throws IOException {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
-    when(diff.diff(actual, expected)).thenReturn(diffs);
+    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(diffs);
     AssertionInfo info = someInfo();
     try {
-      files.assertSameContentAs(info, actual, expected);
+      files.assertSameContentAs(info, actual, defaultCharset(), expected);
     } catch (AssertionError e) {
       verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
       return;

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -56,20 +56,20 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
   @Test
   public void should_throw_error_if_expected_is_null() {
     thrown.expectNullPointerException("The file to compare to should not be null");
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null, defaultCharset());
   }
 
   @Test
   public void should_throw_error_if_expected_is_not_file() {
     thrown.expectIllegalArgumentException("Expected file:<'xyz'> should be an existing file");
     File notAFile = new File("xyz");
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile, defaultCharset());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected);
+    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected, defaultCharset());
   }
 
   @Test
@@ -77,7 +77,7 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
     try {
-      files.assertSameContentAs(info, notAFile, defaultCharset(), expected);
+      files.assertSameContentAs(info, notAFile, defaultCharset(), expected, defaultCharset());
     } catch (AssertionError e) {
       verify(failures).failure(info, shouldBeFile(notAFile));
       return;
@@ -87,16 +87,16 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   public void should_pass_if_files_have_equal_content() throws IOException {
-    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(new ArrayList<Delta<String>>());
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(new ArrayList<Delta<String>>());
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected, defaultCharset());
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
     IOException cause = new IOException();
-    when(diff.diff(actual, defaultCharset(), expected)).thenThrow(cause);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenThrow(cause);
     try {
-      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
+      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected, defaultCharset());
       fail("Expected a RuntimeIOException to be thrown");
     } catch (RuntimeIOException e) {
       assertThat(e.getCause()).isSameAs(cause);
@@ -106,10 +106,10 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
   @Test
   public void should_fail_if_files_do_not_have_equal_content() throws IOException {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
-    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(diffs);
+    when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(diffs);
     AssertionInfo info = someInfo();
     try {
-      files.assertSameContentAs(info, actual, defaultCharset(), expected);
+      files.assertSameContentAs(info, actual, defaultCharset(), expected, defaultCharset());
     } catch (AssertionError e) {
       verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
       return;

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.files;
 
+import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
@@ -55,20 +56,20 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
   @Test
   public void should_throw_error_if_expected_is_null() {
     thrown.expectNullPointerException("The file to compare to should not be null");
-    files.assertSameContentAs(someInfo(), actual, null);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), null);
   }
 
   @Test
   public void should_throw_error_if_expected_is_not_file() {
     thrown.expectIllegalArgumentException("Expected file:<'xyz'> should be an existing file");
     File notAFile = new File("xyz");
-    files.assertSameContentAs(someInfo(), actual, notAFile);
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), notAFile);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    files.assertSameContentAs(someInfo(), null, expected);
+    files.assertSameContentAs(someInfo(), null, defaultCharset(), expected);
   }
 
   @Test
@@ -76,7 +77,7 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
     try {
-      files.assertSameContentAs(info, notAFile, expected);
+      files.assertSameContentAs(info, notAFile, defaultCharset(), expected);
     } catch (AssertionError e) {
       verify(failures).failure(info, shouldBeFile(notAFile));
       return;
@@ -86,16 +87,16 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   public void should_pass_if_files_have_equal_content() throws IOException {
-    when(diff.diff(actual, expected)).thenReturn(new ArrayList<Delta<String>>());
-    files.assertSameContentAs(someInfo(), actual, expected);
+    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(new ArrayList<Delta<String>>());
+    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
     IOException cause = new IOException();
-    when(diff.diff(actual, expected)).thenThrow(cause);
+    when(diff.diff(actual, defaultCharset(), expected)).thenThrow(cause);
     try {
-      files.assertSameContentAs(someInfo(), actual, expected);
+      files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected);
       fail("Expected a RuntimeIOException to be thrown");
     } catch (RuntimeIOException e) {
       assertThat(e.getCause()).isSameAs(cause);
@@ -105,10 +106,10 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
   @Test
   public void should_fail_if_files_do_not_have_equal_content() throws IOException {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
-    when(diff.diff(actual, expected)).thenReturn(diffs);
+    when(diff.diff(actual, defaultCharset(), expected)).thenReturn(diffs);
     AssertionInfo info = someInfo();
     try {
-      files.assertSameContentAs(info, actual, expected);
+      files.assertSameContentAs(info, actual, defaultCharset(), expected);
     } catch (AssertionError e) {
       verify(failures).failure(info, ShouldHaveSameContent.shouldHaveSameContent(actual, expected, diffs));
       return;

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.paths;
 
 import static java.lang.String.format;
+import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
@@ -44,24 +45,24 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_path_has_same_content_as_other() throws IOException {
-	when(diff.diff(actual, other)).thenReturn(new ArrayList<Delta<String>>());
+	when(diff.diff(actual, defaultCharset(), other)).thenReturn(new ArrayList<Delta<String>>());
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
-	paths.assertHasSameContentAs(someInfo(), actual, other);
+	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other);
   }
 
   @Test
   public void should_throw_error_if_other_is_null() {
 	thrown.expectNullPointerException("The given Path to compare actual content to should not be null");
-	paths.assertHasSameContentAs(someInfo(), actual, null);
+	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), null);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
 	thrown.expectAssertionError(actualIsNull());
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
-	paths.assertHasSameContentAs(someInfo(), null, other);
+	paths.assertHasSameContentAs(someInfo(), null, defaultCharset(), other);
   }
 
   @Test
@@ -70,7 +71,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	when(nioFilesWrapper.exists(actual)).thenReturn(false);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(info, actual, other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
 	  return;
@@ -85,7 +86,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(info, actual, other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
 	  return;
@@ -98,7 +99,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	AssertionInfo info = someInfo();
 	when(nioFilesWrapper.isReadable(other)).thenReturn(false);
 	try {
-	  paths.assertHasSameContentAs(info, actual, other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
 	  failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
 	} catch (IllegalArgumentException e) {
 	  assertThat(e).hasMessage(format("The given Path <%s> to compare actual content to should be readable", other));
@@ -108,12 +109,12 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
 	IOException cause = new IOException();
-	when(diff.diff(actual, other)).thenThrow(cause);
+	when(diff.diff(actual, defaultCharset(), other)).thenThrow(cause);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(someInfo(), actual, other);
+	  paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other);
 	  failBecauseExceptionWasNotThrown(RuntimeIOException.class);
 	} catch (RuntimeIOException e) {
 	  assertThat(e.getCause()).isSameAs(cause);
@@ -124,13 +125,13 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   public void should_fail_if_actual_and_given_path_does_not_have_the_same_content() throws IOException {
     @SuppressWarnings("unchecked")
     List<Delta<String>> diffs = newArrayList((Delta<String>) mock(Delta.class));
-	when(diff.diff(actual, other)).thenReturn(diffs);
+	when(diff.diff(actual, defaultCharset(), other)).thenReturn(diffs);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	AssertionInfo info = someInfo();
 	try {
-	  paths.assertHasSameContentAs(info, actual, other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldHaveSameContent(actual, other, diffs));
 	  return;

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -45,24 +45,24 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_path_has_same_content_as_other() throws IOException {
-	when(diff.diff(actual, defaultCharset(), other)).thenReturn(new ArrayList<Delta<String>>());
+	when(diff.diff(actual, defaultCharset(), other, defaultCharset())).thenReturn(new ArrayList<Delta<String>>());
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
-	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other);
+	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other, defaultCharset());
   }
 
   @Test
   public void should_throw_error_if_other_is_null() {
 	thrown.expectNullPointerException("The given Path to compare actual content to should not be null");
-	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), null);
+	paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), null, defaultCharset());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
 	thrown.expectAssertionError(actualIsNull());
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
-	paths.assertHasSameContentAs(someInfo(), null, defaultCharset(), other);
+	paths.assertHasSameContentAs(someInfo(), null, defaultCharset(), other, defaultCharset());
   }
 
   @Test
@@ -71,7 +71,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	when(nioFilesWrapper.exists(actual)).thenReturn(false);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other, defaultCharset());
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
 	  return;
@@ -86,7 +86,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other, defaultCharset());
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
 	  return;
@@ -99,7 +99,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	AssertionInfo info = someInfo();
 	when(nioFilesWrapper.isReadable(other)).thenReturn(false);
 	try {
-	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other, defaultCharset());
 	  failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
 	} catch (IllegalArgumentException e) {
 	  assertThat(e).hasMessage(format("The given Path <%s> to compare actual content to should be readable", other));
@@ -109,12 +109,12 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
 	IOException cause = new IOException();
-	when(diff.diff(actual, defaultCharset(), other)).thenThrow(cause);
+	when(diff.diff(actual, defaultCharset(), other, defaultCharset())).thenThrow(cause);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	try {
-	  paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other);
+	  paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other, defaultCharset());
 	  failBecauseExceptionWasNotThrown(RuntimeIOException.class);
 	} catch (RuntimeIOException e) {
 	  assertThat(e.getCause()).isSameAs(cause);
@@ -125,13 +125,13 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   public void should_fail_if_actual_and_given_path_does_not_have_the_same_content() throws IOException {
     @SuppressWarnings("unchecked")
     List<Delta<String>> diffs = newArrayList((Delta<String>) mock(Delta.class));
-	when(diff.diff(actual, defaultCharset(), other)).thenReturn(diffs);
+	when(diff.diff(actual, defaultCharset(), other, defaultCharset())).thenReturn(diffs);
 	when(nioFilesWrapper.exists(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 	AssertionInfo info = someInfo();
 	try {
-	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other);
+	  paths.assertHasSameContentAs(info, actual, defaultCharset(), other, defaultCharset());
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldHaveSameContent(actual, other, diffs));
 	  return;


### PR DESCRIPTION
…o read the actual file/path (fixes #576)