### PR TITLE
Throwables.hasStackTraceContaining(String) 

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -149,6 +149,18 @@ public abstract class AbstractThrowableAssert<S extends AbstractThrowableAssert<
     throwables.assertHasMessageContaining(info, actual, description);
     return myself;
   }
+  /**
+   * Verifies that the stack trace of the actual {@code Throwable} contains with the given description.
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the stack trace of the actual {@code Throwable} does not contain the given description.
+   */
+  public S hasStackTraceContaining(String description) {
+    throwables.assertHasStackTraceContaining(info, actual, description);
+    return myself;
+  }
 
   /**
    * Verifies that the message of the actual {@code Throwable} matches with the given regular expression.

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -207,6 +207,33 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
   }
 
   /**
+   * Verifies that the stack trace of the actual {@code Throwable} contains with the given description.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -> {throw illegalArgumentException;})
+   *           .withStackTraceContaining("amount");
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -> {throw illegalArgumentException;})
+   *           .withStackTraceContaining("456");</code></pre>
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the stack trace of the actual {@code Throwable} does not contain the given description.
+   * @see AbstractThrowableAssert#hasStackTraceContaining(String)
+   */
+  public ThrowableAssertAlternative<T> withStackTraceContaining(String description) {
+    delegate.hasStackTraceContaining(description);
+    return this;
+  }
+  
+  /**
    * Verifies that the message of the actual {@code Throwable} matches with the given regular expression.
    * <p>
    * Examples:

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -28,6 +28,9 @@ import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Throwables.getRootCause;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -130,6 +133,22 @@ public class Throwables {
 	assertNotNull(info, actual);
 	if (actual.getMessage() != null && actual.getMessage().contains(description)) return;
 	throw failures.failure(info, shouldContain(actual.getMessage(), description));
+  }
+  
+  /**
+   * Asserts that the stack trace of the actual {@code Throwable} contains with the given description.
+   * 
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the stack trace of the actual {@code Throwable} does not contain the given description.
+   */
+  public void assertHasStackTraceContaining(AssertionInfo info, Throwable actual, String description) {
+    assertNotNull(info, actual);
+    String stackTrace = org.assertj.core.util.Throwables.getStackTrace(actual);
+    if (stackTrace != null && stackTrace.contains(description)) return;
+    throw failures.failure(info, shouldContain(stackTrace, description));
   }
 
   /**
@@ -243,4 +262,5 @@ public class Throwables {
   private static void assertNotNull(AssertionInfo info, Throwable actual) {
 	Objects.instance().assertNotNull(info, actual);
   }
+  
 }

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -28,9 +28,6 @@ import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Throwables.getRootCause;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -119,10 +119,11 @@ public final class Throwables {
   /**
    * Get the stack trace from a {@link Throwable} as a {@link String}.
    * 
-   * <p>The result of this method vary by JDK version as this method
-   * uses {@link Throwable#printStackTrace(java.io.PrintWriter)}.
-   * On JDK1.3 and earlier, the cause exception will not be shown
-   * unless the specified throwable alters printStackTrace.</p>
+   * <p>
+   * The result of this method vary by JDK version as this method uses
+   * {@link Throwable#printStackTrace(java.io.PrintWriter)}. On JDK1.3 and earlier, the cause exception will not be
+   * shown unless the specified throwable alters printStackTrace.
+   * </p>
    * 
    * @param throwable the {@code Throwable} to get stack trace from.
    * @return the stack trace as a {@link String}.
@@ -130,12 +131,19 @@ public final class Throwables {
    * @author Daniel Zlotin
    */
   public static String getStackTrace(Throwable throwable) {
-    final StringWriter sw = new StringWriter();
-    final PrintWriter pw = new PrintWriter(sw, true);
-    throwable.printStackTrace(pw);
-    return sw.getBuffer().toString();
+    StringWriter sw = null;
+    PrintWriter pw = null;
+    try {
+      sw = new StringWriter();
+      pw = new PrintWriter(sw, true);
+      throwable.printStackTrace(pw);
+      return sw.getBuffer().toString();
+    } finally
+    {
+      Closeables.closeQuietly(sw, pw);
+    }
   }
-  
+
   private Throwables() {
   }
 }

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -14,6 +14,8 @@ package org.assertj.core.util;
 
 import static org.assertj.core.util.Lists.newArrayList;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 
 /**
@@ -114,6 +116,26 @@ public final class Throwables {
     return throwable;
   }
 
+  /**
+   * Get the stack trace from a {@link Throwable} as a {@link String}.
+   * 
+   * <p>The result of this method vary by JDK version as this method
+   * uses {@link Throwable#printStackTrace(java.io.PrintWriter)}.
+   * On JDK1.3 and earlier, the cause exception will not be shown
+   * unless the specified throwable alters printStackTrace.</p>
+   * 
+   * @param throwable the {@code Throwable} to get stack trace from.
+   * @return the stack trace as a {@link String}.
+   * 
+   * @author Daniel Zlotin
+   */
+  public static String getStackTrace(Throwable throwable) {
+    final StringWriter sw = new StringWriter();
+    final PrintWriter pw = new PrintWriter(sw, true);
+    throwable.printStackTrace(pw);
+    return sw.getBuffer().toString();
+  }
+  
   private Throwables() {
   }
 }

--- a/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
@@ -30,6 +30,7 @@ public class ExpectThrowableAssert_isThrownBy_Test {
                                                      .withMessageStartingWith("this")
                                                      .withMessageEndingWith("too")
                                                      .withMessageMatching(".*is.*")
+                                                     .withStackTraceContaining("this")
                                                      .withCauseExactlyInstanceOf(IllegalArgumentException.class)
                                                      .withCauseInstanceOf(IllegalArgumentException.class);
     // @format:on

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasStackTraceContaining_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasStackTraceContaining_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasStackTraceContaining(String)}</code>.
+ * 
+ * @author Daniel Zlotin
+ */
+public class ThrowableAssert_hasStackTraceContaining_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasStackTraceContaining("able");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasStackTraceContaining(getInfo(assertions), getActual(assertions), "able");
+  }
+  
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.error.ShouldContainCharSequence.*;
+import static org.assertj.core.test.TestData.*;
+import static org.assertj.core.util.FailureMessages.*;
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Throwables;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Throwables#assertHasStackTraceContaining(AssertionInfo, Throwable, String)}</code>.
+ * 
+ * @author Daniel Zlotin
+ */
+public class Throwables_assertHasStackTraceContaining_Test extends ThrowablesBaseTest {
+
+  @Test
+  public void should_fail_if_actual_has_stacktrace_not_containing_with_expected_description() {
+    final AssertionInfo info = someInfo();
+    try {
+      throwables.assertHasStackTraceContaining(info, actual, "expected descirption part");
+      fail("AssertionError expected");
+    } catch (final AssertionError err) {
+      verify(failures).failure(info,
+                               shouldContain(org.assertj.core.util.Throwables.getStackTrace(actual),
+                                             "expected descirption part"));
+    }
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    throwables.assertHasStackTraceContaining(someInfo(), null, "Throwable");
+  }
+
+  @Test
+  public void should_pass_if_actual_has_stacktrace_containing_with_expected_description() {
+    throwables.assertHasStackTraceContaining(someInfo(), actual, "able");
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class Throwables_assertHasStackTraceContaining_Test extends ThrowablesBaseTest {
 
   @Test
-  public void should_fail_if_actual_has_stacktrace_not_containing_with_expected_description() {
+  public void should_fail_if_actual_has_stacktrace_not_containing_the_expected_description() {
     final AssertionInfo info = someInfo();
     try {
       throwables.assertHasStackTraceContaining(info, actual, "expected descirption part");
@@ -50,7 +50,7 @@ public class Throwables_assertHasStackTraceContaining_Test extends ThrowablesBas
   }
 
   @Test
-  public void should_pass_if_actual_has_stacktrace_containing_with_expected_description() {
+  public void should_pass_if_actual_has_stacktrace_containing_the_expected_description() {
     throwables.assertHasStackTraceContaining(someInfo(), actual, "able");
   }
 

--- a/src/test/java/org/assertj/core/util/Throwables_getStackTrace_Test.java
+++ b/src/test/java/org/assertj/core/util/Throwables_getStackTrace_Test.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link Throwables#getStackTrace(Throwable)}.
+ * 
+ * @author Daniel Zlotin
+ */
+public class Throwables_getStackTrace_Test {
+
+  @Test
+  public void calls_printStackTrace_with_temp_PrintWriter() throws Exception {
+    final Throwable mock = mock(Throwable.class);
+    Throwables.getStackTrace(mock);
+    verify(mock, times(1)).printStackTrace(isA(PrintWriter.class));
+  }
+
+  @Test
+  public void should_return_stacktrace_as_String() throws Exception {
+    final Throwable throwable = new Throwable("some message");
+    assertThat(Throwables.getStackTrace(throwable)).isInstanceOf(String.class)
+                                                   .contains("java.lang.Throwable: some message")
+                                                   .containsPattern("\tat .*\\(Throwables_getStackTrace_Test.java:\\d");
+  }
+
+}


### PR DESCRIPTION
see issue #607 
Also added util.Throwables.getStackTrace(Throwable) which converts the stack trace to String