### PR TITLE
increase ExpectedException usage

### DIFF
--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_withRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_withRepresentation_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.presentation.StandardRepresentation;
@@ -41,15 +40,9 @@ public class AbstractAssert_withRepresentation_Test {
 
   @Test
   public void should_be_able_to_override_an_existing_representation() {
-    try {
-      assertThat("foo").withRepresentation(new CustomRepresentation())
+    thrown.expectAssertionErrorWithMessageContaining("$foo$", "$bar$");
+    assertThat("foo").withRepresentation(new CustomRepresentation())
                        .startsWith("bar");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessageContaining("$foo$")
-                   .hasMessageContaining("$bar$");
-      return;
-    }
-    fail("AssertionError expected");
   }
 
   private class Example {

--- a/src/test/java/org/assertj/core/api/array/AbstractEnumerableAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/assertj/core/api/array/AbstractEnumerableAssert_hasSameSizeAs_with_Array_Test.java
@@ -15,7 +15,6 @@ package org.assertj.core.api.array;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.test.ExpectedException.none;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import org.junit.Rule;
@@ -75,13 +74,8 @@ public class AbstractEnumerableAssert_hasSameSizeAs_with_Array_Test {
   public void should_fail_if_size_of_actual_has_same_as_other_array() {
     final byte[] actual = new byte[]{1, 2};
     final byte[] other = new byte[]{1, 2, 3};
-    try {
-      assertThat(actual).hasSameSizeAs(other);
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(shouldHaveSameSizeAs(actual, actual.length, other.length).create());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveSameSizeAs(actual, actual.length, other.length).create());
+    assertThat(actual).hasSameSizeAs(other);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.setLenientDateParsing;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.DateUtil.parseDatetime;
@@ -81,13 +80,10 @@ public class DateAssert_setLenientDateParsing extends DateAssertBaseTest {
   @Test
   public void should_fail_if_date_can_be_parsed_leniently_but_lenient_mode_is_disabled() {
     final Date date = parse("2001-02-03");
-
     setLenientDateParsing(false);
+    thrown.expectAssertionErrorWithMessageContaining("Failed to parse");
     try {
       assertThat(date).isEqualTo("2001-01-34");
-      failBecauseExceptionWasNotThrown(AssertionError.class);
-    } catch (AssertionError error) {
-      assertThat(error).hasMessageContaining("Failed to parse");
     } finally {
       setLenientDateParsing(true);
     }

--- a/src/test/java/org/assertj/core/api/filter/AbstractTest_equals_filter.java
+++ b/src/test/java/org/assertj/core/api/filter/AbstractTest_equals_filter.java
@@ -13,16 +13,19 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.filter.Filters.filter;
+import static org.assertj.core.test.ExpectedException.none;
 
+import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
-import org.assertj.core.util.introspection.IntrospectionError;
+import org.junit.Rule;
 import org.junit.Test;
 
 
 public abstract class AbstractTest_equals_filter extends AbstractTest_filter {
+
+  @Rule
+  public ExpectedException thrown = none();
 
   @Test
   public void should_filter_iterable_elements_with_property_equals_to_given_value() {
@@ -49,22 +52,14 @@ public abstract class AbstractTest_equals_filter extends AbstractTest_filter {
 
   @Test
   public void should_fail_if_property_to_filter_on_is_null() {
-    try {
-      filterIterable(players, null, 6000L);
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("The property/field name to filter on should not be null or empty");
-    }
+    thrown.expectIllegalArgumentException("The property/field name to filter on should not be null or empty");
+    filterIterable(players, null, 6000L);
   }
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    try {
-      filterIterable(players, "country", "France");
-      fail("IntrospectionError expected");
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'country'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
+    filterIterable(players, "country", "France");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_in_given_values_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_in_given_values_Test.java
@@ -13,16 +13,19 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.filter.Filters.filter;
+import static org.assertj.core.test.ExpectedException.none;
 
+import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
-import org.assertj.core.util.introspection.IntrospectionError;
+import org.junit.Rule;
 import org.junit.Test;
 
 
 public class Filter_with_property_in_given_values_Test extends AbstractTest_filter {
+
+  @Rule
+  public ExpectedException thrown = none();
 
   @Test
   public void should_filter_iterable_elements_with_property_in_given_values() {
@@ -39,22 +42,14 @@ public class Filter_with_property_in_given_values_Test extends AbstractTest_filt
 
   @Test
   public void should_fail_if_property_to_filter_on_is_null() {
-    try {
-      filter(players).with(null).in("foo", "bar");
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("The property/field name to filter on should not be null or empty");
-    }
+    thrown.expectIllegalArgumentException("The property/field name to filter on should not be null or empty");
+    filter(players).with(null).in("foo", "bar");
   }
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_or_field_used_by_filter() {
-    try {
-      filter(players).with("country").in("France", "Italy");
-      fail("IntrospectionError expected");
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'country'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
+    filter(players).with("country").in("France", "Italy");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_equals_to_given_value_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_equals_to_given_value_Test.java
@@ -13,16 +13,19 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.filter.Filters.filter;
+import static org.assertj.core.test.ExpectedException.none;
 
+import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
-import org.assertj.core.util.introspection.IntrospectionError;
+import org.junit.Rule;
 import org.junit.Test;
 
 
 public class Filter_with_property_not_equals_to_given_value_Test extends AbstractTest_filter {
+
+  @Rule
+  public ExpectedException thrown = none();
 
   @Test
   public void should_filter_iterable_elements_with_property_not_equals_to_given_value() {
@@ -39,22 +42,14 @@ public class Filter_with_property_not_equals_to_given_value_Test extends Abstrac
 
   @Test
   public void should_fail_if_property_to_filter_on_is_null() {
-    try {
-      filter(players).with(null).notEqualsTo("foo");
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("The property/field name to filter on should not be null or empty");
-    }
+    thrown.expectIllegalArgumentException("The property/field name to filter on should not be null or empty");
+    filter(players).with(null).notEqualsTo("foo");
   }
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    try {
-      filter(players).with("country").notEqualsTo("France");
-      fail("IntrospectionError expected");
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'country'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
+    filter(players).with("country").notEqualsTo("France");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_in_given_values_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_in_given_values_Test.java
@@ -13,16 +13,19 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.filter.Filters.filter;
+import static org.assertj.core.test.ExpectedException.none;
 
+import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
-import org.assertj.core.util.introspection.IntrospectionError;
+import org.junit.Rule;
 import org.junit.Test;
 
 
 public class Filter_with_property_not_in_given_values_Test extends AbstractTest_filter {
+
+  @Rule
+  public ExpectedException thrown = none();
 
   @Test
   public void should_filter_iterable_elements_with_property_not_in_given_values() {
@@ -39,22 +42,14 @@ public class Filter_with_property_not_in_given_values_Test extends AbstractTest_
 
   @Test
   public void should_fail_if_property_to_filter_on_is_null() {
-    try {
-      filter(players).with(null).notIn("foo", "bar");
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("The property/field name to filter on should not be null or empty");
-    }
+    thrown.expectIllegalArgumentException("The property/field name to filter on should not be null or empty");
+    filter(players).with(null).notIn("foo", "bar");
   }
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    try {
-      filter(players).with("country").in("France", "Italy");
-      fail("IntrospectionError expected");
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'country'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
+    filter(players).with("country").in("France", "Italy");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOnNull_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOnNull_Test.java
@@ -26,9 +26,7 @@ package org.assertj.core.api.iterable;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOnNull_Test extends IterableAssert_filtered_baseTest {
@@ -45,12 +43,8 @@ public class IterableAssert_filteredOnNull_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOnNull("secret");
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOnNull("secret");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -71,12 +71,10 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", "New York").isEmpty();
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -112,23 +110,16 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_given_expected_value_is_null() {
-    try {
-      assertThat(employees).filteredOn("name", null);
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(format("The expected value should not be null.%n"
-                                      + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
-    }
+    thrown.expectWithMessageContaining(IllegalArgumentException.class,
+                                       format("The expected value should not be null.%n"
+                                           + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
+    assertThat(employees).filteredOn("name", null);
   }
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", "???");
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", "???");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
@@ -26,7 +26,6 @@ package org.assertj.core.api.iterable;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
@@ -60,12 +59,10 @@ public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_b
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", in("New York")).isEmpty();
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -101,12 +98,8 @@ public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_b
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", in("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", in("???"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
@@ -26,7 +26,6 @@ package org.assertj.core.api.iterable;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.notIn;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
@@ -62,12 +61,10 @@ public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtere
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -104,12 +101,8 @@ public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtere
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", notIn("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", notIn("???"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
@@ -27,7 +27,6 @@ package org.assertj.core.api.iterable;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
@@ -60,12 +59,10 @@ public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", not("New York"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -101,22 +98,14 @@ public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_given_expected_value_is_null() {
-    try {
-      assertThat(employees).filteredOn("name", null);
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(format("The expected value should not be null.%n"
-                                      + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
-    }
+    thrown.expectIllegalArgumentException(format("The expected value should not be null.%n"
+        + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
+    assertThat(employees).filteredOn("name", null);
   }
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", not("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", not("???"));
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
@@ -97,23 +97,15 @@ public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtere
 
   @Test
   public void should_fail_if_given_expected_value_is_null() {
-    try {
-      assertThat(employees).filteredOn("name", null);
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(format("The expected value should not be null.%n"
-                                      + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
-    }
+    thrown.expectIllegalArgumentException(format("The expected value should not be null.%n"
+                                                 + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
+    assertThat(employees).filteredOn("name", null);
   }
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", "???");
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", "???");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
@@ -96,12 +96,8 @@ public class ObjectArrayAssert_filteredOn_in_Test extends ObjectArrayAssert_filt
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", in("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", in("???"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
@@ -26,7 +26,6 @@ package org.assertj.core.api.objectarray;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.notIn;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
@@ -62,12 +61,10 @@ public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_f
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -99,12 +96,8 @@ public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_f
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", notIn("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", notIn("???"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
@@ -27,7 +27,6 @@ package org.assertj.core.api.objectarray;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
@@ -60,12 +59,10 @@ public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_fil
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
+    thrown.expect(IntrospectionError.class);
     setAllowExtractingPrivateFields(false);
     try {
       assertThat(employees).filteredOn("city", not("New York"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      // expected
     } finally {
       setAllowExtractingPrivateFields(true);
     }
@@ -96,22 +93,14 @@ public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_fil
 
   @Test
   public void should_fail_if_given_expected_value_is_null() {
-    try {
-      assertThat(employees).filteredOn("name", null);
-      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(format("The expected value should not be null.%n"
-                                      + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
-    }
+    thrown.expectIllegalArgumentException(format("The expected value should not be null.%n"
+                                               + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead"));
+    assertThat(employees).filteredOn("name", null);
   }
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    try {
-      assertThat(employees).filteredOn("secret", not("???"));
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError e) {
-      assertThat(e).hasMessageContaining("Can't find any field or property with name 'secret'");
-    }
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
+    assertThat(employees).filteredOn("secret", not("???"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
@@ -13,8 +13,6 @@
 package org.assertj.core.internal.objects;
 
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeEqualByComparingOnlyGivenFields.shouldBeEqualComparingOnlyGivenFields;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -152,16 +150,11 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
 
   @Test
   public void should_fail_when_one_of_actual_field_to_compare_can_not_be_found_in_the_other_object() {
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'lightSaberColor'");
     Jedi actual = new Jedi("Yoda", "Green");
     Employee other = new Employee();
-    try {
-      objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(), defaultTypeComparators(),
-          "lightSaberColor");
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError err) {
-      assertThat(err).hasMessageContaining("Can't find any field or property with name 'lightSaberColor'");
-      return;
-    }
+    objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(), defaultTypeComparators(),
+        "lightSaberColor");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.internal.objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.error.ShouldBeEqualToIgnoringFields.shouldBeEqualToIgnoringGivenFields;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -31,7 +30,6 @@ import org.assertj.core.test.Jedi;
 import org.assertj.core.test.Person;
 import org.assertj.core.test.TestClassWithRandomId;
 import org.assertj.core.util.introspection.FieldSupport;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 /**
@@ -120,15 +118,10 @@ public class Objects_assertIsEqualToIgnoringNullFields_Test extends ObjectsBaseT
 
   @Test
   public void should_fail_when_one_of_actual_field_to_compare_can_not_be_found_in_the_other_object() {
+    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'lightSaberColor'");
     Jedi actual = new Jedi("Yoda", "Green");
     Employee other = new Employee();
-    try {
-      objects.assertIsEqualToIgnoringNullFields(someInfo(), actual, other, noFieldComparators(), defaultTypeComparators());
-      failBecauseExceptionWasNotThrown(IntrospectionError.class);
-    } catch (IntrospectionError err) {
-      assertThat(err).hasMessageContaining("Can't find any field or property with name 'lightSaberColor'");
-      return;
-    }
+    objects.assertIsEqualToIgnoringNullFields(someInfo(), actual, other, noFieldComparators(), defaultTypeComparators());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -12,6 +12,13 @@
  */
 package org.assertj.core.test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.util.introspection.IntrospectionError;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.StringContains;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -39,6 +46,10 @@ public class ExpectedException implements TestRule {
     expect(AssertionError.class, message);
   }
 
+  public void expectAssertionErrorWithMessageContaining(String... parts) {
+    expectWithMessageContaining(AssertionError.class, parts);
+  }
+
   public void expectNullPointerException(String message) {
     expect(NullPointerException.class, message);
   }
@@ -55,9 +66,18 @@ public class ExpectedException implements TestRule {
     expect(UnsupportedOperationException.class, message);
   }
 
+  public void expectIntrospectionErrorWithMessageContaining(String... parts) {
+    expectWithMessageContaining(IntrospectionError.class, parts);
+  }
+
   public void expect(Class<? extends Throwable> type, String message) {
     expect(type);
     expectMessage(message);
+  }
+
+  public void expectWithMessageContaining(Class<? extends Throwable> type, String... parts) {
+    expect(type);
+    expectMessageContaining(parts);
   }
 
   public void expect(Throwable error) {
@@ -72,4 +92,13 @@ public class ExpectedException implements TestRule {
   public void expectMessage(String message) {
     delegate.expectMessage(String.format(message));
   }
+
+  private void expectMessageContaining(String... parts) {
+    List<Matcher<? super String>> matchers = new ArrayList<>();
+    for (String part : parts) {
+      matchers.add(StringContains.containsString(part));
+    }
+    delegate.expectMessage(AllOf.allOf(matchers));
+  }
+
 }


### PR DESCRIPTION
There are many more tests which could be updated to use `ExpectedException`, but maybe we should rather wait till assertj is java 8 only and use `assertThatThrownBy`?