### PR TITLE
Long literal ending with 'l' instead of 'L' (master only)

### DIFF
--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -775,7 +775,7 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   @Test
   public void withAssertions_assertThat_longPredicate_Test() {
     LongPredicate predicate = l -> l == 0;
-    assertThat(predicate).accepts(0l);
+    assertThat(predicate).accepts(0L);
   }
 
   @Test


### PR DESCRIPTION
In addition to #899 the master only one.


