### PR TITLE
Add Path assertions to WithAssertions

### DIFF
--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -15,6 +15,8 @@ package org.assertj.core.api;
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.text.DateFormat;
@@ -33,6 +35,10 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.DoublePredicate;
+import java.util.function.IntPredicate;
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -134,7 +140,7 @@ public interface WithAssertions {
   /**
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Map)}
    */
-  default <K, V> AbstractMapAssert<?, ? extends Map<K, V>, K, V> assertThat(final Map<K, V> actual) {
+  default <K, V> MapAssert<K, V> assertThat(final Map<K, V> actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -260,17 +266,33 @@ public interface WithAssertions {
   /**
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Iterable)}
    */
-  default <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> assertThat(
-      final Iterable<? extends T> actual) {
+  default <T> IterableAssert<T> assertThat(final Iterable<? extends T> actual) {
     return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Iterable, AssertFactory)}
+   */
+  default <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
+  FactoryBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(Iterable<? extends ELEMENT> actual,
+                                                                                     AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
+    return Assertions.assertThat(actual, assertFactory);
   }
 
   /**
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Iterator)}
    */
-  default <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> assertThat(
-      final Iterator<? extends T> actual) {
+  default <T> IterableAssert<T> assertThat(final Iterator<? extends T> actual) {
     return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Iterable, Class)}
+   */
+  default <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
+  ClassBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(ACTUAL actual,
+                                                                                   Class<ELEMENT_ASSERT> assertClass) {
+    return Assertions.assertThat(actual, assertClass);
   }
 
   /**
@@ -395,9 +417,27 @@ public interface WithAssertions {
   /**
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(List)}
    */
-  default <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> assertThat(final List<? extends T> actual) {
+  default <T> ListAssert<? extends T> assertThat(final List<? extends T> actual) {
     return Assertions.assertThat(actual);
-  } 
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(List, Class)} )}
+   */
+  default <ELEMENT, ACTUAL extends List<? extends ELEMENT>, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
+  ClassBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
+                                                                               Class<ELEMENT_ASSERT> assertClass) {
+    return Assertions.assertThat(actual, assertClass);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(List, AssertFactory)} )}
+   */
+  default <ACTUAL extends List<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
+  FactoryBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
+                                                                                 AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
+    return Assertions.assertThat(actual, assertFactory);
+  }
 
   /**
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(List)}
@@ -674,6 +714,55 @@ public interface WithAssertions {
    */
   default <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
       return Assertions.assertThatExceptionOfType(exceptionType);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Predicate)}
+   */
+  default <T> PredicateAssert<T> assertThat(final Predicate<T> actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(IntPredicate)}
+   */
+  default IntPredicateAssert assertThat(final IntPredicate actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(LongPredicate)}
+   */
+  default LongPredicateAssert assertThat(final LongPredicate actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(DoublePredicate)}
+   */
+  default DoublePredicateAssert assertThat(final DoublePredicate actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(URL)}
+   */
+  default AbstractUrlAssert assertThat(final URL actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(URI)}
+   */
+  default AbstractUriAssert assertThat(final URI actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(AssertProvider)}
+   */
+  default <T> T assertThat(final AssertProvider<T> component) {
+    return Assertions.assertThat(component);
   }
 
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -332,6 +333,13 @@ public interface WithAssertions {
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(File)}
    */
   default AbstractFileAssert<?> assertThat(final File actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(Path)}
+   */
+  default AbstractPathAssert<?> assertThat(final Path actual) {
     return Assertions.assertThat(actual);
   }
 

--- a/src/test/java/org/assertj/core/api/AssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/AssertionsTest.java
@@ -44,4 +44,14 @@ public class AssertionsTest extends BaseAssertionsTest {
                                      .containsExactlyInAnyOrder(assertThatMethods);
 
   }
+
+  @Test
+  public void with_assertions_should_have_the_same_methods_as_in_assertions() {
+    Method[] withAssertionsMethods = findMethodsWithName(WithAssertions.class, "assertThat");
+    Method[] assertionsMethods = findMethodsWithName(Assertions.class, "assertThat");
+
+    assertThat(withAssertionsMethods)
+      .usingElementComparator(IGNORING_DECLARING_CLASS_AND_METHOD_NAME)
+      .containsExactlyInAnyOrder(assertionsMethods);
+  }
 }

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -15,7 +15,12 @@ package org.assertj.core.api;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DateFormat;
@@ -33,6 +38,11 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.DoublePredicate;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.exception.RuntimeIOException;
@@ -212,6 +222,22 @@ public class WithAssertions_delegation_Test implements WithAssertions {
    * Test that the delegate method is called.
    */
   @Test
+  public void withAssertions_assertThat_list_assert_class_Test() {
+    assertThat(Arrays.asList(ITEMS), ObjectAssert.class).first().isEqualTo(ITEMS[0]);
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThat_list_assert_factory_Test() {
+    assertThat(Arrays.asList(ITEMS), ObjectAssert::new).first().isEqualTo(ITEMS[0]);
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
   public void withAssertions_assertThat_stream_Test() {
     assertThat(Stream.of("")).hasSize(1);
   }
@@ -344,6 +370,22 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   @Test
   public void withAssertions_assertThat_iterable_Test() {
     assertThat((Iterable<TestItem>) Arrays.asList(ITEMS)).contains(ITEMS[0]);
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThat_iterable_assert_class_Test() {
+    assertThat((Iterable<TestItem>) Arrays.asList(ITEMS), ObjectAssert.class).first().isEqualTo(ITEMS[0]);
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThat_iterable_assert_factory_Test() {
+    assertThat((Iterable<TestItem>) Arrays.asList(ITEMS), ObjectAssert::new).first().isEqualTo(ITEMS[0]);
   }
 
   /**
@@ -718,4 +760,46 @@ public class WithAssertions_delegation_Test implements WithAssertions {
     });
     assertThat(t).hasMessage("message");
   }
+
+  @Test
+  public void withAssertions_assertThat_predicate_Test() {
+    Predicate<Boolean> predicate = b -> b;
+    assertThat(predicate).accepts(true);
+  }
+
+  @Test
+  public void withAssertions_assertThat_intPredicate_Test() {
+    IntPredicate predicate = i -> i == 0;
+    assertThat(predicate).accepts(0);
+  }
+
+  @Test
+  public void withAssertions_assertThat_longPredicate_Test() {
+    LongPredicate predicate = l -> l == 0;
+    assertThat(predicate).accepts(0l);
+  }
+
+  @Test
+  public void withAssertions_assertThat_doublePredicate_Test() {
+    DoublePredicate predicate = d -> d > 0;
+    assertThat(predicate).accepts(1.0);
+  }
+
+  @Test
+  public void withAssertions_assertThat_url_Test() throws MalformedURLException {
+    assertThat(new URL("https://github.com/joel-costigliola/assertj-core")).hasHost("github.com");
+  }
+
+  @Test
+  public void withAssertions_assertThat_uri_Test() throws URISyntaxException {
+    assertThat(new URI("https://github.com/joel-costigliola/assertj-core")).hasHost("github.com");
+  }
+
+  @Test
+  public void withAssertions_assertThat_assertProvider_Test() throws URISyntaxException {
+    Predicate<Boolean> predicate = b -> b;
+    AssertProvider<Predicate> assertProvider = () -> predicate;
+    assertThat(new URI("https://github.com/joel-costigliola/assertj-core")).hasHost("github.com");
+  }
 }
+

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -16,6 +16,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -450,6 +452,14 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   @Test
   public void withAssertions_assertThat_file_Test() {
     assertThat(new File(".")).isNotNull();
+  }
+
+  /**
+   * Test that the delegate method is called.
+   */
+  @Test
+  public void withAssertions_assertThat_path_Test() {
+    assertThat(Paths.get(".")).isNotNull();
   }
 
   /**


### PR DESCRIPTION
#### Check List:
* Unit tests : YES
* Javadoc with a code example (API only) : NA

Hi Joel,

I just noticed that Path assertions are absent from the `WithAssertions` interface. Is it an inadvertent omission or a deliberate omission ? 


