### PR TITLE
allMatch prints all the elements that do not match

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.Condition;
@@ -851,12 +852,14 @@ public class Iterables {
                                  PredicateDescription predicateDescription) {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
-    stream(actual.spliterator(), false).filter(predicate.negate())
-                                       .findFirst()
-                                       .ifPresent(e -> {
-                                         throw failures.failure(info, elementsShouldMatch(actual, e,
-                                                                                          predicateDescription));
-                                       });
+    List<? extends E> nonMatches = stream(actual.spliterator(), false).filter(predicate.negate())
+                                       .collect(Collectors.toList());
+    
+    if(!nonMatches.isEmpty()) {
+    	throw failures.failure(info, elementsShouldMatch(actual, 
+    	                                                 (nonMatches.size() == 1 ? nonMatches.get(0) : nonMatches), 
+    	                                                 predicateDescription));    	
+    }
   }
 
   public <E> void assertNoneMatch(AssertionInfo info, Iterable<? extends E> actual, Predicate<? super E> predicate,

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllMatch_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllMatch_Test.java
@@ -65,5 +65,18 @@ public class Iterables_assertAllMatch_Test extends IterablesBaseTest {
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
   }
+  
+  @Test
+  public void should_report_all_items_that_do_not_match() {
+    List<String> actual = newArrayList("123", "1234", "12345");
+    
+    try {
+      iterables.assertAllMatch(someInfo(), actual,  s -> s.length() <= 3, PredicateDescription.GIVEN);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, elementsShouldMatch(actual, newArrayList("1234", "12345"), PredicateDescription.GIVEN));
+      return;
+    }
+      failBecauseExpectedAssertionErrorWasNotThrown();
+  }
 
 }


### PR DESCRIPTION
The `allMatch` assert now prints all the elements that do not match in the message. Currently, it only prints the first one that doesn't match.

#### Check List:
* Fixes #816 
* Unit tests : YES
* Javadoc with a code example (API only) : NA

