### PR TITLE
Changed constructor of AbstractZonedDateTimeAssert to protected

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
@@ -699,7 +699,7 @@ public abstract class AbstractZonedDateTimeAssert<S extends AbstractZonedDateTim
     return actual.getYear() == other.getYear();
   }
 
-  AbstractZonedDateTimeAssert(ZonedDateTime actual, Class<?> selfType) {
+  protected AbstractZonedDateTimeAssert(ZonedDateTime actual, Class<?> selfType) {
     super(actual, selfType);
   }
 


### PR DESCRIPTION
Changed constructor of AbstractZonedDateTimeAssert to protected from package-private to allow custom extensions.