### PR TITLE
Add containsOnlyInstancesOf() to ObjectEnumerableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -283,6 +283,13 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return myself;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public SELF containsOnlyInstancesOf(@SuppressWarnings("unchecked") Class<?>... types) {
+    iterables.assertContainsOnlyInstancesOf(info, actual, types);
+    return myself;
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -456,6 +456,33 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   public SELF contains(ELEMENT value, Index index) {
     arrays.assertContains(info, actual, value, index);
     return myself;
+  } 
+
+  /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  @Override
+  public SELF containsOnlyInstancesOf(Class<?>... types) {
+    arrays.assertContainsOnlyInstancesOf(info, actual, types);
+    return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -539,6 +539,33 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Object[] objects = {new String(), new StringBuilder()};
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> containsOnlyInstancesOf(Class<?>... types) {
+    arrays.assertContainsOnlyInstancesOf(info, array, types);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual AtomicReferenceArray does not contain the given object at the given index.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -639,6 +639,29 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF containsAll(Iterable<? extends ELEMENT> iterable);
 
   /**
+   * Verifies that all elements of the actual group are instances of given classes or interfaces.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Iterable&lt;Object&gt; objects = Arrays.asList(new String(), new StringBuilder());
+   * 
+   * // assertions will pass
+   * assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class, StringBuilder.class);
+   * 
+   * // assertions will fail
+   * assertThat(objects).containsOnlyInstancesOf(Number.class);
+   * assertThat(objects).containsOnlyInstancesOf(String.class);</code></pre>
+   * 
+   * @param types the expected classes and interfaces
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if not all elements of the actual group are instances of one of the given types
+   * @since 2.7.0 / 3.7.0
+   */
+  SELF containsOnlyInstancesOf(Class<?>... types);
+
+ /**
    * Verifies that at least one element in the actual {@code Object} group has the specified type (matching
    * includes subclasses of the given type).
    * <p>

--- a/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a group of elements contains elements that
+ * are not an instance of one of the given types. A group of elements can be an iterable or an array of objects.
+ * 
+ * @author Martin Winandy
+ */
+public class ShouldContainOnlyInstances extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link shouldContainOnlyInstances}</code>.
+   * 
+   * @param object the object value in the failed assertion.
+   * @param types the expected classes and interfaces.
+   * @param dismatches elements that are not an instance of one of the given types.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ShouldContainOnlyInstances shouldContainOnlyInstances(Object actual, Class<?>[] types,
+                                                                      Iterable<?> dismatches) {
+    return new ShouldContainOnlyInstances(actual, types, dismatches);
+  }
+
+  private ShouldContainOnlyInstances(Object actual, Class<?>[] types, Iterable<?> dismatches) {
+    super("%n" +
+        "Expecting:%n" +
+        "  <%s>%n" +
+        "to contain only instances of:%n" +
+        "  <%s>%n" +
+        "elements are not instances:%n" +
+        "  <%s>",
+        actual, types, dismatches);
+  }
+
+}

--- a/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnlyInstances.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.presentation.StandardRepresentation;
+
 /**
  * Creates an error message indicating that an assertion that verifies a group of elements contains elements that
  * are not an instance of one of the given types. A group of elements can be an iterable or an array of objects.
@@ -40,8 +42,27 @@ public class ShouldContainOnlyInstances extends BasicErrorMessageFactory {
         "to contain only instances of:%n" +
         "  <%s>%n" +
         "elements are not instances:%n" +
-        "  <%s>",
-        actual, types, dismatches);
+        "  <[" + resolveClassNames(dismatches) + "]>",
+        actual, types);
+  }
+
+  private static String resolveClassNames(Iterable<?> instances) {
+    StringBuilder builder = new StringBuilder();
+    
+    for (Object instance : instances) {
+      if (builder.length() > 0) {
+        builder.append(", ");
+      }
+      
+      String formatted = StandardRepresentation.STANDARD_REPRESENTATION.toStringOf(instance);
+      builder.append(formatted);
+      
+      if (instance != null && !formatted.contains(instance.getClass().getName())) {
+        builder.append(" (").append(instance.getClass().getName()).append(")");
+      }
+    }
+    
+    return builder.toString();
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/src/main/java/org/assertj/core/internal/Arrays.java
@@ -40,6 +40,7 @@ import static org.assertj.core.error.ShouldContainExactly.shouldHaveSameSize;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
+import static org.assertj.core.error.ShouldContainOnlyInstances.shouldContainOnlyInstances;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
@@ -55,6 +56,7 @@ import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsEmp
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 import static org.assertj.core.internal.CommonErrors.iterableToLookForIsNull;
 import static org.assertj.core.internal.CommonValidations.checkIndexValueIsValid;
+import static org.assertj.core.internal.CommonValidations.checkIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkIterableIsNotNull;
 import static org.assertj.core.internal.CommonValidations.hasSameSizeAsCheck;
 import static org.assertj.core.internal.IterableDiff.diff;
@@ -329,6 +331,27 @@ public class Arrays {
     }
     if (subsequenceIndex < sizeOfSubsequence)
       throw failures.failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
+  }
+ 
+  void assertContainsOnlyInstancesOf(AssertionInfo info, Failures failures, Object actual, Class<?>[] types) {
+    checkIsNotNull(types);
+    assertNotNull(info, actual);
+
+    List<Object> dismatches = newArrayList();
+    
+    loop:
+    for (Object value : asList(actual)) {
+      for (Class<?> type : types) {
+        if (type.isInstance(value)) {
+          continue loop;
+        }
+      }
+      dismatches.add(value);
+    }
+    
+    if (!dismatches.isEmpty()) {
+      throw failures.failure(info, shouldContainOnlyInstances(actual, types, dismatches));
+    }
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -34,6 +34,7 @@ import static org.assertj.core.error.ShouldContainExactly.shouldHaveSameSize;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
+import static org.assertj.core.error.ShouldContainOnlyInstances.shouldContainOnlyInstances;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
@@ -844,6 +845,27 @@ public class Iterables {
 
     throw failures.failure(info,
                            shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+  }
+
+  public void assertContainsOnlyInstancesOf(AssertionInfo info, Iterable<?> actual, Class<?>[] types) {
+    checkIsNotNull(types);
+    assertNotNull(info, actual);
+
+    List<Object> dismatches = newArrayList();
+    
+    loop:
+    for (Object value : actual) {
+      for (Class<?> type : types) {
+        if (type.isInstance(value)) {
+          continue loop;
+        }
+      }
+      dismatches.add(value);
+    }
+    
+    if (!dismatches.isEmpty()) {
+      throw failures.failure(info, shouldContainOnlyInstances(actual, types, dismatches));
+    }
   }
 
   void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/main/java/org/assertj/core/internal/ObjectArrays.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrays.java
@@ -267,6 +267,10 @@ public class ObjectArrays {
     arrays.assertContainsSubsequence(info, failures, actual, subsequence);
   }
 
+  public <E> void assertContainsOnlyInstancesOf(AssertionInfo info, E[] actual, Class<?>[] types) {
+    arrays.assertContainsOnlyInstancesOf(info, failures, actual, types);
+  }
+
   /**
    * Asserts that the given array does not contain the given values.
    * 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AtomicReferenceArrayAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class AtomicReferenceArrayAssert_containsOnlyInstancesOf_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsOnlyInstancesOf(getInfo(assertions), internalArray(), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class IterableAssert_containsOnlyInstancesOf_Test extends IterableAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertContainsOnlyInstancesOf(getInfo(assertions), getActual(assertions), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsOnlyInstancesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsOnlyInstancesOf_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractObjectArrayAssert#containsOnlyInstancesOf(Class...)} </code>.
+ * 
+ * @author Martin Winandy
+ */
+public class ObjectArrayAssert_containsOnlyInstancesOf_Test extends ObjectArrayAssertBaseTest {
+
+  private final Class<?>[] types = { CharSequence.class };
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.containsOnlyInstancesOf(types);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsOnlyInstancesOf(getInfo(assertions), getActual(assertions), types);
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
@@ -45,7 +45,7 @@ public class ShouldContainOnlyInstances_create_Test {
                                          "to contain only instances of:%n" +
                                          "  <[java.lang.Number]>%n" +
                                          "elements are not instances:%n" +
-                                         "  <[\"Yoda\"]>"));
+                                         "  <[\"Yoda\" (java.lang.String)]>"));
   }
   
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnlyInstances_create_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldContainOnlyInstances.shouldContainOnlyInstances;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ShouldContainOnlyInstances#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ * 
+ * @author Martin Winandy
+ */
+public class ShouldContainOnlyInstances_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldContainOnlyInstances(newArrayList("Yoda", 42), new Class<?>[] { Number.class }, newArrayList("Yoda"));
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting:%n" +
+                                         "  <[\"Yoda\", 42]>%n" +
+                                         "to contain only instances of:%n" +
+                                         "  <[java.lang.Number]>%n" +
+                                         "elements are not instances:%n" +
+                                         "  <[\"Yoda\"]>"));
+  }
+  
+}


### PR DESCRIPTION
Add a method to verify that all elements of an iterable or array are instances of given classes or interfaces.

Example:
```
Iterable objects = Arrays.asList(new String(), new StringBuilder());
assertThat(objects).containsOnlyInstancesOf(CharSequence.class);
```

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES
