### PR TITLE
Allow to register custom object formatter in error messages #455

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -23,6 +23,7 @@ import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Conditions;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -431,6 +432,12 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
   @Override
   public S withThreadDumpOnError() {
     Failures.instance().enablePrintThreadDump();
+    return myself;
+  }
+
+  @Override
+  public S withErrorRepresentation(Representation representation) {
+    info.useRepresentation(representation);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -14,6 +14,8 @@ package org.assertj.core.api;
 
 import java.util.Comparator;
 
+import org.assertj.core.presentation.Representation;
+
 /**
  * Base contract of all assertion objects: the minimum functionality that any assertion object should provide.
  * 
@@ -563,4 +565,6 @@ public interface Assert<S extends Assert<S, A>, A> extends Descriptable<S>, Exte
    * @return this assertion object.
    */
   S withThreadDumpOnError();
+  
+  S withErrorRepresentation(Representation representation);
 }

--- a/src/main/java/org/assertj/core/api/WritableAssertionInfo.java
+++ b/src/main/java/org/assertj/core/api/WritableAssertionInfo.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static java.lang.String.format;
 
 import static org.assertj.core.api.DescriptionValidations.checkIsNotNull;
+import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.quote;
 
 import org.assertj.core.description.Description;
@@ -115,6 +116,7 @@ public class WritableAssertionInfo implements AssertionInfo {
   }
 
   public void useRepresentation(Representation newRepresentation) {
+    checkNotNull(newRepresentation, "The representation to use should not be null.");
     representation = newRepresentation;
   }
 
@@ -123,7 +125,7 @@ public class WritableAssertionInfo implements AssertionInfo {
    */
   @Override
   public String toString() {
-    String format = "%s[overridingErrorMessage=%s, description=%s]";
-    return format(format, getClass().getSimpleName(), quote(overridingErrorMessage()), quote(descriptionText()));
+    String format = "%s[overridingErrorMessage=%s, description=%s, representation=%s]";
+    return format(format, getClass().getSimpleName(), quote(overridingErrorMessage()), quote(descriptionText()), quote(representation()));
   }
 }

--- a/src/main/java/org/assertj/core/presentation/BinaryRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/BinaryRepresentation.java
@@ -88,4 +88,8 @@ public class BinaryRepresentation implements Representation {
     return String.format("%" + size + "s", value).replace(' ', '0');
   }
 
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName();
+  }
 }

--- a/src/main/java/org/assertj/core/presentation/HexadecimalRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/HexadecimalRepresentation.java
@@ -91,4 +91,8 @@ public class HexadecimalRepresentation implements Representation {
     return String.format("%0" + sizeInBits / NIBBLE_SIZE + "X", value);
   }
 
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName();
+  }
 }

--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -104,5 +104,10 @@ public class StandardRepresentation implements Representation {
   private static String toStringOf(SimpleDateFormat dateFormat) {
     return dateFormat.toPattern();
   }
+  
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName();
+  }
 
 }

--- a/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
@@ -21,7 +21,6 @@ import java.util.Formatter;
  */
 public class UnicodeRepresentation implements Representation {
 
-
   /**
    * Returns hexadecimal the {@code toString} representation of the given String or Character.
    *
@@ -57,4 +56,8 @@ public class UnicodeRepresentation implements Representation {
     return b.toString();
   }
 
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName();
+  }
 }

--- a/src/test/java/org/assertj/core/api/WritableAssertionInfo_toString_Test.java
+++ b/src/test/java/org/assertj/core/api/WritableAssertionInfo_toString_Test.java
@@ -43,6 +43,6 @@ public class WritableAssertionInfo_toString_Test {
   @Test
   public void should_implement_toString() {
     when(description.value()).thenReturn("Yoda");
-    assertThat(info.toString()).isEqualTo("WritableAssertionInfo[overridingErrorMessage='Jedi', description='Yoda']");
+    assertThat(info.toString()).isEqualTo("WritableAssertionInfo[overridingErrorMessage='Jedi', description='Yoda', representation=StandardRepresentation]");
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_withErrorRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_withErrorRepresentation_Test.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.ExpectedException.none;
+
+import java.util.Objects;
+
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class AbstractAssert_withErrorRepresentation_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Test
+  public void should_throw_error_if_description_is_null() {
+    thrown.expectNullPointerException("The representation to use should not be null.");
+    assertThat(new Example()).withErrorRepresentation(null);
+  }
+
+  @Test
+  public void should_be_able_to_use_a_custom_representation_for_error_messages() {
+    thrown.expectAssertionError("expected:<[null]> but was:<[Example]>");
+    assertThat(new Example()).withErrorRepresentation(new ExampleErrorRepresentation()).isNull();
+  }
+
+  private class Example {}
+
+  private class ExampleErrorRepresentation implements Representation {
+    @Override
+    public String toStringOf(Object o) {
+      if (o instanceof Example) return "Example";
+      return Objects.toString(o);
+    }
+  }
+}


### PR DESCRIPTION
I would like to use this feature, so I put together a quick prototype. If you rather not expose `Representation`, I'm open to every other approach.