### PR TITLE
limit the number of elements from an iterable, array and/or map that are printed in an error message

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -929,6 +929,32 @@ public class Assertions {
     StandardRepresentation.setMaxLengthForSingleLineDescription(maxLengthForSingleLineDescription);
   }
 
+  /**
+   * In error messages, sets the threshold for how many elements from one iterable/array/map will be included in the
+   * in the description.
+   *
+   * E.q. When this method is called with a value of {@code 3}.
+   * <p>
+   * The following array will be formatted entirely as it's length is <= 3:
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice");
+   *
+   * // formatted as:
+   *
+   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice"]</code></pre>
+   *
+   * whereas this array is formatted only with it's first 3 elements, followed by {@code ...}:
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", "Guards! Guards!");
+   *
+   * // formatted as:
+   *
+   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", ...]</code></pre>
+   *
+   * @param maxElementsForPrinting the maximum elements that would be printed from one iterable/array/map
+   */
+  public static void setMaxElementsForPrinting(int maxElementsForPrinting) {
+    StandardRepresentation.setMaxElementsForPrinting(maxElementsForPrinting);
+  }
+
   // ------------------------------------------------------------------------------------------------------
   // properties methods : not assertions but here to have a single entry point to all AssertJ features.
   // ------------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -890,6 +890,32 @@ public class Java6Assertions {
     StandardRepresentation.setMaxLengthForSingleLineDescription(maxLengthForSingleLineDescription);
   }
 
+  /**
+   * In error messages, sets the threshold for how many elements from one iterable/array/map will be included in the
+   * in the description.
+   *
+   * E.q. When this method is called with a value of {@code 3}.
+   * <p>
+   * The following array will be formatted entirely as it's length is <= 3:
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice");
+   *
+   * // formatted as:
+   *
+   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice"]</code></pre>
+   *
+   * whereas this array is formatted only with it's first 3 elements, followed by {@code ...}:
+   * <pre><code class='java'> String[] greatBooks = array("A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", "Guards! Guards!");
+   *
+   * // formatted as:
+   *
+   * ["A Game of Thrones", "The Lord of the Rings", "Assassin's Apprentice", ...]</code></pre>
+   *
+   * @param maxElementsForPrinting the maximum elements that would be printed from one iterable/array/map
+   */
+  public static void setMaxElementsForPrinting(int maxElementsForPrinting) {
+    StandardRepresentation.setMaxElementsForPrinting(maxElementsForPrinting);
+  }
+
   // ------------------------------------------------------------------------------------------------------
   // properties methods : not assertions but here to have a single entry point to all AssertJ features.
   // ------------------------------------------------------------------------------------------------------

--- a/src/test/java/org/assertj/core/presentation/AbstractBaseRepresentationTest.java
+++ b/src/test/java/org/assertj/core/presentation/AbstractBaseRepresentationTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.presentation;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author Filip Hrisafov
+ */
+public abstract class AbstractBaseRepresentationTest {
+
+  @Before
+  public void setUp() {
+    StandardRepresentation.resetDefaults();
+  }
+
+  @After
+  public void afterTests() {
+    StandardRepresentation.resetDefaults();
+  }
+}

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
@@ -16,8 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Strings.quote;
 
-import org.assertj.core.presentation.HexadecimalRepresentation;
-import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -25,7 +25,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  */
-public class StandardRepresentation_array_format_Test {
+public class StandardRepresentation_array_format_Test extends AbstractBaseRepresentationTest {
 
   @Test
   public void should_return_null_if_array_is_null() {
@@ -82,6 +82,13 @@ public class StandardRepresentation_array_format_Test {
   }
 
   @Test
+  public void should_format_primitive_array_up_to_the_maximum_allowed_elements() {
+    Object array = new int[] { 1, 2, 3, 4 };
+    StandardRepresentation.setMaxElementsForPrinting(3);
+    assertThat(STANDARD_REPRESENTATION.formatArray(array)).isEqualTo("[1, 2, 3, ...]");
+  }
+
+  @Test
   public void should_format_long_array() {
     Object array = new long[] { 160l, 98l };
     assertThat(STANDARD_REPRESENTATION.formatArray(array)).isEqualTo("[160L, 98L]");
@@ -133,6 +140,13 @@ public class StandardRepresentation_array_format_Test {
     Object[] array2 = { array1 };
     array1[1] = array2;
     assertThat(STANDARD_REPRESENTATION.formatArray(array2)).isEqualTo("[[\"Hello\", (this array)]]");
+  }
+
+  @Test
+  public void should_format_array_up_to_the_maximum_allowed_elements() {
+    StandardRepresentation.setMaxElementsForPrinting(3);
+    Object[] array = { "First", "Second", "Third", "Fourth" };
+    assertThat(STANDARD_REPRESENTATION.formatArray(array)).isEqualTo("[\"First\", \"Second\", \"Third\", ...]");
   }
 
   private static class Person {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-public class StandardRepresentation_iterable_format_Test {
+public class StandardRepresentation_iterable_format_Test extends AbstractBaseRepresentationTest {
 
   @Test
   public void should_return_null_if_iterable_is_null() {
@@ -66,6 +66,26 @@ public class StandardRepresentation_iterable_format_Test {
                                                        "    \"foo\",%n" +
                                                        "    \"bar\"]>"));
   }
+
+  @Test
+  public void should_format_iterable_up_to_the_maximum_allowed_elements_multi_line() {
+    StandardRepresentation.setMaxElementsForPrinting(3);
+    String formatted = STANDARD_REPRESENTATION.multiLineFormat(asList("First", 3, "foo", "bar"));
+    String formattedAfterNewLine = org.assertj.core.util.Compatibility.System.lineSeparator() + "  <" + formatted + ">";
+    assertThat(formattedAfterNewLine).isEqualTo(format("%n" +
+                                                       "  <[\"First\",%n" +
+                                                       "    3,%n" +
+                                                       "    \"foo\",%n" +
+                                                       "    ...]>"));
+  }
+
+  @Test
+  public void should_format_iterable_up_to_the_maximum_allowed_elements_single_line() {
+    StandardRepresentation.setMaxElementsForPrinting(3);
+    String formatted = STANDARD_REPRESENTATION.smartFormat(asList("First", 3, "foo", "bar"));
+    assertThat(formatted).isEqualTo("[\"First\", 3, \"foo\", ...]");
+  }
+
 
   @Test
   public void should_format_iterable_with_an_element_per_line_according_the_given_representation() {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  * @author Alex Ruiz
  * @author gabga
  */
-public class StandardRepresentation_map_format_Test {
+public class StandardRepresentation_map_format_Test extends AbstractBaseRepresentationTest {
 
   @Test
   public void should_return_null_if_Map_is_null() {
@@ -49,6 +49,16 @@ public class StandardRepresentation_map_format_Test {
     map.put("One", String.class);
     map.put("Two", File.class);
     assertThat(STANDARD_REPRESENTATION.toStringOf(map)).isEqualTo("{\"One\"=java.lang.String, \"Two\"=java.io.File}");
+  }
+
+  @Test
+  public void should_format_Map_up_to_the_maximum_allowed_elements() {
+    Map<Character, Integer> map = new HashMap<>();
+    map.put('C', 3);
+    map.put('B', 2);
+    map.put('A', 1);
+    StandardRepresentation.setMaxElementsForPrinting(2);
+    assertThat(STANDARD_REPRESENTATION.toStringOf(map)).isEqualTo("{'A'=1, 'B'=2, ...}");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/StandardRepresentation_toStringOf_Test.java
+++ b/src/test/java/org/assertj/core/util/StandardRepresentation_toStringOf_Test.java
@@ -30,6 +30,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.presentation.AbstractBaseRepresentationTest;
+import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
 
 /**
@@ -37,7 +39,7 @@ import org.junit.Test;
  *
  * @author Joel Costigliola
  */
-public class StandardRepresentation_toStringOf_Test {
+public class StandardRepresentation_toStringOf_Test extends AbstractBaseRepresentationTest {
 
   @Test
   public void should_return_null_if_object_is_null() {
@@ -87,11 +89,29 @@ public class StandardRepresentation_toStringOf_Test {
   }
 
   @Test
+  public void should_return_toString_of_Collection_of_arrays_up_to_the_maximum_allowed_elements() {
+    List<Boolean[]> collection = newArrayList(array(true, false), array(true, false, true), array(true, true));
+    StandardRepresentation.setMaxElementsForPrinting(2);
+    assertThat(STANDARD_REPRESENTATION.toStringOf(collection)).isEqualTo("[[true, false], [true, false, ...], ...]");
+  }
+
+  @Test
   public void should_return_toString_of_Collection_of_Collections() {
     Collection<List<String>> collection = new ArrayList<>();
     collection.add(newArrayList("s1", "s2"));
     collection.add(newArrayList("s3", "s4", "s5"));
     assertThat(STANDARD_REPRESENTATION.toStringOf(collection)).isEqualTo("[[\"s1\", \"s2\"], [\"s3\", \"s4\", \"s5\"]]");
+  }
+
+  @Test
+  public void should_return_toString_of_Collection_of_Collections_up_to_the_maximum_allowed_elements() {
+    Collection<List<String>> collection = new ArrayList<>();
+    collection.add(newArrayList("s1", "s2"));
+    collection.add(newArrayList("s3", "s4", "s5"));
+    collection.add(newArrayList("s6", "s7"));
+    StandardRepresentation.setMaxElementsForPrinting(2);
+    assertThat(STANDARD_REPRESENTATION.toStringOf(collection))
+      .isEqualTo("[[\"s1\", \"s2\"], [\"s3\", \"s4\", ...], ...]");
   }
 
   @Test
@@ -111,6 +131,13 @@ public class StandardRepresentation_toStringOf_Test {
   public void should_return_toString_of_array_of_arrays() {
     String[][] array = array(array("s1", "s2"), array("s3", "s4", "s5"));
     assertThat(STANDARD_REPRESENTATION.toStringOf(array)).isEqualTo("[[\"s1\", \"s2\"], [\"s3\", \"s4\", \"s5\"]]");
+  }
+
+  @Test
+  public void should_return_toString_of_array_of_arrays_up_to_the_maximum_allowed_elements() {
+    String[][] array = array(array("s1", "s2"), array("s3", "s4", "s5"), array("s6", "s7"));
+    StandardRepresentation.setMaxElementsForPrinting(2);
+    assertThat(STANDARD_REPRESENTATION.toStringOf(array)).isEqualTo("[[\"s1\", \"s2\"], [\"s3\", \"s4\", ...], ...]");
   }
 
   @Test
@@ -192,6 +219,12 @@ public class StandardRepresentation_toStringOf_Test {
   @Test
   public void should_format_tuples() {
     assertThat(toStringOf(tuple(1, 2, 3))).isEqualTo("(1, 2, 3)");
+  }
+
+  @Test
+  public void should_format_tuples_up_to_the_maximum_allowed_elements() {
+    StandardRepresentation.setMaxElementsForPrinting(2);
+    assertThat(toStringOf(tuple(1, 2, 3))).isEqualTo("(1, 2, ...)");
   }
 
   private String toStringOf(Object o) {


### PR DESCRIPTION
#### Check List:
* Fixes #747 
* Unit tests : YES 
* Javadoc with a code example (API only) : YES 

I've set the default number of elements at 1000. We can also change this.

Btw. what is the reason for doing a `Collection` and not `Iterable` `instance of` in [StandardRepresentation#L124](https://github.com/joel-costigliola/assertj-core/blob/0ba3fa5d0d7f3efefdc9e0e71b1ea9fccf2cfab1/src/main/java/org/assertj/core/presentation/StandardRepresentation.java#L124)?