### PR TITLE
Fixed hasCode of MapEntry

### DIFF
--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -55,10 +55,7 @@ public class MapEntry<K, V> {
 
   @Override
   public int hashCode() {
-    int result = 1;
-    result = HASH_CODE_PRIME * result + hashCodeFor(key);
-    result = HASH_CODE_PRIME * result + hashCodeFor(value);
-    return result;
+    return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
   }
 
   @Override

--- a/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
@@ -67,4 +67,9 @@ public class MapEntry_equals_hashCode_Test {
   public void should_not_be_equal_to_MapEntry_with_different_value() {
     assertThat(entry.equals(entry("key0", "value0"))).isFalse();
   }
+
+  @Test
+  public void should_have_hashCode() {
+    assertThat(entry.hashCode()).isEqualTo("key".hashCode() ^ "value".hashCode());
+  }
 }


### PR DESCRIPTION
The MapEntry has a wrong implementation of the hashCode method. I have fixed it to meet the specification as defined at https://docs.oracle.com/javase/8/docs/api/index.html?java/util/Map.html