### PR TITLE
enable fluent assertions on size of list (#301, #589) and map

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -44,6 +44,8 @@ import org.assertj.core.internal.Iterables;
 import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.OnFieldsComparator;
+import org.assertj.core.util.IterableUtil;
+import org.assertj.core.util.Preconditions;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.IntrospectionError;
 
@@ -1514,5 +1516,11 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
   @Override
   public S withThreadDumpOnError() {
     return super.withThreadDumpOnError();
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public AbstractIterableSizeAssert<S, A, T> size() {
+    Preconditions.checkNotNull(actual, "Can not assert on size of iterable which is null.");
+    return new IterableSizeAssert(this, IterableUtil.sizeOf(actual));
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractIterableSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableSizeAssert.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+public abstract class AbstractIterableSizeAssert<S extends AbstractIterableAssert<S, A, T>, A extends Iterable<? extends T>, T>
+    extends AbstractIntegerAssert<AbstractIterableSizeAssert<S, A, T>> {
+
+  protected AbstractIterableSizeAssert(Integer actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public abstract AbstractIterableAssert<S, A, T> returnToIterable();
+}

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Maps;
+import org.assertj.core.util.Preconditions;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -840,5 +841,11 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
   @Override
   public S withThreadDumpOnError() {
     return super.withThreadDumpOnError();
+  }
+  
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public AbstractMapSizeAssert<S, A, K, V> size() {
+    Preconditions.checkNotNull(actual, "Can not assert on size of map which is null.");
+    return new MapSizeAssert(this, actual.size());
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractMapSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapSizeAssert.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.Map;
+
+public abstract class AbstractMapSizeAssert<S extends AbstractMapAssert<S, A, K, V>, A extends Map<K, V>, K, V>
+    extends AbstractIntegerAssert<AbstractMapSizeAssert<S, A, K, V>> {
+
+  protected AbstractMapSizeAssert(Integer actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public abstract AbstractMapAssert<S, A, K, V> returnToMap();
+}

--- a/src/main/java/org/assertj/core/api/IterableSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableSizeAssert.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+public class IterableSizeAssert<T> extends AbstractIterableSizeAssert<IterableAssert<T>, Iterable<? extends T>, T> {
+
+  private AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T> source;
+
+  public IterableSizeAssert(AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T> source, Integer i) {
+    super(i, IterableSizeAssert.class);
+    this.source = source;
+  }
+
+  public AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T> returnToIterable() {
+    return source;
+  }
+}

--- a/src/main/java/org/assertj/core/api/MapSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/MapSizeAssert.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.Map;
+
+public class MapSizeAssert<K, V> extends AbstractMapSizeAssert<MapAssert<K, V>, Map<K, V>, K, V> {
+
+  private AbstractMapAssert<MapAssert<K, V>, Map<K, V>, K, V> source;
+
+  public MapSizeAssert(AbstractMapAssert<MapAssert<K, V>, Map<K, V>, K, V> source, Integer i) {
+    super(i, MapSizeAssert.class);
+    this.source = source;
+  }
+
+  @Override
+  public AbstractMapAssert<MapAssert<K, V>, Map<K, V>, K, V> returnToMap() {
+    return source;
+  }
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_size_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_size_Test.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.ExpectedException.none;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class IterableAssert_size_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Test
+  public void should_be_able_to_use_integer_assertions_on_size_of_iterable() {
+    Iterable<String> strings = new HashSet<String>(Arrays.asList("a", "b", "c"));
+    assertThat(strings).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToIterable().contains("a").doesNotContain("d");
+
+    Iterable<Integer> integers = Arrays.asList(1, 2, 3);
+    assertThat(integers).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToIterable().contains(1).doesNotContain(4);
+  }
+
+  @Test
+  public void should_have_nice_error_message_when_size_is_used_on_iterable_which_is_null() {
+    Iterable<Integer> nullList = null;
+    thrown.expectNullPointerException("Can not assert on size of iterable which is null.");
+    assertThat(nullList).size().isGreaterThan(1);
+  }
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_size_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_size_Test.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.test.Maps.mapOf;
+
+import java.util.Map;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MapAssert_size_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_be_able_to_use_integer_assertions_on_size_of_map() {
+    Map<String, String> stringToString = mapOf(entry("a", "1"), entry("b", "2"));
+    assertThat(stringToString).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToMap().contains(entry("a", "1"));
+  }
+
+  @Test
+  public void should_have_nice_error_message_when_size_is_used_on_map_which_is_null() {
+    Map<String, String> nullMap = null;
+    thrown.expectNullPointerException("Can not assert on size of map which is null.");
+    assertThat(nullMap).size().isGreaterThan(1);
+  }
+}


### PR DESCRIPTION
I adopted the navigable assertion idea of assertj-db. 

It's different from assertj's current api, but having the option to use the following assertion chain:

```java
List<Integer> ints = Arrays.asList(1, 2, 3);
assertThat(ints).size().isGreaterThan(0).isLessThanOrEqualTo(3).returnToList().contains(1).doesNotContain(4);
```

is interesting I think. (This is a fixed version of #630. I had to create a new pull request as I could not reopen the old one.)