### PR TITLE
Fix platform specific test

### DIFF
--- a/src/test/java/org/assertj/core/error/ShouldHaveSuppressedException_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSuppressedException_create_Test.java
@@ -37,7 +37,7 @@ public class ShouldHaveSuppressedException_create_Test {
                                          "to have a suppressed exception with the following type and message:%n" +
                                          "  <\"java.lang.IllegalArgumentException\"> / <\"foo\">%n" +
                                          "but could not find any in actual's suppressed exceptions:%n" +
-                                         "  <[java.lang.IllegalArgumentException: invalid arg,\n" +
+                                         "  <[java.lang.IllegalArgumentException: invalid arg,%n" +
                                          "    java.lang.NullPointerException: null arg]>."));
   }
 }


### PR DESCRIPTION
While doing https://github.com/joel-costigliola/assertj-core/pull/759, this test was failing on my side (I am using Windows :)). This fixes the test (it makes sure that it uses `%s` instead of `\n`