### PR TITLE
use "@since 2.5.0 / 3.5.0" instead of "@since 2.5.0" because otherwis…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -1403,7 +1403,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return the assertion on the first element
    * @throws AssertionError if the actual {@link Iterable} is empty. 
-   * @since 2.5.0 
+   * @since 2.5.0 / 3.5.0
    */
   public ELEMENT_ASSERT first() {
     isNotEmpty();
@@ -1449,7 +1449,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return the assertion on the first element
    * @throws AssertionError if the actual {@link Iterable} is empty. 
-   * @since 2.5.0 
+   * @since 2.5.0 / 3.5.0 
    */
   public ELEMENT_ASSERT last() {
     isNotEmpty();
@@ -1508,7 +1508,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return the assertion on the given element
    * @throws AssertionError if the given index is out of bound.
-   * @since 2.5.0 
+   * @since 2.5.0 / 3.5.0
    */
   public ELEMENT_ASSERT element(int index) {
     isNotEmpty();

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1752,7 +1752,7 @@ public class Assertions {
    * to start with:
    *  <$bar$></code></pre>
    *  
-   * @since 2.5.0
+   * @since 2.5.0 / 3.5.0
    */
   public static void useRepresentation(Representation customRepresentation) {
     AbstractAssert.setCustomRepresentation(customRepresentation);
@@ -1761,7 +1761,7 @@ public class Assertions {
   /**
    * Fallback to use {@link StandardRepresentation} to revert the effect of calling {@link #useRepresentation(Representation)}.
    * 
-   * @since 2.5.0
+   * @since 2.5.0 / 3.5.0
    */
   public static void useDefaultRepresentation() {
     AbstractAssert.setCustomRepresentation(STANDARD_REPRESENTATION);

--- a/src/main/java/org/assertj/core/api/ComparableAssert.java
+++ b/src/main/java/org/assertj/core/api/ComparableAssert.java
@@ -166,7 +166,7 @@ public interface ComparableAssert<S extends ComparableAssert<S, A>, A extends Co
    * @throws NullPointerException if end value is {@code null}.
    * @throws AssertionError if the actual value is not in [start, end] range.
    * 
-   * @since 2.5.0
+   * @since 2.5.0 / 3.5.0
    */
   S isBetween(A startInclusive, A endInclusive);
 
@@ -191,7 +191,7 @@ public interface ComparableAssert<S extends ComparableAssert<S, A>, A extends Co
    * @throws NullPointerException if end value is {@code null}.
    * @throws AssertionError if the actual value is not in ]start, end[ range.
    * 
-   * @since 2.5.0
+   * @since 2.5.0 / 3.5.0
    */
   S isStrictlyBetween(A startExclusive, A endExclusive);
 }


### PR DESCRIPTION
I think using just 2.5.0 can confuse users who are not familiar with the AssertJ versioning scheme. They may think that e.g. 3.0.0 contains methods introduced in 2.5.0, because 3.0.0 is greater that 2.5.0

If you disagree, just close the pull request. :smile: 

