### PR TITLE
Add containsOnlyInstancesOf() to ObjectEnumerableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -280,6 +280,13 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return myself;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public SELF containsOnlyInstancesOf(@SuppressWarnings("unchecked") Class<?>... types) {
+    iterables.assertContainsOnlyInstancesOf(info, actual, types);
+    return myself;
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -538,6 +538,33 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
   public S contains(T value, Index index) {
     arrays.assertContains(info, actual, value, index);
     return myself;
+  } 
+
+  /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsAll(Arrays.asList(Number.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  @Override
+  public S containsOnlyInstancesOf(Class<?>... types) {
+    iterables.assertContainsOnlyInstancesOf(info, newArrayList(actual), types);
+    return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -547,12 +547,12 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
    * 
    * // assertions will pass
-   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
    * 
    * // assertions will fail
-   * assertThat(objects).containsAll(Arrays.asList(Number.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
    * 
    * @param types the expected classes and interfaces
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -548,12 +548,12 @@ public class AtomicReferenceArrayAssert<T>
    * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
    * 
    * // assertions will pass
-   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
    * 
    * // assertions will fail
-   * assertThat(objects).containsAll(Arrays.asList(Number.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
    * 
    * @param types the expected classes and interfaces
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -542,6 +542,33 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsAll(Arrays.asList(Number.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> containsOnlyInstancesOf(Class<?>... types) {
+    iterables.assertContainsOnlyInstancesOf(info, newArrayList(actual), types);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual AtomicReferenceArray does not contain the given object at the given index.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -611,12 +611,12 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * <pre><code class='java'> Iterable&lt;Object&gt; objects = Arrays.asList(new String(), new StringBuilder());
    * 
    * // assertions will pass
-   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
    * 
    * // assertions will fail
-   * assertThat(objects).containsAll(Arrays.asList(Number.class));
-   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
    * 
    * @param types the expected classes and interfaces
    * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -605,6 +605,29 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
   S containsAll(Iterable<? extends T> iterable);
 
   /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Iterable&lt;Object&gt; objects = Arrays.asList(new String(), new StringBuilder());
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsAll(Arrays.asList(CharSequence.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class, StringBuilder.class));
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsAll(Arrays.asList(Number.class));
+   * assertThat(objects).containsAll(Arrays.asList(String.class));</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  S containsOnlyInstancesOf(Class<?>... types);
+
+ /**
    * Verifies that at least one element in the actual {@code Object} group has the specified type (matching
    * includes subclasses of the given type).
    * <p>

--- a/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a group of elements contains elements that
+ * are not an instance of one of the given types. A group of elements can be an iterable or an array of objects.
+ * 
+ * @author Martin Winandy
+ */
+public class ShouldContainOnlyInstances extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link shouldContainOnlyInstances}</code>.
+   * 
+   * @param object the object value in the failed assertion.
+   * @param types the expected classes and interfaces.
+   * @param dismatches elements that are not an instance of one of the given types.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ShouldContainOnlyInstances shouldContainOnlyInstances(Object actual, Class<?>[] types,
+                                                                      Iterable<?> dismatches) {
+    return new ShouldContainOnlyInstances(actual, types, dismatches);
+  }
+
+  private ShouldContainOnlyInstances(Object actual, Class<?>[] types, Iterable<?> dismatches) {
+    super("%n" +
+        "Expecting:%n" +
+        "  <%s>%n" +
+        "to contain only instances of:%n" +
+        "  <%s>%n" +
+        "elements are not instances:%n" +
+        "  <%s>",
+        actual, types, dismatches);
+  }
+
+}

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -39,6 +39,7 @@ import static org.assertj.core.error.ShouldContainExactly.shouldHaveSameSize;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
+import static org.assertj.core.error.ShouldContainOnlyInstances.shouldContainOnlyInstances;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
@@ -888,6 +889,27 @@ public class Iterables {
 
     throw failures.failure(info,
                            shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+  }
+
+  public void assertContainsOnlyInstancesOf(AssertionInfo info, Iterable<?> actual, Class<?>[] types) {
+    checkIsNotNull(types);
+    assertNotNull(info, actual);
+
+    List<Object> dismatches = newArrayList();
+    
+    loop:
+    for (Object value : actual) {
+      for (Class<?> type : types) {
+        if (type.isInstance(value)) {
+          continue loop;
+        }
+      }
+      dismatches.add(value);
+    }
+    
+    if (!dismatches.isEmpty()) {
+      throw failures.failure(info, shouldContainOnlyInstances(actual, types, dismatches));
+    }
   }
 
   void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AtomicReferenceArrayAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertContainsOnlyInstancesOf(getInfo(assertions), newArrayList(getActual(assertions)), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class IterableAssert_containsOnlyInstancesOf_Test extends IterableAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertContainsOnlyInstancesOf(getInfo(assertions), getActual(assertions), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractObjectArrayAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class ObjectArrayAssert_containsOnlyInstancesOf_Test extends ObjectArrayAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertContainsOnlyInstancesOf(getInfo(assertions), newArrayList(getActual(assertions)), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldContainOnlyInstances.shouldContainOnlyInstances;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ShouldContainOnlyInstances#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ * 
+ * @author Martin Winandy
+ */
+public class ShouldContainOnlyInstances_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldContainOnlyInstances(newArrayList("Yoda", 42), new Class<?>[] { Number.class }, newArrayList("Yoda"));
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <[\"Yoda\", 42]>%n" +
+                                         "to contain only instances of:%n" +
+                                         "  <[java.lang.Number]>%n" +
+                                         "elements are not instances:%n" +
+                                         "  <[\"Yoda\"]>"));
+  }
+  
+}


### PR DESCRIPTION
Add a method to verify that all elements of an iterable or array are instances of given classes or interfaces.

Example:
```
Iterable objects = Arrays.asList(new String(), new StringBuilder());
assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
```

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES

