### PR TITLE
Add missing tests for various classes

### DIFF
--- a/src/test/java/org/assertj/core/api/AbstractComparableAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/AbstractComparableAssertBaseTest.java
@@ -36,4 +36,8 @@ public abstract class AbstractComparableAssertBaseTest extends BaseTestTemplate<
     comparables = mock(Comparables.class);
     assertions.comparables = comparables;
   }
+
+  protected Comparables getComparables(ConcreteComparableAssert someAssertions) {
+    return someAssertions.comparables;
+  }
 }

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseToPercentage_primitive_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseToPercentage_primitive_byte_Test.java
@@ -14,29 +14,23 @@ package org.assertj.core.api.byte_;
 
 import org.assertj.core.api.ByteAssert;
 import org.assertj.core.api.ByteAssertBaseTest;
-import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
+public class ByteAssert_isCloseToPercentage_primitive_byte_Test extends ByteAssertBaseTest {
 
-/**
- * Tests for <code>{@link ByteAssert#isNotCloseTo(Byte, Offset)}</code>.
- *
- * @author Chris Arnott
- */
-public class ByteAssert_isNotCloseTo_byte_Test extends ByteAssertBaseTest {
+    private final Percentage percentage = withPercentage((byte) 5);
+    private final byte value = 10;
 
-  private final Offset<Byte> offset = offset((byte)5);
-  private final Byte value = (byte)8;
+    @Override
+    protected ByteAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
 
-  @Override
-  protected ByteAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, offset);
-  }
-
-  @Override
-  protected void verify_internal_effects() {
-    verify(bytes).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
-  }
+    @Override
+    protected void verify_internal_effects() {
+        verify(bytes).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
 }

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseTo_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseTo_byte_Test.java
@@ -21,7 +21,7 @@ import org.assertj.core.data.Offset;
 
 
 /**
- * Tests for <code>{@link org.assertj.core.api.ByteAssert#isCloseTo(byte, org.assertj.core.data.Offset)}</code>.
+ * Tests for <code>{@link org.assertj.core.api.ByteAssert#isCloseTo(Byte, org.assertj.core.data.Offset)}</code>.
  *
  * @author Joel Costigliola
  */

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseTo_primitive_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isCloseTo_primitive_byte_Test.java
@@ -19,24 +19,23 @@ import org.assertj.core.data.Offset;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.verify;
 
-
 /**
- * Tests for <code>{@link ByteAssert#isNotCloseTo(Byte, Offset)}</code>.
+ * Tests for <code>{@link ByteAssert#isCloseTo(byte, Offset)}</code>.
  *
- * @author Chris Arnott
+ * @author Filip Hrisafov
  */
-public class ByteAssert_isNotCloseTo_byte_Test extends ByteAssertBaseTest {
+public class ByteAssert_isCloseTo_primitive_byte_Test extends ByteAssertBaseTest {
 
   private final Offset<Byte> offset = offset((byte)5);
-  private final Byte value = (byte)8;
+  private final byte value = (byte)8;
 
   @Override
   protected ByteAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, offset);
+    return assertions.isCloseTo(value, offset);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(bytes).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
+    verify(bytes).assertIsCloseTo(getInfo(assertions), getActual(assertions), value, offset);
   }
 }

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isNotCloseToPercentage_primitive_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isNotCloseToPercentage_primitive_byte_Test.java
@@ -14,29 +14,28 @@ package org.assertj.core.api.byte_;
 
 import org.assertj.core.api.ByteAssert;
 import org.assertj.core.api.ByteAssertBaseTest;
-import org.assertj.core.data.Offset;
+import org.assertj.core.data.Percentage;
 
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-
 /**
- * Tests for <code>{@link ByteAssert#isNotCloseTo(Byte, Offset)}</code>.
+ * Tests for <code>{@link ByteAssert#isNotCloseTo(byte, Percentage)}</code>.
  *
- * @author Chris Arnott
+ * @author Filip Hrisafov
  */
-public class ByteAssert_isNotCloseTo_byte_Test extends ByteAssertBaseTest {
+public class ByteAssert_isNotCloseToPercentage_primitive_byte_Test extends ByteAssertBaseTest {
 
-  private final Offset<Byte> offset = offset((byte)5);
-  private final Byte value = (byte)8;
+    private final Percentage percentage = withPercentage((byte) 5);
+    private final byte value = 10;
 
-  @Override
-  protected ByteAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, offset);
-  }
+    @Override
+    protected ByteAssert invoke_api_method() {
+        return assertions.isNotCloseTo(value, percentage);
+    }
 
-  @Override
-  protected void verify_internal_effects() {
-    verify(bytes).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
-  }
+    @Override
+    protected void verify_internal_effects() {
+        verify(bytes).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
 }

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isNotCloseTo_primitive_byte_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isNotCloseTo_primitive_byte_Test.java
@@ -19,16 +19,15 @@ import org.assertj.core.data.Offset;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.verify;
 
-
 /**
- * Tests for <code>{@link ByteAssert#isNotCloseTo(Byte, Offset)}</code>.
+ * Tests for <code>{@link ByteAssert#isNotCloseTo(byte, Offset)}</code>.
  *
- * @author Chris Arnott
+ * @author Filip Hrisafov
  */
-public class ByteAssert_isNotCloseTo_byte_Test extends ByteAssertBaseTest {
+public class ByteAssert_isNotCloseTo_primitive_byte_Test extends ByteAssertBaseTest {
 
   private final Offset<Byte> offset = offset((byte)5);
-  private final Byte value = (byte)8;
+  private final byte value = (byte)8;
 
   @Override
   protected ByteAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsOnlyOnce_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsOnlyOnce_with_Integer_Arguments_Test.java
@@ -12,34 +12,26 @@
  */
 package org.assertj.core.api.bytearray;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ByteArrays.arrayOf;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.assertj.core.api.ByteArrayAssert;
 import org.assertj.core.api.ByteArrayAssertBaseTest;
-import org.assertj.core.test.IntArrays;
-import org.junit.Test;
+
+import static org.assertj.core.test.IntArrays.arrayOf;
+import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link org.assertj.core.api.ByteArrayAssert#containsExactly(int...)}</code>.
+ * Tests for <code>{@link ByteArrayAssert#containsOnlyOnce(int...)}</code>.
+ * 
+ * @author Filip Hrisafov
  */
-public class ByteArrayAssert_containsExactly_with_Integer_Arguments_Test extends ByteArrayAssertBaseTest {
-
-  @Test
-  public void invoke_api_like_user() {
-    assertThat(new byte[] { 1, 2, 3 }).containsExactly(1, 2, 3);
-  }
+public class ByteArrayAssert_containsOnlyOnce_with_Integer_Arguments_Test extends ByteArrayAssertBaseTest {
 
   @Override
   protected ByteArrayAssert invoke_api_method() {
-    when(arrays.toByteArray(IntArrays.arrayOf(1, 2))).thenReturn(arrayOf(1, 2));
-    return assertions.containsExactly(1, 2);
+    return assertions.containsOnlyOnce(6, 8);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+    verify(arrays).assertContainsOnlyOnce(getInfo(assertions), getActual(assertions), arrayOf(6, 8));
   }
 }

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsOnly_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsOnly_with_Integer_Arguments_Test.java
@@ -13,18 +13,29 @@
 package org.assertj.core.api.bytearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.IntArrays.arrayOf;
+import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.ByteArrayAssert;
+import org.assertj.core.api.ByteArrayAssertBaseTest;
 import org.junit.Test;
 
 
 /**
  * Tests for <code>{@link ByteArrayAssert#containsOnly(int...)}</code>.
  */
-public class ByteArrayAssert_containsOnly_with_Integer_Arguments_Test {
+public class ByteArrayAssert_containsOnly_with_Integer_Arguments_Test extends ByteArrayAssertBaseTest {
 
   @Test
   public void invoke_api_like_user() {
     assertThat(new byte[] { 1, 2, 3 }).containsOnly(3, 2, 1);
+  }
+
+  @Override protected ByteArrayAssert invoke_api_method() {
+    return assertions.containsOnly(6, 8);
+  }
+
+  @Override protected void verify_internal_effects() {
+    verify(arrays).assertContainsOnly(getInfo(assertions), getActual(assertions), arrayOf(6, 8));
   }
 }

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsSequence_with_var_args_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsSequence_with_var_args_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsSequence(CharSequence...)} <CharSequence>)}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_containsSequence_with_var_args_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.containsSequence("od", "do");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsSequence(getInfo(assertions), getActual(assertions), new String[] { "od", "do" });
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_hasLineCount_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_hasLineCount_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#hasLineCount(int)}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_hasLineCount_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.hasLineCount(4);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertHasLineCount(getInfo(assertions), getActual(assertions), 4);
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isBlank_Test.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+import org.junit.Test;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isBlank()}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_isBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isJavaBlank_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isJavaBlank()}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_isJavaBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isJavaBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertJavaBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotBlank_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isNotBlank()}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_isNotBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isNotBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertNotBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotJavaBlank_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isNotJavaBlank()}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class CharSequenceAssert_isNotJavaBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isNotJavaBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertNotJavaBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_isBetween_Test.java
+++ b/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_isBetween_Test.java
@@ -13,17 +13,30 @@
 package org.assertj.core.api.comparable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigInteger;
 
+import org.assertj.core.api.AbstractComparableAssertBaseTest;
+import org.assertj.core.api.ConcreteComparableAssert;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AbstractComparableAssert_isBetween_Test {
+public class AbstractComparableAssert_isBetween_Test extends AbstractComparableAssertBaseTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
+
+  @Override
+  protected ConcreteComparableAssert invoke_api_method() {
+    return assertions.isBetween(6, 9);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), 6, 9, true, true);
+  }
 
   @Test
   public void succeds_if_actual_is_between_start_and_end() {

--- a/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_isStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_isStrictlyBetween_Test.java
@@ -13,17 +13,30 @@
 package org.assertj.core.api.comparable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigInteger;
 
+import org.assertj.core.api.AbstractComparableAssertBaseTest;
+import org.assertj.core.api.ConcreteComparableAssert;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AbstractComparableAssert_isStrictlyBetween_Test {
+public class AbstractComparableAssert_isStrictlyBetween_Test extends AbstractComparableAssertBaseTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
+
+  @Override
+  protected ConcreteComparableAssert invoke_api_method() {
+    return assertions.isStrictlyBetween(6, 9);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), 6, 9, false, false);
+  }
 
   @Test
   public void succeds_if_actual_is_between_start_and_end() {

--- a/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_usingComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_usingComparator_Test.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.comparable;
+
+import java.util.Comparator;
+
+import org.assertj.core.api.AbstractComparableAssert;
+import org.assertj.core.api.AbstractComparableAssertBaseTest;
+import org.assertj.core.api.ConcreteComparableAssert;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for <code>{@link AbstractComparableAssert#usingComparator(Comparator)}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class AbstractComparableAssert_usingComparator_Test extends AbstractComparableAssertBaseTest {
+
+  @Mock
+  private Comparator<Integer> comparator;
+
+  @Before
+  public void before() {
+    initMocks(this);
+  }
+
+  @Override
+  protected ConcreteComparableAssert invoke_api_method() {
+    // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
+    return assertions.usingComparator(comparator);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    assertThat(comparator).isSameAs(getObjects(assertions).getComparator());
+    assertThat(comparator).isSameAs(getComparables(assertions).getComparator());
+  }
+}

--- a/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_usingDefaultComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/comparable/AbstractComparableAssert_usingDefaultComparator_Test.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.comparable;
+
+import java.util.Comparator;
+
+import org.assertj.core.api.AbstractComparableAssert;
+import org.assertj.core.api.AbstractComparableAssertBaseTest;
+import org.assertj.core.api.ConcreteComparableAssert;
+import org.assertj.core.internal.Comparables;
+import org.assertj.core.internal.Objects;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for <code>{@link AbstractComparableAssert#usingDefaultComparator()}</code>.
+ * 
+ * @author Filip Hrisafov
+ */
+public class AbstractComparableAssert_usingDefaultComparator_Test extends AbstractComparableAssertBaseTest {
+
+  @Mock
+  private Comparator<Integer> comparator;
+
+  @Before
+  public void before() {
+    initMocks(this);
+    assertions.usingComparator(comparator);
+  }
+
+  @Override
+  protected ConcreteComparableAssert invoke_api_method() {
+    return assertions.usingDefaultComparator();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    assertThat(Objects.instance()).isSameAs(getObjects(assertions));
+    assertThat(Comparables.instance()).isSameAs(getComparables(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseToPercentage_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseToPercentage_primitive_long_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+public class LongAssert_isCloseToPercentage_primitive_long_Test extends LongAssertBaseTest {
+
+    private final Percentage percentage = withPercentage(5L);
+    private final long value = 10L;
+
+    @Override
+    protected LongAssert invoke_api_method() {
+        return assertions.isCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(longs).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_primitive_long_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+import org.assertj.core.data.Offset;
+
+import static org.assertj.core.data.Offset.offset;
+import static org.mockito.Mockito.verify;
+
+public class LongAssert_isCloseTo_primitive_long_Test extends LongAssertBaseTest {
+
+  private final Offset<Long> offset = offset(5l);
+  private final long value = 8l;
+
+  @Override
+  protected LongAssert invoke_api_method() {
+    return assertions.isCloseTo(value, offset);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(longs).assertIsCloseTo(getInfo(assertions), getActual(assertions), value, offset);
+  }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseToPercentage_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseToPercentage_primitive_long_Test.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link LongAssert#isNotCloseTo(long, Percentage)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class LongAssert_isNotCloseToPercentage_primitive_long_Test extends LongAssertBaseTest {
+
+    private final Percentage percentage = withPercentage(5L);
+    private final long value = 10L;
+
+    @Override
+    protected LongAssert invoke_api_method() {
+        return assertions.isNotCloseTo(value, percentage);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+        verify(longs).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_primitive_long_Test.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+import org.assertj.core.data.Offset;
+
+import static org.assertj.core.data.Offset.offset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link LongAssert#isNotCloseTo(Long, Offset)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class LongAssert_isNotCloseTo_primitive_long_Test extends LongAssertBaseTest {
+
+  private final Offset<Long> offset = offset(5l);
+  private final long value = 8l;
+
+  @Override
+  protected LongAssert invoke_api_method() {
+    return assertions.isNotCloseTo(value, offset);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(longs).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
+  }
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+import org.junit.Before;
+
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link MapAssert#hasEntrySatisfying(Object, Condition)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class MapAssert_hasEntrySatisfying_Test extends MapAssertBaseTest {
+
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"));
+
+  private final Condition<Object> condition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.hasEntrySatisfying("key1", condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertHasEntrySatisfying(getInfo(assertions), getActual(assertions), "key1", condition);
+  }
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsSubSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsSubSequence_Test.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ObjectArrayAssert#containsSubsequence(Object[])}</code>.
+ * 
+ * @author Filip Hrisfaov
+ */
+public class ObjectArrayAssert_containsSubSequence_Test extends ObjectArrayAssertBaseTest {
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.containsSubsequence("Luke", "Yoda");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsSubsequence(getInfo(assertions), getActual(assertions), array("Luke", "Yoda"));
+  }
+}


### PR DESCRIPTION
I've been playing a bit with [pitest](http://pitest.org/) and I saw that there are some tests which were missing.

@joel-costigliola, if you are interested I can setup a maven profile that will allow anyone to run pitest analysis over AssertJ. 