### PR TITLE
add AbstractIterableAssert#hasOnlyOneElementSatisfying and ObjectArra…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -112,6 +113,11 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
   public S hasSize(int expected) {
     iterables.assertHasSize(info, actual, expected);
     return myself;
+  }
+
+  public void hasOnlyOneElementSatisfying(Consumer<T> elementAssertions) {
+    iterables.assertHasSize(info, actual, 1);
+    elementAssertions.accept(actual.iterator().next());
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -241,6 +242,11 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
   @Override
   public S containsOnlyElementsOf(Iterable<? extends T> iterable) {
     return containsOnly(toArray(iterable));
+  }
+
+  public void hasOnlyOneElementSatisfying(Consumer<T> elementAssertions) {
+    arrays.assertHasSize(info, actual, 1);
+    elementAssertions.accept(actual[0]);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasOnlyOneElementSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasOnlyOneElementSatisfying_Test.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.assertj.core.test.ExpectedException;
+import org.assertj.core.test.Jedi;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class IterableAssert_hasOnlyOneElementSatisfying_Test {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void succeeds_if_iterable_has_only_one_element_and_that_element_statisfies_the_given_assertion() {
+    List<Jedi> jedis = asList(new Jedi("Yoda", "red"));
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("Y"));
+  }
+
+  @Test
+  public void succeeds_if_iterable_has_only_one_element_and_that_element_statisfies_the_given_assertions() {
+    assertThat(asList(new Jedi("Yoda", "red"))).hasOnlyOneElementSatisfying(yoda -> {
+      assertThat(yoda.getName()).isEqualTo("Yoda");
+      assertThat(yoda.lightSaberColor).isEqualTo("red");
+    });
+  }
+
+  @Test
+  public void fails_if_iterable_has_only_one_element_and_that_element_does_not_statisfy_the_given_assertion() {
+    thrown.expectAssertionError("Expecting:%n <\"Yoda\">%nto start with:%n <\"L\">");
+    List<Jedi> jedis = asList(new Jedi("Yoda", "red"));
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("L"));
+  }
+
+  @Test
+  public void fails_if_iterable_has_more_than_one_element() {
+    thrown.expectAssertionError("Expected size:<1> but was:<2>");
+    List<Jedi> jedis = asList(new Jedi("Yoda", "red"), new Jedi("Luke", "green"));
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("Y"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasOnlyOneElementSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasOnlyOneElementSatisfying_Test.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.test.ExpectedException;
+import org.assertj.core.test.Jedi;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ObjectArrayAssert_hasOnlyOneElementSatisfying_Test {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void succeeds_if_array_has_only_one_element_and_that_element_statisfies_the_given_assertion() {
+    Jedi[] jedis = { new Jedi("Yoda", "red") };
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("Y"));
+  }
+
+  @Test
+  public void succeeds_if_arry_has_only_one_element_and_that_element_statisfies_the_given_assertions() {
+    assertThat(new Jedi[] { new Jedi("Yoda", "red") }).hasOnlyOneElementSatisfying(yoda -> {
+      assertThat(yoda.getName()).isEqualTo("Yoda");
+      assertThat(yoda.lightSaberColor).isEqualTo("red");
+    });
+  }
+
+  @Test
+  public void fails_if_arry_has_only_one_element_and_that_element_does_not_statisfy_the_given_assertion() {
+    thrown.expectAssertionError("Expecting:%n <\"Yoda\">%nto start with:%n <\"L\">");
+    Jedi[] jedis = { new Jedi("Yoda", "red") };
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("L"));
+  }
+
+  @Test
+  public void fails_if_arry_has_more_than_one_element() {
+    thrown.expectAssertionError("Expected size:<1> but was:<2>");
+    Jedi[] jedis = { new Jedi("Yoda", "red"), new Jedi("Luke", "green") };
+    assertThat(jedis).hasOnlyOneElementSatisfying(yoda -> assertThat(yoda.getName()).startsWith("Y"));
+  }
+}


### PR DESCRIPTION
...yAssert#hasOnlyOneElementSatisfying (closes #518)

Javadoc is still missing. I will add it if the pull request is accepted.