### PR TITLE
FailureMessages should use String.format to replace the %n with corre…

### DIFF
--- a/src/main/java/org/assertj/core/util/FailureMessages.java
+++ b/src/main/java/org/assertj/core/util/FailureMessages.java
@@ -18,11 +18,11 @@ package org.assertj.core.util;
 public final class FailureMessages {
 
   public static String actualIsEmpty() {
-    return "%nExpecting actual not to be empty";
+    return String.format("%nExpecting actual not to be empty");
   }
 
   public static String actualIsNull() {
-    return "%nExpecting actual not to be null";
+    return String.format("%nExpecting actual not to be null");
   }
 
   private FailureMessages() {}


### PR DESCRIPTION
The %n is not properly replaced with the system specific line separator if the string is not formatted with String.format method.