### PR TITLE
remove unused methods and constructors in diff package

### DIFF
--- a/src/main/java/org/assertj/core/util/diff/Chunk.java
+++ b/src/main/java/org/assertj/core/util/diff/Chunk.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.util.diff;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -50,19 +49,6 @@ public class Chunk<T> {
   }
 
   /**
-   * Creates a chunk and saves a copy of affected lines
-   * 
-   * @param position
-   *            the start position
-   * @param lines
-   *            the affected lines
-   */
-  public Chunk(int position, T[] lines) {
-    this.position = position;
-    this.lines = Arrays.asList(lines);
-  }
-
-  /**
    * Verifies that this chunk's saved text matches the corresponding text in
    * the given sequence.
    * 
@@ -85,10 +71,6 @@ public class Chunk<T> {
    */
   public int getPosition() {
     return position;
-  }
-
-  public void setLines(List<T> lines) {
-    this.lines = lines;
   }
 
   /**

--- a/src/main/java/org/assertj/core/util/diff/Delta.java
+++ b/src/main/java/org/assertj/core/util/diff/Delta.java
@@ -96,24 +96,10 @@ public abstract class Delta<T> {
   }
 
   /**
-   * @param original The Chunk describing the original text to set.
-   */
-  public void setOriginal(Chunk<T> original) {
-    this.original = original;
-  }
-
-  /**
    * @return The Chunk describing the revised text.
    */
   public Chunk<T> getRevised() {
     return revised;
-  }
-
-  /**
-   * @param revised The Chunk describing the revised text to set.
-   */
-  public void setRevised(Chunk<T> revised) {
-    this.revised = revised;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/util/diff/DiffAlgorithm.java
+++ b/src/main/java/org/assertj/core/util/diff/DiffAlgorithm.java
@@ -32,15 +32,5 @@ public interface DiffAlgorithm<T> {
    * @param revised The revised sequence. Must not be {@code null}.
    * @return The patch representing the diff of the given sequences. Never {@code null}.
    */
-  Patch<T> diff(T[] original, T[] revised);
-
-  /**
-   * Computes the difference between the original sequence and the revised
-   * sequence and returns it as a {@link Patch} object.
-   * 
-   * @param original The original sequence. Must not be {@code null}.
-   * @param revised The revised sequence. Must not be {@code null}.
-   * @return The patch representing the diff of the given sequences. Never {@code null}.
-   */
   Patch<T> diff(List<T> original, List<T> revised);
 }

--- a/src/main/java/org/assertj/core/util/diff/DiffUtils.java
+++ b/src/main/java/org/assertj/core/util/diff/DiffUtils.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.util.diff;
 
-import org.assertj.core.util.diff.myers.Equalizer;
 import org.assertj.core.util.diff.myers.MyersDiff;
 
 import java.util.ArrayList;
@@ -43,30 +42,6 @@ public class DiffUtils {
    *         revised sequences. Never {@code null}.
    */
   public static <T> Patch<T> diff(List<T> original, List<T> revised) {
-    return DiffUtils.diff(original, revised, new MyersDiff<T>());
-  }
-
-  /**
-   * Computes the difference between the original and revised list of elements
-   * with default diff algorithm
-   *
-   * @param original
-   *            The original text. Must not be {@code null}.
-   * @param revised
-   *            The revised text. Must not be {@code null}.
-   *
-   * @param equalizer
-   *            the equalizer object to replace the default compare algorithm
-   *            (Object.equals). If {@code null} the default equalizer of the
-   *            default algorithm is used..
-   * @return The patch describing the difference between the original and
-   *         revised sequences. Never {@code null}.
-   */
-  public static <T> Patch<T> diff(List<T> original, List<T> revised,
-                                  Equalizer<T> equalizer) {
-    if (equalizer != null) {
-      return DiffUtils.diff(original, revised, new MyersDiff<>(equalizer));
-    }
     return DiffUtils.diff(original, revised, new MyersDiff<T>());
   }
 

--- a/src/main/java/org/assertj/core/util/diff/myers/MyersDiff.java
+++ b/src/main/java/org/assertj/core/util/diff/myers/MyersDiff.java
@@ -13,7 +13,6 @@
 package org.assertj.core.util.diff.myers;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.util.diff.ChangeDelta;
@@ -54,26 +53,6 @@ public class MyersDiff<T> implements DiffAlgorithm<T> {
       }
 
     };
-  }
-
-  /**
-   * Constructs an instance of the Myers differencing algorithm.
-   * @param equalizer Must not be {@code null}.
-   */
-  public MyersDiff(final Equalizer<T> equalizer) {
-    if (equalizer == null) {
-      throw new IllegalArgumentException("equalizer must not be null");
-    }
-    this.equalizer = equalizer;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @return Returns an empty diff if get the error while procession the difference.
-   */
-  public Patch<T> diff(final T[] original, final T[] revised) {
-    return diff(Arrays.asList(original), Arrays.asList(revised));
   }
 
   /**


### PR DESCRIPTION
This change breaks binary compatibility if somebody uses these classes and there methods/constructors directly, so feel free to reject.