### PR TITLE
Fix message if cause is not instance of expected type

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldHaveCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveCause.java
@@ -60,7 +60,7 @@ public class ShouldHaveCause extends BasicErrorMessageFactory {
           "  <%s>%n" +
           "but type was:%n" +
           "  <%s>.",
-          actualCause.getClass().getName(), expectedCauseClass.getName());
+          expectedCauseClass.getName(), actualCause.getClass().getName());
   }
 
   private ShouldHaveCause(Throwable actualCause, String expectedCauseMessage) {


### PR DESCRIPTION
#### Check List:
* Fixes #883
* Unit tests : NO (I didn't find tests on exception messages =( )
* Javadoc with a code example (API only) : NA