### PR TITLE
Long literal ending with 'l' instead of 'L' (since l might look prett…

### DIFF
--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -243,11 +243,11 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     // simple atomic value
     softly.then(new AtomicBoolean(true)).isTrue();
     softly.then(new AtomicInteger(1)).hasValueGreaterThan(0);
-    softly.then(new AtomicLong(1l)).hasValueGreaterThan(0l);
+    softly.then(new AtomicLong(1L)).hasValueGreaterThan(0L);
     softly.then(new AtomicReference<String>("abc")).hasValue("abc");
     // atomic array value
     softly.then(new AtomicIntegerArray(new int[] { 1, 2, 3 })).containsExactly(1, 2, 3);
-    softly.then(new AtomicLongArray(new long[] { 1l, 2l, 3l })).containsExactly(1l, 2l, 3l);
+    softly.then(new AtomicLongArray(new long[] {1L, 2L, 3L})).containsExactly(1L, 2L, 3L);
     softly.then(new AtomicReferenceArray<>(array("a", "b", "c"))).containsExactly("a", "b", "c");
     softly.assertAll();
   }

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -707,11 +707,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // simple atomic value
     softly.assertThat(new AtomicBoolean(true)).isTrue();
     softly.assertThat(new AtomicInteger(1)).hasValueGreaterThan(0);
-    softly.assertThat(new AtomicLong(1l)).hasValueGreaterThan(0l);
+    softly.assertThat(new AtomicLong(1L)).hasValueGreaterThan(0L);
     softly.assertThat(new AtomicReference<String>("abc")).hasValue("abc");
     // atomic array value
     softly.assertThat(new AtomicIntegerArray(new int[] { 1, 2, 3 })).containsExactly(1, 2, 3);
-    softly.assertThat(new AtomicLongArray(new long[] { 1l, 2l, 3l })).containsExactly(1l, 2l, 3l);
+    softly.assertThat(new AtomicLongArray(new long[] {1L, 2L, 3L})).containsExactly(1L, 2L, 3L);
     softly.assertThat(new AtomicReferenceArray<>(array("a", "b", "c"))).containsExactly("a", "b", "c");
     softly.assertAll();
   }

--- a/src/test/java/org/assertj/core/api/atomic/long_/AtomicLongAssert_doesNotHaveValue_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/long_/AtomicLongAssert_doesNotHaveValue_Test.java
@@ -29,13 +29,13 @@ public class AtomicLongAssert_doesNotHaveValue_Test {
 
   @Test
   public void should_pass_when_actual_does_not_have_the_expected_value() {
-    AtomicLong actual = new AtomicLong(123l);
-    assertThat(actual).doesNotHaveValue(456l);
+    AtomicLong actual = new AtomicLong(123L);
+    assertThat(actual).doesNotHaveValue(456L);
   }
 
   @Test
   public void should_fail_when_actual_has_the_expected_value() {
-    long value = 123l;
+    long value = 123L;
     AtomicLong actual = new AtomicLong(value);
     thrown.expectAssertionError(shouldNotContainValue(actual, value).create());
     assertThat(actual).doesNotHaveValue(value);
@@ -45,7 +45,7 @@ public class AtomicLongAssert_doesNotHaveValue_Test {
   public void should_fail_when_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
     AtomicLong actual = null;
-    assertThat(actual).doesNotHaveValue(1234l);
+    assertThat(actual).doesNotHaveValue(1234L);
   }
   
 }

--- a/src/test/java/org/assertj/core/api/atomic/long_/AtomicLongAssert_hasValue_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/long_/AtomicLongAssert_hasValue_Test.java
@@ -29,15 +29,15 @@ public class AtomicLongAssert_hasValue_Test {
 
   @Test
   public void should_pass_when_actual_has_the_expected_value() {
-    long initialValue = 123l;
+    long initialValue = 123L;
     AtomicLong actual = new AtomicLong(initialValue);
     assertThat(actual).hasValue(initialValue);
   }
 
   @Test
   public void should_fail_when_actual_does_not_have_the_expected_value() {
-    AtomicLong actual = new AtomicLong(123l);
-    long expectedValue = 1234l;
+    AtomicLong actual = new AtomicLong(123L);
+    long expectedValue = 1234L;
     thrown.expectAssertionError(shouldHaveValue(actual, expectedValue).create());
     assertThat(actual).hasValue(expectedValue);
   }
@@ -46,7 +46,7 @@ public class AtomicLongAssert_hasValue_Test {
   public void should_fail_when_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
     AtomicLong actual = null;
-    assertThat(actual).hasValue(1234l);
+    assertThat(actual).hasValue(1234L);
   }
   
 }

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_long_Test.java
@@ -21,8 +21,8 @@ import org.assertj.core.data.Offset;
 
 public class LongAssert_isCloseTo_long_Test extends LongAssertBaseTest {
 
-  private final Offset<Long> offset = offset(5l);
-  private final Long value = 8l;
+  private final Offset<Long> offset = offset(5L);
+  private final Long value = 8L;
 
   @Override
   protected LongAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isCloseTo_primitive_long_Test.java
@@ -21,8 +21,8 @@ import static org.mockito.Mockito.verify;
 
 public class LongAssert_isCloseTo_primitive_long_Test extends LongAssertBaseTest {
 
-  private final Offset<Long> offset = offset(5l);
-  private final long value = 8l;
+  private final Offset<Long> offset = offset(5L);
+  private final long value = 8L;
 
   @Override
   protected LongAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_long_Test.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verify;
  */
 public class LongAssert_isNotCloseTo_long_Test extends LongAssertBaseTest {
 
-  private final Offset<Long> offset = offset(5l);
-  private final Long value = 8l;
+  private final Offset<Long> offset = offset(5L);
+  private final Long value = 8L;
 
   @Override
   protected LongAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_primitive_long_Test.java
+++ b/src/test/java/org/assertj/core/api/long_/LongAssert_isNotCloseTo_primitive_long_Test.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verify;
  */
 public class LongAssert_isNotCloseTo_primitive_long_Test extends LongAssertBaseTest {
 
-  private final Offset<Long> offset = offset(5l);
-  private final long value = 8l;
+  private final Offset<Long> offset = offset(5L);
+  private final long value = 8L;
 
   @Override
   protected LongAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/error/ShouldHaveValue_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveValue_create_Test.java
@@ -36,7 +36,7 @@ public class ShouldHaveValue_create_Test {
     joe = new Person();
     joe.name = "Joe";
     joe.age = 33;
-    joe.account = 123456789l;
+    joe.account = 123456789L;
   }
 
   @Test
@@ -60,7 +60,7 @@ public class ShouldHaveValue_create_Test {
     // GIVEN
     AtomicLongFieldUpdater<Person> updater = AtomicLongFieldUpdater.newUpdater(Person.class, "account");
     // WHEN
-    String message = shouldHaveValue(updater, 123456789l, 0l, joe).create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
+    String message = shouldHaveValue(updater, 123456789L, 0L, joe).create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting <AtomicLongFieldUpdater> to have value:%n" +

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
@@ -30,10 +30,10 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 @RunWith(DataProviderRunner.class)
 public class Longs_assertIsCloseTo_Test extends LongsBaseTest {
 
-  private static final Long ZERO = 0l;
-  private static final Long ONE = 1l;
-  private static final Long TWO = 2l;
-  private static final Long TEN = 10l;
+  private static final Long ZERO = 0L;
+  private static final Long ONE = 1L;
+  private static final Long TWO = 2L;
+  private static final Long TEN = 10L;
 
   @Test
   public void should_fail_if_actual_is_null() {

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNegative_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNegative_Test.java
@@ -30,13 +30,13 @@ public class Longs_assertIsNegative_Test extends LongsBaseTest {
 
   @Test
   public void should_succeed_since_actual_is_negative() {
-    longs.assertIsNegative(someInfo(), -6l);
+    longs.assertIsNegative(someInfo(), -6L);
   }
 
   @Test
   public void should_fail_since_actual_is_not_negative() {
     thrown.expectAssertionError("%nExpecting:%n <6L>%nto be less than:%n <0L> ");
-    longs.assertIsNegative(someInfo(), 6l);
+    longs.assertIsNegative(someInfo(), 6L);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
@@ -30,11 +30,11 @@ import static org.mockito.Mockito.verify;
 @RunWith(DataProviderRunner.class)
 public class Longs_assertIsNotCloseTo_Test extends LongsBaseTest {
 
-  private static final Long ZERO = 0l;
-  private static final Long ONE = 1l;
-  private static final Long TWO = 2l;
-  private static final Long THREE = 3l;
-  private static final Long TEN = 10l;
+  private static final Long ZERO = 0L;
+  private static final Long ONE = 1L;
+  private static final Long TWO = 2L;
+  private static final Long THREE = 3L;
+  private static final Long TEN = 10L;
 
   @Test
   public void should_fail_if_actual_is_null() {

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotZero_Test.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Longs#assertIsNegative(AssertionInfo, Long)}</code>.
+ * Tests for <code>{@link Longs#assertIsNotZero(AssertionInfo, Long)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
@@ -30,13 +30,13 @@ public class Longs_assertIsNotZero_Test extends LongsBaseTest {
 
   @Test
   public void should_succeed_since_actual_is_not_zero() {
-    longs.assertIsNotZero(someInfo(), 2l);
+    longs.assertIsNotZero(someInfo(), 2L);
   }
 
   @Test
   public void should_fail_since_actual_is_zero() {
     thrown.expectAssertionError("%nExpecting:%n <0L>%nnot to be equal to:%n <0L>%n");
-    longs.assertIsNotZero(someInfo(), 0l);
+    longs.assertIsNotZero(someInfo(), 0L);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsPositive_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsPositive_Test.java
@@ -29,13 +29,13 @@ public class Longs_assertIsPositive_Test extends LongsBaseTest {
 
   @Test
   public void should_succeed_since_actual_is_positive() {
-    longs.assertIsPositive(someInfo(), 6l);
+    longs.assertIsPositive(someInfo(), 6L);
   }
 
   @Test
   public void should_fail_since_actual_is_not_positive() {
     thrown.expectAssertionError("%nExpecting:%n <-6L>%nto be greater than:%n <0L> ");
-    longs.assertIsPositive(someInfo(), -6l);
+    longs.assertIsPositive(someInfo(), -6L);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsZero_Test.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Longs#assertIsNegative(AssertionInfo, Comparable)}</code>.
+ * Tests for <code>{@link Longs#assertIsZero(AssertionInfo, Long)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
@@ -30,13 +30,13 @@ public class Longs_assertIsZero_Test extends LongsBaseTest {
 
   @Test
   public void should_succeed_since_actual_is_zero() {
-    longs.assertIsZero(someInfo(), 0l);
+    longs.assertIsZero(someInfo(), 0L);
   }
 
   @Test
   public void should_fail_since_actual_is_not_zero() {
     thrown.expectAssertionError("expected:<[0]L> but was:<[2]L>");
-    longs.assertIsZero(someInfo(), 2l);
+    longs.assertIsZero(someInfo(), 2L);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
@@ -20,7 +20,7 @@ import static org.assertj.core.util.Strings.quote;
 import org.junit.Test;
 
 /**
- * Tests for <code>{@link StandardRepresentation#formatArray(org.assertj.core.presentation.Representation, Object)}</code>.
+ * Tests for <code>{@link StandardRepresentation#formatArray(Object)}</code>.
  */
 public class StandardRepresentation_array_format_Test extends AbstractBaseRepresentationTest {
 
@@ -87,7 +87,7 @@ public class StandardRepresentation_array_format_Test extends AbstractBaseRepres
 
   @Test
   public void should_format_long_array() {
-    Object array = new long[] { 160l, 98l };
+    Object array = new long[] {160L, 98L};
     assertThat(STANDARD_REPRESENTATION.formatArray(array)).isEqualTo("[160L, 98L]");
   }
 
@@ -104,7 +104,7 @@ public class StandardRepresentation_array_format_Test extends AbstractBaseRepres
 
   @Test
   public void should_format_longArray() {
-    assertThat(STANDARD_REPRESENTATION.formatArray(new long[] { 6l, 8l })).isEqualTo("[6L, 8L]");
+    assertThat(STANDARD_REPRESENTATION.formatArray(new long[] {6L, 8L})).isEqualTo("[6L, 8L]");
   }
 
   @Test


### PR DESCRIPTION
…y similar to 1 in certain fonts)

just a minor one but some tools are generating warnings for this one.



