### PR TITLE
enable fluent assertions on size of list #301, #589

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractListAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractListAssert.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.assertj.core.data.Index;
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.*;
+import org.assertj.core.util.Preconditions;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -327,4 +328,9 @@ public abstract class AbstractListAssert<S extends AbstractListAssert<S, A, T>, 
     return super.withThreadDumpOnError();
   }
 
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public SizeAssert<Integer> size() {
+    Preconditions.checkNotNull(actual, "Can not assert on size of empty list.");
+    return new SizeAssert(this, actual.size());
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractSizeAssert.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.List;
+
+public abstract class AbstractSizeAssert<S extends AbstractListAssert<S, A, T>, A extends List<? extends T>, T> extends AbstractIntegerAssert<SizeAssert<Integer>>{
+
+  protected AbstractSizeAssert(Integer actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public abstract AbstractListAssert<S, A, T> returnToList();
+}

--- a/src/main/java/org/assertj/core/api/SizeAssert.java
+++ b/src/main/java/org/assertj/core/api/SizeAssert.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.List;
+
+public class SizeAssert<T> extends AbstractSizeAssert<ListAssert<T>, List<? extends T>, T>{
+  
+  private AbstractListAssert<ListAssert<T>, List<? extends T>, T> source;
+
+  public SizeAssert(AbstractListAssert<ListAssert<T>, List<? extends T>, T> source, Integer i) {
+    super(i, SizeAssert.class);
+    this.source = source;
+  }
+  
+  public AbstractListAssert<ListAssert<T>, List<? extends T>, T> returnToList() {
+    return source;
+  }
+}

--- a/src/test/java/org/assertj/core/api/list/ListAssert_size_Test.java
+++ b/src/test/java/org/assertj/core/api/list/ListAssert_size_Test.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.list;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.ExpectedException.none;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class ListAssert_size_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Test
+  public void should_be_able_to_use_integer_assertions_on_size_of_list() {
+    List<Integer> ints = Arrays.asList(1, 2, 3);
+    assertThat(ints).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToList().contains(1).doesNotContain(9);
+  }
+
+  @Test
+  public void should_have_nice_error_message_when_size_is_used_on_list_which_is_null() {
+    List<Integer> nullList = null;
+    thrown.expectNullPointerException("Can not assert on size of empty list.");
+    assertThat(nullList).size().isGreaterThan(1);
+  }
+}


### PR DESCRIPTION
I adopted the navigable assertion idea of assertj-db. 

It's different from assertj's current api, but having the option to use the following assertion chain:

```java
List<Integer> ints = Arrays.asList(1, 2, 3);
assertThat(ints).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToList().contains(1).doesNotContain(4);
```

is interesting I think.
