### PR TITLE
Provide @SafeVarargs for ListAssert and IterableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -374,7 +374,7 @@ public class Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterable<? extends ELEMENT> actual) {
+  public static <ELEMENT> IterableAssert<ELEMENT> assertThat(Iterable<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
 
@@ -389,7 +389,7 @@ public class Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> AbstractIterableAssert<?, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Iterator<? extends ELEMENT> actual) {
+  public static <ELEMENT> IterableAssert<ELEMENT> assertThat(Iterator<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
 
@@ -400,7 +400,7 @@ public class Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(List<? extends ELEMENT> actual) {
+  public static <ELEMENT> ListAssert<ELEMENT> assertThat(List<? extends ELEMENT> actual) {
     return new ListAssert<>(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -200,7 +200,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterable<? extends T> actual) {
+  public static <T> IterableAssert<T> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -214,7 +214,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterator<? extends T> actual) {
+  public static <T> IterableAssert<T> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -500,7 +500,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> then(List<? extends T> actual) {
+  public static <T> ListAssert<T> then(List<? extends T> actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/IterableAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableAssert.java
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  * <p>
  * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Iterable)}</code>.
  * </p>
+ * 
  * @param <ELEMENT> the type of elements of the "actual" value.
  * 
  * @author Yvonne Wang
@@ -47,15 +48,8 @@ public class IterableAssert<ELEMENT> extends
     this(toLazyIterable(actual));
   }
 
-  private static <T> Iterable<T> toLazyIterable(Iterator<T> actual) {
-    if (actual == null) {
-      return null;
-    }
-    return new LazyIterable<>(actual);
-  }
-
   @Override
-  public IterableAssert<ELEMENT> isEqualTo(Object expected)  {
+  public IterableAssert<ELEMENT> isEqualTo(Object expected) {
     if (actual instanceof LazyIterable) {
       objects.assertEqual(info, asLazyIterable().iterator, expected);
       return myself;
@@ -154,7 +148,8 @@ public class IterableAssert<ELEMENT> extends
   }
 
   @Override
-  public IterableAssert<ELEMENT> startsWith(@SuppressWarnings("unchecked") ELEMENT... sequence) {
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> startsWith(ELEMENT... sequence) {
     if (!(actual instanceof LazyIterable)) {
       return super.startsWith(sequence);
     }
@@ -223,6 +218,54 @@ public class IterableAssert<ELEMENT> extends
       list.add(iterator.next());
     }
     return list;
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsOnly(ELEMENT... values) {
+    return super.containsOnly(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsOnlyOnce(ELEMENT... values) {
+    return super.containsOnlyOnce(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsExactly(ELEMENT... values) {
+    return super.containsExactly(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsExactlyInAnyOrder(ELEMENT... values) {
+    return super.containsExactlyInAnyOrder(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> isSubsetOf(ELEMENT... values) {
+    return super.isSubsetOf(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsSequence(ELEMENT... sequence) {
+    return super.containsSequence(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> containsSubsequence(ELEMENT... sequence) {
+    return super.containsSubsequence(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> endsWith(ELEMENT... sequence) {
+    return super.endsWith(sequence);
   }
 
 }

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -180,8 +180,8 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> IterableAssert<T> then(Iterable<? extends T> actual) {
-    return proxy(IterableAssert.class, Iterable.class, actual);
+  public <T> SoftAssertionIterableAssert<T> then(Iterable<? extends T> actual) {
+    return proxy(SoftAssertionIterableAssert.class, Iterable.class, actual);
   }
 
   /**
@@ -194,8 +194,8 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> IterableAssert<T> then(Iterator<T> actual) {
-    return proxy(IterableAssert.class, Iterator.class, actual);
+  public <T> SoftAssertionIterableAssert<T> then(Iterator<T> actual) {
+    return proxy(SoftAssertionIterableAssert.class, Iterator.class, actual);
   }
 
   /**
@@ -327,8 +327,8 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> ListAssert<T> then(List<? extends T> actual) {
-    return proxy(ListAssert.class, List.class, actual);
+  public <T> SoftAssertionListAssert<T> then(List<? extends T> actual) {
+    return proxy(SoftAssertionListAssert.class, List.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -172,28 +172,31 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
 
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
+   * <p>
+   * We don't return {@link IterableAssert} as it has overridden methods to annotated with {@link SafeVarargs}.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> IterableAssert<T> assertThat(Iterable<? extends T> actual) {
-    return proxy(IterableAssert.class, Iterable.class, actual);
+  public <T> SoftAssertionIterableAssert<T> assertThat(Iterable<? extends T> actual) {
+    return proxy(SoftAssertionIterableAssert.class, Iterable.class, actual);
   }
 
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>. The <code>{@link Iterator}</code> is first
-   * converted
-   * into an <code>{@link Iterable}</code>
+   * converted into an <code>{@link Iterable}</code>
+   * <p>
+   * We don't return {@link IterableAssert} as it has overridden methods to annotated with {@link SafeVarargs}.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> IterableAssert<T> assertThat(Iterator<T> actual) {
-    return proxy(IterableAssert.class, Iterator.class, actual);
+  public <T> SoftAssertionIterableAssert<T> assertThat(Iterator<T> actual) {
+    return proxy(SoftAssertionIterableAssert.class, Iterator.class, actual);
   }
 
   /**
@@ -239,7 +242,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
   public FileAssert assertThat(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
-
 
   /**
    * Creates a new instance of <code>{@link InputStreamAssert}</code>.
@@ -320,14 +322,16 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
 
   /**
    * Creates a new instance of <code>{@link ListAssert}</code>.
-   *
+   * <p>
+   * We don't return {@link IterableAssert} as it has overridden methods to annotated with {@link SafeVarargs}.
+   * 
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <T> ListAssert<T> assertThat(List<? extends T> actual) {
-    return proxy(ListAssert.class, List.class, actual);
+  public <T> SoftAssertionListAssert<T> assertThat(List<? extends T> actual) {
+    return proxy(SoftAssertionListAssert.class, List.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -19,6 +19,7 @@ import java.util.List;
  * <p>
  * To create an instance of this class, invoke <code>{@link Assertions#assertThat(List)}</code>.
  * <p>
+ * 
  * @param <ELEMENT> the type of elements of the "actual" value.
  * 
  * @author Yvonne Wang
@@ -30,8 +31,67 @@ public class ListAssert<ELEMENT> extends
     FactoryBasedNavigableListAssert<ListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
 
   public ListAssert(List<? extends ELEMENT> actual) {
-
     super(actual, ListAssert.class, new ObjectAssertFactory<ELEMENT>());
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> contains(ELEMENT... values) {
+    return super.contains(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsOnlyOnce(ELEMENT... values) {
+    return super.containsOnlyOnce(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsExactly(ELEMENT... values) {
+    return super.containsExactly(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsExactlyInAnyOrder(ELEMENT... values) {
+    return super.containsExactlyInAnyOrder(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> isSubsetOf(ELEMENT... values) {
+    return super.isSubsetOf(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsSequence(ELEMENT... sequence) {
+    return super.containsSequence(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsSubsequence(ELEMENT... sequence) {
+    return super.containsSubsequence(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> doesNotContain(ELEMENT... values) {
+    return super.doesNotContain(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> startsWith(ELEMENT... sequence) {
+    return super.startsWith(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> endsWith(ELEMENT... sequence) {
+    return super.endsWith(sequence);
   }
 
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertionIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionIterableAssert.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Concrete assertions for {@link Iterable}s without any final methods to allow proxying.
+ * 
+ * @author Gaël LHEZ
+ * @since 2.5.1 / 3.5.1
+ */
+public class SoftAssertionIterableAssert<ELEMENT> extends
+    FactoryBasedNavigableIterableAssert<SoftAssertionIterableAssert<ELEMENT>, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
+
+  public SoftAssertionIterableAssert(Iterable<? extends ELEMENT> actual) {
+    super(actual, SoftAssertionIterableAssert.class, new ObjectAssertFactory<ELEMENT>());
+  }
+
+  public SoftAssertionIterableAssert(Iterator<? extends ELEMENT> actual) {
+    this(toLazyIterable(actual));
+  }
+
+  @Override
+  protected <ELEMENT2> AbstractListAssert<?, List<? extends ELEMENT2>, ELEMENT2, ObjectAssert<ELEMENT2>> newListAssertInstance(List<? extends ELEMENT2> newActual) {
+    return new SoftAssertionListAssert<>(newActual);
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/SoftAssertionListAssert.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionListAssert.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.List;
+
+/**
+ * Concrete assertions for {@link List}s without any final methods to allow proxying.
+ * 
+ * @author Gaël LHEZ
+ * @since 2.5.1 / 3.5.1
+ */
+public class SoftAssertionListAssert<ELEMENT> extends
+    FactoryBasedNavigableListAssert<SoftAssertionListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
+
+  public SoftAssertionListAssert(List<? extends ELEMENT> actual) {
+    super(actual, SoftAssertionListAssert.class, new ObjectAssertFactory<ELEMENT>());
+  }
+
+  @Override
+  protected <ELEMENT2> AbstractListAssert<?, List<? extends ELEMENT2>, ELEMENT2, ObjectAssert<ELEMENT2>> newListAssertInstance(List<? extends ELEMENT2> newActual) {
+    return new SoftAssertionListAssert<>(newActual);
+  }
+
+}


### PR DESCRIPTION
Hello,

To continue my PR #704 , here the version for Assertj 2.5.1 which handle `ListAssert` and `IterableAssert`. I'll try to add it in 3.5.1 tomorrow so except a new PR.

The commit is a little tricky: 

- Some test failed because some method in `AbstractIterableAssert` returned a `ListAssert` while it should have been a `SoftAssertionIterableAssert`. 
- Some methods in `AbstractIterableAssert` returned `ListAssert` with a cast to `SELF`. It probably works (at runtime) because Java replace `SELF` by `AbstractIterableAssert` but it is wrong: in some place, `SELF` might mean `IterableAssert` and I don't think that `(IterableAssert) new ListAssert<>()` is valid especially if you try to call a method specific to `IterableAssert`.

So I added a new method `newListAssertInstance` which create an `AbstractListAssert` letting the implementation overriding it with the best choice - the default being `ListAssert`.

It is probably too complicated for "just" some warnings but the other alternatives à la `EnumSet.of` is no better unless there is a code generator that could silently generate those.

