### PR TITLE
Adds support for other stream shapes : IntStream, LongStream, DoubleStream

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import org.assertj.core.util.CheckReturnValue;
-
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,7 +29,8 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.stream.BaseStream;
+import org.assertj.core.util.CheckReturnValue;
 
 public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAssertions {
 
@@ -229,18 +228,21 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
   }
 
   /**
-   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
+   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link BaseStream}.
    * <p>
-   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
+   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link BaseStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link BaseStream}.
    *
-   * @param actual the actual {@link Stream} value.
+   * <p>This method accepts {@link java.util.stream.Stream} and primitive stream variants
+   * {@link java.util.stream.IntStream}, {@link java.util.stream.LongStream} and {@link java.util.stream.DoubleStream}.
+   *
+   * @param actual the actual {@link BaseStream} value.
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <ELEMENT> ListAssert<ELEMENT> then(Stream<? extends ELEMENT> actual) {
-    return proxy(ListAssert.class, Stream.class, actual);
+  public <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> ListAssert<ELEMENT> then(BaseStream<? extends ELEMENT, STREAM> actual) {
+    return proxy(ListAssert.class, BaseStream.class, actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import org.assertj.core.util.CheckReturnValue;
-
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,7 +29,8 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.stream.BaseStream;
+import org.assertj.core.util.CheckReturnValue;
 
 public abstract class AbstractStandardSoftAssertions extends Java6AbstractStandardSoftAssertions {
 
@@ -229,19 +228,22 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
   }
 
   /**
-   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
+   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link BaseStream}.
    * <p>
-   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
+   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link BaseStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link BaseStream}.
    *
-   * @param actual the actual {@link Stream} value.
+   * <p>This method accepts {@link java.util.stream.Stream} and primitive stream variants
+   * {@link java.util.stream.IntStream}, {@link java.util.stream.LongStream} and {@link java.util.stream.DoubleStream}.
+   *
+   * @param actual the actual {@link BaseStream} value.
    * @return the created assertion object.
    */
-  @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
-    return proxy(ListAssert.class, Stream.class, actual);
+  @SuppressWarnings("unchecked")
+  public <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> ListAssert<ELEMENT> assertThat(BaseStream<? extends ELEMENT, STREAM> actual) {
+    return proxy(ListAssert.class, BaseStream.class, actual);
   }
 
 }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -12,9 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.data.Percentage.withPercentage;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +37,8 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -52,15 +51,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.function.DoublePredicate;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
-
+import java.util.stream.BaseStream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.api.filter.FilterOperator;
@@ -90,6 +86,9 @@ import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 /**
  * Entry point for assertion methods for different types. Each method in this class is a static factory for a
@@ -2241,17 +2240,20 @@ public class Assertions {
   }
 
   /**
-   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
+   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link BaseStream}.
    * <p>
-   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
+   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link BaseStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link BaseStream}.
    *
-   * @param actual the actual {@link Stream} value.
+   * <p>This method accepts {@link java.util.stream.Stream} and primitive stream variants
+   * {@link java.util.stream.IntStream}, {@link java.util.stream.LongStream} and {@link java.util.stream.DoubleStream}.
+   *
+   * @param actual the actual {@link BaseStream} value.
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
+  public static <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(BaseStream<? extends ELEMENT, STREAM> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import org.assertj.core.util.CheckReturnValue;
-
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -22,7 +20,8 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.stream.BaseStream;
+import org.assertj.core.util.CheckReturnValue;
 
 /**
  * Entry point for assertion methods for different data types. Each method in this class is a static factory for the
@@ -127,20 +126,22 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   }
 
   /**
-   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
+   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link BaseStream}.
    * <p>
-   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be 
+   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link BaseStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only 
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link BaseStream}.
    *
-   * @param actual the actual {@link Stream} value.
+   * <p>This method accepts {@link java.util.stream.Stream} and primitive stream variants
+   * {@link java.util.stream.IntStream}, {@link java.util.stream.LongStream} and {@link java.util.stream.DoubleStream}.
+   *
+   * @param actual the actual {@link BaseStream} value.
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
+  public static <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> ListAssert<ELEMENT> assertThat(BaseStream<? extends ELEMENT, STREAM> actual) {
     return new ListAssert<>(actual);
   }
-
   
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -17,13 +17,13 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
-import java.nio.file.Path;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -44,14 +46,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
-
+import java.util.stream.BaseStream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.util.CheckReturnValue;
 
@@ -1124,17 +1123,20 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
+   * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link BaseStream}.
    * <p>
-   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
+   * <b>Be aware that to create the returned {@link ListAssert} the given the {@link BaseStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link BaseStream}.
    *
-   * @param actual the actual {@link Stream} value.
+   * <p>This method accepts {@link java.util.stream.Stream} and primitive stream variants
+   * {@link java.util.stream.IntStream}, {@link java.util.stream.LongStream} and {@link java.util.stream.DoubleStream}.
+   *
+   * @param actual the actual {@link BaseStream} value.
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(Stream<? extends ELEMENT> actual) {
+  public static <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(BaseStream<? extends ELEMENT, STREAM> actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -12,17 +12,17 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
-import static org.assertj.core.internal.CommonValidations.checkIsNotNull;
-
 import java.util.AbstractList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.BaseStream;
 import java.util.stream.Stream;
-
 import org.assertj.core.internal.Failures;
+import org.assertj.core.util.Lists;
 import org.assertj.core.util.VisibleForTesting;
+
+import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
+import static org.assertj.core.internal.CommonValidations.checkIsNotNull;
 
 /**
  * Assertion methods for {@link List}s.
@@ -44,8 +44,9 @@ public class ListAssert<ELEMENT> extends
     super(actual, ListAssert.class, new ObjectAssertFactory<ELEMENT>());
   }
 
-  protected ListAssert(Stream<? extends ELEMENT> actual) {
-    this(actual == null ? null : new ListFromStream<>(actual));
+  @SuppressWarnings("unchecked")
+  protected <STREAM extends BaseStream<ELEMENT, STREAM>> ListAssert(BaseStream<? extends ELEMENT, STREAM> actual) {
+    this(actual == null ? null : new ListFromStream<>((BaseStream<ELEMENT, STREAM>) actual));
   }
 
   @Override
@@ -183,11 +184,11 @@ public class ListAssert<ELEMENT> extends
   }
 
   @VisibleForTesting
-  static class ListFromStream<ELEMENT> extends AbstractList<ELEMENT> {
-    private Stream<ELEMENT> stream;
+  static class ListFromStream<ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> extends AbstractList<ELEMENT> {
+    private BaseStream<ELEMENT, STREAM> stream;
     private List<ELEMENT> list;
 
-    public ListFromStream(Stream<ELEMENT> stream) {
+    public ListFromStream(BaseStream<ELEMENT, STREAM> stream) {
       this.stream = stream;
     }
 
@@ -198,7 +199,7 @@ public class ListAssert<ELEMENT> extends
 
     private List<ELEMENT> initList() {
       if (list == null) {
-        list = stream.collect(Collectors.toList());
+        list = Lists.newArrayList(stream.iterator());
       }
       return list;
     }

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -52,8 +52,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
-
+import java.util.stream.BaseStream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.condition.DoesNotHave;
@@ -651,8 +650,8 @@ public interface WithAssertions {
    * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(List)}
    */
   @CheckReturnValue
-  default <T> AbstractListAssert<?, ? extends List<? extends T>, T, ObjectAssert<T>> assertThat(
-      final Stream<? extends T> actual) {
+  default <ELEMENT, STREAM extends BaseStream<ELEMENT, STREAM>> AbstractListAssert<?, ? extends List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(
+      final BaseStream<? extends ELEMENT, STREAM> actual) {
     return Assertions.assertThat(actual);
   }
   

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_DoubleStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_DoubleStream_Test.java
@@ -13,10 +13,9 @@
 package org.assertj.core.api;
 
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.stream.DoubleStream;
 import org.assertj.core.api.IterableAssert.LazyIterable;
 import org.assertj.core.test.ExpectedException;
-import org.assertj.core.test.StringStream;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,86 +23,94 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class Assertions_assertThat_with_Stream_Test {
+public class Assertions_assertThat_with_DoubleStream_Test {
 
   @Rule
   public ExpectedException thrown = none();
 
-  private StringStream stringStream = new StringStream();
+  private DoubleStream intStream = DoubleStream.empty();
 
   @Test
   public void should_create_Assert() {
-    Object assertions = Assertions.assertThat(Stream.of("Luke", "Leia"));
+    Object assertions = assertThat(DoubleStream.of(823952.8, 1947230585.9));
     assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  public void should_assert_on_size() {
+    assertThat(DoubleStream.empty()).isEmpty();
+    assertThat(DoubleStream.of(123.3, 5674.5, 363.4)).isNotEmpty()
+                                                     .hasSize(3);
   }
 
   @SuppressWarnings("unchecked")
   @Test
   public void should_initialise_actual() {
-    Stream<String> iterator = Stream.of("Luke", "Leia");
-    List<? extends String> actual = assertThat(iterator).actual;
-    assertThat((List<String>) actual).contains("Luke", atIndex(0))
-                                     .contains("Leia", atIndex(1));
+    DoubleStream iterator = DoubleStream.of(823952.8, 1947230585.9);
+    List<? extends Double> actual = assertThat(iterator).actual;
+    assertThat((List<Double>) actual).contains(823952.8, atIndex(0))
+                                     .contains(1947230585.9, atIndex(1));
   }
 
   @Test
   public void should_allow_null() {
-    assertThat(assertThat((Stream<String>) null).actual).isNull();
+    assertThat(assertThat((DoubleStream) null).actual).isNull();
   }
 
   @Test
   public void isEqualTo_should_honor_comparing_the_same_mocked_stream() {
-    Stream<?> stream = mock(Stream.class);
+    DoubleStream stream = mock(DoubleStream.class);
     assertThat(stream).isEqualTo(stream);
   }
 
   @Test
   public void stream_can_be_asserted_twice() {
-    Stream<String> names = Stream.of("Luke", "Leia");
-    assertThat(names).containsExactly("Luke", "Leia")
-                     .containsExactly("Luke", "Leia");
+    DoubleStream names = DoubleStream.of(823952.8, 1947230585.9);
+    assertThat(names).containsExactly(823952.8, 1947230585.9)
+                     .containsExactly(823952.8, 1947230585.9);
   }
 
   @Test
   public void should_not_consume_stream_when_asserting_non_null() {
-    Stream<?> stream = mock(Stream.class);
+    DoubleStream stream = mock(DoubleStream.class);
     assertThat(stream).isNotNull();
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOf_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOf(Stream.class);
+    DoubleStream stream = mock(DoubleStream.class);
+    assertThat(stream).isInstanceOf(DoubleStream.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOfAny_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOfAny(Stream.class, String.class);
+    DoubleStream stream = mock(DoubleStream.class);
+    assertThat(stream).isInstanceOfAny(DoubleStream.class, String.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isOfAnyClassIn_should_check_the_original_stream_without_consuming_it() {
-    assertThat(stringStream).isOfAnyClassIn(Double.class, StringStream.class);
+    DoubleStream stream = mock(DoubleStream.class);
+    assertThat(stream).isOfAnyClassIn(Double.class, stream.getClass());
   }
 
   @Test
   public void isExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(new StringStream()).isExactlyInstanceOf(StringStream.class);
+    // factory creates use internal classes
+    assertThat(intStream).isExactlyInstanceOf(intStream.getClass());
   }
 
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotExactlyInstanceOf(Stream.class);
+    assertThat(intStream).isNotExactlyInstanceOf(DoubleStream.class);
     try {
-      assertThat(stringStream).isNotExactlyInstanceOf(StringStream.class);
+      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
     } catch (AssertionError e) {
       // ok
       return;
@@ -113,29 +120,29 @@ public class Assertions_assertThat_with_Stream_Test {
 
   @Test
   public void isNotInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOf(LazyIterable.class);
+    assertThat(intStream).isNotInstanceOf(LazyIterable.class);
   }
 
   @Test
   public void isNotInstanceOfAny_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOfAny(LazyIterable.class, String.class);
+    assertThat(intStream).isNotInstanceOfAny(LazyIterable.class, String.class);
   }
 
   @Test
   public void isNotOfAnyClassIn_should_check_the_original_stream() {
-    assertThat(stringStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
+    assertThat(intStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
   }
 
   @Test
   public void isSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    DoubleStream stream = mock(DoubleStream.class);
     assertThat(stream).isSameAs(stream);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isNotSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    DoubleStream stream = mock(DoubleStream.class);
     try {
       assertThat(stream).isNotSameAs(stream);
     } catch (AssertionError e) {
@@ -144,51 +151,4 @@ public class Assertions_assertThat_with_Stream_Test {
     }
     Assertions.fail("Expected assertionError, because assert notSame on same stream.");
   }
-
-  @Test
-  public void test_issue_245() throws Exception {
-    Foo foo1 = new Foo("id", 1);
-    foo1._f2 = "foo1";
-    Foo foo2 = new Foo("id", 2);
-    foo2._f2 = "foo1";
-    List<Foo> stream2 = newArrayList(foo2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("_f2").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("id").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorIgnoringFields("bar").isEqualTo(stream2);
-  }
-
-  @Test
-  public void test_issue_236() throws Exception {
-    List<Foo> stream2 = newArrayList(new Foo("id", 2));
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorOnFields("id")
-                                           .isEqualTo(stream2);
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorIgnoringFields("bar")
-                                           .isEqualTo(stream2);
-  }
-
-  public static class Foo {
-    private String id;
-    private int bar;
-    public String _f2;
-
-    public String getId() {
-      return id;
-    }
-
-    public int getBar() {
-      return bar;
-    }
-
-    public Foo(String id, int bar) {
-      super();
-      this.id = id;
-      this.bar = bar;
-    }
-
-    @Override
-    public String toString() {
-      return "Foo [id=" + id + ", bar=" + bar + "]";
-    }
-  }
-
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_IntStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_IntStream_Test.java
@@ -13,10 +13,9 @@
 package org.assertj.core.api;
 
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.stream.IntStream;
 import org.assertj.core.api.IterableAssert.LazyIterable;
 import org.assertj.core.test.ExpectedException;
-import org.assertj.core.test.StringStream;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,86 +23,94 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class Assertions_assertThat_with_Stream_Test {
+public class Assertions_assertThat_with_IntStream_Test {
 
   @Rule
   public ExpectedException thrown = none();
 
-  private StringStream stringStream = new StringStream();
+  private IntStream intStream = IntStream.empty();
 
   @Test
   public void should_create_Assert() {
-    Object assertions = Assertions.assertThat(Stream.of("Luke", "Leia"));
+    Object assertions = assertThat(IntStream.of(823952, 1947230585));
     assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  public void should_assert_on_size() {
+    assertThat(IntStream.empty()).isEmpty();
+    assertThat(IntStream.of(123, 5674, 363)).isNotEmpty()
+                                            .hasSize(3);
   }
 
   @SuppressWarnings("unchecked")
   @Test
   public void should_initialise_actual() {
-    Stream<String> iterator = Stream.of("Luke", "Leia");
-    List<? extends String> actual = assertThat(iterator).actual;
-    assertThat((List<String>) actual).contains("Luke", atIndex(0))
-                                     .contains("Leia", atIndex(1));
+    IntStream iterator = IntStream.of(823952, 1947230585);
+    List<? extends Integer> actual = assertThat(iterator).actual;
+    assertThat((List<Integer>) actual).contains(823952, atIndex(0))
+                                     .contains(1947230585, atIndex(1));
   }
 
   @Test
   public void should_allow_null() {
-    assertThat(assertThat((Stream<String>) null).actual).isNull();
+    assertThat(assertThat((IntStream) null).actual).isNull();
   }
 
   @Test
   public void isEqualTo_should_honor_comparing_the_same_mocked_stream() {
-    Stream<?> stream = mock(Stream.class);
+    IntStream stream = mock(IntStream.class);
     assertThat(stream).isEqualTo(stream);
   }
 
   @Test
   public void stream_can_be_asserted_twice() {
-    Stream<String> names = Stream.of("Luke", "Leia");
-    assertThat(names).containsExactly("Luke", "Leia")
-                     .containsExactly("Luke", "Leia");
+    IntStream names = IntStream.of(823952, 1947230585);
+    assertThat(names).containsExactly(823952, 1947230585)
+                     .containsExactly(823952, 1947230585);
   }
 
   @Test
   public void should_not_consume_stream_when_asserting_non_null() {
-    Stream<?> stream = mock(Stream.class);
+    IntStream stream = mock(IntStream.class);
     assertThat(stream).isNotNull();
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOf_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOf(Stream.class);
+    IntStream stream = mock(IntStream.class);
+    assertThat(stream).isInstanceOf(IntStream.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOfAny_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOfAny(Stream.class, String.class);
+    IntStream stream = mock(IntStream.class);
+    assertThat(stream).isInstanceOfAny(IntStream.class, String.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isOfAnyClassIn_should_check_the_original_stream_without_consuming_it() {
-    assertThat(stringStream).isOfAnyClassIn(Double.class, StringStream.class);
+    IntStream stream = mock(IntStream.class);
+    assertThat(stream).isOfAnyClassIn(Double.class, stream.getClass());
   }
 
   @Test
   public void isExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(new StringStream()).isExactlyInstanceOf(StringStream.class);
+    // factory creates use internal classes
+    assertThat(intStream).isExactlyInstanceOf(intStream.getClass());
   }
 
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotExactlyInstanceOf(Stream.class);
+    assertThat(intStream).isNotExactlyInstanceOf(IntStream.class);
     try {
-      assertThat(stringStream).isNotExactlyInstanceOf(StringStream.class);
+      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
     } catch (AssertionError e) {
       // ok
       return;
@@ -113,29 +120,29 @@ public class Assertions_assertThat_with_Stream_Test {
 
   @Test
   public void isNotInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOf(LazyIterable.class);
+    assertThat(intStream).isNotInstanceOf(LazyIterable.class);
   }
 
   @Test
   public void isNotInstanceOfAny_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOfAny(LazyIterable.class, String.class);
+    assertThat(intStream).isNotInstanceOfAny(LazyIterable.class, String.class);
   }
 
   @Test
   public void isNotOfAnyClassIn_should_check_the_original_stream() {
-    assertThat(stringStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
+    assertThat(intStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
   }
 
   @Test
   public void isSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    IntStream stream = mock(IntStream.class);
     assertThat(stream).isSameAs(stream);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isNotSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    IntStream stream = mock(IntStream.class);
     try {
       assertThat(stream).isNotSameAs(stream);
     } catch (AssertionError e) {
@@ -144,51 +151,4 @@ public class Assertions_assertThat_with_Stream_Test {
     }
     Assertions.fail("Expected assertionError, because assert notSame on same stream.");
   }
-
-  @Test
-  public void test_issue_245() throws Exception {
-    Foo foo1 = new Foo("id", 1);
-    foo1._f2 = "foo1";
-    Foo foo2 = new Foo("id", 2);
-    foo2._f2 = "foo1";
-    List<Foo> stream2 = newArrayList(foo2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("_f2").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("id").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorIgnoringFields("bar").isEqualTo(stream2);
-  }
-
-  @Test
-  public void test_issue_236() throws Exception {
-    List<Foo> stream2 = newArrayList(new Foo("id", 2));
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorOnFields("id")
-                                           .isEqualTo(stream2);
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorIgnoringFields("bar")
-                                           .isEqualTo(stream2);
-  }
-
-  public static class Foo {
-    private String id;
-    private int bar;
-    public String _f2;
-
-    public String getId() {
-      return id;
-    }
-
-    public int getBar() {
-      return bar;
-    }
-
-    public Foo(String id, int bar) {
-      super();
-      this.id = id;
-      this.bar = bar;
-    }
-
-    @Override
-    public String toString() {
-      return "Foo [id=" + id + ", bar=" + bar + "]";
-    }
-  }
-
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_LongStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_LongStream_Test.java
@@ -13,10 +13,9 @@
 package org.assertj.core.api;
 
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.stream.LongStream;
 import org.assertj.core.api.IterableAssert.LazyIterable;
 import org.assertj.core.test.ExpectedException;
-import org.assertj.core.test.StringStream;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,86 +23,94 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class Assertions_assertThat_with_Stream_Test {
+public class Assertions_assertThat_with_LongStream_Test {
 
   @Rule
   public ExpectedException thrown = none();
 
-  private StringStream stringStream = new StringStream();
+  private LongStream intStream = LongStream.empty();
 
   @Test
   public void should_create_Assert() {
-    Object assertions = Assertions.assertThat(Stream.of("Luke", "Leia"));
+    Object assertions = assertThat(LongStream.of(823952L, 1947230585L));
     assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  public void should_assert_on_size() {
+    assertThat(LongStream.empty()).isEmpty();
+    assertThat(LongStream.of(123L, 5674L, 363L)).isNotEmpty()
+                                                .hasSize(3);
   }
 
   @SuppressWarnings("unchecked")
   @Test
   public void should_initialise_actual() {
-    Stream<String> iterator = Stream.of("Luke", "Leia");
-    List<? extends String> actual = assertThat(iterator).actual;
-    assertThat((List<String>) actual).contains("Luke", atIndex(0))
-                                     .contains("Leia", atIndex(1));
+    LongStream iterator = LongStream.of(823952L, 1947230585L);
+    List<? extends Long> actual = assertThat(iterator).actual;
+    assertThat((List<Long>) actual).contains(823952L, atIndex(0))
+                                   .contains(1947230585L, atIndex(1));
   }
 
   @Test
   public void should_allow_null() {
-    assertThat(assertThat((Stream<String>) null).actual).isNull();
+    assertThat(assertThat((LongStream) null).actual).isNull();
   }
 
   @Test
   public void isEqualTo_should_honor_comparing_the_same_mocked_stream() {
-    Stream<?> stream = mock(Stream.class);
+    LongStream stream = mock(LongStream.class);
     assertThat(stream).isEqualTo(stream);
   }
 
   @Test
   public void stream_can_be_asserted_twice() {
-    Stream<String> names = Stream.of("Luke", "Leia");
-    assertThat(names).containsExactly("Luke", "Leia")
-                     .containsExactly("Luke", "Leia");
+    LongStream names = LongStream.of(823952L, 1947230585L);
+    assertThat(names).containsExactly(823952L, 1947230585L)
+                     .containsExactly(823952L, 1947230585L);
   }
 
   @Test
   public void should_not_consume_stream_when_asserting_non_null() {
-    Stream<?> stream = mock(Stream.class);
+    LongStream stream = mock(LongStream.class);
     assertThat(stream).isNotNull();
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOf_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOf(Stream.class);
+    LongStream stream = mock(LongStream.class);
+    assertThat(stream).isInstanceOf(LongStream.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isInstanceOfAny_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
-    assertThat(stream).isInstanceOfAny(Stream.class, String.class);
+    LongStream stream = mock(LongStream.class);
+    assertThat(stream).isInstanceOfAny(LongStream.class, String.class);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isOfAnyClassIn_should_check_the_original_stream_without_consuming_it() {
-    assertThat(stringStream).isOfAnyClassIn(Double.class, StringStream.class);
+    LongStream stream = mock(LongStream.class);
+    assertThat(stream).isOfAnyClassIn(Double.class, stream.getClass());
   }
 
   @Test
   public void isExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(new StringStream()).isExactlyInstanceOf(StringStream.class);
+    // factory creates use internal classes
+    assertThat(intStream).isExactlyInstanceOf(intStream.getClass());
   }
 
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotExactlyInstanceOf(Stream.class);
+    assertThat(intStream).isNotExactlyInstanceOf(LongStream.class);
     try {
-      assertThat(stringStream).isNotExactlyInstanceOf(StringStream.class);
+      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
     } catch (AssertionError e) {
       // ok
       return;
@@ -113,29 +120,29 @@ public class Assertions_assertThat_with_Stream_Test {
 
   @Test
   public void isNotInstanceOf_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOf(LazyIterable.class);
+    assertThat(intStream).isNotInstanceOf(LazyIterable.class);
   }
 
   @Test
   public void isNotInstanceOfAny_should_check_the_original_stream() {
-    assertThat(stringStream).isNotInstanceOfAny(LazyIterable.class, String.class);
+    assertThat(intStream).isNotInstanceOfAny(LazyIterable.class, String.class);
   }
 
   @Test
   public void isNotOfAnyClassIn_should_check_the_original_stream() {
-    assertThat(stringStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
+    assertThat(intStream).isNotOfAnyClassIn(LazyIterable.class, String.class);
   }
 
   @Test
   public void isSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    LongStream stream = mock(LongStream.class);
     assertThat(stream).isSameAs(stream);
     verifyZeroInteractions(stream);
   }
 
   @Test
   public void isNotSameAs_should_check_the_original_stream_without_consuming_it() {
-    Stream<?> stream = mock(Stream.class);
+    LongStream stream = mock(LongStream.class);
     try {
       assertThat(stream).isNotSameAs(stream);
     } catch (AssertionError e) {
@@ -144,51 +151,4 @@ public class Assertions_assertThat_with_Stream_Test {
     }
     Assertions.fail("Expected assertionError, because assert notSame on same stream.");
   }
-
-  @Test
-  public void test_issue_245() throws Exception {
-    Foo foo1 = new Foo("id", 1);
-    foo1._f2 = "foo1";
-    Foo foo2 = new Foo("id", 2);
-    foo2._f2 = "foo1";
-    List<Foo> stream2 = newArrayList(foo2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("_f2").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorOnFields("id").isEqualTo(stream2);
-    assertThat(Stream.of(foo1)).usingElementComparatorIgnoringFields("bar").isEqualTo(stream2);
-  }
-
-  @Test
-  public void test_issue_236() throws Exception {
-    List<Foo> stream2 = newArrayList(new Foo("id", 2));
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorOnFields("id")
-                                           .isEqualTo(stream2);
-    assertThat(Stream.of(new Foo("id", 1))).usingElementComparatorIgnoringFields("bar")
-                                           .isEqualTo(stream2);
-  }
-
-  public static class Foo {
-    private String id;
-    private int bar;
-    public String _f2;
-
-    public String getId() {
-      return id;
-    }
-
-    public int getBar() {
-      return bar;
-    }
-
-    public Foo(String id, int bar) {
-      super();
-      this.id = id;
-      this.bar = bar;
-    }
-
-    @Override
-    public String toString() {
-      return "Foo [id=" + id + ", bar=" + bar + "]";
-    }
-  }
-
 }


### PR DESCRIPTION
AssertJ currently lacks support for the primitive variants like `IntStream`. While Stream methods are defined in the specific interfaces, `Stream` and other stream shapes extends `BaseStream`. This interfaces defines a _little_ set of common methods that are useful enough for assertion as the stream is transformed into a `ListAssert` internally.

From outside it basically changes the signature of `assertThat(Stream<T>)` to `assertThat(BaseStream<T, S extends BaseStream<T, S>>)`.

This PR only adds tests for the external API since ListAssert is already tested.

One thing that still bothers me right now, is that I had to suppress warning for unchecked cast, I'm not sure how to resolve that now.

I'm open for comment and modifications.