### PR TITLE
Reuse empty Optional error message in other situations

### DIFF
--- a/src/main/java/org/assertj/core/error/OptionalShouldContain.java
+++ b/src/main/java/org/assertj/core/error/OptionalShouldContain.java
@@ -23,6 +23,8 @@ import java.util.OptionalLong;
  *
  * @author Jean-Christophe Gay
  * @author Nicolai Parlog
+ * @author Grzegorz Piwowarek
+ *
  */
 public class OptionalShouldContain extends BasicErrorMessageFactory {
 
@@ -46,7 +48,9 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static <T> OptionalShouldContain shouldContain(Optional<T> optional, T expectedValue) {
-    return new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue);
+    return optional.isPresent() ?
+            new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue) :
+            shouldContain(expectedValue);
   }
 
   /**
@@ -57,7 +61,9 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static OptionalShouldContain shouldContain(OptionalDouble optional, double expectedValue) {
-    return new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue);
+    return optional.isPresent() ?
+            new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue) :
+            shouldContain(expectedValue);
   }
 
   /**
@@ -68,7 +74,9 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static OptionalShouldContain shouldContain(OptionalInt optional, int expectedValue) {
-    return new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue);
+    return optional.isPresent() ?
+            new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue) :
+            shouldContain(expectedValue);
   }
 
   /**
@@ -79,7 +87,9 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static OptionalShouldContain shouldContain(OptionalLong optional, long expectedValue) {
-    return new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue);
+    return optional.isPresent() ?
+            new OptionalShouldContain(EXPECTING_TO_CONTAIN, optional, expectedValue) :
+            shouldContain(expectedValue);
   }
 
   /**
@@ -92,7 +102,9 @@ public class OptionalShouldContain extends BasicErrorMessageFactory {
    * @return a error message factory
    */
   public static <T> OptionalShouldContain shouldContainSame(Optional<T> optional, T expectedValue) {
-    return new OptionalShouldContain(EXPECTING_TO_CONTAIN_SAME, optional, expectedValue);
+    return optional.isPresent() ?
+            new OptionalShouldContain(EXPECTING_TO_CONTAIN_SAME, optional, expectedValue) :
+            shouldContain(expectedValue);
   }
 
   /**

--- a/src/test/java/org/assertj/core/error/OptionalShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldContain_create_Test.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class OptionalShouldContain_create_Test {
 
   @Test
-  public void should_create_error_message_when_optional_is_empty() {
+  public void should_create_error_message_when_value_not_present() {
     String errorMessage = shouldContain(10).create();
     assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
                                               "  <10>%n" +
@@ -45,6 +45,14 @@ public class OptionalShouldContain_create_Test {
   }
 
   @Test
+  public void should_create_error_message_when_optional_empty() {
+    String errorMessage = shouldContain(Optional.empty(), 10).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
+                                              "  <10>%n" +
+                                              "but was empty."));
+  }
+
+  @Test
   public void should_create_error_message_with_optionaldouble() {
     String errorMessage = shouldContain(OptionalDouble.of(20.0), 10.0).create();
     assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
@@ -52,6 +60,14 @@ public class OptionalShouldContain_create_Test {
                                               "to contain:%n" +
                                               "  <10.0>%n" +
                                               "but did not."));
+  }
+
+  @Test
+  public void should_create_error_message_with_empty_optionaldouble() {
+    String errorMessage = shouldContain(OptionalDouble.empty(), 10.0).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
+                                              "  <10.0>%n" +
+                                              "but was empty."));
   }
 
   @Test
@@ -65,6 +81,14 @@ public class OptionalShouldContain_create_Test {
   }
 
   @Test
+  public void should_create_error_message_with_empty_optionalint() {
+    String errorMessage = shouldContain(OptionalInt.empty(), 10).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
+                                              "  <10>%n" +
+                                              "but was empty."));
+  }
+
+  @Test
   public void should_create_error_message_with_optionallong() {
     String errorMessage = shouldContain(OptionalLong.of(20L), 10L).create();
     assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
@@ -75,8 +99,16 @@ public class OptionalShouldContain_create_Test {
   }
 
   @Test
+  public void should_create_error_message_with_empty_optionallong() {
+    String errorMessage = shouldContain(OptionalLong.empty(), 10L).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Optional to contain:%n" +
+                                              "  <10L>%n" +
+                                              "but was empty."));
+  }
+
+  @Test
   public void should_create_error_message_for_different_instances() {
-    String errorMessage = shouldContainSame(Optional.of(new Integer(10)), new Integer(10)).create();
+    String errorMessage = shouldContainSame(Optional.of(10), 10).create();
     assertThat(errorMessage).isEqualTo(format("%nExpecting:%n" +
                                        "  <Optional[10]>%n" +
                                        "to contain the instance (i.e. compared with ==):%n" +


### PR DESCRIPTION
When we are comparing Optional's content against something else and Optional turns out to be empty, we get:

`Expecting:
  <Optional.empty>
to contain:
  <10>
but did not."`

I made it reuse already defined error message for the empty Optional case:

`Expecting Optional to contain:
  <10>
but was empty."`