### PR TITLE
add internal wrapper for the the comparator by types;

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -41,6 +41,7 @@ import org.assertj.core.groups.FieldsOrPropertiesExtractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.internal.CommonErrors;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.FieldByFieldComparator;
 import org.assertj.core.internal.IgnoringFieldsComparator;
@@ -88,7 +89,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   private static final String ASSERT = "Assert";
 
   private Map<String, Comparator<?>> comparatorsForElementPropertyOrFieldNames = new HashMap<>();
-  private Map<Class<?>, Comparator<?>> comparatorsForElementPropertyOrFieldTypes = new HashMap<>();
+  private TypeComparators comparatorsForElementPropertyOrFieldTypes = new TypeComparators();
 
   protected Iterables iterables = Iterables.instance();
 

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -39,6 +39,7 @@ import org.assertj.core.groups.FieldsOrPropertiesExtractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.internal.CommonErrors;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.internal.FieldByFieldComparator;
 import org.assertj.core.internal.IgnoringFieldsComparator;
 import org.assertj.core.internal.ObjectArrayElementComparisonStrategy;
@@ -74,7 +75,7 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
   ObjectArrays arrays = ObjectArrays.instance();
 
   private Map<String, Comparator<?>> comparatorsForElementPropertyOrFieldNames = new HashMap<>();
-  private Map<Class<?>, Comparator<?>> comparatorsForElementPropertyOrFieldTypes = new HashMap<>();
+  private TypeComparators comparatorsForElementPropertyOrFieldTypes = new TypeComparators();
 
   public AbstractObjectArrayAssert(T[] actual, Class<?> selfType) {
     super(actual, selfType);

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Tuple;
+import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.util.DoubleComparator;
 import org.assertj.core.util.FloatComparator;
 import org.assertj.core.util.introspection.IntrospectionError;
@@ -45,14 +46,14 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
   private static final float FLOAT_COMPARATOR_PRECISION = 1e-6f;
 
   private Map<String, Comparator<?>> comparatorByPropertyOrField = new HashMap<>();
-  private Map<Class<?>, Comparator<?>> comparatorByType = defaultTypeComparators();
+  private TypeComparators comparatorByType = defaultTypeComparators();
 
   public AbstractObjectAssert(A actual, Class<?> selfType) {
     super(actual, selfType);
   }
 
-  public static Map<Class<?>, Comparator<?>> defaultTypeComparators() {
-    Map<Class<?>, Comparator<?>> comparatorByType = new HashMap<>();
+  public static TypeComparators defaultTypeComparators() {
+    TypeComparators comparatorByType = new TypeComparators();
     comparatorByType.put(Double.class, new DoubleComparator(DOUBLE_COMPARATOR_PRECISION));
     comparatorByType.put(Float.class, new FloatComparator(FLOAT_COMPARATOR_PRECISION));
     return comparatorByType;

--- a/src/main/java/org/assertj/core/internal/DeepDifference.java
+++ b/src/main/java/org/assertj/core/internal/DeepDifference.java
@@ -140,6 +140,7 @@ public class DeepDifference {
    * 
    * @param a Object one to compare
    * @param b Object two to compare
+   * @param comparatorByType
    * @return the list of differences found or an empty list if objects are equivalent.
    *         Equivalent means that all field values of both subgraphs are the same,
    *         either at the field level or via the respectively encountered overridden
@@ -147,7 +148,7 @@ public class DeepDifference {
    */
   public static List<Difference> determineDifferences(Object a, Object b,
                                                       Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                      Map<Class<?>, Comparator<?>> comparatorByType) {
+                                                      TypeComparators comparatorByType) {
     final Set<DualKey> visited = new HashSet<>();
     final Deque<DualKey> toCompare = initStack(a, b, visited);
     final List<Difference> differences = new ArrayList<>();
@@ -303,7 +304,7 @@ public class DeepDifference {
   }
 
   private static boolean hasCustomComparator(DualKey dualKey, Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                             Map<Class<?>, Comparator<?>> comparatorByType) {
+                                             TypeComparators comparatorByType) {
     if (dualKey.key1.getClass() == dualKey.key2.getClass()) {
       String fieldName = dualKey.getConcatenatedPath();
       Comparator<?> fieldComparator = comparatorByPropertyOrField.containsKey(fieldName)

--- a/src/main/java/org/assertj/core/internal/FieldByFieldComparator.java
+++ b/src/main/java/org/assertj/core/internal/FieldByFieldComparator.java
@@ -28,17 +28,17 @@ public class FieldByFieldComparator implements Comparator<Object> {
   private static final int NOT_EQUAL = -1;
 
   protected final Map<String, Comparator<?>> comparatorByPropertyOrField;
-  protected final Map<Class<?>, Comparator<?>> comparatorByType;
+  protected final TypeComparators comparatorByType;
 
   public FieldByFieldComparator(Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                Map<Class<?>, Comparator<?>> comparatorByType) {
+                                TypeComparators comparatorByType) {
     this.comparatorByPropertyOrField = comparatorByPropertyOrField;
     this.comparatorByType = comparatorByType;
   }
 
   public FieldByFieldComparator() {
     this.comparatorByPropertyOrField = new HashMap<>();
-    this.comparatorByType = new HashMap<>();
+    this.comparatorByType = new TypeComparators();
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
@@ -25,7 +25,7 @@ public class IgnoringFieldsComparator extends FieldByFieldComparator {
   private String[] fields;
 
   public IgnoringFieldsComparator(Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                  Map<Class<?>, Comparator<?>> comparatorByType, String... fields) {
+                                  TypeComparators comparatorByType, String... fields) {
     super(comparatorByPropertyOrField, comparatorByType);
     this.fields = fields;
   }

--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -522,7 +522,7 @@ public class Objects {
    */
   public <A> void assertIsEqualToIgnoringNullFields(AssertionInfo info, A actual, A other,
                                                     Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                    Map<Class<?>, Comparator<?>> comparatorByType) {
+                                                    TypeComparators comparatorByType) {
     assertNotNull(info, actual);
     List<String> fieldsNames = new LinkedList<>();
     List<Object> rejectedValues = new LinkedList<>();
@@ -564,7 +564,7 @@ public class Objects {
    */
   public <A> void assertIsEqualToComparingOnlyGivenFields(AssertionInfo info, A actual, A other,
                                                           Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                          Map<Class<?>, Comparator<?>> comparatorByType,
+                                                          TypeComparators comparatorByType,
                                                           String... fields) {
     assertNotNull(info, actual);
     ByFieldsComparison byFieldsComparison = isEqualToComparingOnlyGivenFields(actual, other,
@@ -580,7 +580,7 @@ public class Objects {
 
   private <A> ByFieldsComparison isEqualToComparingOnlyGivenFields(A actual, A other,
                                                                    Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                                   Map<Class<?>, Comparator<?>> comparatorByType,
+                                                                   TypeComparators comparatorByType,
                                                                    String[] fields) {
     List<String> rejectedFieldsNames = new LinkedList<>();
     List<Object> expectedValues = new LinkedList<>();
@@ -613,7 +613,7 @@ public class Objects {
    */
   public <A> void assertIsEqualToIgnoringGivenFields(AssertionInfo info, A actual, A other,
                                                      Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                     Map<Class<?>, Comparator<?>> comparatorByType, String... fields) {
+                                                     TypeComparators comparatorByType, String... fields) {
     assertNotNull(info, actual);
     ByFieldsComparison byFieldsComparison = isEqualToIgnoringGivenFields(actual, other, comparatorByPropertyOrField,
                                                                          comparatorByType, fields);
@@ -626,7 +626,7 @@ public class Objects {
 
   private <A> ByFieldsComparison isEqualToIgnoringGivenFields(A actual, A other,
                                                               Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                              Map<Class<?>, Comparator<?>> comparatorByType,
+                                                              TypeComparators comparatorByType,
                                                               String[] givenIgnoredFields) {
     Set<Field> declaredFieldsIncludingInherited = getDeclaredFieldsIncludingInherited(actual.getClass());
     List<String> fieldsNames = new LinkedList<>();
@@ -655,7 +655,7 @@ public class Objects {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   static boolean propertyOrFieldValuesAreEqual(Object actualFieldValue, Object otherFieldValue, String fieldName,
                                                Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                               Map<Class<?>, Comparator<?>> comparatorByType) {
+                                               TypeComparators comparatorByType) {
     if (actualFieldValue != null && otherFieldValue != null
         && actualFieldValue.getClass() == otherFieldValue.getClass()) {
       Comparator fieldComparator = comparatorByPropertyOrField.containsKey(fieldName)
@@ -704,9 +704,9 @@ public class Objects {
    * @throws AssertionError if actual is {@code null}.
    * @throws AssertionError if the actual and the given object are not "deeply" equal.
    */
-  public <A> void assertIsEqualToComparingFieldByFieldRecursively(AssertionInfo info, A actual, A other,
+  public <A> void assertIsEqualToComparingFieldByFieldRecursively(AssertionInfo info, Object actual, Object other,
                                                                   Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                                  Map<Class<?>, Comparator<?>> comparatorByType) {
+                                                                  TypeComparators comparatorByType) {
     assertNotNull(info, actual);
     List<Difference> differences = determineDifferences(actual, other, comparatorByPropertyOrField, comparatorByType);
     if (!differences.isEmpty()) {
@@ -770,14 +770,14 @@ public class Objects {
 
   public boolean areEqualToIgnoringGivenFields(Object actual, Object other,
                                                Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                               Map<Class<?>, Comparator<?>> comparatorByType, String... fields) {
+                                               TypeComparators comparatorByType, String... fields) {
     return isEqualToIgnoringGivenFields(actual, other, comparatorByPropertyOrField, comparatorByType,
                                         fields).isFieldsNamesEmpty();
   }
 
   public boolean areEqualToComparingOnlyGivenFields(Object actual, Object other,
                                                     Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                                    Map<Class<?>, Comparator<?>> comparatorByType, String... fields) {
+                                                    TypeComparators comparatorByType, String... fields) {
     return isEqualToComparingOnlyGivenFields(actual, other, comparatorByPropertyOrField, comparatorByType,
                                              fields).isFieldsNamesEmpty();
   }

--- a/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
@@ -28,7 +28,7 @@ public class OnFieldsComparator extends FieldByFieldComparator {
   private String[] fields;
 
   public OnFieldsComparator(Map<String, Comparator<?>> comparatorByPropertyOrField,
-                            Map<Class<?>, Comparator<?>> comparatorByType, String... fields) {
+                            TypeComparators comparatorByType, String... fields) {
     super(comparatorByPropertyOrField, comparatorByType);
     if (isNullOrEmpty(fields)) throw new IllegalArgumentException("No fields/properties specified");
     for (String field : fields) {
@@ -40,7 +40,7 @@ public class OnFieldsComparator extends FieldByFieldComparator {
   }
 
   public OnFieldsComparator(String... fields) {
-    this(new HashMap<String, Comparator<?>>(), new HashMap<Class<?>, Comparator<?>>(), fields);
+    this(new HashMap<String, Comparator<?>>(), new TypeComparators(), fields);
   }
 
   @VisibleForTesting

--- a/src/main/java/org/assertj/core/internal/RecursiveFieldByFieldComparator.java
+++ b/src/main/java/org/assertj/core/internal/RecursiveFieldByFieldComparator.java
@@ -28,15 +28,15 @@ public class RecursiveFieldByFieldComparator implements Comparator<Object> {
   private static final int NOT_EQUAL = -1;
 
   private final Map<String, Comparator<?>> comparatorByPropertyOrField;
-  private final Map<Class<?>, Comparator<?>> comparatorByType;
+  private final TypeComparators comparatorByType;
 
   public RecursiveFieldByFieldComparator(Map<String, Comparator<?>> comparatorByPropertyOrField,
-                                         Map<Class<?>, Comparator<?>> comparatorByType) {
+                                         TypeComparators comparatorByType) {
     this.comparatorByPropertyOrField = comparatorByPropertyOrField;
     this.comparatorByType = isNullOrEmpty(comparatorByType) ? defaultTypeComparators() : comparatorByType;
   }
 
-  private boolean isNullOrEmpty(Map<Class<?>, Comparator<?>> comparatorByType) {
+  private boolean isNullOrEmpty(TypeComparators comparatorByType) {
     return comparatorByType == null || comparatorByType.isEmpty();
   }
 

--- a/src/main/java/org/assertj/core/internal/TypeComparators.java
+++ b/src/main/java/org/assertj/core/internal/TypeComparators.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.util.introspection.ClassUtils;
+
+/**
+ * An internal holder of the comparators for type. It is used to store comparators for registered classes.
+ * When looking for a Comparator for a given class the holder returns the most relevant comparator.
+ *
+ * @author Filip Hrisafov
+ */
+public class TypeComparators {
+
+  private Map<Class<?>, Comparator<?>> typeComparators;
+
+  public TypeComparators() {
+    typeComparators = new HashMap<>();
+  }
+
+  /**
+   * This method returns the most relevant comparator for the given class. The most relevant comparator is the
+   * comparator which is registered for the class that is closest in the inheritance chain of the given {@code clazz}.
+   * The order of checks is the following:
+   * 1. If there is a registered comparator for {@code clazz} then this one is used
+   * 2. We check if there is a registered comparator for all the superclasses of {@code clazz}
+   * 3. We check if there is a registered comparator for all the interfaces if {@code clazz}
+   *
+   * @param clazz the class for which to find a comparator
+   * @return the most relevant comparator, or {@code null} if no comparator could be found
+   */
+  public Comparator<?> get(Class<?> clazz) {
+    Comparator<?> comparator = typeComparators.get(clazz);
+
+    if (comparator == null) {
+      for (Class<?> superClass : ClassUtils.getAllSuperclasses(clazz)) {
+        if (typeComparators.containsKey(superClass)) {
+          comparator = typeComparators.get(superClass);
+          break;
+        }
+      }
+
+      if (comparator == null) {
+        for (Class<?> interfaceClass : ClassUtils.getAllInterfaces(clazz)) {
+          if (typeComparators.containsKey(interfaceClass)) {
+            comparator = typeComparators.get(interfaceClass);
+            break;
+          }
+        }
+      }
+    }
+    return comparator;
+  }
+
+  /**
+   * Puts the {@code comparator} for the given {@code clazz}.
+   *
+   * @param clazz the class for the comparator
+   * @param comparator the comparator it self
+   * @param <T> the type of the objects for the comparator
+   */
+  public <T> void put(Class<T> clazz, Comparator<T> comparator) {
+    typeComparators.put(clazz, comparator);
+  }
+
+  /**
+   * @return {@code true} is there are registered comparators, {@code false} otherwise
+   */
+  public boolean isEmpty() {
+    return typeComparators.isEmpty();
+  }
+
+  @Override
+  public int hashCode() {
+    return typeComparators.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TypeComparators && typeComparators.equals(((TypeComparators) obj).typeComparators);
+  }
+
+  @Override
+  public String toString() {
+    return typeComparators.toString();
+  }
+}

--- a/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
+++ b/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
@@ -20,6 +20,26 @@ import java.util.List;
 public class ClassUtils {
 
   /**
+   * <p>Gets a {@code List} of superclasses for the given class.</p>
+   *
+   * @param cls the class to look up, may be {@code null}
+   * @return the {@code List} of superclasses in order going up from this one
+   * {@code null} if null input
+   */
+  public static List<Class<?>> getAllSuperclasses(final Class<?> cls) {
+    if (cls == null) {
+      return null;
+    }
+    final List<Class<?>> classes = new ArrayList<Class<?>>();
+    Class<?> superclass = cls.getSuperclass();
+    while (superclass != null) {
+      classes.add(superclass);
+      superclass = superclass.getSuperclass();
+    }
+    return classes;
+  }
+
+  /**
    * <p>
    * Gets a {@code List} of all interfaces implemented by the given class and its superclasses.
    * </p>
@@ -33,7 +53,7 @@ public class ClassUtils {
    * @param cls the class to look up, may be {@code null}
    * @return the {@code List} of interfaces in order, {@code null} if null input
    */
-  static List<Class<?>> getAllInterfaces(Class<?> cls) {
+  public static List<Class<?>> getAllInterfaces(Class<?> cls) {
     if (cls == null) return null;
   
     LinkedHashSet<Class<?>> interfacesFound = new LinkedHashSet<>();

--- a/src/test/java/org/assertj/core/internal/ObjectsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ObjectsBaseTest.java
@@ -64,7 +64,7 @@ public class ObjectsBaseTest {
     return new HashMap<>();
   }
 
-  public static Map<Class<?>, Comparator<?>> defaultTypeComparators() {
+  public static TypeComparators defaultTypeComparators() {
     return AbstractObjectAssert.defaultTypeComparators();
   }
 

--- a/src/test/java/org/assertj/core/internal/RecursiveFieldByFieldComparator_compareTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/RecursiveFieldByFieldComparator_compareTo_Test.java
@@ -21,7 +21,7 @@ public class RecursiveFieldByFieldComparator_compareTo_Test {
 
   @SuppressWarnings("unchecked")
   private static final RecursiveFieldByFieldComparator RECURSIVE_FIELD_BY_FIELD_COMPARATOR = new RecursiveFieldByFieldComparator(EMPTY_MAP,
-                                                                                                                                 EMPTY_MAP);
+                                                                                                                                 new TypeComparators());
 
   @Test
   public void should_return_true_if_Objects_are_equal() {

--- a/src/test/java/org/assertj/core/internal/RecursiveFieldByFieldComparator_toString_Test.java
+++ b/src/test/java/org/assertj/core/internal/RecursiveFieldByFieldComparator_toString_Test.java
@@ -22,6 +22,6 @@ public class RecursiveFieldByFieldComparator_toString_Test {
   @Test
   @SuppressWarnings("unchecked")
   public void should_return_description_of_RecursiveFieldByFieldComparator() {
-    assertThat(new RecursiveFieldByFieldComparator(EMPTY_MAP, EMPTY_MAP)).hasToString("recursive field/property by field/property comparator on all fields/properties");
+    assertThat(new RecursiveFieldByFieldComparator(EMPTY_MAP, new TypeComparators())).hasToString("recursive field/property by field/property comparator on all fields/properties");
   }
 }

--- a/src/test/java/org/assertj/core/internal/TypeComparators_Test.java
+++ b/src/test/java/org/assertj/core/internal/TypeComparators_Test.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import java.util.Comparator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class TypeComparators_Test {
+
+  private TypeComparators typeComparators;
+
+  @Before
+  public void setUp() {
+    typeComparators = new TypeComparators();
+  }
+
+  @Test
+  public void should_return_exact_match() {
+    Comparator<Foo> fooComparator = newComparator();
+    Comparator<Bar> barComparator = newComparator();
+    typeComparators.put(Foo.class, fooComparator);
+    typeComparators.put(Bar.class, barComparator);
+
+    Comparator<?> foo = typeComparators.get(Foo.class);
+    Comparator<?> bar = typeComparators.get(Bar.class);
+    assertThat(foo).isEqualTo(fooComparator);
+    assertThat(bar).isEqualTo(barComparator);
+  }
+
+  @Test
+  public void should_return_parent_comparator() {
+    Comparator<Bar> barComparator = newComparator();
+    typeComparators.put(Bar.class, barComparator);
+
+    Comparator<?> foo = typeComparators.get(Foo.class);
+    Comparator<?> bar = typeComparators.get(Bar.class);
+    assertThat(foo).isEqualTo(bar);
+    assertThat(bar).isEqualTo(barComparator);
+  }
+
+  @Test
+  public void should_return_most_relevant() {
+
+    Comparator<I3> i3Comparator = newComparator();
+    Comparator<I4> i4Comparator = newComparator();
+    Comparator<I1> i1Comparator = newComparator();
+    Comparator<I2> i2Comparator = newComparator();
+    Comparator<Foo> fooComparator = newComparator();
+    typeComparators.put(I3.class, i3Comparator);
+    typeComparators.put(I4.class, i4Comparator);
+    typeComparators.put(I1.class, i1Comparator);
+    typeComparators.put(I2.class, i2Comparator);
+    typeComparators.put(Foo.class, fooComparator);
+
+    Comparator<?> foo = typeComparators.get(Foo.class);
+    Comparator<?> bar = typeComparators.get(Bar.class);
+    Comparator<?> i3 = typeComparators.get(I3.class);
+    Comparator<?> i4 = typeComparators.get(I4.class);
+    Comparator<?> i5 = typeComparators.get(I5.class);
+    assertThat(foo).isEqualTo(fooComparator);
+    assertThat(bar).isEqualTo(i3Comparator);
+    assertThat(i3).isEqualTo(i3Comparator);
+    assertThat(i4).isEqualTo(i4Comparator);
+    assertThat(i5).isEqualTo(i1Comparator);
+  }
+
+  @Test
+  public void should_find_no_comparator() {
+
+    Comparator<I3> i3Comparator = newComparator();
+    Comparator<I4> i4Comparator = newComparator();
+    Comparator<Foo> fooComparator = newComparator();
+    typeComparators.put(I3.class, i3Comparator);
+    typeComparators.put(I4.class, i4Comparator);
+    typeComparators.put(Foo.class, fooComparator);
+
+    Comparator<?> i5 = typeComparators.get(I5.class);
+    assertThat(i5).isNull();
+  }
+
+  @Test
+  public void should_be_empty() {
+    assertThat(typeComparators.isEmpty()).isTrue();
+  }
+
+  private static <T> Comparator<T> newComparator() {
+    return new Comparator<T>() {
+      @Override
+      public int compare(T o1, T o2) {
+        return 0;
+      }
+    };
+  }
+
+  private interface I1 {
+  }
+
+  private interface I2 {
+  }
+
+  private interface I3 {
+  }
+
+  private interface I4 {
+  }
+
+  private interface I5 extends I1, I2 {
+  }
+
+  private class Bar implements I3 {
+
+  }
+
+  private class Foo extends Bar implements I4, I5 {
+
+  }
+
+}


### PR DESCRIPTION
Add new method to the ClassUtils, so all super classes can be retrieved

@joel-costigliola This is just my first iteration of the fix. I am not entirely sure about the change of modifier and the new method in the `ClassUtils`. Maybe we need to do this a bit differently.

* Fixes #758 

