### PR TITLE
add missing javadoc example to AbstractFileAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -50,7 +50,22 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} exists, regardless it's a file or directory.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * File tmpDir = Files.createTempDirectory(&quot;tmpDir&quot;).toFile();
    * 
+   * // assertions will pass
+   * assertThat(tmpFile).exists();
+   * assertThat(tmpDir).exists();
+   * 
+   * tmpFile.delete();
+   * tmpDir.delete();
+   *
+   * // assertions will fail
+   * assertThat(tmpFile).exists();
+   * assertThat(tmpDir).exists();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} does not exist.
@@ -62,7 +77,23 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} does not exist.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File parentDir = Files.createTempDirectory(&quot;tmpDir&quot;).toFile();
+   * File tmpDir = new File(parentDir, &quot;subDir&quot;);
+   * File tmpFile = new File(parentDir, &quot;a.txt&quot;);
    * 
+   * // assertions will pass
+   * assertThat(tmpDir).doesNotExist();
+   * assertThat(tmpFile).doesNotExist();
+   * 
+   * tmpDir.mkdir();
+   * tmpFile.createNewFile();
+   * 
+   * // assertions will fail
+   * assertThat(tmpFile).doesNotExist();
+   * assertThat(tmpDir).doesNotExist();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} exists.
@@ -74,7 +105,20 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} is an existing file.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
    * 
+   * // assertion will pass
+   * assertThat(tmpFile).isFile();
+   * 
+   * tmpFile.delete();
+   * File tmpDir = Files.createTempDirectory(&quot;tmpDir&quot;).toFile();
+   * 
+   * // assertions will fail
+   * assertThat(tmpFile).isFile();
+   * assertThat(tmpDir).isFile();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} is not an existing file.
@@ -86,7 +130,20 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} is an existing directory.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpDir = Files.createTempDirectory(&quot;tmpDir&quot;).toFile();
    * 
+   * // assertion will pass
+   * assertThat(tmpDir).isDirectory();
+   * 
+   * tmpDir.delete();
+   * File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * 
+   * // assertions will fail
+   * assertThat(tmpFile).isDirectory();
+   * assertThat(tmpDir).isDirectory();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} is not an existing file.
@@ -98,7 +155,18 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} is an absolute path.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File absoluteFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
    * 
+   * // assertions will pass
+   * assertThat(absoluteFile).isAbsolute();
+   * 
+   * File relativeFile = new File(&quot;./test&quot;);
+   * 
+   * // assertion will fail
+   * assertThat(relativeFile).isAbsolute();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} is not an absolute path.
@@ -110,7 +178,18 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the actual {@code File} is a relative path.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File relativeFile = new File(&quot;./test&quot;);
    * 
+   * // assertion will pass
+   * assertThat(relativeFile).isRelative();
+   * 
+   * File absoluteFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * 
+   * // assertion will fail
+   * assertThat(absoluteFile).isRelative();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} is not a relative path.
@@ -199,7 +278,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * The charset to use when reading the actual file can be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
    * {@link Charset#defaultCharset()}) will be used.
-   * 
+   * <p>
    * Examples:
    * <pre><code class="java"> File fileUTF8 = Files.write(Paths.get("actual"), Collections.singleton("Gerçek"), StandardCharsets.UTF_8).toFile();
    * Charset turkishCharset = Charset.forName("windows-1254");
@@ -210,7 +289,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * 
    * // The following assertion fails:
    * assertThat(fileUTF8).usingCharset(StandardCharsets.UTF_8).hasSameContentAs(fileTurkischCharset, StandardCharsets.UTF_8);</code></pre>
-   * 
+   * </p>
    * @param expected the given {@code File} to compare the actual {@code File} to.
    * @param expectedCharset the {@Charset} used to read the content of the expected file.
    * @return {@code this} assertion object.
@@ -228,7 +307,18 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
 
   /**
    * Verifies that the binary content of the actual {@code File} is <b>exactly</b> equal to the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File bin = File.createTempFile(&quot;tmp&quot;, &quot;bin&quot;);
+   * Files.write(bin.toPath(), new byte[] {1, 1});
    * 
+   * // assertion will pass
+   * assertThat(bin).hasBinaryContent(new byte[] {1, 1});
+   * 
+   * // assertions will fail
+   * assertThat(bin).hasBinaryContent(new byte[] { });
+   * assertThat(bin).hasBinaryContent(new byte[] {0, 0});</code></pre>
+   * </p> 
    * @param expected the expected binary content to compare the actual {@code File}'s content to.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given content is {@code null}.
@@ -272,7 +362,28 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * The charset to use when reading the file should be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
    * {@link Charset#defaultCharset()}) will be used.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use the default charset
+   * File xFile = Files.write(Paths.get(&quot;xfile.txt&quot;), &quot;The Truth Is Out There&quot;.getBytes()).toFile();
    * 
+   * // The following assertion succeeds (default charset is used):
+   * assertThat(xFile).hasContent(&quot;The Truth Is Out There&quot;);
+   * 
+   * // The following assertion fails:
+   * assertThat(xFile).hasContent(&quot;La Vérité Est Ailleurs&quot;);
+   * 
+   * // using a specific charset 
+   * Charset turkishCharset = Charset.forName(&quot;windows-1254&quot;);
+   * 
+   * File xFileTurkish = Files.write(Paths.get(&quot;xfile.turk&quot;), Collections.singleton(&quot;Gerçek&quot;), turkishCharset).toFile();
+   * 
+   * // The following assertion succeeds:
+   * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent(&quot;Gerçek&quot;);
+   * 
+   * // The following assertion fails :
+   * assertThat(xFileTurkish).usingCharset(StandardCharsets.UTF_8).hasContent(&quot;Gerçek&quot;);</code></pre>
+   * </p>
    * @param expected the expected text content to compare the actual {@code File}'s content to.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given content is {@code null}.
@@ -287,9 +398,23 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
   }
 
   /**
-   * 
    * Verifies that the actual {@code File} can be modified by the application.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * File tmpDir = Files.createTempDirectory(&quot;tmp&quot;).toFile();
    * 
+   * // assertions will pass
+   * assertThat(tmpFile).canWrite();
+   * assertThat(tmpDir).canWrite();
+   * 
+   * tmpFile.setReadOnly();
+   * tmpDir.setReadOnly();
+   * 
+   * // assertions will fail
+   * assertThat(tmpFile).canWrite();
+   * assertThat(tmpDir).canWrite();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} can not be modified by the application.
@@ -300,9 +425,23 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
   }
 
   /**
-   * 
    * Verifies that the actual {@code File} can be read by the application.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * File tmpDir = Files.createTempDirectory(&quot;tmp&quot;).toFile();
    * 
+   * // assertions will pass
+   * assertThat(tmpFile).canRead();
+   * assertThat(tmpDir).canRead();
+   * 
+   * tmpFile.setReadable(false);
+   * tmpDir.setReadable(false);
+   * 
+   * // assertions will fail
+   * assertThat(tmpFile).canRead();
+   * assertThat(tmpDir).canRead();</code></pre>
+   * </p>
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} can not be read by the application.


### PR DESCRIPTION
As far as I can tell https://github.com/joel-costigliola/assertj-core/issues/349 is now complete, at least for the 2.x branch. :smile: 