### PR TITLE
Pull apart Future assertions from CompletableFuture

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCompletableFutureAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCompletableFutureAssert.java
@@ -15,15 +15,11 @@ package org.assertj.core.api;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.error.ShouldMatch.shouldMatch;
-import static org.assertj.core.error.future.ShouldBeCancelled.shouldBeCancelled;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 import static org.assertj.core.error.future.ShouldBeCompletedExceptionally.shouldHaveCompletedExceptionally;
-import static org.assertj.core.error.future.ShouldBeDone.shouldBeDone;
 import static org.assertj.core.error.future.ShouldHaveFailed.shouldHaveFailed;
-import static org.assertj.core.error.future.ShouldNotBeCancelled.shouldNotBeCancelled;
 import static org.assertj.core.error.future.ShouldNotBeCompleted.shouldNotBeCompleted;
 import static org.assertj.core.error.future.ShouldNotBeCompletedExceptionally.shouldNotHaveCompletedExceptionally;
-import static org.assertj.core.error.future.ShouldNotBeDone.shouldNotBeDone;
 import static org.assertj.core.error.future.ShouldNotHaveFailed.shouldNotHaveFailed;
 
 import java.util.Objects;
@@ -40,7 +36,7 @@ import org.assertj.core.presentation.PredicateDescription;
  * @param <T> type of the value contained in the {@link CompletableFuture}.
  */
 public abstract class AbstractCompletableFutureAssert<S extends AbstractCompletableFutureAssert<S, T>, T> extends
-    AbstractAssert<S, CompletableFuture<T>> {
+    AbstractFutureAssert<S, CompletableFuture<T>, T> {
 
   protected AbstractCompletableFutureAssert(CompletableFuture<T> actual, Class<?> selfType) {
     super(actual, selfType);
@@ -59,10 +55,9 @@ public abstract class AbstractCompletableFutureAssert<S extends AbstractCompleta
    *
    * @see CompletableFuture#isDone()
    */
+  //TODO: remove in next minor release
   public S isDone() {
-    isNotNull();
-    if (!actual.isDone()) throwAssertionError(shouldBeDone(actual));
-    return myself;
+    return super.isDone();
   }
 
   /**
@@ -78,10 +73,9 @@ public abstract class AbstractCompletableFutureAssert<S extends AbstractCompleta
    *
    * @see CompletableFuture#isDone()
    */
+  //TODO: remove in next minor release
   public S isNotDone() {
-    isNotNull();
-    if (actual.isDone()) throwAssertionError(shouldNotBeDone(actual));
-    return myself;
+    return super.isNotDone();
   }
 
   /**
@@ -144,10 +138,9 @@ public abstract class AbstractCompletableFutureAssert<S extends AbstractCompleta
    *
    * @see CompletableFuture#isCancelled()
    */
+  //TODO: remove in next minor release
   public S isCancelled() {
-    isNotNull();
-    if (!actual.isCancelled()) throwAssertionError(shouldBeCancelled(actual));
-    return myself;
+    return super.isCancelled();
   }
 
   /**
@@ -165,10 +158,9 @@ public abstract class AbstractCompletableFutureAssert<S extends AbstractCompleta
    *
    * @see CompletableFuture#isCancelled()
    */
+  //TODO: remove in next minor release
   public S isNotCancelled() {
-    isNotNull();
-    if (actual.isCancelled()) throwAssertionError(shouldNotBeCancelled(actual));
-    return myself;
+    return super.isNotCancelled();
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractFutureAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFutureAssert.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.error.future.ShouldBeCancelled.shouldBeCancelled;
+import static org.assertj.core.error.future.ShouldBeDone.shouldBeDone;
+import static org.assertj.core.error.future.ShouldNotBeCancelled.shouldNotBeCancelled;
+import static org.assertj.core.error.future.ShouldNotBeDone.shouldNotBeDone;
+
+import java.util.concurrent.Future;
+
+public abstract class AbstractFutureAssert<S extends AbstractFutureAssert<S, A, T>, A extends Future<T>, T> extends
+    AbstractAssert<S, A> {
+
+  protected AbstractFutureAssert(A actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Verifies that the {@link Future} is cancelled.
+   * <p>
+   * Assertion will pass :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * future.cancel(true);
+   * assertThat(future).isCancelled();</code></pre>
+   *
+   * Assertion will fail :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * assertThat(future).isCancelled();</code></pre>
+   *
+   * @return this assertion object.
+   *
+   * @see Future#isCancelled()
+   */
+  public S isCancelled() {
+    isNotNull();
+    if (!actual.isCancelled()) throwAssertionError(shouldBeCancelled(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the {@link Future} is not cancelled.
+   * <p>
+   * Assertion will pass :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * assertThat(future).isNotCancelled();</code></pre>
+   *
+   * Assertion will fail :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * future.cancel(true);
+   * assertThat(future).isNotCancelled();</code></pre>
+   *
+   * @return this assertion object.
+   *
+   * @see Future#isCancelled()
+   */
+  public S isNotCancelled() {
+    isNotNull();
+    if (actual.isCancelled()) throwAssertionError(shouldNotBeCancelled(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the {@link Future} is done.
+   * <p>
+   * Assertion will pass :
+   * <pre><code class='java'> Future future = CompletableFuture.completedFuture("something");
+   * assertThat(future).isDone();</code></pre>
+   *
+   * Assertion will fail :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * assertThat(future).isDone();</code></pre>
+   *
+   * @return this assertion object.
+   *
+   * @see Future#isDone()
+   */
+  public S isDone() {
+    isNotNull();
+    if (!actual.isDone()) throwAssertionError(shouldBeDone(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the {@link Future} is not done.
+   * <p>
+   * Assertion will pass :
+   * <pre><code class='java'> Future future = new CompletableFuture();
+   * assertThat(future).isNotDone();</code></pre>
+   *
+   * Assertion will fail :
+   * <pre><code class='java'> Future future = CompletableFuture.completedFuture("something");
+   * assertThat(future).isNotDone();</code></pre>
+   *
+   * @return this assertion object.
+   *
+   * @see Future#isDone()
+   */
+  public S isNotDone() {
+    isNotNull();
+    if (actual.isDone()) throwAssertionError(shouldNotBeDone(actual));
+    return myself;
+  }
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -39,6 +39,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.function.DoublePredicate;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
@@ -157,6 +158,19 @@ public class Assertions {
    */
   @CheckReturnValue
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
+    return AssertionsForInterfaceTypes.assertThat(actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.concurrent.Future}.
+   *
+   * @param actual the actual value.
+   * @param <T> the type of the value contained in the {@link java.util.concurrent.Future}.
+   *
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static <T> FutureAssert<T> assertThat(Future<T> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -35,7 +35,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
@@ -70,19 +69,6 @@ import org.assertj.core.util.introspection.FieldSupport;
  * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
  */
 public class AssertionsForClassTypes {
-
-  /**
-   * Create assertion for {@link java.util.concurrent.Future}.
-   *
-   * @param actual the actual value.
-   * @param <T> the type of the value contained in the {@link java.util.concurrent.Future}.
-   *
-   * @return the created assertion object.
-   */
-  @CheckReturnValue
-  public static <T> FutureAssert<T> assertThat(Future<T> actual) {
-    return new FutureAssert<>(actual);
-  }
 
   /**
    * Create assertion for {@link java.util.concurrent.CompletableFuture}.

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -35,6 +35,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
@@ -69,6 +70,19 @@ import org.assertj.core.util.introspection.FieldSupport;
  * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
  */
 public class AssertionsForClassTypes {
+
+  /**
+   * Create assertion for {@link java.util.concurrent.Future}.
+   *
+   * @param actual the actual value.
+   * @param <T> the type of the value contained in the {@link java.util.concurrent.Future}.
+   *
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static <T> FutureAssert<T> assertThat(Future<T> actual) {
+    return new FutureAssert<>(actual);
+  }
 
   /**
    * Create assertion for {@link java.util.concurrent.CompletableFuture}.

--- a/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
@@ -87,6 +88,19 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.concurrent.Future}.
+   *
+   * @param actual the actual value.
+   * @param <T> the type of the value contained in the {@link java.util.concurrent.Future}.
+   *
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static <T> FutureAssert<T> assertThat(Future<T> actual) {
+    return new FutureAssert<>(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/FutureAssert.java
+++ b/src/main/java/org/assertj/core/api/FutureAssert.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.concurrent.Future;
+
+public class FutureAssert<T> extends AbstractFutureAssert<FutureAssert<T>, Future<T>, T> {
+
+  protected FutureAssert(Future<T> actual) {
+    super(actual, FutureAssert.class);
+  }
+
+}

--- a/src/main/java/org/assertj/core/error/future/ShouldBeCancelled.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldBeCancelled.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldBeCancelled extends BasicErrorMessageFactory {
 
   private static final String SHOULD_BE_CANCELLED = "%nExpecting%n  <%s>%nto be cancelled";
 
+  // TODO: remove in next minor release
   public static ErrorMessageFactory shouldBeCancelled(CompletableFuture<?> actual) {
     return new ShouldBeCancelled(actual);
   }
 
-  private ShouldBeCancelled(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldBeCancelled(Future<?> actual) {
+    return new ShouldBeCancelled(actual);
+  }
+
+  private ShouldBeCancelled(Future<?> actual) {
     super(SHOULD_BE_CANCELLED, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/future/ShouldBeCompleted.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldBeCompleted.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldBeCompleted extends BasicErrorMessageFactory {
 
   private static final String SHOULD_BE_COMPLETED = "%nExpecting%n  <%s>%nto be completed";
 
+  // TODO: remove in next minor release
   public static ErrorMessageFactory shouldBeCompleted(CompletableFuture<?> actual) {
     return new ShouldBeCompleted(actual);
   }
 
-  private ShouldBeCompleted(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldBeCompleted(Future<?> actual) {
+    return new ShouldBeCompleted(actual);
+  }
+
+  private ShouldBeCompleted(Future<?> actual) {
     super(SHOULD_BE_COMPLETED, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/future/ShouldBeDone.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldBeDone.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldBeDone extends BasicErrorMessageFactory {
 
   private static final String SHOULD_BE_DONE = "%nExpecting%n  <%s>%nto be done";
 
+  //TODO: remove in next minor releease
   public static ErrorMessageFactory shouldBeDone(CompletableFuture<?> actual) {
     return new ShouldBeDone(actual);
   }
 
-  private ShouldBeDone(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldBeDone(Future<?> actual) {
+    return new ShouldBeDone(actual);
+  }
+
+  private ShouldBeDone(Future<?> actual) {
     super(SHOULD_BE_DONE, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/future/ShouldNotBeCancelled.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldNotBeCancelled.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldNotBeCancelled extends BasicErrorMessageFactory {
 
   private static final String SHOULD_NOT_BE_CANCELLED = "%nExpecting%n  <%s>%nnot to be cancelled";
 
+  //TODO: remove in next minor release
   public static ErrorMessageFactory shouldNotBeCancelled(CompletableFuture<?> actual) {
     return new ShouldNotBeCancelled(actual);
   }
 
-  private ShouldNotBeCancelled(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldNotBeCancelled(Future<?> actual) {
+    return new ShouldNotBeCancelled(actual);
+  }
+
+  private ShouldNotBeCancelled(Future<?> actual) {
     super(SHOULD_NOT_BE_CANCELLED, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/future/ShouldNotBeCompleted.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldNotBeCompleted.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldNotBeCompleted extends BasicErrorMessageFactory {
 
   private static final String SHOULD_NOT_BE_COMPLETED = "%nExpecting%n  <%s>%nnot to be completed";
 
+  // TODO: remove in next minor release
   public static ErrorMessageFactory shouldNotBeCompleted(CompletableFuture<?> actual) {
     return new ShouldNotBeCompleted(actual);
   }
 
-  private ShouldNotBeCompleted(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldNotBeCompleted(Future<?> actual) {
+    return new ShouldNotBeCompleted(actual);
+  }
+
+  private ShouldNotBeCompleted(Future<?> actual) {
     super(SHOULD_NOT_BE_COMPLETED, actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/future/ShouldNotBeDone.java
+++ b/src/main/java/org/assertj/core/error/future/ShouldNotBeDone.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error.future;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -21,11 +22,16 @@ public class ShouldNotBeDone extends BasicErrorMessageFactory {
 
   private static final String SHOULD_NOT_BE_DONE = "%nExpecting%n  <%s>%nnot to be done";
 
+  // TODO: remove in next minor release
   public static ErrorMessageFactory shouldNotBeDone(CompletableFuture<?> actual) {
     return new ShouldNotBeDone(actual);
   }
 
-  private ShouldNotBeDone(CompletableFuture<?> actual) {
+  public static ErrorMessageFactory shouldNotBeDone(Future<?> actual) {
+    return new ShouldNotBeDone(actual);
+  }
+
+  private ShouldNotBeDone(Future<?> actual) {
     super(SHOULD_NOT_BE_DONE, actual);
   }
 }


### PR DESCRIPTION
I noticed that a few methods apply to `Future` as well.
This means that `Future` subclasses will be accepted by the type system (like `ForkJoinTask`, or custom `Future`s).

#### Check List:
* Fixes #??? **(would that be necessary @joel-costigliola?)**
* Unit tests : YES / NO / NA **(will add tests after this is acknowledged)**
* Javadoc with a code example (API only) : **YES** / NO / NA



