### PR TITLE
Added shortcut for assertThatExceptionOfType to exception:

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -16,6 +16,7 @@ import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -896,6 +897,46 @@ public class Assertions {
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return AssertionsForClassTypes.assertThatExceptionOfType(exceptionType);
   }
+  
+  /**
+   * Alias for {@link #assertThatExceptionOfType(Class)} for {@link NullPointerException}.
+   * 
+   * @return the created {@link ThrowableTypeAssert}.
+   */
+  @CheckReturnValue
+  public static ThrowableTypeAssert<NullPointerException> assertThatNullPointerException() {
+    return assertThatExceptionOfType(NullPointerException.class);
+  }
+  
+  /**
+   * Alias for {@link #assertThatExceptionOfType(Class)} for {@link IllegalArgumentException}.
+   * 
+   * @return the created {@link ThrowableTypeAssert}.
+   */
+  @CheckReturnValue
+  public static ThrowableTypeAssert<IllegalArgumentException> assertThatIllegalArgumentException() {
+    return assertThatExceptionOfType(IllegalArgumentException.class);
+  }
+  
+  /**
+   * Alias for {@link #assertThatExceptionOfType(Class)} for {@link IOException}.
+   * 
+   * @return the created {@link ThrowableTypeAssert}.
+   */
+  @CheckReturnValue
+  public static ThrowableTypeAssert<IOException> assertThatIOException() {
+    return assertThatExceptionOfType(IOException.class);
+  }  
+  
+  /**
+   * Alias for {@link #assertThatExceptionOfType(Class)} for {@link IllegalStateException}.
+   * 
+   * @return the created {@link ThrowableTypeAssert}.
+   */
+  @CheckReturnValue
+  public static ThrowableTypeAssert<IllegalStateException> assertThatIllegalStateException() {
+    return assertThatExceptionOfType(IllegalStateException.class);
+  }  
 
   // -------------------------------------------------------------------------------------------------
   // fail methods : not assertions but here to have a single entry point to all AssertJ features.

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatExceptionOfType_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatExceptionOfType_Test.java
@@ -14,38 +14,80 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Supplier;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class Assertions_assertThatExceptionOfType_Test {
+
+  private final Supplier<ThrowableTypeAssert<? extends Exception>> assertionGenerator;
+  private final Class<? extends Exception> exceptionType;
+  private final Supplier<? extends Exception> exceptionGenerator;
+
+  public Assertions_assertThatExceptionOfType_Test(Supplier<ThrowableTypeAssert<? extends Exception>> assertionGenerator,
+                                                   Class<? extends Exception> exceptionType,
+                                                   Supplier<? extends Exception> exceptionBuilder) {
+    this.assertionGenerator = assertionGenerator;
+    this.exceptionType = exceptionType;
+    this.exceptionGenerator = exceptionBuilder;
+  }
+
+  private static <E> Supplier<E> s(Supplier<E> supplier) {
+    return supplier;
+  }
+
+  @Parameters
+  public static Iterable<? extends Object> data() {
+    return Arrays.asList(
+      new Object[] {
+        s(() -> assertThatExceptionOfType(UnsupportedOperationException.class)),
+        UnsupportedOperationException.class,
+        s(() -> new UnsupportedOperationException())  
+      },
+      new Object[] {s(() -> assertThatNullPointerException()), NullPointerException.class, s(() -> new NullPointerException("value"))},
+      new Object[] {s(() -> assertThatIllegalArgumentException()), IllegalArgumentException.class, s(() -> new IllegalArgumentException("arg"))},
+      new Object[] {s(() -> assertThatIllegalStateException()), IllegalStateException.class, s(() -> new IllegalStateException("state"))},
+      new Object[] {s(() -> assertThatIOException()), IOException.class, s(() -> new IOException("io"))}      
+    );
+  }
 
   @Test
   public void should_create_ExpectThrowableAssert() {
-    ThrowableTypeAssert<NullPointerException> assertions = assertThatExceptionOfType(NullPointerException.class);
+    ThrowableTypeAssert<? extends Exception> assertions = assertionGenerator.get();
     assertThat(assertions).isNotNull();
   }
 
   @Test
   public void should_pass_ExceptionType() {
-    Class<NullPointerException> exceptionType = NullPointerException.class;
-    ThrowableTypeAssert<NullPointerException> assertions = assertThatExceptionOfType(exceptionType);
+    ThrowableTypeAssert<? extends Exception> assertions = assertionGenerator.get();
     assertThat(assertions.expectedThrowableType).isSameAs(exceptionType);
   }
 
   @Test
   public void should_create_ChainedThrowableAssert() {
-    ThrowableAssertAlternative<NullPointerException> assertions = assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
-      throw new NullPointerException("boom!");
+    ThrowableAssertAlternative<? extends Exception> assertions = assertionGenerator.get().isThrownBy(() -> {
+      throw exceptionGenerator.get();
     });
     assertThat(assertions).isNotNull();
   }
 
   @Test
   public void should_pass_thrown_exception_to_ChainedThrowableAssert() {
-    NullPointerException nullPointerException = new NullPointerException("boom!");
-    ThrowableAssertAlternative<NullPointerException> assertions = assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
-      throw nullPointerException;
+    Exception exception = exceptionGenerator.get();
+    ThrowableAssertAlternative<? extends Exception> assertions = assertionGenerator.get().isThrownBy(() -> {
+      throw exception;
     });
-    assertThat(assertions.actual).isSameAs(nullPointerException);
+    assertThat(assertions.actual).isSameAs(exception);
   }
 }


### PR DESCRIPTION
Hello,

I've pushed some short cut method for "common" exception such as NullPointerException: I though it was rather sad to always write something like:

```
assertThatExceptionOfType(NullPointerException.class)
  .isThrownBy(() -> file.save((Path) null)).withMessage("path");
```

While it could be:

```
assertThatNullPointerException().isThrownBy(() -> file.save((Path) null)).withMessage("path");
```

I did not add API example as there are purely alias to existing methods (eg: `assertThatExceptionOfType(NullPointerException.class)`).

