### PR TITLE
Propose a new assertThat(ThrowingCallable) signature with hasNotThrownException() assertion

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -17,6 +17,8 @@ import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Throwables;
 import org.assertj.core.util.VisibleForTesting;
 
+import static java.lang.String.format;
+
 /**
  * Base class for all implementations of assertions for {@link Throwable}s.
  * 
@@ -356,7 +358,21 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
     return myself;
   }
 
-  public void hasNotThrownException() {
-    if (actual != null) throw Failures.instance().failure("Expecting code not to raise a throwable.");
+  /**
+   * Verifies that the {@link org.assertj.core.api.ThrowableAssert.ThrowingCallable} didn't raise a throwable.
+   *
+   * Example :
+   * <pre><code class='java'>assertThat(() -> foo.bar()).didNotThrowAnyException();
+   * assertThat(() -> jedi.saber()).didNotThrowAnyException();</code></pre>
+   *
+   * @throws AssertionError if the actual statement raised a {@code Throwable}.
+   */
+  public void didNotThrowAnyException() {
+    if (actual != null) {
+      throw Failures.instance()
+                    .failure(format("Expecting code not to raise a throwable but caught '%s' with message : %s",
+                                    actual.getClass().getName(),
+                                    actual.getMessage()));
+    }
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -12,11 +12,10 @@
  */
 package org.assertj.core.api;
 
+import java.util.IllegalFormatException;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Throwables;
 import org.assertj.core.util.VisibleForTesting;
-
-import java.util.IllegalFormatException;
 
 /**
  * Base class for all implementations of assertions for {@link Throwable}s.
@@ -355,5 +354,9 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   public SELF hasSuppressedException(Throwable suppressedException) {
     throwables.assertHasSuppressedException(info, actual, suppressedException);
     return myself;
+  }
+
+  public void hasNotThrownException() {
+    if (actual != null) throw Failures.instance().failure("Expecting code not to raise a throwable.");
   }
 }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1058,8 +1058,7 @@ public class Assertions {
    * public void testException() {
    *   assertThat(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
    *                                                      .hasMessageContaining("boom");
-   *   assertThat(() -> { throw new Exception("boom!"); }).doesNotThrow();
-   * }</code></pre>
+   *   assertThat(() -> { throw new Exception("boom!"); }).didNotThrowAnyException();</code></pre>
    *
    * If the provided {@link ThrowingCallable} does not validate against next assertions, an error is immediately raised,
    * in that case the test description provided with {@link AbstractAssert#as(String, Object...) as(String, Object...)} is not honored.

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -12,9 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.data.Percentage.withPercentage;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,7 +58,6 @@ import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import java.util.stream.BaseStream;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.api.filter.FilterOperator;
@@ -91,6 +87,9 @@ import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 /**
  * Entry point for assertion methods for different types. Each method in this class is a static factory for a
@@ -1046,6 +1045,38 @@ public class Assertions {
   @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * Example :
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   assertThat(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+   *                                                      .hasMessageContaining("boom");
+   *   assertThat(() -> { throw new Exception("boom!"); }).doesNotThrow();
+   * }</code></pre>
+   *
+   * If the provided {@link ThrowingCallable} does not validate against next assertions, an error is immediately raised,
+   * in that case the test description provided with {@link AbstractAssert#as(String, Object...) as(String, Object...)} is not honored.
+   * To use a test description, use {@link #catchThrowable(ThrowableAssert.ThrowingCallable)} as shown below.
+   * <pre><code class='java'>// assertion will fail and "display me" will appear in the error
+   * assertThat(() -> { // do nothing }).as("display me").isInstanceOf(Exception.class);
+   *
+   * // assertion will fail AND "display me" will appear in the error
+   * Throwable thrown = catchThrowable(() -> { // do nothing });
+   * assertThat(thrown).as("display me").isInstanceOf(Exception.class); </code></pre>
+   *
+   * @param shouldRaiseOrNotThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  @CheckReturnValue
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(ThrowingCallable shouldRaiseOrNotThrowable) {
+    return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -967,6 +967,25 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Allows to capture and then assert on a {@link ThrowingCallable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * Java 8 example :
+   * <pre><code class='java'> {@literal @}Test
+   *  public void testException() {
+   *    then(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+   *                                                 .hasMessageContaining("boom");
+   *    then(() -> { throw new Exception("boom!"); }).didNotThrowAnyException();</code></pre>
+   *
+   * @param shouldRaiseOrNotThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  @CheckReturnValue
+  public static AbstractThrowableAssert<?, ? extends Throwable> then(ThrowingCallable shouldRaiseOrNotThrowable) {
+    return assertThat(shouldRaiseOrNotThrowable);
+  }
+
+  /**
    * Creates a new instance of <code>{@link org.assertj.core.api.LocalDateAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import org.assertj.core.util.CheckReturnValue;
-
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -37,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
+import org.assertj.core.util.CheckReturnValue;
 
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -700,6 +699,40 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
   @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return then(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * Example :
+   * </p>
+   *
+   * <pre><code class='java'>BDDSoftAssertions softly = new BDDSoftAssertions();
+   * softly.then(new ThrowingCallable() {
+   *
+   *   {@literal @}Override
+   *   public Void call() throws Exception {
+   *     throw new Exception("boom!");
+   *   }
+   *
+   * }).isInstanceOf(Exception.class)
+   *   .hasMessageContaining("boom");
+   * softly.then(new ThrowingCallable() {
+   *
+   *   {@literal @}Override
+   *   public Void call() throws Exception {
+   *     throw new Exception("boom!");
+   *   }
+   *
+   * }).didNotThrowAnyException();</code></pre>
+   **
+   * @param shouldRaiseOrNotThrowable The {@link org.assertj.core.api.ThrowableAssert.ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  @CheckReturnValue
+  public AbstractThrowableAssert<?, ? extends Throwable> then(ThrowableAssert.ThrowingCallable shouldRaiseOrNotThrowable) {
+    return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
-
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -37,8 +35,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
-
 import org.assertj.core.util.CheckReturnValue;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * AbstractStandardSoftAssertions compatible with Android. Duplicated from {@link AbstractStandardSoftAssertions}.
@@ -706,6 +705,27 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
   @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * Example :
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   assertThat(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+   *                                                      .hasMessageContaining("boom");
+   *   assertThat(() -> { throw new Exception("boom!"); }).didNotThrowAnyException();</code></pre>
+   *
+   * @param shouldRaiseOrNotThrowable The {@link org.assertj.core.api.ThrowableAssert.ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  @CheckReturnValue
+  public AbstractThrowableAssert<?, ? extends Throwable> assertThat(ThrowableAssert.ThrowingCallable shouldRaiseOrNotThrowable) {
+    return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.data.Percentage.withPercentage;
-
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -39,7 +37,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.api.filter.FilterOperator;
@@ -62,6 +59,8 @@ import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
+
+import static org.assertj.core.data.Percentage.withPercentage;
 
 /**
  * Assertions compatible with Android. Duplicated from {@link Assertions}.
@@ -951,6 +950,38 @@ public class Java6Assertions {
   @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
+  }
+
+  /**
+   * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * Example :
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   assertThat(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+   *                                                      .hasMessageContaining("boom");
+   *   assertThat(() -> { throw new Exception("boom!"); }).doesNotThrow();
+   * }</code></pre>
+   *
+   * If the provided {@link ThrowingCallable} does not validate against next assertions, an error is immediately raised,
+   * in that case the test description provided with {@link AbstractAssert#as(String, Object...) as(String, Object...)} is not honored.
+   * To use a test description, use {@link #catchThrowable(ThrowableAssert.ThrowingCallable)} as shown below.
+   * <pre><code class='java'>// assertion will fail and "display me" will appear in the error
+   * assertThat(() -> { // do nothing }).as("display me").isInstanceOf(Exception.class);
+   *
+   * // assertion will fail AND "display me" will appear in the error
+   * Throwable thrown = catchThrowable(() -> { // do nothing });
+   * assertThat(thrown).as("display me").isInstanceOf(Exception.class); </code></pre>
+   *
+   * @param shouldRaiseOrNotThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   */
+  @CheckReturnValue
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(ThrowingCallable shouldRaiseOrNotThrowable) {
+    return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -963,8 +963,7 @@ public class Java6Assertions {
    * public void testException() {
    *   assertThat(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
    *                                                      .hasMessageContaining("boom");
-   *   assertThat(() -> { throw new Exception("boom!"); }).doesNotThrow();
-   * }</code></pre>
+   *   assertThat(() -> { throw new Exception("boom!"); }).didNotThrowAnyException();</code></pre>
    *
    * If the provided {@link ThrowingCallable} does not validate against next assertions, an error is immediately raised,
    * in that case the test description provided with {@link AbstractAssert#as(String, Object...) as(String, Object...)} is not honored.

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -917,6 +917,14 @@ public interface WithAssertions {
   }
 
   /**
+   * Delegate call to {@link org.assertj.core.api.Assertions#assertThat(ThrowableAssert.ThrowingCallable)}
+   */
+  default AbstractThrowableAssert<?, ? extends Throwable> assertThat(
+      final ThrowingCallable shouldRaiseThrowable) {
+    return Assertions.assertThat(shouldRaiseThrowable);
+  }
+
+  /**
    * Delegate call to {@link org.assertj.core.api.Assertions#catchThrowable(ThrowableAssert.ThrowingCallable)}
    */
   default Throwable catchThrowable(final ThrowingCallable shouldRaiseThrowable) {

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -92,12 +92,12 @@ public class Assertions_assertThat_with_Throwable_Test {
 
     try {
       // When
-      assertThat(boom).hasNotThrownException();
+      assertThat(boom).didNotThrowAnyException();
 
       fail("Assertion error expected");
     } catch (AssertionError assertionError) {
       // Then
-      assertThat(assertionError).hasMessageContaining("Expecting code not to raise a throwable.");
+      assertThat(assertionError).hasMessageContaining("Expecting code not to raise a throwable but caught 'java.lang.Exception' with message : boom");
     }
   }
 
@@ -108,7 +108,7 @@ public class Assertions_assertThat_with_Throwable_Test {
 
     try {
       // When
-      assertThat(silent).hasNotThrownException();
+      assertThat(silent).didNotThrowAnyException();
     } catch (AssertionError assertionError) {
       // Then
       fail("Assertion error not expected");

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.test.ExpectedException.none;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.test.ExpectedException.none;
 
 public class Assertions_assertThat_with_Throwable_Test {
 
@@ -66,6 +67,52 @@ public class Assertions_assertThat_with_Throwable_Test {
                                                      "but was:",
                                                      "<\"boom\">");
     assertThatThrownBy(raisingException("boom")).hasMessage("yo");
+  }
+
+  @Test
+  public void can_invoke_late_assertion_on_assertThat_ThrowingCallable() {
+    // Given
+    ThrowingCallable boom = raisingException("boom");
+
+    try {
+      // When
+      assertThat(boom).isInstanceOf(Exception.class)
+                      .hasMessageContaining("boom");
+
+    } catch (AssertionError assertionError) {
+      // Then
+      fail("Assertion error expected");
+    }
+  }
+
+  @Test
+  public void should_fail_when_asserting_not_exception_raised() {
+    // Given
+    ThrowingCallable boom = raisingException("boom");
+
+    try {
+      // When
+      assertThat(boom).hasNotThrownException();
+
+      fail("Assertion error expected");
+    } catch (AssertionError assertionError) {
+      // Then
+      assertThat(assertionError).hasMessageContaining("Expecting code not to raise a throwable.");
+    }
+  }
+
+  @Test
+  public void should_not_fail_when_asserting_not_exception_raised() {
+    // Given
+    ThrowingCallable silent = () -> {};
+
+    try {
+      // When
+      assertThat(silent).hasNotThrownException();
+    } catch (AssertionError assertionError) {
+      // Then
+      fail("Assertion error not expected");
+    }
   }
 
   private ThrowingCallable raisingException(final String reason) {

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -12,17 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.shouldHaveThrown;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.util.Arrays.array;
-import static org.assertj.core.util.DateUtil.parseDatetime;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.lang.reflect.Method;
@@ -53,7 +42,6 @@ import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.test.ComparableExample;
@@ -64,6 +52,17 @@ import org.assertj.core.test.Name;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.shouldHaveThrown;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.DateUtil.parseDatetime;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
 
 /**
  * Tests for <code>{@link SoftAssertions}</code>.
@@ -875,7 +874,6 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
         assertions.assertThat("red").isEqualTo("blue");
       });
     }).as("it should call assertAll() and fail with multiple validation errors")
-      .hasBeenThrown()
       .hasMessageContaining("meaning of life")
       .hasMessageContaining("blue");
   }


### PR DESCRIPTION
The signature can be used to verify that call **don't** raise an exception, instead of relying on other technics. This allows to have a finer control over statement(s) that should or should not raise an exception.

The idea of this API is to be able to write assertions like that : 

```java
assertThat(() -> foo.bar()).hasNotThrownException();
assertThat(() -> jedi.saber()).hasNotThrownException();
```

Ideas on how to improve this PR are welcome ; API signature, name alternative, documentation, ...