### PR TITLE
MWF nexient patch 1

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import java.util.List;
+
 public class AbstractSoftAssertions {
 
   protected final SoftProxies proxies;
@@ -23,7 +25,7 @@ public class AbstractSoftAssertions {
   protected <T, V> V proxy(Class<V> assertClass, Class<T> actualClass, T actual) {
     return proxies.create(assertClass, actualClass, actual);
   }
-  
+
   protected List<Throwable> errorsCollected(){
     return proxies.errorsCollected();
   }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -23,4 +23,8 @@ public class AbstractSoftAssertions {
   protected <T, V> V proxy(Class<V> assertClass, Class<T> actualClass, T actual) {
     return proxies.create(assertClass, actualClass, actual);
   }
+  
+  protected List<Throwable> errorsCollected(){
+    return proxies.errorsCollected();
+  }
 }

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.groups.Properties.extractProperty;
-
 import java.util.List;
+
+import static org.assertj.core.groups.Properties.extractProperty;
 
 /**
  * <p>
@@ -34,21 +34,21 @@ import java.util.List;
  *   then(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  * }</code></pre>
  * </p>
- * 
+ *
  * <p>
  * After running the test, JUnit provides us with the following exception message:
  * <pre><code class='java'> org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;</code></pre>
- * 
+ *
  * <p>
  * Oh no! A guest has been murdered! But where, how, and by whom?
  * </p>
- * 
+ *
  * <p>
  * Unfortunately frameworks like JUnit halt the test upon the first failed assertion. Therefore, to collect more
  * evidence, we'll have to rerun the test (perhaps after attaching a debugger or modifying the test to skip past the
  * first assertion). Given that hosting dinner parties takes a long time, this seems rather inefficient.
  * </p>
- * 
+ *
  * <p>
  * Instead let's change the test so that at its completion we get the result of all assertions at once. We can do that
  * by using a BDDSoftAssertions instance instead of the static methods on {@link BDDAssertions} as follows:
@@ -66,7 +66,7 @@ import java.util.List;
  *   softly.then(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.assertAll();
  * } </code></pre>
- * 
+ *
  * <p>
  * Now upon running the test our JUnit exception message is far more detailed:
  * <pre><code class='java'> org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
@@ -74,19 +74,19 @@ import java.util.List;
  * 2) [Library] expected:&lt;'[clean]'&gt; but was:&lt;'[messy]'&gt;
  * 3) [Candlestick] expected:&lt;'[pristine]'&gt; but was:&lt;'[bent]'&gt;
  * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;</code></pre>
- * 
+ *
  * <p>
  * Aha! It appears that perhaps the Professor used the candlestick to perform the nefarious deed in the library. We
  * should let the police take it from here.
  * </p>
- * 
+ *
  * <p>
  * BDDSoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link BDDAssertions}#then...) whose assertion failures are caught and stored. Only when you call
  * {@link BDDSoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of
  * those previously caught assertion failures.
  * </p>
- * 
+ *
  * <p>
  * Note that because BDDSoftAssertions is stateful you should use a new instance of BDDSoftAssertions per test method.
  * Also, if you forget to call assertAll() at the end of your test, the test <strong>will pass</strong> even if any
@@ -94,14 +94,14 @@ import java.util.List;
  * {@link JUnitBDDSoftAssertions} or {@link AutoCloseableBDDSoftAssertions} to get assertAll() to be called
  * automatically.
  * </p>
- * 
+ *
  * <p>
  * It is recommended to use {@link AbstractAssert#as(String, Object...)} so that the multiple failed assertions can be
  * easily distinguished from one another.
  * </p>
- * 
+ *
  * @author Brian Laframboise
- * 
+ *
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing assertions</a> for the
  *      inspiration
  */
@@ -113,7 +113,7 @@ public class BDDSoftAssertions extends AbstractBDDSoftAssertions {
    * @throws SoftAssertionError if any proxied assertion objects threw
    */
   public void assertAll() {
-	List<Throwable> errors = proxies.errorsCollected();
+	List<Throwable> errors = errorsCollected();
 	if (!errors.isEmpty()) {
 	  throw new SoftAssertionError(extractProperty("message", String.class).from(errors));
 	}

--- a/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
@@ -45,7 +45,7 @@ public class JUnitBDDSoftAssertions extends AbstractBDDSoftAssertions implements
 	  @Override
 	  public void evaluate() throws Throwable {
 		base.evaluate();
-		MultipleFailureException.assertEmpty(proxies.errorsCollected());
+		MultipleFailureException.assertEmpty(errorsCollected());
 	  }
 	};
   }

--- a/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
@@ -45,7 +45,7 @@ public class JUnitSoftAssertions extends AbstractStandardSoftAssertions implemen
 	  @Override
 	  public void evaluate() throws Throwable {
 		base.evaluate();
-		MultipleFailureException.assertEmpty(proxies.errorsCollected());
+		MultipleFailureException.assertEmpty(errorsCollected());
 	  }
 	};
   }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.groups.Properties.extractProperty;
-
 import java.util.List;
+
+import static org.assertj.core.groups.Properties.extractProperty;
 
 /**
  * <p>
@@ -33,21 +33,21 @@ import java.util.List;
  *   assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
  *   assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  * }</code></pre>
- * 
+ *
  * <p>
  * After running the test, JUnit provides us with the following exception message:
  * <pre><code class='java'> org.junit.ComparisonFailure: [Living Guests] expected:&lt;[7]&gt; but was:&lt;[6]&gt;</code></pre>
- * 
+ *
  * <p>
  * Oh no! A guest has been murdered! But where, how, and by whom?
  * </p>
- * 
+ *
  * <p>
  * Unfortunately frameworks like JUnit halt the test upon the first failed assertion. Therefore, to collect more
  * evidence, we'll have to rerun the test (perhaps after attaching a debugger or modifying the test to skip past the
  * first assertion). Given that hosting dinner parties takes a long time, this seems rather inefficient.
  * </p>
- * 
+ *
  * <p>
  * Instead let's change the test so that at its completion we get the result of all assertions at once. We can do that
  * by using a SoftAssertions instance instead of the static methods on {@link Assertions} as follows:
@@ -65,7 +65,7 @@ import java.util.List;
  *   softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
  *   softly.assertAll();
  * }</code></pre>
- * 
+ *
  * <p>
  * Now upon running the test our JUnit exception message is far more detailed:
  * <pre><code class='java'> org.assertj.core.api.SoftAssertionError: The following 4 assertions failed:
@@ -73,33 +73,33 @@ import java.util.List;
  * 2) [Library] expected:&lt;'[clean]'&gt; but was:&lt;'[messy]'&gt;
  * 3) [Candlestick] expected:&lt;'[pristine]'&gt; but was:&lt;'[bent]'&gt;
  * 4) [Professor] expected:&lt;'[well kempt]'&gt; but was:&lt;'[bloodied and disheveled]'&gt;</code></pre>
- * 
+ *
  * <p>
  * Aha! It appears that perhaps the Professor used the candlestick to perform the nefarious deed in the library. We
  * should let the police take it from here.
  * </p>
- * 
+ *
  * <p>
  * SoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link Assertions}#assertThat...) whose assertion failures are caught and stored. Only when you call
  * {@link SoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of those
  * previously caught assertion failures.
  * </p>
- * 
+ *
  * <p>
  * Note that because SoftAssertions is stateful you should use a new instance of SoftAssertions per test method. Also,
  * if you forget to call assertAll() at the end of your test, the test <strong>will pass</strong> even if any assertion
  * objects threw exceptions (because they're proxied, remember?). So don't forget. You might use
  * {@link JUnitSoftAssertions} or {@link AutoCloseableSoftAssertions} to get assertAll() to be called automatically.
  * </p>
- * 
+ *
  * <p>
  * It is recommended to use {@link AbstractAssert#as(String, Object...)} so that the multiple failed assertions can be
  * easily distinguished from one another.
  * </p>
- * 
+ *
  * @author Brian Laframboise
- * 
+ *
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing assertions</a> for the
  *      inspiration
  */
@@ -111,7 +111,7 @@ public class SoftAssertions extends AbstractStandardSoftAssertions {
    * @throws SoftAssertionError if any proxied assertion objects threw
    */
   public void assertAll() {
-	List<Throwable> errors = proxies.errorsCollected();
+	List<Throwable> errors = errorsCollected();
 	if (!errors.isEmpty()) {
 	  throw new SoftAssertionError(extractProperty("message", String.class).from(errors));
 	}

--- a/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsErrorsCollectedTest.java
+++ b/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsErrorsCollectedTest.java
@@ -1,0 +1,36 @@
+package org.assertj.core.api.abstract_; //Make sure that package-private access is lost
+
+import java.util.List;
+
+import org.assertj.core.api.AbstractStandardSoftAssertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This tests that classes extended from {@link AbstractStandardSoftAssertions} will have access to the list of
+ * collected errors that the various proxies have collected.
+ */
+public class SoftAssertionsErrorsCollectedTest{
+	private final Object        objectForTesting = null;
+	private final TestCollector softly           = new TestCollector();
+
+	@Test
+	public void return_empty_list_of_errors() throws Exception{
+		softly.assertThat(objectForTesting).isNull(); //No errors to collect
+		assertThat(softly.getErrors()).isEmpty();
+	}
+
+	@Test
+	public void returns_nonempty_list_of_errors() throws Exception{
+		softly.assertThat(objectForTesting).isNotNull(); //This should allow something to be collected
+		assertThat(softly.getErrors()).hasAtLeastOneElementOfType(Throwable.class);
+	}
+
+	private class TestCollector extends AbstractStandardSoftAssertions{
+		public List<Throwable> getErrors(){
+			return errorsCollected();
+		}
+	}
+}
+


### PR DESCRIPTION
This contribution attempts to close #598 by

1. adding errorsCollected() to AbstractSoftAssertions
2. removing the need from the various *SoftAssertion classes from accessing their proxies field directly
3. Testing that custom collectors with non-package access can access the errors they've collected