### PR TITLE
add ExpectedException#expectAssertionError(ErrorMessageFactory errorM…

### DIFF
--- a/src/main/java/org/assertj/core/internal/DoubleArrays.java
+++ b/src/main/java/org/assertj/core/internal/DoubleArrays.java
@@ -41,11 +41,9 @@ public class DoubleArrays {
 
   private Arrays arrays = Arrays.instance();
 
-  @VisibleForTesting
-  Failures failures = Failures.instance();
+  private Failures failures = Failures.instance();
 
-  @VisibleForTesting
-  DoubleArrays() {
+  private DoubleArrays() {
     this(StandardComparisonStrategy.instance());
   }
 

--- a/src/test/java/org/assertj/core/internal/DoubleArraysBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/DoubleArraysBaseTest.java
@@ -15,13 +15,10 @@ package org.assertj.core.internal;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
 import static org.assertj.core.test.ExpectedException.none;
 
-import static org.mockito.Mockito.spy;
-
 import java.util.Comparator;
 
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.DoubleArrays;
-import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.util.AbsValueComparator;
@@ -46,7 +43,6 @@ public class DoubleArraysBaseTest {
    * is initialized with {@link #initActualArray()} with default value = {6.0, 8.0, 10.0}
    */
   protected double[] actual;
-  protected Failures failures;
   protected DoubleArrays arrays;
 
   protected ComparatorBasedComparisonStrategy absValueComparisonStrategy;
@@ -56,12 +52,9 @@ public class DoubleArraysBaseTest {
 
   @Before
   public void setUp() {
-    failures = spy(new Failures());
-    arrays = new DoubleArrays();
-    arrays.failures = failures;
+    arrays = DoubleArrays.instance();
     absValueComparisonStrategy = new ComparatorBasedComparisonStrategy(comparatorForCustomComparisonStrategy());
     arraysWithCustomComparisonStrategy = new DoubleArrays(absValueComparisonStrategy);
-    arraysWithCustomComparisonStrategy.failures = failures;
     initActualArray();
   }
 

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -20,10 +20,8 @@ import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.test.DoubleArrays.*;
 import static org.assertj.core.test.ErrorMessages.*;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.*;
 import static org.assertj.core.util.FailureMessages.*;
 import static org.assertj.core.util.Lists.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests for <code>{@link DoubleArrays#assertContainsExactlyInAnyOrder(AssertionInfo, double[], double[])}</code>.
@@ -72,62 +70,35 @@ public class DoubleArrays_assertContainsExactlyInAnyOrder_Test extends DoubleArr
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
-    AssertionInfo info = someInfo();
-    double[] expected = {6d, 8d, 20d};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20d), newArrayList(10d),
-          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 6d, 8d, 20d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20d), newArrayList(10d),
+                                                               StandardComparisonStrategy.instance()));
+    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
-    AssertionInfo info = someInfo();
-    double[] expected = {6d, 8d};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10d),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 6d, 8d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10d),
+                                                               StandardComparisonStrategy.instance()));
+    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_actual_contains_duplicates_and_expected_does_not() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1d, 2d, 3d);
-    double[] expected = {1d, 2d};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3d),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 1d, 2d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3d),
+                                                               StandardComparisonStrategy.instance()));
+    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_expected_contains_duplicates_and_actual_does_not() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1d, 2d);
     double[] expected = {1d, 2d, 3d};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3d), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3d), emptyList(), StandardComparisonStrategy.instance()));
+    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -165,60 +136,37 @@ public class DoubleArrays_assertContainsExactlyInAnyOrder_Test extends DoubleArr
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = {6d, -8d, 20d};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20d),
-          newArrayList(10d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20d),
+                                                               newArrayList(10d), absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
-    double[] expected = {6d, 8d};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10d),
-          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 6d, 8d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10d),
+                                                               absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
+
   }
 
   @Test
   public void should_fail_if_actual_contains_duplicates_and_expected_does_not_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1d, 2d, 3d);
-    double[] expected = {1d, 2d};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 1d, 2d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3d),
+                                                               absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_expected_contains_duplicates_and_actual_does_not_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1d, 2d);
-    double[] expected = {1d, 2d, 3d};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3d), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    double[] expected = { 1d, 2d, 3d };
+    thrown.expectAssertionError(shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3d), emptyList(),
+                                                               absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, expected);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactly_Test.java
@@ -19,10 +19,8 @@ import static org.assertj.core.test.DoubleArrays.arrayOf;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -53,14 +51,8 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
-    AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6d, 10d, 8d));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8d, 10d, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(elementsDifferAtIndex(8d, 10d, 1));
+    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6d, 10d, 8d));
   }
 
   @Test
@@ -89,29 +81,16 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d, 20d };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, expected, newArrayList(20d), newArrayList(10d)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainExactly(actual, expected, newArrayList(20d), newArrayList(10d)));
+    arrays.assertContainsExactly(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldHaveSameSize(actual, expected, 3, 2, StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveSameSize(actual, expected, 3, 2, StandardComparisonStrategy.instance()));
+    arrays.assertContainsExactly(someInfo(), actual, expected);
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -126,15 +105,9 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { -6d, 10d, 8d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8d, 10d, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(elementsDifferAtIndex(8d, 10d, 1, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
   }
 
   @Test
@@ -157,28 +130,16 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, -8d, 20d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, expected, newArrayList(20d),
-                                                          newArrayList(10d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainExactly(actual, expected, newArrayList(20d),
+                                                     newArrayList(10d), absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveSameSize(actual, expected, 3, 2, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveSameSize(actual, expected, 3, 2, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnlyOnce_Test.java
@@ -13,14 +13,12 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
-import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -46,19 +44,11 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_actual_contains_given_values_only_more_than_once() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     double[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20),
-              newLinkedHashSet((double) 6, (double) -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20),
+                                                       newLinkedHashSet((double) 6, (double) -8)));
+    arrays.assertContainsOnlyOnce(someInfo(), actual, expected);
   }
 
   @Test
@@ -92,16 +82,9 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError( shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20), newLinkedHashSet()));
+    arrays.assertContainsOnlyOnce(someInfo(), actual, expected);
   }
 
   @Test
@@ -116,19 +99,11 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_actual_contains_given_values_only_more_than_once_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     double[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20),
-              newLinkedHashSet((double) 6, (double) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20),
+                                                       newLinkedHashSet((double) 6, (double) -8), absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected);
   }
 
   @Test
@@ -156,17 +131,9 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((double) 20), newLinkedHashSet(),
+                                                       absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnly_Test.java
@@ -17,10 +17,8 @@ import static org.assertj.core.test.DoubleArrays.arrayOf;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -83,15 +81,9 @@ public class DoubleArrays_assertContainsOnly_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d, 20d };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20d), newArrayList(10d)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainOnly(actual, expected, newArrayList(20d), newArrayList(10d)));
+    arrays.assertContainsOnly(someInfo(), actual, expected);
   }
 
   @Test
@@ -135,16 +127,9 @@ public class DoubleArrays_assertContainsOnly_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, -8d, 20d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList(20d), newArrayList(10d),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainOnly(actual, expected, newArrayList(20d), newArrayList(10d),
+                                                  absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsSequence_Test.java
@@ -13,14 +13,11 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
-import static org.assertj.core.test.DoubleArrays.*;
-import static org.assertj.core.test.ErrorMessages.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -67,41 +64,23 @@ public class DoubleArrays_assertContainsSequence_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 8d, 10d, 12d, 20d, 22d };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence));
+    arrays.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence));
+    arrays.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d, 22d };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence));
+    arrays.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test
@@ -134,41 +113,23 @@ public class DoubleArrays_assertContainsSequence_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, -8d, 10d, 12d, 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainSequence(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, sequence);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_Test.java
@@ -13,15 +13,12 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldContain.shouldContain;
-import static org.assertj.core.test.DoubleArrays.*;
-import static org.assertj.core.test.ErrorMessages.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -89,15 +86,9 @@ public class DoubleArrays_assertContains_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_contain_values() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d, 9d };
-    try {
-      arrays.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet(9d)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContain(actual, expected, newLinkedHashSet(9d)));
+    arrays.assertContains(someInfo(), actual, expected);
   }
 
   @Test
@@ -146,14 +137,8 @@ public class DoubleArrays_assertContains_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, -8d, 9d };
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet(9d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContain(actual, expected, newLinkedHashSet(9d), absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_at_Index_Test.java
@@ -15,12 +15,10 @@ package org.assertj.core.internal.doublearrays;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
-import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.*;
-
-
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.test.TestData.someIndex;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsEmpty;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
@@ -63,16 +61,10 @@ public class DoubleArrays_assertContains_at_Index_Test extends DoubleArraysBaseT
 
   @Test
   public void should_fail_if_actual_does_not_contain_value_at_index() {
-    AssertionInfo info = someInfo();
     double value = 6;
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainAtIndex(actual, value, index, 8d));
+    arrays.assertContains(someInfo(), actual, value, index);
   }
 
   @Test
@@ -106,16 +98,10 @@ public class DoubleArrays_assertContains_at_Index_Test extends DoubleArraysBaseT
 
   @Test
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double value = 6;
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldContainAtIndex(actual, value, index, 8d, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, value, index);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotContain_Test.java
@@ -13,15 +13,13 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
-import static org.assertj.core.test.DoubleArrays.*;
-import static org.assertj.core.test.ErrorMessages.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsEmpty;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -72,15 +70,9 @@ public class DoubleArrays_assertDoesNotContain_Test extends DoubleArraysBaseTest
 
   @Test
   public void should_fail_if_actual_contains_given_values() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, 8d, 20d };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6d, 8d)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotContain(actual, expected, newLinkedHashSet(6d, 8d)));
+    arrays.assertDoesNotContain(someInfo(), actual, expected);
   }
 
   @Test
@@ -113,14 +105,9 @@ public class DoubleArrays_assertDoesNotContain_Test extends DoubleArraysBaseTest
 
   @Test
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] expected = { 6d, -8d, 20d };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6d, -8d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotContain(actual, expected, newLinkedHashSet(6d, -8d),
+                                                 absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertDoesNotContain(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotContain_at_Index_Test.java
@@ -15,12 +15,9 @@ package org.assertj.core.internal.doublearrays;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
-import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestData.someIndex;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
@@ -66,15 +63,9 @@ public class DoubleArrays_assertDoesNotContain_at_Index_Test extends DoubleArray
 
   @Test
   public void should_fail_if_actual_contains_value_at_index() {
-    AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 6d, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6d, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotContainAtIndex(actual, 6d, index));
+    arrays.assertDoesNotContain(someInfo(), actual, 6d, index);
   }
 
   @Test
@@ -106,14 +97,8 @@ public class DoubleArrays_assertDoesNotContain_at_Index_Test extends DoubleArray
 
   @Test
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6d, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6d, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotContainAtIndex(actual, 6d, index, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertDoesNotContain(someInfo(), actual, 6d, index);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertDoesNotHaveDuplicates_Test.java
@@ -13,14 +13,11 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
-import static org.assertj.core.test.DoubleArrays.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -54,15 +51,9 @@ public class DoubleArrays_assertDoesNotHaveDuplicates_Test extends DoubleArraysB
 
   @Test
   public void should_fail_if_actual_contains_duplicates() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(6d, 8d, 6d, 8d);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6d, 8d)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotHaveDuplicates(actual, newLinkedHashSet(6d, 8d)));
+    arrays.assertDoesNotHaveDuplicates(someInfo(), actual);
   }
 
   @Test
@@ -83,14 +74,8 @@ public class DoubleArrays_assertDoesNotHaveDuplicates_Test extends DoubleArraysB
 
   @Test
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(6d, -8d, 6d, -8d);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6d, -8d), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotHaveDuplicates(actual, newLinkedHashSet(6d, -8d), absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(someInfo(), actual);
   }
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEmpty_Test.java
@@ -15,11 +15,7 @@ package org.assertj.core.internal.doublearrays;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -43,15 +39,9 @@ public class DoubleArrays_assertEmpty_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_empty() {
-    AssertionInfo info = someInfo();
     double[] actual = { 6d, 8d };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeEmpty(actual));
+    arrays.assertEmpty(someInfo(), actual);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEndsWith_Test.java
@@ -13,14 +13,11 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
-import static org.assertj.core.test.DoubleArrays.*;
-import static org.assertj.core.test.ErrorMessages.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -67,41 +64,23 @@ public class DoubleArrays_assertEndsWith_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 8d, 10d, 12d, 20d, 22d };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence));
+    arrays.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 20d, 22d };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence));
+    arrays.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d, 22d };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence));
+    arrays.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test
@@ -134,41 +113,23 @@ public class DoubleArrays_assertEndsWith_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, -8d, 10d, 12d, 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldEndWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, sequence);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertHasSize_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertHasSize_Test.java
@@ -14,11 +14,7 @@ package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -42,14 +38,8 @@ public class DoubleArrays_assertHasSize_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
-    AssertionInfo info = someInfo();
-    try {
-      arrays.assertHasSize(info, actual, 2);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveSize(actual, actual.length, 2));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveSize(actual, actual.length, 2));
+    arrays.assertHasSize(someInfo(), actual, 2);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
@@ -15,11 +15,7 @@ package org.assertj.core.internal.doublearrays;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import java.util.Comparator;
 
@@ -84,15 +80,9 @@ public class DoubleArrays_assertIsSortedAccordingToComparator_Test extends Doubl
 
   @Test
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
-    AssertionInfo info = someInfo();
     actual = new double[] { 3.0, 2.0, 1.0, 9.0 };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, doubleDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, doubleDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeSortedAccordingToGivenComparator(2, actual, doubleDescendingOrderComparator));
+    arrays.assertIsSortedAccordingToComparator(someInfo(), actual, doubleDescendingOrderComparator);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSorted_Test.java
@@ -12,14 +12,12 @@
  */
 package org.assertj.core.internal.doublearrays;
 
-import static org.assertj.core.error.ShouldBeSorted.*;
-import static org.assertj.core.test.DoubleArrays.*;
+import static org.assertj.core.error.ShouldBeSorted.shouldBeSorted;
+import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -62,15 +60,9 @@ public class DoubleArrays_assertIsSorted_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1.0, 3.0, 2.0);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeSorted(1, actual));
+    arrays.assertIsSorted(someInfo(), actual);
   }
 
   @Test
@@ -97,16 +89,9 @@ public class DoubleArrays_assertIsSorted_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     actual = arrayOf(1.0, 3.0, 2.0);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
+    arraysWithCustomComparisonStrategy.assertIsSorted(someInfo(), actual);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertNotEmpty_Test.java
@@ -13,13 +13,10 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
-import static org.assertj.core.test.DoubleArrays.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -43,14 +40,8 @@ public class DoubleArrays_assertNotEmpty_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_actual_is_empty() {
-    AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldNotBeEmpty());
+    arrays.assertNotEmpty(someInfo(), emptyArray());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertNullOrEmpty_Test.java
@@ -15,10 +15,6 @@ package org.assertj.core.internal.doublearrays;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -36,15 +32,9 @@ public class DoubleArrays_assertNullOrEmpty_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
-    AssertionInfo info = someInfo();
     double[] actual = { 6d, 8d };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeNullOrEmpty(actual));
+    arrays.assertNullOrEmpty(someInfo(), actual);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertStartsWith_Test.java
@@ -13,14 +13,11 @@
 package org.assertj.core.internal.doublearrays;
 
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
-import static org.assertj.core.test.DoubleArrays.*;
-import static org.assertj.core.test.ErrorMessages.*;
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.assertj.core.test.DoubleArrays.emptyArray;
+import static org.assertj.core.test.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DoubleArrays;
@@ -67,41 +64,23 @@ public class DoubleArrays_assertStartsWith_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 8d, 10d, 12d, 20d, 22d };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence));
+    arrays.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 8d, 10d };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence));
+    arrays.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence));
+    arrays.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test
@@ -134,41 +113,23 @@ public class DoubleArrays_assertStartsWith_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, -8d, 10d, 12d, 20d, 22d };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { -8d, 10d };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
-    AssertionInfo info = someInfo();
     double[] sequence = { 6d, 20d };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldStartWith(actual, sequence, absValueComparisonStrategy));
+    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, sequence);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -17,6 +17,7 @@ import static java.lang.String.format;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.util.introspection.IntrospectionError;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
@@ -50,6 +51,10 @@ public class ExpectedException implements TestRule {
 
   public void expectAssertionError(String message) {
     expect(AssertionError.class, message);
+  }
+
+  public void expectAssertionError(ErrorMessageFactory errorMessageFactory) {
+    expect(AssertionError.class, errorMessageFactory.create());
   }
 
   public void expectAssertionErrorWithMessageContaining(String... parts) {


### PR DESCRIPTION
…essageFactory) to reduce boilerplate code in tests

Just an idea (I wish I would have picked an example with less usages ;)).

Of course this is not as isolated as using mocks and arguably still tests implementation not behavior.


