### PR TITLE
Add `hasParameter` and `hasNoParameter` assertion methods for URIs and URLs

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -287,4 +287,104 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
     uris.assertHasUserInfo(info, actual, null);
     return myself;
   }
+
+  /**
+   * Verifies that the actual {@code URI} has a parameter with the expected name.
+   * <p>
+   * The value of the parameter is not checked.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy")).hasParameter("happy");
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy");
+   * 
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("happy");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be present.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasParameter(String name) {
+    uris.assertHasParameter(info, actual, name);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URI} has a parameter with the expected name and value.
+   * <p>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy")).hasParameter("happy", null);
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", "very");
+   * 
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasParameter("sad", "much");
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", null);</code></pre>
+   * 
+   * @param name the name of the parameter expected to be present.
+   * @param value the value of the parameter expected to be present.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasParameter(String name, String value) {
+    uris.assertHasParameter(info, actual, name, value);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URI} does not have a parameter with the specified name.
+   * <p>
+   * The value of the parameter is not checked.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // This assertion succeeds:
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * 
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasParameter("sad");
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be absent.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual has the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasNoParameter(String name) {
+    uris.assertHasNoParameter(info, actual, name);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URI} does not have a parameter with the expected name and value.
+   * <p>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy", "very");
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy")).hasParameter("happy", "very");
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", null);
+   * 
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasParameter("sad", null);
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", "much");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be absent.
+   * @param value the value of the parameter expected to be absent.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual has the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasNoParameter(String name, String value) {
+    uris.assertHasNoParameter(info, actual, name, value);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -348,8 +348,8 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy");
    * 
    * // These assertions fail:
-   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasParameter("sad");
-   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad");</code></pre>
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasNoParameter("sad");
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasNoParameter("sad");</code></pre>
    * 
    * @param name the name of the parameter expected to be absent.
    * @return {@code this} assertion object.
@@ -369,13 +369,13 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * <p>
    * Examples:
    * <pre><code class='java'> // These assertions succeed:
-   * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy", "very");
-   * assertThat(new URI("http://www.helloworld.org/index.html?happy")).hasParameter("happy", "very");
-   * assertThat(new URI("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", null);
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasNoParameter("happy", "very");
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy")).hasNoParameter("happy", "very");
+   * assertThat(new URI("http://www.helloworld.org/index.html?happy=very")).hasNoParameter("happy", null);
    * 
    * // These assertions fail:
-   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasParameter("sad", null);
-   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", "much");</code></pre>
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasNoParameter("sad", null);
+   * assertThat(new URI("http://www.helloworld.org/index.html?sad=much")).hasNoParameter("sad", "much");</code></pre>
    * 
    * @param name the name of the parameter expected to be absent.
    * @param value the value of the parameter expected to be absent.

--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -345,7 +345,7 @@ public abstract class AbstractUriAssert<S extends AbstractUriAssert<S>> extends 
    * <p>
    * Examples:
    * <pre><code class='java'> // This assertion succeeds:
-   * assertThat(new URI("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * assertThat(new URI("http://www.helloworld.org/index.html")).hasNoParameter("happy");
    * 
    * // These assertions fail:
    * assertThat(new URI("http://www.helloworld.org/index.html?sad")).hasNoParameter("sad");

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -349,11 +349,11 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * <p>
    * Examples:
    * <pre><code class='java'> // This assertion succeeds:
-   * assertThat(new URL("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasNoParameter("happy");
    * 
    * // These assertions fail:
-   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasParameter("sad");
-   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad");</code></pre>
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasNoParameter("sad");
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasNoParameter("sad");</code></pre>
    * 
    * @param name the name of the parameter expected to be absent.
    * @return {@code this} assertion object.
@@ -373,13 +373,13 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
    * <p>
    * Examples:
    * <pre><code class='java'> // These assertions succeed:
-   * assertThat(new URL("http://www.helloworld.org/index.html")).hasParameter("happy", "very");
-   * assertThat(new URL("http://www.helloworld.org/index.html?happy")).hasParameter("happy", "very");
-   * assertThat(new URL("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", null);
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasNoParameter("happy", "very");
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy")).hasNoParameter("happy", "very");
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy=very")).hasNoParameter("happy", null);
    * 
    * // These assertions fail:
-   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasParameter("sad", null);
-   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", "much");</code></pre>
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasNoParameter("sad", null);
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasNoParameter("sad", "much");</code></pre>
    * 
    * @param name the name of the parameter expected to be absent.
    * @param value the value of the parameter expected to be absent.

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -291,4 +291,104 @@ public abstract class AbstractUrlAssert<S extends AbstractUrlAssert<S>> extends 
     urls.assertHasUserInfo(info, actual, null);
     return myself;
   }
+
+  /**
+   * Verifies that the actual {@code URL} has a parameter with the expected name.
+   * <p>
+   * The value of the parameter is not checked.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy")).hasParameter("happy");
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy");
+   * 
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("happy");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be present.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasParameter(String name) {
+    urls.assertHasParameter(info, actual, name);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URL} has a parameter with the expected name and value.
+   * <p>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy")).hasParameter("happy", null);
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", "very");
+   * 
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasParameter("sad", "much");
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", null);</code></pre>
+   * 
+   * @param name the name of the parameter expected to be present.
+   * @param value the value of the parameter expected to be present.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasParameter(String name, String value) {
+    urls.assertHasParameter(info, actual, name, value);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URL} does not have a parameter with the specified name.
+   * <p>
+   * The value of the parameter is not checked.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // This assertion succeeds:
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasParameter("happy");
+   * 
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasParameter("sad");
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be absent.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual has the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasNoParameter(String name) {
+    urls.assertHasNoParameter(info, actual, name);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URL} does not have a parameter with the expected name and value.
+   * <p>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // These assertions succeed:
+   * assertThat(new URL("http://www.helloworld.org/index.html")).hasParameter("happy", "very");
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy")).hasParameter("happy", "very");
+   * assertThat(new URL("http://www.helloworld.org/index.html?happy=very")).hasParameter("happy", null);
+   * 
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad")).hasParameter("sad", null);
+   * assertThat(new URL("http://www.helloworld.org/index.html?sad=much")).hasParameter("sad", "much");</code></pre>
+   * 
+   * @param name the name of the parameter expected to be absent.
+   * @param value the value of the parameter expected to be absent.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual has the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public S hasNoParameter(String name, String value) {
+    urls.assertHasNoParameter(info, actual, name, value);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
@@ -26,10 +26,10 @@ public class ShouldHaveParameter extends BasicErrorMessageFactory {
   private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_MISSING = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut was absent";
   private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_NO_VALUE = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had no value";
   private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_WRONG = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had value:%n  <%s>";
-  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_NO_VALUE = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nbut was present with no value";
-  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_VALUE = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nbut was present with value:%n  <%s>";
-  private static final String SHOULD_HAVE_NO_PARAMETER_NO_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nwith no value, but was present";
-  private static final String SHOULD_HAVE_NO_PARAMETER_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nwith value:%n  <%s>%nbut was present";
+  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_NO_VALUE = "%nExpecting:%n  <%s>%nnot to have parameter:%n  <%s>%nbut was present with no value";
+  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_VALUE = "%nExpecting:%n  <%s>%nnot to have parameter:%n  <%s>%nbut was present with value:%n  <%s>";
+  private static final String SHOULD_HAVE_NO_PARAMETER_NO_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nnot to have parameter:%n  <%s>%nwith no value, but was present";
+  private static final String SHOULD_HAVE_NO_PARAMETER_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nnot to have parameter:%n  <%s>%nwith value:%n  <%s>%nbut was present";
 
   public static ErrorMessageFactory shouldHaveParameter(URI actual, String name) {
     return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_BUT_MISSING, actual, name);

--- a/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.error.uri;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+public class ShouldHaveParameter extends BasicErrorMessageFactory {
+
+  private static final String SHOULD_HAVE_PARAMETER_BUT_MISSING = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nbut was absent";
+  private static final String SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_MISSING = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith no value, but was absent";
+  private static final String SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_VALUE = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith no value, but had value:%n  <%s>";
+  private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_MISSING = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut was absent";
+  private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_NO_VALUE = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had no value";
+  private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_WRONG = "%nExpecting:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had value:%n  <%s>";
+  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_NO_VALUE = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nbut was present with no value";
+  private static final String SHOULD_HAVE_NO_PARAMETER_BUT_VALUE = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nbut was present with value:%n  <%s>";
+  private static final String SHOULD_HAVE_NO_PARAMETER_NO_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nwith no value, but was present";
+  private static final String SHOULD_HAVE_NO_PARAMETER_VALUE_BUT_FOUND = "%nExpecting:%n  <%s>%nto not have parameter:%n  <%s>%nwith value:%n  <%s>%nbut was present";
+
+  public static ErrorMessageFactory shouldHaveParameter(URI actual, String name) {
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_BUT_MISSING, actual, name);
+  }
+
+  public static ErrorMessageFactory shouldHaveParameter(URI actual, String name, String expectedValue) {
+    if (expectedValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_MISSING, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_MISSING, actual, name, expectedValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveParameter(URI actual, String name, String expectedValue,
+                                                        String actualValue) {
+    if (expectedValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_VALUE, actual, name, actualValue);
+    }
+
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_NO_VALUE, actual, name, expectedValue);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_WRONG, actual, name, expectedValue, actualValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveNoParameter(URI actual, String name, String actualValue) {
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_NO_VALUE, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_VALUE, actual, name, actualValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveNoParameter(URI actual, String name, String expectedValue,
+                                                          String actualValue) {
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_NO_VALUE_BUT_FOUND, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_VALUE_BUT_FOUND, actual, name, expectedValue);
+  }
+
+  private ShouldHaveParameter(String format, URI actual, String name) {
+    super(format, actual, name);
+  }
+
+  private ShouldHaveParameter(String format, URI actual, String name, String value) {
+    super(format, actual, name, value);
+  }
+
+  private ShouldHaveParameter(String format, URI actual, String name, String expectedValue, String actualValue) {
+    super(format, actual, name, expectedValue, actualValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveParameter(URL actual, String name) {
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_BUT_MISSING, actual, name);
+  }
+
+  public static ErrorMessageFactory shouldHaveParameter(URL actual, String name, String expectedValue) {
+    if (expectedValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_MISSING, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_MISSING, actual, name, expectedValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveParameter(URL actual, String name, String expectedValue,
+                                                        String actualValue) {
+    if (expectedValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_NO_VALUE_BUT_VALUE, actual, name, actualValue);
+    }
+
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_NO_VALUE, actual, name, expectedValue);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_VALUE_BUT_WRONG, actual, name, expectedValue, actualValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveNoParameter(URL actual, String name, String actualValue) {
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_NO_VALUE, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_VALUE, actual, name, actualValue);
+  }
+
+  public static ErrorMessageFactory shouldHaveNoParameter(URL actual, String name, String expectedValue,
+                                                          String actualValue) {
+    if (actualValue == null) {
+      return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_NO_VALUE_BUT_FOUND, actual, name);
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_VALUE_BUT_FOUND, actual, name, expectedValue);
+  }
+
+  private ShouldHaveParameter(String format, URL actual, String name) {
+    super(format, actual, name);
+  }
+
+  private ShouldHaveParameter(String format, URL actual, String name, String value) {
+    super(format, actual, name, value);
+  }
+
+  private ShouldHaveParameter(String format, URL actual, String name, String expectedValue, String actualValue) {
+    super(format, actual, name, expectedValue, actualValue);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -147,7 +147,11 @@ public class Uris {
     List<String> values = parameters.get(name);
 
     if (!values.contains(value)) {
-      throw failures.failure(info, shouldHaveParameter(actual, name, value, values.get(0)));
+      if (values.size() == 1) {
+        throw failures.failure(info, shouldHaveParameter(actual, name, value, values.get(0)));
+      }
+
+      throw failures.failure(info, shouldHaveParameter(actual, name, value, values.toString()));
     }
   }
 
@@ -159,7 +163,11 @@ public class Uris {
     if (parameters.containsKey(name)) {
       List<String> values = parameters.get(name);
 
-      throw failures.failure(info, shouldHaveNoParameter(actual, name, values.get(0)));
+      if (values.size() == 1) {
+        throw failures.failure(info, shouldHaveNoParameter(actual, name, values.get(0)));
+      }
+
+      throw failures.failure(info, shouldHaveNoParameter(actual, name, values.toString()));
     }
   }
 

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -109,7 +109,11 @@ public class Urls {
     List<String> values = parameters.get(name);
 
     if (!values.contains(value)) {
-      throw failures.failure(info, shouldHaveParameter(actual, name, value, values.get(0)));
+      if (values.size() == 1) {
+        throw failures.failure(info, shouldHaveParameter(actual, name, value, values.get(0)));
+      }
+
+      throw failures.failure(info, shouldHaveParameter(actual, name, value, values.toString()));
     }
   }
 
@@ -121,7 +125,11 @@ public class Urls {
     if (parameters.containsKey(name)) {
       List<String> values = parameters.get(name);
 
-      throw failures.failure(info, shouldHaveNoParameter(actual, name, values.get(0)));
+      if (values.size() == 1) {
+        throw failures.failure(info, shouldHaveNoParameter(actual, name, values.get(0)));
+      }
+
+      throw failures.failure(info, shouldHaveNoParameter(actual, name, values.toString()));
     }
   }
 

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
 import static org.assertj.core.error.uri.ShouldHavePath.shouldHavePath;
 import static org.assertj.core.error.uri.ShouldHavePort.shouldHavePort;
 import static org.assertj.core.error.uri.ShouldHaveProtocol.shouldHaveProtocol;
@@ -24,6 +26,8 @@ import static org.assertj.core.internal.Comparables.assertNotNull;
 import static org.assertj.core.util.Objects.areEqual;
 
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
@@ -81,5 +85,57 @@ public class Urls {
   public void assertHasUserInfo(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
     if (!areEqual(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
+  }
+
+  public void assertHasParameter(AssertionInfo info, URL actual, String name) {
+    assertNotNull(info, actual);
+
+    Map<String, List<String>> parameters = Uris.getParameters(actual.getQuery());
+
+    if (!parameters.containsKey(name)) {
+      throw failures.failure(info, shouldHaveParameter(actual, name));
+    }
+  }
+
+  public void assertHasParameter(AssertionInfo info, URL actual, String name, String value) {
+    assertNotNull(info, actual);
+
+    Map<String, List<String>> parameters = Uris.getParameters(actual.getQuery());
+
+    if (!parameters.containsKey(name)) {
+      throw failures.failure(info, shouldHaveParameter(actual, name, value));
+    }
+
+    List<String> values = parameters.get(name);
+
+    if (!values.contains(value)) {
+      throw failures.failure(info, shouldHaveParameter(actual, name, value, values.get(0)));
+    }
+  }
+
+  public void assertHasNoParameter(AssertionInfo info, URL actual, String name) {
+    assertNotNull(info, actual);
+
+    Map<String, List<String>> parameters = Uris.getParameters(actual.getQuery());
+
+    if (parameters.containsKey(name)) {
+      List<String> values = parameters.get(name);
+
+      throw failures.failure(info, shouldHaveNoParameter(actual, name, values.get(0)));
+    }
+  }
+
+  public void assertHasNoParameter(AssertionInfo info, URL actual, String name, String value) {
+    assertNotNull(info, actual);
+
+    Map<String, List<String>> parameters = Uris.getParameters(actual.getQuery());
+
+    if (parameters.containsKey(name)) {
+      List<String> values = parameters.get(name);
+
+      if (values.contains(value)) {
+        throw failures.failure(info, shouldHaveNoParameter(actual, name, value, values.get(0)));
+      }
+    }
   }
 }

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoParameter_String_String_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoParameter_String_String_Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+public class UriAssert_hasNoParameter_String_String_Test extends UriAssertBaseTest {
+  private final String name = "article";
+  private final String value = "10";
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasNoParameter(name, value);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasNoParameter(getInfo(assertions), getActual(assertions), name, value);
+  }
+}

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoParameter_String_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoParameter_String_Test.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+public class UriAssert_hasNoParameter_String_Test extends UriAssertBaseTest {
+  private final String name = "article";
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasNoParameter(name);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasNoParameter(getInfo(assertions), getActual(assertions), name);
+  }
+}

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasParameter_String_String_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasParameter_String_String_Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+public class UriAssert_hasParameter_String_String_Test extends UriAssertBaseTest {
+  private final String name = "article";
+  private final String value = "10";
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasParameter(name, value);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasParameter(getInfo(assertions), getActual(assertions), name, value);
+  }
+}

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasParameter_String_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasParameter_String_Test.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+public class UriAssert_hasParameter_String_Test extends UriAssertBaseTest {
+  private final String name = "article";
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasParameter(name);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasParameter(getInfo(assertions), getActual(assertions), name);
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoParameter_String_String_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoParameter_String_String_Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+public class UrlAssert_hasNoParameter_String_String_Test extends UrlAssertBaseTest {
+  private final String name = "article";
+  private final String value = "10";
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasNoParameter(name, value);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasNoParameter(getInfo(assertions), getActual(assertions), name, value);
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoParameter_String_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoParameter_String_Test.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+public class UrlAssert_hasNoParameter_String_Test extends UrlAssertBaseTest {
+  private final String name = "article";
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasNoParameter(name);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasNoParameter(getInfo(assertions), getActual(assertions), name);
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasParameter_String_String_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasParameter_String_String_Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+public class UrlAssert_hasParameter_String_String_Test extends UrlAssertBaseTest {
+  private final String name = "article";
+  private final String value = "10";
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasParameter(name, value);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasParameter(getInfo(assertions), getActual(assertions), name, value);
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasParameter_String_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasParameter_String_Test.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+public class UrlAssert_hasParameter_String_Test extends UrlAssertBaseTest {
+  private final String name = "article";
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasParameter(name);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasParameter(getInfo(assertions), getActual(assertions), name);
+  }
+}

--- a/src/test/java/org/assertj/core/error/uri/ShouldHaveParameter_create_Test.java
+++ b/src/test/java/org/assertj/core/error/uri/ShouldHaveParameter_create_Test.java
@@ -119,7 +119,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "but was present with no value"));
   }
@@ -132,7 +132,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article=10>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "but was present with value:%n" +
         "  <\"10\">"));
@@ -146,7 +146,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "with no value, but was present"));
   }
@@ -159,7 +159,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article=10>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "with value:%n" +
         "  <\"10\">%n" +
@@ -260,7 +260,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "but was present with no value"));
   }
@@ -273,7 +273,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article=10>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "but was present with value:%n" +
         "  <\"10\">"));
@@ -287,7 +287,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "with no value, but was present"));
   }
@@ -300,7 +300,7 @@ public class ShouldHaveParameter_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
         "Expecting:%n" +
         "  <http://assertj.org/news?article=10>%n" +
-        "to not have parameter:%n" +
+        "not to have parameter:%n" +
         "  <\"article\">%n" +
         "with value:%n" +
         "  <\"10\">%n" +

--- a/src/test/java/org/assertj/core/error/uri/ShouldHaveParameter_create_Test.java
+++ b/src/test/java/org/assertj/core/error/uri/ShouldHaveParameter_create_Test.java
@@ -1,0 +1,309 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.error.uri;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.Test;
+
+public class ShouldHaveParameter_create_Test {
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_missing() throws Exception {
+    URI uri = new URI("http://assertj.org/news");
+    String error = shouldHaveParameter(uri, "article").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_no_value_but_missing() throws Exception {
+    URI uri = new URI("http://assertj.org/news");
+    String error = shouldHaveParameter(uri, "article", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_value_but_missing() throws Exception {
+    URI uri = new URI("http://assertj.org/news");
+    String error = shouldHaveParameter(uri, "article", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_no_value_but_value() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article=10");
+    String error = shouldHaveParameter(uri, "article", null, "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but had value:%n" +
+        "  <\"10\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_value_but_no_value() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article");
+    String error = shouldHaveParameter(uri, "article", "10", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but had no value"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_parameter_value_but_wrong() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article=11");
+    String error = shouldHaveParameter(uri, "article", "10", "11").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=11>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but had value:%n" +
+        "  <\"11\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_no_parameter_but_no_value() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article");
+    String error = shouldHaveNoParameter(uri, "article", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was present with no value"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_no_parameter_but_value() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article=10");
+    String error = shouldHaveNoParameter(uri, "article", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was present with value:%n" +
+        "  <\"10\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_no_parameter_no_value_but_found() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article");
+    String error = shouldHaveNoParameter(uri, "article", null, null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but was present"));
+  }
+
+  @Test
+  public void should_create_error_message_for_uri_no_parameter_value_but_found() throws Exception {
+    URI uri = new URI("http://assertj.org/news?article=10");
+    String error = shouldHaveNoParameter(uri, "article", "10", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but was present"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_missing() throws Exception {
+    URL url = new URL("http://assertj.org/news");
+    String error = shouldHaveParameter(url, "article").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_no_value_but_missing() throws Exception {
+    URL url = new URL("http://assertj.org/news");
+    String error = shouldHaveParameter(url, "article", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_value_but_missing() throws Exception {
+    URL url = new URL("http://assertj.org/news");
+    String error = shouldHaveParameter(url, "article", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but was absent"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_no_value_but_value() throws Exception {
+    URL url = new URL("http://assertj.org/news?article=10");
+    String error = shouldHaveParameter(url, "article", null, "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but had value:%n" +
+        "  <\"10\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_value_but_no_value() throws Exception {
+    URL url = new URL("http://assertj.org/news?article");
+    String error = shouldHaveParameter(url, "article", "10", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but had no value"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_parameter_value_but_wrong() throws Exception {
+    URL url = new URL("http://assertj.org/news?article=11");
+    String error = shouldHaveParameter(url, "article", "10", "11").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=11>%n" +
+        "to have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but had value:%n" +
+        "  <\"11\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_no_parameter_but_no_value() throws Exception {
+    URL url = new URL("http://assertj.org/news?article");
+    String error = shouldHaveNoParameter(url, "article", null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was present with no value"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_no_parameter_but_value() throws Exception {
+    URL url = new URL("http://assertj.org/news?article=10");
+    String error = shouldHaveNoParameter(url, "article", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "but was present with value:%n" +
+        "  <\"10\">"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_no_parameter_no_value_but_found() throws Exception {
+    URL url = new URL("http://assertj.org/news?article");
+    String error = shouldHaveNoParameter(url, "article", null, null).create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "with no value, but was present"));
+  }
+
+  @Test
+  public void should_create_error_message_for_url_no_parameter_value_but_found() throws Exception {
+    URL url = new URL("http://assertj.org/news?article=10");
+    String error = shouldHaveNoParameter(url, "article", "10", "10").create(new TestDescription("TEST"));
+
+    assertThat(error).isEqualTo(format("[TEST] %n" +
+        "Expecting:%n" +
+        "  <http://assertj.org/news?article=10>%n" +
+        "to not have parameter:%n" +
+        "  <\"article\">%n" +
+        "with value:%n" +
+        "  <\"10\">%n" +
+        "but was present"));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.assertj.core.internal.UrisBaseTest;
+import org.junit.Test;
+
+public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
+
+  @Test
+  public void should_pass_if_parameter_is_missing() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news"), "article");
+  }
+
+  @Test
+  public void should_fail_if_parameter_is_present_without_value() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article");
+    String name = "article";
+    String actualValue = null;
+
+    try {
+      uris.assertHasNoParameter(info, uri, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_is_present_with_value() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article=10");
+    String name = "article";
+    String actualValue = "10";
+
+    try {
+      uris.assertHasNoParameter(info, uri, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_missing() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news"), "article", null);
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_is_present() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = null;
+
+    try {
+      uris.assertHasNoParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_present_with_value() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news=10"), "article", null);
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_missing() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news"), "article", "10");
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_present_without_value() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news?article"), "article", "10");
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_present_with_wrong_value() throws URISyntaxException {
+    uris.assertHasNoParameter(info, new URI("http://assertj.org/news?article=11"), "article", "10");
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_present() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article=10");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "10";
+
+    try {
+      uris.assertHasNoParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
@@ -62,6 +62,22 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
   }
 
   @Test
+  public void should_fail_if_parameter_is_present_multiple_times() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article&article=10");
+    String name = "article";
+    String actualValue = "[null, 10]";
+
+    try {
+      uris.assertHasNoParameter(info, uri, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_pass_if_parameter_without_value_is_missing() throws URISyntaxException {
     uris.assertHasNoParameter(info, new URI("http://assertj.org/news"), "article", null);
   }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
@@ -88,6 +88,23 @@ public class Uris_assertHasParameter_Test extends UrisBaseTest {
   }
 
   @Test
+  public void should_fail_if_parameter_without_value_has_multiple_values() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article=11&article=12");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = "[11, 12]";
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_fail_if_parameter_with_value_is_missing() throws URISyntaxException {
     URI uri = new URI("http://assertj.org/news");
     String name = "article";
@@ -109,6 +126,23 @@ public class Uris_assertHasParameter_Test extends UrisBaseTest {
     String name = "article";
     String expectedValue = "10";
     String actualValue = null;
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_has_multiple_no_values() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article&article");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "[null, null]";
 
     try {
       uris.assertHasParameter(info, uri, name, expectedValue);

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.assertj.core.internal.UrisBaseTest;
+import org.junit.Test;
+
+public class Uris_assertHasParameter_Test extends UrisBaseTest {
+
+  @Test
+  public void should_fail_if_parameter_is_missing() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news");
+    String name = "article";
+
+    try {
+      uris.assertHasParameter(info, uri, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_has_no_value() throws URISyntaxException {
+    uris.assertHasParameter(info, new URI("http://assertj.org/news?article"), "article");
+  }
+
+  @Test
+  public void should_pass_if_parameter_has_value() throws URISyntaxException {
+    uris.assertHasParameter(info, new URI("http://assertj.org/news?article=10"), "article");
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_is_missing() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news");
+    String name = "article";
+    String expectedValue = null;
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_found() throws URISyntaxException {
+    uris.assertHasParameter(info, new URI("http://assertj.org/news?article"), "article", null);
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_has_value() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article=11");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = "11";
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_missing() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news");
+    String name = "article";
+    String expectedValue = "10";
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_has_no_value() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = null;
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_wrong() throws URISyntaxException {
+    URI uri = new URI("http://assertj.org/news?article=11");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "11";
+
+    try {
+      uris.assertHasParameter(info, uri, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(uri, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_found() throws URISyntaxException {
+    uris.assertHasParameter(info, new URI("http://assertj.org/news?article=10"), "article", "10");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Uris_getParameters_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_getParameters_Test.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.internal.Uris.getParameters;
+
+public class Uris_getParameters_Test {
+
+  @Test
+  public void should_return_empty_for_empty_query()  {
+    assertThat(getParameters("")).isEmpty();
+  }
+
+  @Test
+  public void should_return_empty_for_null_query()  {
+    assertThat(getParameters(null)).isEmpty();
+  }
+
+  @Test
+  public void should_accept_parameter_with_no_value() {
+    Map<String, List<String>> parameters = getParameters("foo");
+
+    assertThat(parameters).containsKey("foo");
+    assertThat(parameters.get("foo")).size().isEqualTo(1);
+    assertThat(parameters.get("foo").get(0)).isNull();
+  }
+
+  @Test
+  public void should_accept_parameter_with_value() {
+    Map<String, List<String>> parameters = getParameters("foo=bar");
+
+    assertThat(parameters).containsKey("foo");
+    assertThat(parameters.get("foo")).size().isEqualTo(1);
+    assertThat(parameters.get("foo")).contains("bar");
+  }
+
+  @Test
+  public void should_decode_name() {
+    assertThat(getParameters("foo%3Dbar=baz")).containsKey("foo=bar");
+  }
+
+  @Test
+  public void should_decode_value() {
+    assertThat(getParameters("foo=bar%3Dbaz").get("foo")).contains("bar=baz");
+  }
+
+  @Test
+  public void should_accept_duplicate_names() {
+    Map<String, List<String>> parameters = getParameters("foo&foo=bar");
+
+    assertThat(parameters).containsKey("foo");
+    assertThat(parameters.get("foo")).size().isEqualTo(2);
+    assertThat(parameters.get("foo").get(0)).isNull();
+    assertThat(parameters.get("foo").get(1)).isEqualTo("bar");
+  }
+
+  @Test
+  public void should_accept_duplicate_values() {
+    Map<String, List<String>> parameters = getParameters("foo=bar&foo=bar");
+
+    assertThat(parameters).containsKey("foo");
+    assertThat(parameters.get("foo")).size().isEqualTo(2);
+    assertThat(parameters.get("foo").get(0)).isEqualTo("bar");
+    assertThat(parameters.get("foo").get(1)).isEqualTo("bar");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
@@ -62,6 +62,22 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
   }
 
   @Test
+  public void should_fail_if_parameter_is_present_multiple_times() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article&article=10");
+    String name = "article";
+    String actualValue = "[null, 10]";
+
+    try {
+      urls.assertHasNoParameter(info, url, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_pass_if_parameter_without_value_is_missing() throws MalformedURLException {
     urls.assertHasNoParameter(info, new URL("http://assertj.org/news"), "article", null);
   }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import org.assertj.core.internal.UrlsBaseTest;
+import org.junit.Test;
+
+public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
+
+  @Test
+  public void should_pass_if_parameter_is_missing() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news"), "article");
+  }
+
+  @Test
+  public void should_fail_if_parameter_is_present_without_value() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article");
+    String name = "article";
+    String actualValue = null;
+
+    try {
+      urls.assertHasNoParameter(info, url, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_is_present_with_value() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article=10");
+    String name = "article";
+    String actualValue = "10";
+
+    try {
+      urls.assertHasNoParameter(info, url, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_missing() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news"), "article", null);
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_is_present() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = null;
+
+    try {
+      urls.assertHasNoParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_present_with_value() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news=10"), "article", null);
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_missing() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news"), "article", "10");
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_present_without_value() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news?article"), "article", "10");
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_present_with_wrong_value() throws MalformedURLException {
+    urls.assertHasNoParameter(info, new URL("http://assertj.org/news?article=11"), "article", "10");
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_present() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article=10");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "10";
+
+    try {
+      urls.assertHasNoParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
@@ -88,6 +88,23 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
   }
 
   @Test
+  public void should_fail_if_parameter_without_value_has_multiple_values() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article=11&article=12");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = "[11, 12]";
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_fail_if_parameter_with_value_is_missing() throws MalformedURLException {
     URL url = new URL("http://assertj.org/news");
     String name = "article";
@@ -109,6 +126,23 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String name = "article";
     String expectedValue = "10";
     String actualValue = null;
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_has_multiple_no_values() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article&article");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "[null, null]";
 
     try {
       urls.assertHasParameter(info, url, name, expectedValue);

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import org.assertj.core.internal.UrlsBaseTest;
+import org.junit.Test;
+
+public class Urls_assertHasParameter_Test extends UrlsBaseTest {
+
+  @Test
+  public void should_fail_if_parameter_is_missing() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news");
+    String name = "article";
+
+    try {
+      urls.assertHasParameter(info, url, name);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_has_no_value() throws MalformedURLException {
+    urls.assertHasParameter(info, new URL("http://assertj.org/news?article"), "article");
+  }
+
+  @Test
+  public void should_pass_if_parameter_has_value() throws MalformedURLException {
+    urls.assertHasParameter(info, new URL("http://assertj.org/news?article=10"), "article");
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_is_missing() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news");
+    String name = "article";
+    String expectedValue = null;
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_without_value_is_found() throws MalformedURLException {
+    urls.assertHasParameter(info, new URL("http://assertj.org/news?article"), "article", null);
+  }
+
+  @Test
+  public void should_fail_if_parameter_without_value_has_value() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article=11");
+    String name = "article";
+    String expectedValue = null;
+    String actualValue = "11";
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_missing() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news");
+    String name = "article";
+    String expectedValue = "10";
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_has_no_value() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = null;
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_parameter_with_value_is_wrong() throws MalformedURLException {
+    URL url = new URL("http://assertj.org/news?article=11");
+    String name = "article";
+    String expectedValue = "10";
+    String actualValue = "11";
+
+    try {
+      urls.assertHasParameter(info, url, name, expectedValue);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValue));
+      return;
+    }
+
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_parameter_with_value_is_found() throws MalformedURLException {
+    urls.assertHasParameter(info, new URL("http://assertj.org/news?article=10"), "article", "10");
+  }
+}


### PR DESCRIPTION
This allows assertions in the style of:
 
    assertThat(new URI("http://foo.com/?bar=baz")).hasParameter("bar");

Additionally, support is available for a few edge cases I've seen in the wild; specifically, parameters with no value (e.g. `?foo&bar`) as well as multiple parameters with the same name.  Therefore, it can be meaningful to write an assertion like:

    assertThat(new URI("http://foo.com/?bar&bar=baz")).hasParameter("bar", null).hasParameter("bar", "baz");

#### Check List:
* Fixes : NA
* Unit tests : YES
* Javadoc with a code example (API only) : YES