### PR TITLE
Use @SafeVarargs to avoid warning on caller' side

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -188,8 +188,8 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> PredicateAssert<T> then(Predicate<T> actual) {
-    return proxy(PredicateAssert.class, Predicate.class, actual);
+  public <T> SoftAssertionPredicateAssert<T> then(Predicate<T> actual) {
+    return proxy(SoftAssertionPredicateAssert.class, Predicate.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -188,8 +188,8 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
-    return proxy(PredicateAssert.class, Predicate.class, actual);
+  public <T> SoftAssertionPredicateAssert<T> assertThat(Predicate<T> actual) {
+    return proxy(SoftAssertionPredicateAssert.class, Predicate.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/SoftAssertionPredicateAssert.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionPredicateAssert.java
@@ -15,29 +15,16 @@ package org.assertj.core.api;
 import java.util.function.Predicate;
 
 /**
- * Assertions for {@link Predicate}.
- *
- * @param <T> type of the value contained in the {@link Predicate}.
- * @author Filip Hrisafov
- *
- * @since 3.5.0
+ * Concrete assertions for {@link Predicate}s without any final methods to allow proxying.
+ * 
+ * @author Gaël LHEZ
+ * @since 3.5.2
  */
-public class PredicateAssert<T> extends AbstractPredicateAssert<PredicateAssert<T>, T> {
+public class SoftAssertionPredicateAssert<T>
+    extends AbstractPredicateAssert<PredicateAssert<T>, T> {
 
-  protected PredicateAssert(Predicate<T> actual) {
-    super(actual, PredicateAssert.class);
-  }
-
-  @SafeVarargs
-  @Override
-  public final PredicateAssert<T> accepts(T... values) {
-    return super.accepts(values);
-  }
-
-  @SafeVarargs
-  @Override
-  public final PredicateAssert<T> rejects(T... values) {
-    return super.rejects(values);
+  public SoftAssertionPredicateAssert(Predicate<T> actual) {
+    super(actual, SoftAssertionPredicateAssert.class);
   }
 
 }


### PR DESCRIPTION
Hello

When user wants to test a predicate or check the content of a collection, such as:

```java
    Predicate<Map.Entry<String, String>> predicate = ...
    assertThat(predicate)
      .rejects(Pair.of("A", "B"))
      .accepts(Pair.of("C", "D"))
    ;
```
Or, with a map:

```java
   Map<String, String> map = ...
   assertThat(map.entrySet())
     .containsExactly(Pair.of("A", "B"))
   ;
```

The compiler will emits the following warning (under Eclipse, javac generates more or less the same kind of message): 

> Type safety: A generic array of Map.Entry<String,String> is created for a varargs parameter

To avoid this, the [`@SafeVarargs`](https://docs.oracle.com/javase/7/docs/api/java/lang/SafeVarargs.html) may be used. 
This implies that assertj does not do unsafe thing with the var args, which should be the case (especially in `IterableAssert `where `Iterables `methods mostly takes Object[] as source).

The alternative version is to use the iterables based methods (`rejectAll`, ...) but that produce more in-digest code:

```java
    assertThatPredicate(pred)
      .acceptsAll(asList(Pair.of("test", 1)))
      .rejectsAll(asList(Pair.of("test", 0)))
    ;
```

**Warning** : this commit will break the unit test code (see test in error here : [test_unit_error.txt](https://github.com/joel-costigliola/assertj-core/files/351084/test_unit_error.txt) ) because some use proxies and because `final` needs to be added (see javadoc of @SafeVarargs), the proxy fail to generate the method. 

Since I don't know what's the intent of that proxy, I committed it without it.





