### PR TITLE
Added missing @SafeVarargs overrides

### DIFF
--- a/src/main/java/org/assertj/core/api/IterableAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableAssert.java
@@ -27,9 +27,9 @@ import org.assertj.core.util.VisibleForTesting;
  * <p>
  * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Iterable)}</code>.
  * </p>
- * 
+ *
  * @param <ELEMENT> the type of elements of the "actual" value.
- * 
+ *
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Matthieu Baechler
@@ -222,6 +222,12 @@ public class IterableAssert<ELEMENT> extends
 
   @Override
   @SafeVarargs
+  public final IterableAssert<ELEMENT> contains(ELEMENT... values) {
+    return super.contains(values);
+  }
+
+  @Override
+  @SafeVarargs
   public final IterableAssert<ELEMENT> containsOnly(ELEMENT... values) {
     return super.containsOnly(values);
   }
@@ -260,6 +266,12 @@ public class IterableAssert<ELEMENT> extends
   @SafeVarargs
   public final IterableAssert<ELEMENT> containsSubsequence(ELEMENT... sequence) {
     return super.containsSubsequence(sequence);
+  }
+
+  @Override
+  @SafeVarargs
+  public final IterableAssert<ELEMENT> doesNotContain(ELEMENT... values) {
+    return super.doesNotContain(values);
   }
 
   @Override

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -19,9 +19,9 @@ import java.util.List;
  * <p>
  * To create an instance of this class, invoke <code>{@link Assertions#assertThat(List)}</code>.
  * <p>
- * 
+ *
  * @param <ELEMENT> the type of elements of the "actual" value.
- * 
+ *
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
@@ -38,6 +38,12 @@ public class ListAssert<ELEMENT> extends
   @SafeVarargs
   public final ListAssert<ELEMENT> contains(ELEMENT... values) {
     return super.contains(values);
+  }
+
+  @Override
+  @SafeVarargs
+  public final ListAssert<ELEMENT> containsOnly(ELEMENT... values) {
+    return super.containsOnly(values);
   }
 
   @Override


### PR DESCRIPTION
#### Check List:
* Unit tests : NA (Methods were already covered)
* Javadoc with a code example (API only) : NA

`IterableAssert` and `ListAssert` are missing a few overrides of varargs methods. Without those overrides, consumers get warnings about unchecked operations.