### PR TITLE
Fixed MapEntry hshCode method

### DIFF
--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -55,10 +55,7 @@ public class MapEntry<K, V> {
 
   @Override
   public int hashCode() {
-    int result = 1;
-    result = HASH_CODE_PRIME * result + hashCodeFor(key);
-    result = HASH_CODE_PRIME * result + hashCodeFor(value);
-    return result;
+    return hashCodeFor(key) ^ hashCodeFor(value);
   }
 
   @Override

--- a/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
@@ -67,4 +67,9 @@ public class MapEntry_equals_hashCode_Test {
   public void should_not_be_equal_to_MapEntry_with_different_value() {
     assertThat(entry.equals(entry("key0", "value0"))).isFalse();
   }
+
+  @Test
+  public void should_have_hashCode() {
+    assertThat(entry.hashCode()).isEqualTo("key".hashCode() ^ "value".hashCode());
+  }
 }


### PR DESCRIPTION
The hashCode method from MapEntry is not implemented as specified at https://docs.oracle.com/javase/8/docs/api/index.html?java/util/Map.html
I have adjusted the implementation to it.