### PR TITLE
Mark JUnit dependency of assertj-core as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
The JUnit dependency of assertj-core is mark as provided but not as optional. The unfortunate consequence is that integration tests using AssertJ requires to have a dependency towards JUnit even if you're not using it at all and using another test framework (TestNG for instance). Since it's not marked as optional, any OSGi framework will refuse to start because it misses the JUnit packages.

Marking this dependency as optional will allow running integration tests using OSGi and TestNG.

#### Check List:
* Unit tests : NA
* Javadoc with a code example (API only) : NA


