### PR TITLE
fixes #641 to add a NavigationListAssert for being able to navigate into elements in a list and chain assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AssertFactory.java
+++ b/src/main/java/org/assertj/core/api/AssertFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * A factory method to create an Assert class for a given type.
+ * This factory method typically wraps a call to <code>assertThat(t)</code> to map to the concrete assert type A
+ * for the element T.
+ * <br>
+ * This interface is typically used by navigation assertions on iterable types like {@link NavigationListAssert}
+ */
+public interface AssertFactory<T, A> {
+
+  /**
+   * Creates the custom Assert object for the given element value.
+   *
+   * Typically this will just invoke <code>assertThat(t)</code>
+   * @param t the type to convert to an Assert object
+   * @return returns <code>assertThat(t)</code>
+   */
+  A createAssert(T t);
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -396,6 +396,16 @@ public class Assertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link NavigationListAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static <T, TA extends AbstractAssert> NavigationListAssert<T, TA> assertThat(List<? extends T> actual, AssertFactory<T, TA> assertFactory) {
+    return new NavigationListAssert<>(actual, assertFactory);
+  }
+
+  /**
    * Creates a new instance of <code>{@link LongAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/NavigationListAssert.java
+++ b/src/main/java/org/assertj/core/api/NavigationListAssert.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.Iterables;
+import org.assertj.core.util.Descriptions;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Provides helper methods for navigating a list property in a generated assertion class so we can chain assertions
+ * through deeply nested models more easily.
+ */
+public class NavigationListAssert<T, EA extends AbstractAssert> extends ListAssert<T> {
+    private final AssertFactory<T, EA> assertFactory;
+
+    public NavigationListAssert(List<? extends T> actual, AssertFactory<T, EA> assertFactory) {
+        super(actual);
+        this.assertFactory = assertFactory;
+    }
+
+    /**
+     * Navigates to the first element in the list if the list is not empty
+     *
+     * @return the assertion on the first element
+     */
+    public EA first() {
+        isNotEmpty();
+        return toAssert(actual.get(0), Descriptions.navigateDescription(this, "first()"));
+    }
+
+    /**
+     * Navigates to the last element in the list if the list is not empty
+     *
+     * @return the assertion on the last element
+     */
+    public EA last() {
+        isNotEmpty();
+        return toAssert(actual.get(actual.size() - 1), Descriptions.navigateDescription(this, "last()"));
+    }
+
+    /**
+     * Navigates to the element at the given index if the index is within the range of the list
+     *
+     * @return the assertion on the given element
+     */
+    public EA item(int index) {
+        isNotEmpty();
+        assertThat(index).describedAs(Descriptions.navigateDescription(this, "index")).isGreaterThanOrEqualTo(0).isLessThan(actual.size());
+        return toAssert(actual.get(index), Descriptions.navigateDescription(this, "index(" + index + ")"));
+    }
+
+    protected EA toAssert(T value, String description) {
+        return (EA) assertFactory.createAssert(value).describedAs(description);
+    }
+}

--- a/src/main/java/org/assertj/core/util/Descriptions.java
+++ b/src/main/java/org/assertj/core/util/Descriptions.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Helper methods for working with descriptions
+ */
+public class Descriptions {
+
+  /**
+   * A helper method to create the description after navigating the assert class to a property or method call.
+   *
+   * If there is no description set on the asssert object then we use the class name to avoid using 'null'.
+   *
+   * @param asserter the assert object we are navigating from
+   * @param propertyName the text of the property, field or method call we are navigating into
+   * @return a combined description of the asserter and the navigation property, field or method call
+   */
+  public static String navigateDescription(AbstractAssert asserter, String propertyName) {
+    String text = asserter.descriptionText();
+    if (text == null || text.length() == 0) {
+      text = asserter.getClass().getSimpleName();
+      String postfix = "Assert";
+      if (text.endsWith(postfix)) {
+        text = text.substring(0, text.length() - postfix.length());
+      }
+    }
+    return text + "." + propertyName;
+  }
+
+  private Descriptions() {}
+
+}

--- a/src/test/java/org/assertj/core/navigation/ListNavigation_Test.java
+++ b/src/test/java/org/assertj/core/navigation/ListNavigation_Test.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.navigation;
+
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.NavigationListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.test.Vehicle;
+import org.assertj.core.test.VehicleFactory;
+import org.assertj.core.test.VehicleFactory.Car;
+import org.assertj.core.util.Descriptions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests navigating a generated Assert class with a List property
+ */
+public class ListNavigation_Test {
+  VehicleFactory vehicleFactory = new VehicleFactory();
+  List<Vehicle> expectedVehicles = vehicleFactory.getVehicles();
+
+  // if we had a generated assertion library for VehicleFactory this code would look more like
+  // NavigationListAssert<Vehicle, ObjectAssert> vehicles = assertThat(vehicleFactory).vehicles();
+
+  NavigationListAssert<Vehicle, ObjectAssert> vehicles = assertThat(expectedVehicles, new AssertFactory<Vehicle, ObjectAssert>() {
+    @Override
+    public ObjectAssert createAssert(Vehicle vehicle) {
+      return (ObjectAssert) assertThat(vehicle);
+    }
+  });
+
+  @Before
+  public void init() {
+    // Note this method wlould be generated in the VehicleFactoryAssert.vehicles() method
+    vehicles.describedAs(Descriptions.navigateDescription(assertThat(vehicleFactory).describedAs("VehicleFactory"), "vehicles"));
+  }
+
+  @Test
+  public void should_pass_assertions_on_list() throws Exception {
+    vehicles.first().isEqualTo(expectedVehicles.get(0));
+    vehicles.last().isEqualTo(expectedVehicles.get(expectedVehicles.size() - 1));
+    vehicles.item(2).isEqualTo(expectedVehicles.get(2));
+    vehicles.contains(expectedVehicles.get(1));
+    vehicles.containsOnly(expectedVehicles.get(1), expectedVehicles.get(2), expectedVehicles.get(0));
+    vehicles.containsExactly(expectedVehicles.get(0), expectedVehicles.get(1), expectedVehicles.get(2));
+    vehicles.doesNotContain(new Car("doesNotExist"), new Car("doesNotExist2"));
+  }
+
+  @Test
+  public void failing_tests() throws Exception {
+    assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        vehicles.item(10).isEqualTo(expectedVehicles.get(0));
+      }
+    }).hasMessageContaining("VehicleFactory.vehicles.index");
+
+    assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        vehicles.item(1).isEqualTo(expectedVehicles.get(2));
+      }
+    }).hasMessageContaining("VehicleFactory.vehicles.index");
+  }
+
+}

--- a/src/test/java/org/assertj/core/test/VehicleFactory.java
+++ b/src/test/java/org/assertj/core/test/VehicleFactory.java
@@ -29,7 +29,7 @@ public class VehicleFactory {
     return Arrays.asList(car1, car2, car3);
   }
 
-  static class Car implements Vehicle {
+  public static class Car implements Vehicle {
     private String brand;
 
     public Car(String brand) {
@@ -39,6 +39,11 @@ public class VehicleFactory {
     @Override
     public String getName() {
       return brand;
+    }
+
+    @Override
+    public String toString() {
+      return "Car(" + brand + ")";
     }
   }
 }


### PR DESCRIPTION
fixes #641 to add a NavigationListAssert for being able to navigate into elements in a list and chain assertions