### PR TITLE
remove path dependency from assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -21,7 +21,6 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.util.Date;
@@ -279,16 +278,6 @@ public class Assertions {
     return new FileAssert(actual);
   }
 
-  /**
-   * Creates a new instance of {@link PathAssert}
-   *
-   * @param actual the path to test
-   * @return the created assertion object
-   */
-  @CheckReturnValue
-  public static AbstractPathAssert<?> assertThat(Path actual) {
-    return new PathAssert(actual);
-  }
 
   /**
    * Creates a new instance of <code>{@link InputStreamAssert}</code>.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -405,16 +405,6 @@ public class BDDAssertions extends Assertions {
     return assertThat(actual);
   }
 
-  /**
-   * Creates a new instance of {@link PathAssert}
-   *
-   * @param actual the path to test
-   * @return the created assertion object
-   */
-  @CheckReturnValue
-  public static AbstractPathAssert<?> then(Path actual) {
-    return assertThat(actual);
-  }
 
   /**
    * Creates a new instance of <code>{@link org.assertj.core.api.InputStreamAssert}</code>.

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSameContentAs_Test.java
@@ -49,29 +49,5 @@ public class PathAssert_hasSameContentAs_Test extends PathAssertBaseTest {
   protected void verify_internal_effects() {
 	verify(paths).assertHasSameContentAs(getInfo(assertions), getActual(assertions), defaultCharset(), expected, defaultCharset());
   }
-  
-  @Test
-  public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
-    Charset turkishCharset = Charset.forName("windows-1254");
-    Path actual = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
-    Path expected = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
 
-    assertThat(actual).usingCharset(turkishCharset).hasSameContentAs(expected);
-  }
-
-  @Test
-  public void should_allow_charset_to_be_specified_for_reading_expected_file_content() throws Exception {
-    Charset turkishCharset = Charset.forName("windows-1254");
-    Path actual = createDeleteOnExitTempFileWithContent("Gerçek", defaultCharset());
-    Path expected = createDeleteOnExitTempFileWithContent("Gerçek", turkishCharset);
-
-    assertThat(actual).hasSameContentAs(expected, turkishCharset);
-  }
-
-  private Path createDeleteOnExitTempFileWithContent(String content, Charset charset) throws IOException {
-    Path tempFile = Files.createTempFile("test", "test");
-    tempFile.toFile().deleteOnExit();
-    Files.write(tempFile, asList(content), charset);
-    return tempFile;
-  }
 }


### PR DESCRIPTION
* Fixes Android couldn't use this version due to issue with not finding `java.nio.file.Path`


