### PR TITLE
Introducing isEqualToNormalizingNewlines

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -1010,4 +1010,26 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
     strings.assertContainsPattern(info, actual, pattern);
     return myself;
   }
+  
+  /**
+   * Verifies that the actual {@code CharSequence} is equals to another
+   * {@code CharSequence} after normalizing new line characters
+   * (e.g. '\r\n' == '\n').
+   * <p>
+   * This assertion will succeed:
+   * <pre><code class='java'> String bookName = &quot;Lord of the Rings\r\n&quot;;
+   * assertThat(bookName).isEqualToNormalizingNewlines(&quot;Lord of the Rings\n&quot;);</code></pre>
+   * 
+   * Whereas this assertion will fail:
+   * <pre><code class='java'> String singleLine = &quot;\n&quot;;
+   * assertThat(singleLine).isEqualToNormalizingNewlines(&quot;&quot;);</code></pre>
+   *
+   * @param expectedLineCount the expected line count of the actual {@code CharSequence}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual line count is not equal to the expected one.
+   */
+  public S isEqualToNormalizingNewlines(CharSequence expected) {
+    strings.assertIsEqualToNormalizingNewlines(info, actual, expected);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -1014,7 +1014,7 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
   /**
    * Verifies that the actual {@code CharSequence} is equals to another
    * {@code CharSequence} after normalizing new line characters
-   * (e.g. '\r\n' == '\n').
+   * (i.e. '\r\n' == '\n').
    * <p>
    * This assertion will succeed:
    * <pre><code class='java'> String bookName = &quot;Lord of the Rings\r\n&quot;;

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -1027,6 +1027,8 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * @param expectedLineCount the expected line count of the actual {@code CharSequence}.
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual line count is not equal to the expected one.
+   * 
+   * @since 2.7.0 / 3.7.0
    */
   public S isEqualToNormalizingNewlines(CharSequence expected) {
     strings.assertIsEqualToNormalizingNewlines(info, actual, expected);

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -420,8 +420,9 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are equal after normalizing newlines.
    */
   public void assertIsEqualToNormalizingNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    String actualNormalized = actual.toString().replaceAll("\\r\\n", "\n");
-    String expectedNormalized = expected.toString().replaceAll("\\r\\n", "\n");
+    Pattern pattern = Pattern.compile("\\r\\n");
+    String actualNormalized = pattern.matcher(actual.toString()).replaceAll("\n");
+    String expectedNormalized = pattern.matcher(expected.toString()).replaceAll("\n");
     if(!actualNormalized.equals(expectedNormalized))
       throw failures.failure(info, shouldBeEqual(actual, expected));
   }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -412,6 +412,21 @@ public class Strings {
   }
 
   /**
+   * Verifies that two {@code CharSequence}s are not equal, normalizing newlines.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence} (newlines will be normalized).
+   * @param expected the expected {@code CharSequence} (newlines will be normalized)..
+   * @throws AssertionError if the given {@code CharSequence}s are equal after normalizing newlines.
+   */
+  public void assertIsEqualToNormalizingNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
+    String actualNormalized = actual.toString().replaceAll("\\r\\n", "\n");
+    String expectedNormalized = expected.toString().replaceAll("\\r\\n", "\n");
+    if(!actualNormalized.equals(expectedNormalized))
+      throw failures.failure(info, shouldBeEqual(actual, expected));
+  }
+  
+  /**
    * Verifies that two {@code CharSequence}s are equal, ignoring any changes in whitespace.
    *
    * @param info contains information about the assertion.
@@ -781,4 +796,5 @@ public class Strings {
       return TABLE.charAt((MULTIPLIER * c) >>> SHIFT) == c;
     }
   }
+
 }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -420,9 +420,8 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are equal after normalizing newlines.
    */
   public void assertIsEqualToNormalizingNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    Pattern pattern = Pattern.compile("\\r\\n");
-    String actualNormalized = pattern.matcher(actual.toString()).replaceAll("\n");
-    String expectedNormalized = pattern.matcher(expected.toString()).replaceAll("\n");
+    String actualNormalized = actual.toString().replace("\r\n", "\n");
+    String expectedNormalized = expected.toString().replace("\r\n", "\n");
     if(!actualNormalized.equals(expectedNormalized))
       throw failures.failure(info, shouldBeEqual(actual, expected));
   }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2016 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Strings#assertIsEqualToNormalizingNewlines(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)}</code>
+ * .
+ *
+ * @author Mauricio Aniche
+ */
+public class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
+
+  @Test
+  public void should_pass_if_both_strings_are_equals_after_normalizing_newline() {
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), "Lord of the Rings\r\nis cool", "Lord of the Rings\nis cool");
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), "Lord of the Rings\nis cool", "Lord of the Rings\nis cool");
+  }
+
+  @Test
+  public void should_pass_if_comparing_string_with_only_newlines() {
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), "\n", "\r\n");
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), "\r\n", "\n");
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), "\n", "\n");
+  }
+
+  @Test
+  public void should_fail_if_newlines_are_different_in_both_strings() {
+    String actual = "Lord of the Rings\r\n\r\nis cool";
+    String expected = "Lord of the Rings\nis cool";
+    try {
+      strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(someInfo(), shouldBeEqual(actual, expected));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+}


### PR DESCRIPTION
Introducing `isEqualToNormalizingNewlines`. It compares whether two strings are equals to each other after normalizing newlines.

#### Check List:
* Fixes #818
* Unit tests : YES
* Javadoc with a code example (API only) : YES



