### PR TITLE
Add isOne to NumberAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -28,6 +28,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 
+ * @author Drummond Dawson
  * @author David DIDIER
  * @author Ted M. Young
  * @author Yvonne Wang
@@ -78,6 +79,24 @@ public abstract class AbstractBigDecimalAssert<S extends AbstractBigDecimalAsser
   @Override
   public S isNotZero() {
     bigDecimals.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(BigDecimal.ONE).isOne();
+   *
+   * // assertion will fail
+   * assertThat(new BigDecimal(&quot;8.00&quot;)).isOne();</code></pre>
+   *
+   * </p>
+   */
+  @Override
+  public S isOne() {
+    bigDecimals.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Ansgar Konermann
@@ -99,6 +100,13 @@ public abstract class AbstractByteAssert<S extends AbstractByteAssert<S>> extend
   @Override
   public S isNotZero() {
     bytes.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    bytes.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Alex Ruiz
@@ -70,6 +71,13 @@ public abstract class AbstractDoubleAssert<S extends AbstractDoubleAssert<S>> ex
   @Override
   public S isNotZero() {
     doubles.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    doubles.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Ansgar Konermann
@@ -68,6 +69,13 @@ public abstract class AbstractFloatAssert<S extends AbstractFloatAssert<S>> exte
   @Override
   public S isNotZero() {
     floats.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    floats.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * 
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Ansgar Konermann
@@ -99,6 +100,13 @@ public abstract class AbstractIntegerAssert<S extends AbstractIntegerAssert<S>> 
   @Override
   public S isNotZero() {
     integers.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    integers.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Ansgar Konermann
@@ -99,6 +100,13 @@ public abstract class AbstractLongAssert<S extends AbstractLongAssert<S>> extend
   @Override
   public S isNotZero() {
     longs.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    longs.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -27,6 +27,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  *
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Ansgar Konermann
@@ -97,6 +98,13 @@ public abstract class AbstractShortAssert<S extends AbstractShortAssert<S>> exte
   @Override
   public S isNotZero() {
     shorts.assertIsNotZero(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public S isOne() {
+    shorts.assertIsOne(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/NumberAssert.java
+++ b/src/main/java/org/assertj/core/api/NumberAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.api;
 
@@ -23,6 +23,7 @@ import org.assertj.core.data.Percentage;
  *          'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
  * @param <A> the type of the "actual" value.
  *
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Nicolas François
  * @author Mikhail Mazursky
@@ -64,6 +65,24 @@ public interface NumberAssert<S extends NumberAssert<S, A>, A extends Number> {
    * @throws AssertionError if the actual value is equal to zero.
    */
   S isNotZero();
+
+  /**
+   * Verifies that the actual value is equal to one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(1).isOne();
+   * assertThat(1.0).isOne();
+   *
+   * // assertions will fail
+   * assertThat(42).isOne();
+   * assertThat(3.142).isOne();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not equal to one.
+   */
+  S isOne();
 
   /**
    * Verifies that the actual value is positive.

--- a/src/main/java/org/assertj/core/internal/BigDecimals.java
+++ b/src/main/java/org/assertj/core/internal/BigDecimals.java
@@ -8,10 +8,11 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
+import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 
 import java.math.BigDecimal;
@@ -21,6 +22,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link BigDecimal}</code>s.
  *
+ * @author Drummond Dawson
  * @author Yvonne Wang
  * @author Joel Costigliola
  */
@@ -49,6 +51,11 @@ public class BigDecimals extends Numbers<BigDecimal> {
   @Override
   protected BigDecimal zero() {
     return ZERO;
+  }
+
+  @Override
+  protected BigDecimal one() {
+    return ONE;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Bytes.java
+++ b/src/main/java/org/assertj/core/internal/Bytes.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -17,6 +17,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Byte}</code>s.
  *
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -45,6 +46,11 @@ public class Bytes extends Numbers<Byte> {
   @Override
   protected Byte zero() {
     return 0;
+  }
+
+  @Override
+  protected Byte one() {
+    return 1;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Doubles.java
+++ b/src/main/java/org/assertj/core/internal/Doubles.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -19,6 +19,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Double}</code>s.
  * 
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -47,6 +48,11 @@ public class Doubles extends RealNumbers<Double> {
   @Override
   protected Double zero() {
     return 0.0d;
+  }
+
+  @Override
+  protected Double one() {
+    return 1.0d;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Floats.java
+++ b/src/main/java/org/assertj/core/internal/Floats.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -19,6 +19,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Float}</code>s.
  * 
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
@@ -48,6 +49,11 @@ public class Floats extends RealNumbers<Float> {
   @Override
   protected Float zero() {
     return 0.0f;
+  }
+
+  @Override
+  protected Float one() {
+    return 1.0f;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Integers.java
+++ b/src/main/java/org/assertj/core/internal/Integers.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -17,6 +17,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Integer}</code>s.
  * 
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -45,6 +46,11 @@ public class Integers extends Numbers<Integer> {
   @Override
   protected Integer zero() {
     return 0;
+  }
+
+  @Override
+  protected Integer one() {
+    return 1;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Longs.java
+++ b/src/main/java/org/assertj/core/internal/Longs.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -17,6 +17,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Long}</code>s.
  * 
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -33,11 +34,6 @@ public class Longs extends Numbers<Long> {
     return INSTANCE;
   }
 
-  @Override
-  protected Long zero() {
-    return 0L;
-  }
-
   @VisibleForTesting
   Longs() {
     super();
@@ -45,6 +41,16 @@ public class Longs extends Numbers<Long> {
 
   public Longs(ComparisonStrategy comparisonStrategy) {
     super(comparisonStrategy);
+  }
+
+  @Override
+  protected Long zero() {
+    return 0L;
+  }
+
+  @Override
+  protected Long one() {
+    return 1L;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/Numbers.java
+++ b/src/main/java/org/assertj/core/internal/Numbers.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -29,6 +29,7 @@ import org.assertj.core.util.Objects;
 /**
  * Base class of reusable assertions for numbers.
  * 
+ * @author Drummond Dawson
  * @author Joel Costigliola
  * @author Nicolas François
  */
@@ -43,6 +44,8 @@ public abstract class Numbers<NUMBER extends Number & Comparable<NUMBER>> extend
   }
 
   protected abstract NUMBER zero();
+
+  protected abstract NUMBER one();
 
   /**
    * Asserts that the actual value is equal to zero.<br>
@@ -68,6 +71,19 @@ public abstract class Numbers<NUMBER extends Number & Comparable<NUMBER>> extend
    */
   public void assertIsNotZero(AssertionInfo info, NUMBER actual) {
     assertNotEqualByComparison(info, actual, zero());
+  }
+
+  /**
+   * Asserts that the actual value is equal to one.<br>
+   * It does not rely on the custom comparisonStrategy (if one is set).
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not equal to one.
+   */
+  public void assertIsOne(AssertionInfo info, NUMBER actual) {
+    assertEqualByComparison(info, actual, one());
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Shorts.java
+++ b/src/main/java/org/assertj/core/internal/Shorts.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -19,6 +19,7 @@ import org.assertj.core.util.VisibleForTesting;
 /**
  * Reusable assertions for <code>{@link Short}</code>s.
  * 
+ * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -47,6 +48,11 @@ public class Shorts extends Numbers<Short> {
   @Override
   protected Short zero() {
     return 0;
+  }
+
+  @Override
+  protected Short one() {
+    return 1;
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.bigdecimal;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.BigDecimalAssert;
+import org.assertj.core.api.BigDecimalAssertBaseTest;
+
+/**
+ * Tests for <code>{@link BigDecimalAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class BigDecimalAssert_isOne_Test extends BigDecimalAssertBaseTest {
+
+  @Override
+  protected BigDecimalAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(bigDecimals).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/byte_/ByteAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/byte_/ByteAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.byte_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ByteAssert;
+import org.assertj.core.api.ByteAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ByteAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class ByteAssert_isOne_Test extends ByteAssertBaseTest {
+
+  @Override
+  protected ByteAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(bytes).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+
+/**
+ * Tests for <code>{@link DoubleAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class DoubleAssert_isOne_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+
+/**
+ * Tests for <code>{@link FloatAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class FloatAssert_isOne_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/integer_/IntegerAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/integer_/IntegerAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.integer_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.core.api.IntegerAssertBaseTest;
+
+/**
+ * Tests for <code>{@link IntegerAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class IntegerAssert_isOne_Test extends IntegerAssertBaseTest {
+
+  @Override
+  protected IntegerAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(integers).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.long_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongAssert;
+import org.assertj.core.api.LongAssertBaseTest;
+
+/**
+ * Tests for <code>{@link LongAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class LongAssert_isOne_Test extends LongAssertBaseTest {
+
+  @Override
+  protected LongAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(longs).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isOne_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isOne_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.short_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ShortAssert;
+import org.assertj.core.api.ShortAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ShortAssert#isOne()}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class ShortAssert_isOne_Test extends ShortAssertBaseTest {
+
+  @Override
+  protected ShortAssert invoke_api_method() {
+    return assertions.isOne();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(shorts).assertIsOne(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsOne_Test.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.bigdecimals;
+
+import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.test.TestData.someInfo;
+
+import java.math.BigDecimal;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.BigDecimals;
+import org.assertj.core.internal.BigDecimalsBaseTest;
+import org.assertj.core.test.ExpectedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BigDecimals#assertIsOne(AssertionInfo, BigDecimal)}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class BigDecimals_assertIsOne_Test extends BigDecimalsBaseTest {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    bigDecimals.assertIsOne(someInfo(), BigDecimal.ONE);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    bigDecimals.assertIsOne(someInfo(), BigDecimal.ZERO);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    bigDecimalsWithComparatorComparisonStrategy.assertIsOne(someInfo(), BigDecimal.ONE);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    bigDecimalsWithComparatorComparisonStrategy.assertIsOne(someInfo(), BigDecimal.ZERO);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsOne_Test.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.bytes;
+
+import static org.assertj.core.test.TestData.someHexInfo;
+import static org.assertj.core.test.TestData.someInfo;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Bytes;
+import org.assertj.core.internal.BytesBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Bytes#assertIsOne(AssertionInfo, Comparable)}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Bytes_assertIsOne_Test extends BytesBaseTest {
+
+  @Override
+  public void setUp() {
+    super.setUp();
+    resetFailures();
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    bytes.assertIsOne(someInfo(), (byte) 1);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    bytes.assertIsOne(someInfo(), (byte) 0);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_in_hex_representation() {
+    thrown.expectAssertionError("expected:<0x0[1]> but was:<0x0[0]>");
+    bytes.assertIsOne(someHexInfo(), (byte) 0x00);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    bytesWithAbsValueComparisonStrategy.assertIsOne(someInfo(), (byte) 1);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one_whatever_custom_comparison_strategy_is_in_hex_representation() {
+    bytesWithAbsValueComparisonStrategy.assertIsOne(someHexInfo(), (byte) 0x01);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    bytesWithAbsValueComparisonStrategy.assertIsOne(someInfo(), (byte) 0);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_whatever_custom_comparison_strategy_is_in_hex_representation() {
+    thrown.expectAssertionError("expected:<0x0[1]> but was:<0x0[0]>");
+    bytesWithAbsValueComparisonStrategy.assertIsOne(someHexInfo(), (byte) 0x0);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsOne_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.doubles;
+
+import static org.assertj.core.test.TestData.someInfo;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Doubles;
+import org.assertj.core.internal.DoublesBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Doubles#assertIsOne(AssertionInfo, Number)}}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Doubles_assertIsOne_Test extends DoublesBaseTest {
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    doubles.assertIsOne(someInfo(), 1.0d);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1].0> but was:<[0].0>");
+    doubles.assertIsOne(someInfo(), 0.0d);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    doublesWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 1.0d);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1].0> but was:<[0].0>");
+    doublesWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 0.0d);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsOne_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.floats;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Floats;
+import org.assertj.core.internal.FloatsBaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link Floats#assertIsOne(AssertionInfo, Float)}}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Floats_assertIsOne_Test extends FloatsBaseTest {
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    floats.assertIsOne(someInfo(), 1.0f);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1].0f> but was:<[0].0f>");
+    floats.assertIsOne(someInfo(), 0.0f);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    floatsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 1.0f);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1].0f> but was:<[0].0f>");
+    floatsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 0.0f);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsOne_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.integers;
+
+import static org.assertj.core.test.TestData.someInfo;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Integers;
+import org.assertj.core.internal.IntegersBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Integers#assertIsOne(AssertionInfo, Integer)}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Integers_assertIsOne_Test extends IntegersBaseTest {
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    integers.assertIsOne(someInfo(), 1);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    integers.assertIsOne(someInfo(), 0);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    integersWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 1);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    integersWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 0);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsOne_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.longs;
+
+import static org.assertj.core.test.TestData.someInfo;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Longs;
+import org.assertj.core.internal.LongsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Longs#assertIsOne(AssertionInfo, Comparable)}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Longs_assertIsOne_Test extends LongsBaseTest {
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    longs.assertIsZero(someInfo(), 0L);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1]L> but was:<[0]L>");
+    longs.assertIsOne(someInfo(), 0L);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    longsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 1L);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1]L> but was:<[0]L>");
+    longsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), 0L);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsOne_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsOne_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.shorts;
+
+import static org.assertj.core.test.TestData.someInfo;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Shorts;
+import org.assertj.core.internal.ShortsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Shorts#assertIsOne(AssertionInfo, Short)}</code>.
+ *
+ * @author Drummond Dawson
+ */
+public class Shorts_assertIsOne_Test extends ShortsBaseTest {
+
+  @Test
+  public void should_succeed_since_actual_is_one() {
+    shorts.assertIsOne(someInfo(), (short) 1);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_not_one() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    shorts.assertIsOne(someInfo(), (short) 0);
+  }
+
+  @Test
+  public void should_succeed_since_actual_is_not_one_whatever_custom_comparison_strategy_is() {
+    shortsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), (short) 1);
+  }
+
+  @Test
+  public void should_fail_since_actual_is_one_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError("expected:<[1]> but was:<[0]>");
+    shortsWithAbsValueComparisonStrategy.assertIsOne(someInfo(), (short) 0);
+  }
+
+}


### PR DESCRIPTION
Adds a convenience assertion `isOne` (similar to `isZero`) to `NumberAssert`.
#### Check List:
* Fixes: NA
* Unit tests : YES
* Javadoc with a code example (API only) : YES


