### PR TITLE
mockito-core version to 2.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.2.9</version>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>

--- a/src/test/java/org/assertj/core/util/Throwables_getStackTrace_Test.java
+++ b/src/test/java/org/assertj/core/util/Throwables_getStackTrace_Test.java
@@ -12,9 +12,11 @@
  */
 package org.assertj.core.util;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.PrintWriter;
 


### PR DESCRIPTION
just to demonstrate that it works with just a minimal change (removed wildcard imports because compiler complains that `isA` is ambiguous

real pull request is https://github.com/joel-costigliola/assertj-maven-parent-pom/pull/16


