### PR TITLE
Fix for excluding fields for deep difference

### DIFF
--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -762,8 +762,9 @@ public class Objects {
     final Set<Field> fields = newLinkedHashSet(clazz.getDeclaredFields());
     for (Iterator<Field> iterator = fields.iterator(); iterator.hasNext();) {
       final Field next = iterator.next();
-      if (next.isSynthetic()) iterator.remove();
-      if (Modifier.isStatic(next.getModifiers())) iterator.remove();
+      if (next.isSynthetic() || Modifier.isStatic(next.getModifiers())) {
+        iterator.remove();
+      }
     }
     return fields;
   }

--- a/src/test/java/org/assertj/core/internal/DeepDifference_Test.java
+++ b/src/test/java/org/assertj/core/internal/DeepDifference_Test.java
@@ -26,6 +26,7 @@ import static org.assertj.core.internal.ObjectsBaseTest.noFieldComparators;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,6 +69,13 @@ public class DeepDifference_Test {
     Date date1 = new Date();
     assertHaveDifferences(null, date1);
     assertHaveDifferences(date1, null);
+  }
+
+  @Test
+  public void testBigDecimals() {
+    BigDecimal bigDecimal1 = new BigDecimal("42.5");
+    BigDecimal bigDecimal2 = new BigDecimal("42.5");
+    assertHaveNoDifferences(bigDecimal1, bigDecimal2);
   }
 
   @Test


### PR DESCRIPTION
Fix for the case when field is both synthetic and static.


