### PR TITLE
add AbstractCharSequenceAssert#isBlank, #isJavaBlank, #isNotBlank and…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -122,6 +122,100 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} is blank, i.e. is {@code null}, has a length of 0 or
+   * contains only whitespace characters.
+   * <p>
+   * These assertions will succeed:
+   * <pre><code class='java'> String emptyString = &quot;&quot;
+   * assertThat(emptyString).isBlank();
+   * assertThat("").isBlank();
+   * assertThat(" ").isBlank();
+   * assertThat("     ").isBlank();</code></pre>
+   * 
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat("a").isBlank();
+   * assertThat(" b").isBlank();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is blank.
+   */
+  public S isBlank() {
+    strings.assertBlank(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is not blank, i.e., is not {@code null} and has a length of 1 or
+   * more and contains not only whitespace characters.
+   * <p>
+   * These assertion will succeed:
+   * <pre><code class='java'> assertThat("a").isNotBlank();
+   * assertThat(" b").isNotBlank();
+   * assertThat(" c ").isNotBlank();</code></pre>
+   * 
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat(" ").isNotBlank();
+   * assertThat("").isNotBlank();
+   * String nullString = null;
+   * assertThat(nullString).isNotBlank();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is blank.
+   */
+  public S isNotBlank() {
+    strings.assertNotBlank(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is blank, i.e. is {@code null}, has a length of 0 or
+   * contains only whitespace characters (according to {@link Character#isWhitespace(char)}).
+   * <p>
+   * These assertions will succeed:
+   * <pre><code class='java'> String emptyString = &quot;&quot;
+   * assertThat(emptyString).isBlank();
+   * assertThat("").isBlank();
+   * assertThat(" ").isBlank();
+   * assertThat("     ").isBlank();</code></pre>
+   * 
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat("a").isBlank();
+   * assertThat(" b").isBlank();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not blank.
+   */
+  public S isJavaBlank() {
+    strings.assertJavaBlank(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is not blank, i.e., is not {@code null} and has a length of 1 or
+   * more and contains not only whitespace characters (according to {@link Character#isWhitespace(char)}).
+   * <p>
+   * These assertion will succeed:
+   * <pre><code class='java'> assertThat("a").isNotBlank();
+   * assertThat(" b").isNotBlank();
+   * assertThat(" c ").isNotBlank();</code></pre>
+   * 
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat(" ").isNotBlank();
+   * assertThat("").isNotBlank();
+   * String nullString = null;
+   * assertThat(nullString).isNotBlank();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is blank.
+   */
+  public S isNotJavaBlank() {
+    strings.assertNotJavaBlank(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} has the expected length using the {@code length()} method.
    * <p>
    * This assertion will succeed:

--- a/src/main/java/org/assertj/core/error/ShouldBeBlank.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeBlank.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies {@link CharSequence} is {@code Null},
+ * empty or contains only whitespace.
+ */
+public class ShouldBeBlank extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeBlank}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeBlank(CharSequence actual) {
+    return new ShouldBeBlank(actual);
+  }
+
+  private ShouldBeBlank(Object actual) {
+    super("%nExpecting blank but was:<%s>", actual);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldNotBeBlank.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotBeBlank.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies {@link CharSequence}
+ * is not {@code Null}, not empty or contains not only whitespace.
+ */
+public class ShouldNotBeBlank extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotBeBlank}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotBeBlank(CharSequence actual) {
+    return new ShouldNotBeBlank(actual);
+  }
+
+  private ShouldNotBeBlank(Object actual) {
+    super("%nExpecting not blank but was:<%s>", actual);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import static java.lang.Character.isDigit;
 import static java.lang.Character.isWhitespace;
 import static java.lang.String.format;
+import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
@@ -29,6 +30,7 @@ import static org.assertj.core.error.ShouldContainOnlyDigits.shouldContainOnlyDi
 import static org.assertj.core.error.ShouldContainPattern.shouldContainPattern;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.error.ShouldMatchPattern.shouldMatch;
+import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringCase.shouldNotBeEqualIgnoringCase;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace.shouldNotBeEqualIgnoringWhitespace;
@@ -141,6 +143,86 @@ public class Strings {
 
   private static boolean hasContent(CharSequence s) {
     return s.length() > 0;
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is {@code Null}, empty or contains only
+   * whitespace.
+   * 
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is not blank.
+   */
+  public void assertBlank(AssertionInfo info, CharSequence actual) {
+    if (!isBlank(actual)) {
+      throw failures.failure(info, shouldBeBlank(actual));
+    }
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is not {@code Null}, not empty
+   * and contains not only whitespace.
+   * 
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is blank.
+   */
+  public void assertNotBlank(AssertionInfo info, CharSequence actual) {
+    if (isBlank(actual)) {
+      throw failures.failure(info, shouldNotBeBlank(actual));
+    }
+  }
+
+  private boolean isBlank(CharSequence actual) {
+    if (actual == null || actual.length() == 0) {
+      return true;
+    }
+    for (int i = 0; i < actual.length(); i++) {
+      if (!Whitespace.isWhitespace(actual.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is {@code Null}, empty or contains only
+   * whitespace according to {@link Character#isWhitespace(char)}.
+   * 
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is not blank.
+   */
+  public void assertJavaBlank(AssertionInfo info, CharSequence actual) {
+    if (!isJavaBlank(actual)) {
+      throw failures.failure(info, shouldBeBlank(actual));
+    }
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is not {@code Null}, 
+   * not empty or contains not only whitespace according to {@link Character#isWhitespace(char)}.
+   * 
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is blank.
+   */
+  public void assertNotJavaBlank(AssertionInfo info, CharSequence actual) {
+    if (isJavaBlank(actual)) {
+      throw failures.failure(info, shouldNotBeBlank(actual));
+    }
+  }
+
+  private boolean isJavaBlank(CharSequence actual) {
+    if (actual == null || actual.length() == 0) {
+      return true;
+    }
+    for (int i = 0; i < actual.length(); i++) {
+      if (!Character.isWhitespace(actual.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -701,4 +783,18 @@ public class Strings {
     }
   }
 
+  // copied from guava and adapted
+  private static final class Whitespace {
+
+    private static final String TABLE = "\u2002\u3000\r\u0085\u200A\u2005\u2000\u3000"
+                                        + "\u2029\u000B\u3000\u2008\u2003\u205F\u3000\u1680"
+                                        + "\u0009\u0020\u2006\u2001\u202F\u00A0\u000C\u2009"
+                                        + "\u3000\u2004\u3000\u3000\u2028\n\u2007\u3000";
+    private static final int MULTIPLIER = 1682554634;
+    private static final int SHIFT = Integer.numberOfLeadingZeros(TABLE.length() - 1);
+
+    public static boolean isWhitespace(char c) {
+      return TABLE.charAt((MULTIPLIER * c) >>> SHIFT) == c;
+    }
+  }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertBlank_Test.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class Strings_assertBlank_Test extends StringsBaseTest {
+
+  @Test
+  @DataProvider(value = {
+      "null",
+      "",
+      " ",
+      "\u005Ct", // tab
+      "\u005Cn", // line feed
+      "\u005Cr", // carriage return
+      "\u00A0", // non-breaking space 
+      "\u2007", // non-breaking space
+      "\u202F", // non-breaking space
+      " \u005Cn\u005Cr  "
+  }, trimValues=false)
+  public void should_pass_string_is_blank(String actual) {
+    strings.assertBlank(someInfo(), actual);
+  }
+
+  @Test
+  @DataProvider(value = {
+      "a",
+      " bc "
+  }, trimValues=false)
+  public void should_fail_if_string_is_not_blank(String actual) {
+    try {
+      strings.assertBlank(someInfo(), actual);
+    } catch (AssertionError expectedAssertionError) {
+      verifyFailureThrownWhenStringIsNotBank(someInfo(), actual);
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  private void verifyFailureThrownWhenStringIsNotBank(AssertionInfo info, String actual) {
+    verify(failures).failure(info, shouldBeBlank(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertJavaBlank_Test.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class Strings_assertJavaBlank_Test extends StringsBaseTest {
+
+  @Test
+  @DataProvider(value = {
+      "null",
+      "",
+      " ",
+      "\u005Ct", // tab
+      "\u005Cn", // line feed
+      "\u005Cr", // carriage return
+      " \u005Cn\u005Cr  "
+  }, trimValues=false)
+  public void should_pass_string_is_blank(String actual) {
+    strings.assertJavaBlank(someInfo(), actual);
+  }
+
+  @Test
+  @DataProvider(value = {
+      "a",
+      " bc ",
+      "\u00A0", // non-breaking space 
+      "\u2007", // non-breaking space
+      "\u202F", // non-breaking space
+  }, trimValues=false)
+  public void should_fail_if_string_is_not_blank(String actual) {
+    try {
+      strings.assertJavaBlank(someInfo(), actual);
+    } catch (AssertionError expectedAssertionError) {
+      verifyFailureThrownWhenStringIsNotBank(someInfo(), actual);
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  private void verifyFailureThrownWhenStringIsNotBank(AssertionInfo info, String actual) {
+    verify(failures).failure(info, shouldBeBlank(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotBlank_Test.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class Strings_assertNotBlank_Test extends StringsBaseTest {
+
+  @Test
+  @DataProvider(value = {
+      "a",
+      " bc "
+  }, trimValues=false)
+  public void should_pass_string_is_not_blank(String actual) {
+    strings.assertNotBlank(someInfo(), actual);
+  }
+
+  @Test
+  @DataProvider(value = {
+      "null",
+      "",
+      " ",
+      "\u005Ct", // tab
+      "\u005Cn", // line feed
+      "\u005Cr", // carriage return
+      "\u00A0", // non-breaking space 
+      "\u2007", // non-breaking space
+      "\u202F", // non-breaking space
+      " \u005Cn\u005Cr  "
+  }, trimValues=false)
+  public void should_fail_if_string_is_blank(String actual) {
+    try {
+      strings.assertNotBlank(someInfo(), actual);
+    } catch (AssertionError expectedAssertionError) {
+      verifyFailureThrownWhenStringIsBank(someInfo(), actual);
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  private void verifyFailureThrownWhenStringIsBank(AssertionInfo info, String actual) {
+    verify(failures).failure(info, shouldNotBeBlank(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotJavaBlank_Test.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+
+@RunWith(DataProviderRunner.class)
+public class Strings_assertNotJavaBlank_Test extends StringsBaseTest {
+
+  @Test
+  @DataProvider(value = {
+      "a",
+      " bc ",
+      "\u00A0", // non-breaking space 
+      "\u2007", // non-breaking space
+      "\u202F", // non-breaking space
+  }, trimValues=false)
+  public void should_pass_string_is_not_blank(String actual) {
+    strings.assertNotJavaBlank(someInfo(), actual);
+  }
+
+  @Test
+  @DataProvider(value = {
+      "null",
+      "",
+      " ",
+      "\u005Ct", // tab
+      "\u005Cn", // line feed
+      "\u005Cr", // carriage return
+      " \u005Cn\u005Cr  "
+  }, trimValues=false)
+  public void should_fail_if_string_is_blank(String actual) {
+    try {
+      strings.assertNotJavaBlank(someInfo(), actual);
+    } catch (AssertionError expectedAssertionError) {
+      verifyFailureThrownWhenStringIsBank(someInfo(), actual);
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  private void verifyFailureThrownWhenStringIsBank(AssertionInfo info, String actual) {
+    verify(failures).failure(info, shouldNotBeBlank(actual));
+  }
+}


### PR DESCRIPTION
… #isNotJavaBlank (closes #726)

I'm not sure what `isBlank` should check. I implemented the method to similar to commons-langs StringUtils#isBlank https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#isBlank(java.lang.CharSequence) Then I noticed that `isEmpty` fails for `Null` so should `isBlank` fail for `Null` and empty Strings?