### PR TITLE
Add a more type-safe way to assert object's property with `returns` API

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.extractor.Extractors.byName;
 
 import java.util.function.Function;
@@ -631,6 +632,33 @@ public abstract class AbstractObjectAssert<S extends AbstractObjectAssert<S, A>,
   public S isEqualToComparingFieldByFieldRecursively(Object other) {
     objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, comparatorByPropertyOrField,
                                                             comparatorByType);
+    return myself;
+  }
+
+  /**
+   * Verify that the test subject returns expected value with given method.
+   * <p>
+   * You can pass a getter method reference to assert object's property.
+   * <p>
+   * Wrapping {@code from} function with {@link Assertions#from(Function)} makes the assertion more fluent.
+   * <p>
+   * Example:
+   * <pre><code class="java">
+   * Jedi yoda = new Jedi("Yoda", "Green");
+   * assertThat(yoda).returns("Yoda", from(Jedi::getName))
+   *                 .returns(2.4, from(Jedi::getHeight))
+   *                 .returns(150, from(Jedi::getWeight));
+   * </code></pre>
+   *
+   * @param expected a expected value that test subject returns.
+   * @param from a function (or a method reference) to acquire value from test subject. Must not be {@code null}
+   * @param <T> type of expected value that {@code method} returns.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if given {@code from} function is null
+   */
+  public <T> S returns(T expected, Function<A, T> from) {
+    requireNonNull(from, "The getter method Function<A, T> must not be null");
+    objects.assertEqual(info, from.apply(actual), expected);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1670,6 +1670,16 @@ public class Assertions {
     return new TemporalUnitLessThanOffset(value, unit);
   }
 
+  /**
+   * A syntax sugar to write fluent assertion using {@link ObjectAssert#returns(Object, Function)}.
+   *
+   * @param extractor A function to extract test subject's property
+   * @param <F> Type of test subject
+   * @param <T> Type of the property under the assertion
+   * @return same instance of {@code extractor}
+   */
+  public static <F, T> Function<F, T> from(Function<F, T> extractor) { return extractor; }
+
   // ------------------------------------------------------------------------------------------------------
   // Condition methods : not assertions but here to have a single entry point to all AssertJ features.
   // ------------------------------------------------------------------------------------------------------

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_returns_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_returns_Test.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.object;
+
+import org.assertj.core.api.*;
+import org.assertj.core.test.Jedi;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link AbstractObjectAssert#returns(Object, Function)}</code>.
+ *
+ * @author Takuya "Mura-Mi" Murakami
+ */
+public class ObjectAssert_returns_Test extends ObjectAssertBaseTest {
+
+  @Override
+  protected ObjectAssert<Jedi> invoke_api_method() {
+    return assertions.returns("Yoda", Jedi::getName);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions).getName(), "Yoda");
+  }
+
+  @Test
+  public void should_fail_with_throwing_NullPointerException_if_method_is_null() {
+    assertThatThrownBy(() -> assertions.returns("May the force be with you.", null))
+      .isExactlyInstanceOf(NullPointerException.class)
+      .hasMessage("The getter method Function<A, T> must not be null");
+  }
+}


### PR DESCRIPTION
We can verify object's multiple properties using `extracting` API to generate `ObjectArrayAssert` instance, but it does not provide type-driven code assist because the type of test subject is changed to `Object[]`.
Though custom assertion generator is provided in AssertJ project, I think more easy and flexible way to assert method's return value (including getter method) of a test subject helps writing test code.

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES


