### PR TITLE
extended stack trace filtering (#873)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Strings.formatIfArgs;
 
 import java.util.Comparator;
@@ -42,6 +43,8 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Nicolas François
  */
 public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implements Assert<S, A> {
+
+  private static final String ORG_ASSERTJ = "org.assert";
 
   @VisibleForTesting
   Objects objects = Objects.instance();
@@ -106,9 +109,16 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    */
   protected void failWithMessage(String errorMessage, Object... arguments) {
     AssertionError failureWithOverriddenErrorMessage = Failures.instance().failureIfErrorMessageIsOverridden(info);
-    if (failureWithOverriddenErrorMessage != null) throw failureWithOverriddenErrorMessage;
+    if (failureWithOverriddenErrorMessage != null) {
+      removeCustomAssertRelatedElementsFromStackTrace(failureWithOverriddenErrorMessage);
+      throw failureWithOverriddenErrorMessage;
+    }
+
     String description = MessageFormatter.instance().format(info.description(), info.representation(), "");
-    throw new AssertionError(description + String.format(errorMessage, arguments));
+    AssertionError assertionError = new AssertionError(description + String.format(errorMessage, arguments));
+    Failures.instance().removeAssertJRelatedElementsFromStackTraceIfNeeded(assertionError);
+    removeCustomAssertRelatedElementsFromStackTrace(assertionError);
+    throw assertionError;
   }
 
   /**
@@ -124,7 +134,35 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
    * @throws an {@link AssertionError} with a message corresponding to the given {@link BasicErrorMessageFactory}.
    */
   protected void throwAssertionError(ErrorMessageFactory errorMessageFactory) {
-    throw Failures.instance().failure(info, errorMessageFactory);
+    AssertionError failure = Failures.instance().failure(info, errorMessageFactory);
+    removeCustomAssertRelatedElementsFromStackTrace(failure);
+    throw failure;
+  }
+
+  private void removeCustomAssertRelatedElementsFromStackTrace(AssertionError assertionError) {
+    if (!Failures.instance().isRemoveAssertJRelatedElementsFromStackTrace()) return;
+    if (getClass().getName().startsWith(ORG_ASSERTJ)) return;
+
+    List<StackTraceElement> filtered = newArrayList(assertionError.getStackTrace());
+    for (StackTraceElement element : assertionError.getStackTrace()) {
+      if (isElementOfCustomAssert(element)) {
+        filtered.remove(element);
+      }
+    }
+    StackTraceElement[] newStackTrace = filtered.toArray(new StackTraceElement[filtered.size()]);
+    assertionError.setStackTrace(newStackTrace);
+  }
+
+  private boolean isElementOfCustomAssert(StackTraceElement element) {
+    Class<?> currentAssertClass = getClass();
+    while (currentAssertClass != AbstractAssert.class) {
+      if (element.getClassName().equals(currentAssertClass.getName())) {
+        return true;
+      }
+      currentAssertClass = currentAssertClass.getSuperclass();
+    }
+
+    return false;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/internal/Failures.java
+++ b/src/main/java/org/assertj/core/internal/Failures.java
@@ -68,6 +68,11 @@ public class Failures {
     this.removeAssertJRelatedElementsFromStackTrace = removeAssertJRelatedElementsFromStackTrace;
   }
 
+  /** Returns whether or not we remove elements related to AssertJ from assertion error stack trace. */
+  public boolean isRemoveAssertJRelatedElementsFromStackTrace() {
+    return removeAssertJRelatedElementsFromStackTrace;
+  }
+
   @VisibleForTesting
   Failures() {}
 

--- a/src/test/java/org/example/custom/CustomAsserts_filter_stacktrace_Test.java
+++ b/src/test/java/org/example/custom/CustomAsserts_filter_stacktrace_Test.java
@@ -1,0 +1,104 @@
+package org.example.custom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Condition;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CustomAsserts_filter_stacktrace_Test {
+
+  @Test
+  public void should_filter_when_custom_assert_fails_with_message() {
+    try {
+      new CustomAssert("").fail();
+    } catch (AssertionError e) {
+      assertThat(e.getStackTrace()).areNot(elementFor(CustomAssert.class));
+    }
+  }
+  
+  @Test
+  public void should_filter_when_custom_assert_fails_with_overridden_message() {
+    try {
+      new CustomAssert("").overridingErrorMessage("overridden message").fail();
+    } catch (AssertionError e) {
+      assertThat(e.getStackTrace()).areNot(elementFor(CustomAssert.class));
+    }
+  }
+  
+  @Test
+  public void should_filter_when_custom_assert_throws_assertion_error() {
+    try {
+      new CustomAssert("").throwAnAssertionError();
+    } catch (AssertionError e) {
+      assertThat(e.getStackTrace()).areNot(elementFor(CustomAssert.class));
+    }
+  }
+
+  @Test
+  public void should_filter_when_abstract_custom_assert_fails() {
+    try {
+      new CustomAssert("").failInAbstractAssert();
+    } catch (AssertionError e) {
+      assertThat(e.getStackTrace()).areNot(elementFor(CustomAbstractAssert.class));
+    }
+  }
+
+  @Test
+  public void should_not_filter_when_global_remove_option_is_disabled() {
+    Failures.instance().setRemoveAssertJRelatedElementsFromStackTrace(false);
+    try {
+      new CustomAssert("").fail();
+    } catch (AssertionError e) {
+      assertThat(e.getStackTrace()).areAtLeastOne(elementFor(CustomAssert.class));
+    }
+  }
+  
+  @Before
+  @After
+  public void enableStackTraceFiltering() {
+    Failures.instance().setRemoveAssertJRelatedElementsFromStackTrace(true);
+  }
+
+  private static Condition<StackTraceElement> elementFor(final Class<?> clazz) {
+    return new Condition<StackTraceElement>("StackTraceElement of " + clazz) {
+      @Override
+      public boolean matches(StackTraceElement value) {
+        return value.getClassName().equals(clazz.getName());
+      }
+    };
+  }
+
+  private static class CustomAssert extends CustomAbstractAssert<CustomAssert> {
+
+    public CustomAssert(String actual) {
+      super(actual, CustomAssert.class);
+    }
+
+    public CustomAssert fail() {
+      failWithMessage("failing assert");
+      return this;
+    }
+    
+    public CustomAssert throwAnAssertionError() {
+      throwAssertionError(new BasicErrorMessageFactory("failing assert"));
+      return this;
+    }
+  }
+
+  private static class CustomAbstractAssert<S extends CustomAbstractAssert<S>> extends AbstractObjectAssert<S, String> {
+
+    protected CustomAbstractAssert(String actual, Class<?> selfType) {
+      super(actual, selfType);
+    }
+
+    public S failInAbstractAssert() {
+      failWithMessage("failing assert");
+      return myself;
+    }
+  }
+}


### PR DESCRIPTION
- remove assertj related elements from stack trace of error thrown by
`failWithMessage(...)`
- also remove all elements of custom assert subclasses

#### Check List:
* Fixes #873
* Unit tests : YES
* Javadoc with a code example (API only) : NA


