### PR TITLE
CheckReturnValue for assertThat statements for Findbugs

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -39,6 +41,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the path
    * @return the created assertion object
    */
+  @CheckReturnValue
   public PathAssert then(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
@@ -52,6 +55,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> OptionalAssert<T> then(Optional<T> actual) {
     return proxy(OptionalAssert.class, Optional.class, actual);
   }
@@ -63,6 +67,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalDoubleAssert then(OptionalDouble actual) {
     return proxy(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
@@ -74,6 +79,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalIntAssert then(OptionalInt actual) {
     return proxy(OptionalIntAssert.class, OptionalInt.class, actual);
   }
@@ -85,6 +91,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalLongAssert then(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
   }
@@ -95,6 +102,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
   * @param actual the actual value.
   * @return the created assertion object.
   */
+  @CheckReturnValue
   public LocalDateAssert then(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
   }
@@ -105,6 +113,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LocalDateTimeAssert then(LocalDateTime actual) {
     return proxy(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
@@ -115,6 +124,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ZonedDateTimeAssert then(ZonedDateTime actual) {
     return proxy(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
@@ -125,6 +135,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LocalTimeAssert then(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
@@ -135,6 +146,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OffsetTimeAssert then(OffsetTime actual) {
     return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
@@ -145,6 +157,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OffsetDateTimeAssert then(OffsetDateTime actual) {
     return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
@@ -158,6 +171,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> CompletableFutureAssert<T> then(CompletableFuture<T> actual) {
     return proxy(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
@@ -173,6 +187,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.5.0
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> PredicateAssert<T> then(Predicate<T> actual) {
     return proxy(PredicateAssert.class, Predicate.class, actual);
   }
@@ -184,6 +199,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public IntPredicateAssert then(IntPredicate actual) {
     return proxy(IntPredicateAssert.class, IntPredicate.class, actual);
   }
@@ -195,6 +211,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public DoublePredicateAssert then(DoublePredicate actual) {
     return proxy(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
@@ -206,6 +223,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public LongPredicateAssert then(LongPredicate actual) {
     return proxy(LongPredicateAssert.class, LongPredicate.class, actual);
   }
@@ -221,6 +239,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <ELEMENT> ListAssert<ELEMENT> then(Stream<? extends ELEMENT> actual) {
     return proxy(ListAssert.class, Stream.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -39,6 +41,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the path
    * @return the created assertion object
    */
+  @CheckReturnValue
   public PathAssert assertThat(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
@@ -52,6 +55,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> OptionalAssert<T> assertThat(Optional<T> actual) {
     return proxy(OptionalAssert.class, Optional.class, actual);
   }
@@ -63,6 +67,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalDoubleAssert assertThat(OptionalDouble actual) {
       return proxy(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
@@ -74,6 +79,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalLongAssert assertThat(OptionalLong actual) {
       return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
   }
@@ -85,6 +91,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OptionalIntAssert assertThat(OptionalInt actual) {
       return proxy(OptionalIntAssert.class, OptionalInt.class, actual);
   }
@@ -95,6 +102,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LocalDateAssert assertThat(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
   }
@@ -105,6 +113,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LocalDateTimeAssert assertThat(LocalDateTime actual) {
     return proxy(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
@@ -115,6 +124,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
     return proxy(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
@@ -125,6 +135,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LocalTimeAssert assertThat(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
@@ -135,6 +146,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OffsetTimeAssert assertThat(OffsetTime actual) {
       return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
@@ -145,6 +157,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
     return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
@@ -158,6 +171,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> CompletableFutureAssert<T> assertThat(CompletableFuture<T> actual) {
     return proxy(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
@@ -173,6 +187,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @since 3.5.0
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
     return proxy(PredicateAssert.class, Predicate.class, actual);
   }
@@ -184,6 +199,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public IntPredicateAssert assertThat(IntPredicate actual) {
     return proxy(IntPredicateAssert.class, IntPredicate.class, actual);
   }
@@ -195,6 +211,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public DoublePredicateAssert assertThat(DoublePredicate actual) {
     return proxy(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
@@ -206,6 +223,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public LongPredicateAssert assertThat(LongPredicate actual) {
     return proxy(LongPredicateAssert.class, LongPredicate.class, actual);
   }
@@ -221,6 +239,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
     return proxy(ListAssert.class, Stream.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -68,6 +68,7 @@ import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.presentation.UnicodeRepresentation;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
@@ -106,6 +107,7 @@ import org.assertj.core.util.introspection.FieldSupport;
  * @author Julien Meddah
  * @author William Delanoue
  */
+@CheckReturnValue
 public class Assertions {
 
   /**
@@ -117,6 +119,7 @@ public class Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -128,6 +131,7 @@ public class Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static IntPredicateAssert assertThat(IntPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -139,6 +143,7 @@ public class Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -150,6 +155,7 @@ public class Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -162,6 +168,7 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> CompletableFutureAssert<T> assertThat(CompletableFuture<T> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -174,6 +181,7 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> OptionalAssert<T> assertThat(Optional<T> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -185,6 +193,7 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -196,6 +205,7 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -207,6 +217,7 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalLongAssert assertThat(OptionalLong actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -217,6 +228,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -227,6 +239,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -237,6 +250,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -247,6 +261,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -257,6 +272,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -267,6 +283,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -277,6 +294,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -287,6 +305,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -297,6 +316,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -307,6 +327,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -317,6 +338,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -327,6 +349,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -337,6 +360,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> assertThat(Class<?> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -347,6 +371,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -357,6 +382,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -367,6 +393,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -377,6 +404,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -387,6 +415,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -397,6 +426,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -407,6 +437,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -417,6 +448,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -427,6 +459,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -437,6 +470,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -447,6 +481,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -604,6 +639,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -614,6 +650,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -624,6 +661,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -634,6 +672,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -644,6 +683,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -654,6 +694,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -664,6 +705,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -674,6 +716,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -684,6 +727,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> assertThat(String actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -694,6 +738,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -704,6 +749,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -714,6 +760,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -724,6 +771,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -734,6 +782,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -744,6 +793,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -754,6 +804,7 @@ public class Assertions {
    * @param localDate the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -764,6 +815,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -794,6 +846,7 @@ public class Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -839,6 +892,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableTypeAssert}.
    */
+  @CheckReturnValue
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return AssertionsForClassTypes.assertThatExceptionOfType(exceptionType);
   }
@@ -1763,6 +1817,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1773,6 +1828,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterable<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
@@ -1787,6 +1843,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterator<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1797,6 +1854,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(List<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1811,6 +1869,7 @@ public class Assertions {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1821,6 +1880,7 @@ public class Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
+  @CheckReturnValue
   public static AbstractPathAssert<?> assertThat(Path actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1834,6 +1894,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1845,6 +1906,7 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -1900,6 +1962,7 @@ public class Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -54,6 +54,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
@@ -77,6 +78,7 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> CompletableFutureAssert<T> assertThat(CompletableFuture<T> actual) {
     return new CompletableFutureAssert<>(actual);
   }
@@ -89,6 +91,7 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> OptionalAssert<T> assertThat(Optional<T> actual) {
     return new OptionalAssert<>(actual);
   }
@@ -100,6 +103,7 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return new OptionalDoubleAssert(actual);
   }
@@ -111,6 +115,7 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return new OptionalIntAssert(actual);
   }
@@ -122,6 +127,7 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalLongAssert assertThat(OptionalLong actual) {
     return new OptionalLongAssert(actual);
   }
@@ -132,6 +138,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
@@ -142,6 +149,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return new UriAssert(actual);
   }
@@ -152,6 +160,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return new UrlAssert(actual);
   }
@@ -162,6 +171,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -172,6 +182,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -182,6 +193,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
@@ -192,6 +204,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return new ByteAssert(actual);
   }
@@ -202,6 +215,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
@@ -212,6 +226,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
@@ -222,6 +237,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return new CharacterAssert(actual);
   }
@@ -232,6 +248,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
@@ -242,6 +259,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
@@ -252,6 +270,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
@@ -262,6 +281,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return new DoubleAssert(actual);
   }
@@ -272,6 +292,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
@@ -282,6 +303,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
@@ -292,6 +314,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return new FileAssert(actual);
   }
@@ -302,6 +325,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
@@ -312,6 +336,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return new FloatAssert(actual);
   }
@@ -322,6 +347,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return new FloatAssert(actual);
   }
@@ -332,6 +358,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
@@ -342,6 +369,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return new IntegerAssert(actual);
   }
@@ -352,6 +380,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
@@ -362,6 +391,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
@@ -372,6 +402,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return new LongAssert(actual);
   }
@@ -382,6 +413,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return new LongAssert(actual);
   }
@@ -392,6 +424,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
@@ -402,6 +435,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
@@ -412,6 +446,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
@@ -422,6 +457,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return new ShortAssert(actual);
   }
@@ -432,6 +468,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return new ShortAssert(actual);
   }
@@ -442,6 +479,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
@@ -452,6 +490,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> assertThat(String actual) {
     return new StringAssert(actual);
   }
@@ -462,6 +501,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return new DateAssert(actual);
   }
@@ -472,6 +512,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime date) {
     return new ZonedDateTimeAssert(date);
   }
@@ -482,6 +523,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime localDateTime) {
     return new LocalDateTimeAssert(localDateTime);
   }
@@ -492,6 +534,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return new OffsetDateTimeAssert(actual);
   }
@@ -502,6 +545,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime offsetTime) {
     return new OffsetTimeAssert(offsetTime);
   }
@@ -512,6 +556,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return new LocalTimeAssert(actual);
   }
@@ -522,6 +567,7 @@ public class AssertionsForClassTypes {
    * @param localDate the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateAssert<?> assertThat(LocalDate localDate) {
     return new LocalDateAssert(localDate);
   }
@@ -532,6 +578,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
@@ -554,6 +601,7 @@ public class AssertionsForClassTypes {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -572,6 +620,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created {@link ThrowableTypeAssert}.
    */
+  @CheckReturnValue
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return new ThrowableTypeAssert<>(exceptionType);
   }

--- a/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -82,6 +84,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
@@ -92,6 +95,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterable<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
@@ -106,6 +110,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterator<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
@@ -116,6 +121,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(List<? extends ELEMENT> actual) {
     return new ListAssert<>(actual);
   }
@@ -130,6 +136,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
     return new ListAssert<>(actual);
   }
@@ -177,6 +184,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the path to test
    * @return the created assertion object
    */
+  @CheckReturnValue
   public static AbstractPathAssert<?> assertThat(Path actual) {
     return new PathAssert(actual);
   }
@@ -190,6 +198,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return new MapAssert<>(actual);
   }
@@ -201,6 +210,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
@@ -256,6 +266,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
@@ -268,6 +279,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
     return new PredicateAssert<>(actual);
   }
@@ -279,6 +291,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static IntPredicateAssert assertThat(IntPredicate actual) {
     return new IntPredicateAssert(actual);
   }
@@ -290,6 +303,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return new LongPredicateAssert(actual);
   }
@@ -301,6 +315,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return new DoublePredicateAssert(actual);
   }

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -40,6 +40,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CheckReturnValue;
 
 /**
  * BDD style entry point for assertion methods for different data types. Each method in this class is a static factory
@@ -85,6 +86,7 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static <T> PredicateAssert<T> then(Predicate<T> actual) {
     return assertThat(actual);
   }
@@ -96,6 +98,7 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static IntPredicateAssert then(IntPredicate actual) {
     return assertThat(actual);
   }
@@ -107,6 +110,7 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static LongPredicateAssert then(LongPredicate actual) {
     return assertThat(actual);
   }
@@ -118,6 +122,7 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
+  @CheckReturnValue
   public static DoublePredicateAssert then(DoublePredicate actual) {
     return assertThat(actual);
   }
@@ -129,6 +134,7 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> OptionalAssert<T> then(Optional<T> optional) {
     return assertThat(optional);
   }
@@ -140,6 +146,7 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalIntAssert then(OptionalInt optional) {
     return assertThat(optional);
   }
@@ -151,6 +158,7 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalLongAssert then(OptionalLong optional) {
     return assertThat(optional);
   }
@@ -162,6 +170,7 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static OptionalDoubleAssert then(OptionalDouble optional) {
     return assertThat(optional);
   }
@@ -172,6 +181,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
     return assertThat(actual);
   }
@@ -182,6 +192,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(boolean actual) {
     return assertThat(actual);
   }
@@ -192,6 +203,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(Boolean actual) {
     return assertThat(actual);
   }
@@ -202,6 +214,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
     return assertThat(actual);
   }
@@ -212,6 +225,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> then(byte actual) {
     return assertThat(actual);
   }
@@ -222,6 +236,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> then(Byte actual) {
     return assertThat(actual);
   }
@@ -232,6 +247,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> then(byte[] actual) {
     return assertThat(actual);
   }
@@ -242,6 +258,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(char actual) {
     return assertThat(actual);
   }
@@ -252,6 +269,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> then(char[] actual) {
     return assertThat(actual);
   }
@@ -262,6 +280,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(Character actual) {
     return assertThat(actual);
   }
@@ -272,6 +291,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> then(Class<?> actual) {
     return assertThat(actual);
   }
@@ -283,6 +303,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -293,6 +314,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
@@ -306,6 +328,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
@@ -459,6 +482,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(double actual) {
     return assertThat(actual);
   }
@@ -469,6 +493,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(Double actual) {
     return assertThat(actual);
   }
@@ -479,6 +504,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> then(double[] actual) {
     return assertThat(actual);
   }
@@ -489,6 +515,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> then(File actual) {
     return assertThat(actual);
   }
@@ -499,6 +526,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
+  @CheckReturnValue
   public static AbstractPathAssert<?> then(Path actual) {
     return assertThat(actual);
   }
@@ -509,6 +537,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
     return assertThat(actual);
   }
@@ -519,6 +548,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> then(float actual) {
     return assertThat(actual);
   }
@@ -529,6 +559,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> then(Float actual) {
     return assertThat(actual);
   }
@@ -539,6 +570,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> then(float[] actual) {
     return assertThat(actual);
   }
@@ -549,6 +581,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(int actual) {
     return assertThat(actual);
   }
@@ -559,6 +592,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> then(int[] actual) {
     return assertThat(actual);
   }
@@ -569,6 +603,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(Integer actual) {
     return assertThat(actual);
   }
@@ -579,6 +614,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> then(List<? extends T> actual) {
     return assertThat(actual);
   }
@@ -589,6 +625,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> then(long actual) {
     return assertThat(actual);
   }
@@ -599,6 +636,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> then(Long actual) {
     return assertThat(actual);
   }
@@ -609,6 +647,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> then(long[] actual) {
     return assertThat(actual);
   }
@@ -619,6 +658,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -629,6 +669,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> then(T[] actual) {
     return assertThat(actual);
   }
@@ -639,6 +680,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> then(Map<K, V> actual) {
     return assertThat(actual);
   }
@@ -649,6 +691,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> then(short actual) {
     return assertThat(actual);
   }
@@ -659,6 +702,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> then(Short actual) {
     return assertThat(actual);
   }
@@ -669,6 +713,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> then(short[] actual) {
     return assertThat(actual);
   }
@@ -679,6 +724,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
     return assertThat(actual);
   }
@@ -689,6 +735,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> then(String actual) {
     return assertThat(actual);
   }
@@ -699,6 +746,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> then(Date actual) {
     return assertThat(actual);
   }
@@ -709,6 +757,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
     return assertThat(actual);
   }
@@ -727,6 +776,7 @@ public class BDDAssertions extends Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThatThrownBy(shouldRaiseThrowable);
   }
@@ -737,6 +787,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateAssert<?> then(LocalDate actual) {
     return assertThat(actual);
   }
@@ -747,6 +798,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> then(LocalDateTime actual) {
     return assertThat(actual);
   }
@@ -757,6 +809,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> then(ZonedDateTime actual) {
     return assertThat(actual);
   }
@@ -767,6 +820,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> then(LocalTime actual) {
     return assertThat(actual);
   }
@@ -777,6 +831,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> then(OffsetTime actual) {
     return assertThat(actual);
   }
@@ -787,6 +842,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> then(URI actual) {
     return assertThat(actual);
   }
@@ -797,6 +853,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> then(URL actual) {
     return assertThat(actual);
   }
@@ -807,6 +864,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> then(OffsetDateTime actual) {
     return assertThat(actual);
   }
@@ -819,6 +877,7 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> CompletableFutureAssert<T> then(CompletableFuture<T> future) {
     return assertThat(future);
   }
@@ -874,6 +933,7 @@ public class BDDAssertions extends Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T then(T assertion) {
     return assertion;
   }
@@ -903,6 +963,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(Stream<? extends ELEMENT> actual) {
     return assertThat(actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -36,6 +38,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BigDecimalAssert then(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -46,6 +49,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert then(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -56,6 +60,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert then(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -66,6 +71,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanArrayAssert then(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -76,6 +82,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert then(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -86,6 +93,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert then(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -96,6 +104,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteArrayAssert then(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -106,6 +115,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert then(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -116,6 +126,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharArrayAssert then(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
@@ -126,6 +137,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert then(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -138,6 +150,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public SoftAssertionClassAssert then(Class<?> actual) {
     return proxy(SoftAssertionClassAssert.class, Class.class, actual);
   }
@@ -150,6 +163,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
@@ -161,6 +175,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> then(Iterable<? extends T> actual) {
     return proxy(IterableAssert.class, Iterable.class, actual);
   }
@@ -174,6 +189,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> then(Iterator<T> actual) {
     return proxy(IterableAssert.class, Iterator.class, actual);
   }
@@ -184,6 +200,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert then(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -194,6 +211,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert then(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -204,6 +222,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleArrayAssert then(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -214,6 +233,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FileAssert then(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
@@ -224,6 +244,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public InputStreamAssert then(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -234,6 +255,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert then(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -244,6 +266,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert then(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -254,6 +277,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatArrayAssert then(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
@@ -264,6 +288,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert then(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -274,6 +299,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntArrayAssert then(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
@@ -284,6 +310,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert then(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -295,6 +322,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ListAssert<T> then(List<? extends T> actual) {
     return proxy(ListAssert.class, List.class, actual);
   }
@@ -305,6 +333,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert then(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -315,6 +344,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert then(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -325,6 +355,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongArrayAssert then(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
@@ -336,6 +367,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectAssert<T> then(T actual) {
     return proxy(ObjectAssert.class, Object.class, actual);
   }
@@ -347,6 +379,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectArrayAssert<T> then(T[] actual) {
     return proxy(ObjectArrayAssert.class, Object[].class, actual);
   }
@@ -360,6 +393,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <K, V> SoftAssertionMapAssert<K, V> then(Map<K, V> actual) {
     return proxy(SoftAssertionMapAssert.class, Map.class, actual);
   }
@@ -370,6 +404,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert then(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -380,6 +415,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert then(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -390,6 +426,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortArrayAssert then(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
@@ -400,6 +437,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharSequenceAssert then(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -410,6 +448,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public StringAssert then(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
@@ -420,6 +459,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DateAssert then(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
@@ -430,6 +470,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
+  @CheckReturnValue
   public ThrowableAssert then(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -461,6 +502,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param shouldRaiseThrowable The {@link ThrowableAssert.ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return then(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -471,6 +513,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public UriAssert then(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
@@ -481,6 +524,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public AbstractUrlAssert<?> then(URL actual) {
     return proxy(AbstractUrlAssert.class, URL.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -34,6 +36,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BigDecimalAssert assertThat(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -44,6 +47,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert assertThat(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -54,6 +58,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanAssert assertThat(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -64,6 +69,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public BooleanArrayAssert assertThat(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -74,6 +80,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert assertThat(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -84,6 +91,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteAssert assertThat(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -94,6 +102,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ByteArrayAssert assertThat(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -104,6 +113,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert assertThat(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -114,6 +124,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharArrayAssert assertThat(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
@@ -124,6 +135,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharacterAssert assertThat(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -136,6 +148,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public SoftAssertionClassAssert assertThat(Class<?> actual) {
     return proxy(SoftAssertionClassAssert.class, Class.class, actual);
   }
@@ -148,6 +161,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
@@ -159,6 +173,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> assertThat(Iterable<? extends T> actual) {
     return proxy(IterableAssert.class, Iterable.class, actual);
   }
@@ -172,6 +187,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> IterableAssert<T> assertThat(Iterator<T> actual) {
     return proxy(IterableAssert.class, Iterator.class, actual);
   }
@@ -182,6 +198,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert assertThat(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -192,6 +209,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleAssert assertThat(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -202,6 +220,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DoubleArrayAssert assertThat(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -212,6 +231,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FileAssert assertThat(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
@@ -223,6 +243,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public InputStreamAssert assertThat(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -233,6 +254,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert assertThat(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -243,6 +265,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatAssert assertThat(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -253,6 +276,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public FloatArrayAssert assertThat(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
@@ -263,6 +287,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert assertThat(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -273,6 +298,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntArrayAssert assertThat(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
@@ -283,6 +309,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public IntegerAssert assertThat(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -294,6 +321,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ListAssert<T> assertThat(List<? extends T> actual) {
     return proxy(ListAssert.class, List.class, actual);
   }
@@ -304,6 +332,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert assertThat(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -314,6 +343,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongAssert assertThat(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -324,6 +354,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public LongArrayAssert assertThat(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
@@ -335,6 +366,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectAssert<T> assertThat(T actual) {
     return proxy(ObjectAssert.class, Object.class, actual);
   }
@@ -346,6 +378,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <T> ObjectArrayAssert<T> assertThat(T[] actual) {
     return proxy(ObjectArrayAssert.class, Object[].class, actual);
   }
@@ -359,6 +392,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public <K, V> SoftAssertionMapAssert<K, V> assertThat(Map<K, V> actual) {
     return proxy(SoftAssertionMapAssert.class, Map.class, actual);
   }
@@ -369,6 +403,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert assertThat(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -379,6 +414,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortAssert assertThat(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -389,6 +425,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public ShortArrayAssert assertThat(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
@@ -399,6 +436,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public CharSequenceAssert assertThat(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -409,6 +447,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public StringAssert assertThat(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
@@ -419,6 +458,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public DateAssert assertThat(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
@@ -429,6 +469,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
+  @CheckReturnValue
   public ThrowableAssert assertThat(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -459,6 +500,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param shouldRaiseThrowable The {@link ThrowableAssert.ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -469,6 +511,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public UriAssert assertThat(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
@@ -479,6 +522,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public AbstractUrlAssert<?> assertThat(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -45,6 +45,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
@@ -83,6 +84,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
@@ -93,6 +95,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return new UriAssert(actual);
   }
@@ -103,6 +106,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return new UrlAssert(actual);
   }
@@ -113,6 +117,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -123,6 +128,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -133,6 +139,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
@@ -143,6 +150,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return new ByteAssert(actual);
   }
@@ -153,6 +161,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
@@ -163,6 +172,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
@@ -173,6 +183,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return new CharacterAssert(actual);
   }
@@ -183,6 +194,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
@@ -193,6 +205,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
@@ -203,6 +216,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
@@ -214,6 +228,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
@@ -224,6 +239,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> IterableAssert<T> assertThat(Iterable<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
@@ -238,6 +254,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> IterableAssert<T> assertThat(Iterator<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
@@ -248,6 +265,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return new DoubleAssert(actual);
   }
@@ -258,6 +276,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
@@ -268,6 +287,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
@@ -278,6 +298,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return new FileAssert(actual);
   }
@@ -288,6 +309,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
@@ -298,6 +320,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return new FloatAssert(actual);
   }
@@ -308,6 +331,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return new FloatAssert(actual);
   }
@@ -318,6 +342,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
@@ -328,6 +353,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return new IntegerAssert(actual);
   }
@@ -338,6 +364,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
@@ -348,6 +375,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
@@ -358,6 +386,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> ListAssert<T> assertThat(List<? extends T> actual) {
     return new ListAssert<>(actual);
   }
@@ -513,6 +542,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return new LongAssert(actual);
   }
@@ -523,6 +553,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return new LongAssert(actual);
   }
@@ -533,6 +564,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
@@ -543,6 +575,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
@@ -598,6 +631,7 @@ public class Java6Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
@@ -623,6 +657,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
@@ -636,6 +671,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return new MapAssert<>(actual);
   }
@@ -646,6 +682,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return new ShortAssert(actual);
   }
@@ -656,6 +693,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return new ShortAssert(actual);
   }
@@ -666,6 +704,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
@@ -676,6 +715,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
@@ -686,6 +726,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> assertThat(String actual) {
     return new StringAssert(actual);
   }
@@ -696,6 +737,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return new DateAssert(actual);
   }
@@ -706,6 +748,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
@@ -746,6 +789,7 @@ public class Java6Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }

--- a/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -39,6 +41,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
     return assertThat(actual);
   }
@@ -49,6 +52,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(boolean actual) {
     return assertThat(actual);
   }
@@ -59,6 +63,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(Boolean actual) {
     return assertThat(actual);
   }
@@ -69,6 +74,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
     return assertThat(actual);
   }
@@ -79,6 +85,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> then(byte actual) {
     return assertThat(actual);
   }
@@ -89,6 +96,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteAssert<?> then(Byte actual) {
     return assertThat(actual);
   }
@@ -99,6 +107,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractByteArrayAssert<?> then(byte[] actual) {
     return assertThat(actual);
   }
@@ -109,6 +118,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(char actual) {
     return assertThat(actual);
   }
@@ -119,6 +129,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharArrayAssert<?> then(char[] actual) {
     return assertThat(actual);
   }
@@ -129,6 +140,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(Character actual) {
     return assertThat(actual);
   }
@@ -139,6 +151,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractClassAssert<?> then(Class<?> actual) {
     return assertThat(actual);
   }
@@ -150,6 +163,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -160,6 +174,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
@@ -173,6 +188,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
@@ -326,6 +342,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(double actual) {
     return assertThat(actual);
   }
@@ -336,6 +353,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(Double actual) {
     return assertThat(actual);
   }
@@ -346,6 +364,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> then(double[] actual) {
     return assertThat(actual);
   }
@@ -356,6 +375,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFileAssert<?> then(File actual) {
     return assertThat(actual);
   }
@@ -366,6 +386,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
     return assertThat(actual);
   }
@@ -376,6 +397,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> then(float actual) {
     return assertThat(actual);
   }
@@ -386,6 +408,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatAssert<?> then(Float actual) {
     return assertThat(actual);
   }
@@ -396,6 +419,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> then(float[] actual) {
     return assertThat(actual);
   }
@@ -406,6 +430,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(int actual) {
     return assertThat(actual);
   }
@@ -416,6 +441,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntArrayAssert<?> then(int[] actual) {
     return assertThat(actual);
   }
@@ -426,6 +452,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(Integer actual) {
     return assertThat(actual);
   }
@@ -436,6 +463,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> then(List<? extends T> actual) {
     return assertThat(actual);
   }
@@ -446,6 +474,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> then(long actual) {
     return assertThat(actual);
   }
@@ -456,6 +485,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongAssert<?> then(Long actual) {
     return assertThat(actual);
   }
@@ -466,6 +496,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractLongArrayAssert<?> then(long[] actual) {
     return assertThat(actual);
   }
@@ -476,6 +507,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -486,6 +518,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> then(T[] actual) {
     return assertThat(actual);
   }
@@ -496,6 +529,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static <K, V> MapAssert<K, V> then(Map<K, V> actual) {
     return assertThat(actual);
   }
@@ -506,6 +540,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> then(short actual) {
     return assertThat(actual);
   }
@@ -516,6 +551,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortAssert<?> then(Short actual) {
     return assertThat(actual);
   }
@@ -526,6 +562,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractShortArrayAssert<?> then(short[] actual) {
     return assertThat(actual);
   }
@@ -536,6 +573,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
     return assertThat(actual);
   }
@@ -546,6 +584,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, String> then(String actual) {
     return assertThat(actual);
   }
@@ -556,6 +595,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractDateAssert<?> then(Date actual) {
     return assertThat(actual);
   }
@@ -566,6 +606,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
     return assertThat(actual);
   }
@@ -595,6 +636,7 @@ public class Java6BDDAssertions {
    * @param shouldRaiseThrowable The {@link ThrowableAssert.ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return assertThatThrownBy(shouldRaiseThrowable);
   }
@@ -605,6 +647,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUriAssert<?> then(URI actual) {
     return assertThat(actual);
   }
@@ -615,6 +658,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
+  @CheckReturnValue
   public static AbstractUrlAssert<?> then(URL actual) {
     return assertThat(actual);
   }
@@ -670,6 +714,7 @@ public class Java6BDDAssertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
+  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T then(T assertion) {
     return assertion;
   }

--- a/src/main/java/org/assertj/core/util/CheckReturnValue.java
+++ b/src/main/java/org/assertj/core/util/CheckReturnValue.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Findbugs handles any annotation with name "CheckReturnValue" in return value check.
+ *
+ * @see <a href="https://github.com/findbugsproject/findbugs/blob/264ae7baf890d2b347d91805c90057062b5dcb1e/findbugs/src/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java#L120">Findbugs source code</a>
+ */
+@Target({
+        ElementType.CONSTRUCTOR,
+        ElementType.METHOD,
+        ElementType.PACKAGE,
+        ElementType.TYPE,
+})
+@Retention(RetentionPolicy.CLASS)
+public @interface CheckReturnValue {
+}


### PR DESCRIPTION
#### Check List:
* Fixes #157
* Unit tests : NA
* Javadoc with a code example (API only) : NA

I've found [this](https://github.com/joel-costigliola/assertj-core/pull/436), dug into Findbugs code, and [apparently](https://github.com/findbugsproject/findbugs/blob/264ae7baf890d2b347d91805c90057062b5dcb1e/findbugs/src/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java#L120), Findbugs handles **any** annotation with name `CheckReturnValue` in its return value usage check. So, if we supply our own annotation, we can avoid being dependent on `jsr305` package.

If you approve it, I'll search for other classes in assertJ where it's reasonable to put this annotation and also will backport to 2.x version as well.

I also checked it against my build of this branch, it totally works! See https://github.com/karlicoss/assertj-return-value-demo
