### PR TITLE
2.x class method visibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -331,7 +331,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
-   * Verifies that the actual {@code Class} has the given {@code methodNames}.
+   * Verifies that the actual {@code Class} has the given methods.
    *
    * <pre><code class='java'> class MyClass {
    *     public void methodOne() {}
@@ -357,7 +357,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
-   * Verifies that the actual {@code Class} has the given declared {@code methodNames}.
+   * Verifies that the actual {@code Class} has the given declared methods.
    *
    * <pre><code class='java'> class MySuperClass {
    *     public void superMethod() {}
@@ -387,7 +387,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
-   * Verifies that the actual {@code Class} has the given public {@code methodNames}.
+   * Verifies that the actual {@code Class} has the given public methods.
    *
    * <pre><code class='java'> class MyClass {
    *     public void methodOne() {}
@@ -415,7 +415,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
-   * Verifies that the actual {@code Class} has the given declared public {@code methodNames}.
+   * Verifies that the actual {@code Class} has the given declared public methods.
    *
    * <pre><code class='java'> class MySuperClass {
    *     public void superMethod() {}

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -179,6 +179,51 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
   }
 
   /**
+   * Verifies that the actual {@code Class} is public (has {@code public} modifier).
+   *
+   * <pre><code class='java'> protected class MyClass { }
+   *
+   * // These assertions succeed:
+   * assertThat(String.class).isPublic();
+   * assertThat(Math.class).isPublic();
+   *
+   * // This assertion fail:
+   * assertThat(MyClass.class).isPublic();</code></pre>
+   *
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} is not public.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S isPublic() {
+    classes.assertIsPublic(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} is protected (has {@code protected} modifier).
+   *
+   * <pre><code class='java'> public class MyClass { }
+   *
+   * // This assertion succeed:
+   * assertThat(MyClass.class).isProtected();
+   *
+   * // These assertions fail:
+   * assertThat(String.class).isProtected();
+   * assertThat(Math.class).isProtected();</code></pre>
+   *
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} is not protected.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S isProtected() {
+    classes.assertIsProtected(info, actual);
+    return myself;
+  }
+
+
+  /**
    * Verifies that the actual {@code Class} has the given {@code Annotation}s.
    * 
    * <pre><code class='java'> &#64;Target(ElementType.TYPE)
@@ -282,6 +327,113 @@ public abstract class AbstractClassAssert<S extends AbstractClassAssert<S>> exte
    */
   public S hasDeclaredFields(String... fields) {
     classes.assertHasDeclaredFields(info, actual, fields);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the {@code methods}.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public void methodOne() {}
+   *     private void methodTwo() {}
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasMethods("methodOne");
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasMethods("methodTwo");
+   * assertThat(MyClass.class).hasMethods("methodThree");</code></pre>
+   *
+   * @param methods the methods which must be in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the methods.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S hasMethods(String... methods) {
+    classes.assertHasMethods(info, actual, methods);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the declared {@code methods}.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public void methodOne() {}
+   *     private void methodTwo() {}
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasDeclaredMethods("methodOne", "methodTwo");
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasDeclaredMethods("methodThree");</code></pre>
+   *
+   * @param methods the methods which must be declared in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the methods.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S hasDeclaredMethods(String... methods) {
+    classes.assertHasDeclaredMethods(info, actual, methods);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the public {@code methods}.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public void methodOne() {}
+   *     public void methodTwo() {}
+   *     protected void methodThree() {}
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasPublicMethods("methodOne");
+   * assertThat(MyClass.class).hasPublicMethods("methodOne", "methodTwo");
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasPublicMethods("methodOne", "methodThree");
+   * assertThat(MyClass.class).hasPublicMethods("methodThree");</code></pre>
+   *
+   * @param methods the public methods which must be in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public methods.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S hasPublicMethods(String... methods) {
+    classes.assertHasPublicMethods(info, actual, methods);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the declared public {@code methods}.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public void methodOne() {}
+   *     public void methodTwo() {}
+   *     protected void methodThree() {}
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne");
+   * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne", "methodTwo");
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne", "methodThree");
+   * assertThat(MyClass.class).hasDeclaredPublicMethods("methodThree");</code></pre>
+   *
+   * @param methods the public methods which must be declared in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public methods.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public S hasDeclaredPublicMethods(String... methods) {
+    classes.assertHasDeclaredPublicMethods(info, actual, methods);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -187,7 +187,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * assertThat(String.class).isPublic();
    * assertThat(Math.class).isPublic();
    *
-   * // This assertion fail:
+   * // This assertion fails:
    * assertThat(MyClass.class).isPublic();</code></pre>
    *
    * @throws AssertionError if {@code actual} is {@code null}.
@@ -205,7 +205,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * <pre><code class='java'> public class MyClass { }
    *
-   * // This assertion succeed:
+   * // This assertion succeeds:
    * assertThat(MyClass.class).isProtected();
    *
    * // These assertions fail:

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -331,58 +331,63 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
-   * Verifies that the actual {@code Class} has the {@code methods}.
+   * Verifies that the actual {@code Class} has the given {@code methodNames}.
    *
    * <pre><code class='java'> class MyClass {
    *     public void methodOne() {}
    *     private void methodTwo() {}
    * }
    *
-   * // This one should pass :
+   * // This assertion succeeds:
    * assertThat(MyClass.class).hasMethods("methodOne");
    *
-   * // This one should fail :
+   * // These assertions fail:
    * assertThat(MyClass.class).hasMethods("methodTwo");
    * assertThat(MyClass.class).hasMethods("methodThree");</code></pre>
    *
-   * @param methods the methods which must be in the class.
+   * @param methodNames the method names which must be in the class.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} doesn't contains all of the methods.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the method names.
    *
    * @since 2.7.0 / 3.7.0
    */
-  public SELF hasMethods(String... methods) {
-    classes.assertHasMethods(info, actual, methods);
+  public SELF hasMethods(String... methodNames) {
+    classes.assertHasMethods(info, actual, methodNames);
     return myself;
   }
 
   /**
-   * Verifies that the actual {@code Class} has the declared {@code methods}.
+   * Verifies that the actual {@code Class} has the given declared {@code methodNames}.
    *
-   * <pre><code class='java'> class MyClass {
+   * <pre><code class='java'> class MySuperClass {
+   *     public void superMethod() {}
+   * }
+   *
+   * class MyClass extends MySuperClass {
    *     public void methodOne() {}
    *     private void methodTwo() {}
    * }
    *
-   * // This one should pass :
+   * // This assertion succeeds:
    * assertThat(MyClass.class).hasDeclaredMethods("methodOne", "methodTwo");
    *
-   * // This one should fail :
+   * // These assertions fail:
+   * assertThat(MyClass.class).hasDeclaredMethods("superMethod");
    * assertThat(MyClass.class).hasDeclaredMethods("methodThree");</code></pre>
    *
-   * @param methods the methods which must be declared in the class.
+   * @param methodNames the method names which must be declared in the class.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} doesn't contains all of the methods.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the method names.
    *
    * @since 2.7.0 / 3.7.0
    */
-  public SELF hasDeclaredMethods(String... methods) {
-    classes.assertHasDeclaredMethods(info, actual, methods);
+  public SELF hasDeclaredMethods(String... methodNames) {
+    classes.assertHasDeclaredMethods(info, actual, methodNames);
     return myself;
   }
 
   /**
-   * Verifies that the actual {@code Class} has the public {@code methods}.
+   * Verifies that the actual {@code Class} has the given public {@code methodNames}.
    *
    * <pre><code class='java'> class MyClass {
    *     public void methodOne() {}
@@ -390,50 +395,55 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *     protected void methodThree() {}
    * }
    *
-   * // This one should pass :
+   * // These assertions succeed:
    * assertThat(MyClass.class).hasPublicMethods("methodOne");
    * assertThat(MyClass.class).hasPublicMethods("methodOne", "methodTwo");
    *
-   * // This one should fail :
+   * // These assertions fail:
    * assertThat(MyClass.class).hasPublicMethods("methodOne", "methodThree");
    * assertThat(MyClass.class).hasPublicMethods("methodThree");</code></pre>
    *
-   * @param methods the public methods which must be in the class.
+   * @param methodNames the public method names which must be in the class.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public methods.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public method names.
    *
    * @since 2.7.0 / 3.7.0
    */
-  public SELF hasPublicMethods(String... methods) {
-    classes.assertHasPublicMethods(info, actual, methods);
+  public SELF hasPublicMethods(String... methodNames) {
+    classes.assertHasPublicMethods(info, actual, methodNames);
     return myself;
   }
 
   /**
-   * Verifies that the actual {@code Class} has the declared public {@code methods}.
+   * Verifies that the actual {@code Class} has the given declared public {@code methodNames}.
    *
-   * <pre><code class='java'> class MyClass {
+   * <pre><code class='java'> class MySuperClass {
+   *     public void superMethod() {}
+   * }
+   *
+   * class MyClass extends MySuperClass{
    *     public void methodOne() {}
    *     public void methodTwo() {}
    *     protected void methodThree() {}
    * }
    *
-   * // This one should pass :
+   * // These assertions succeed:
    * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne");
    * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne", "methodTwo");
    *
-   * // This one should fail :
+   * // These assertions fail:
+   * assertThat(MyClass.class).hasDeclaredPublicMethods("superMethod");
    * assertThat(MyClass.class).hasDeclaredPublicMethods("methodOne", "methodThree");
    * assertThat(MyClass.class).hasDeclaredPublicMethods("methodThree");</code></pre>
    *
-   * @param methods the public methods which must be declared in the class.
+   * @param methodNames the public method names which must be declared in the class.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public methods.
+   * @throws AssertionError if the actual {@code Class} doesn't contains all of the public method names.
    *
    * @since 2.7.0 / 3.7.0
    */
-  public SELF hasDeclaredPublicMethods(String... methods) {
-    classes.assertHasDeclaredPublicMethods(info, actual, methods);
+  public SELF hasDeclaredPublicMethods(String... methodNames) {
+    classes.assertHasDeclaredPublicMethods(info, actual, methodNames);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -195,7 +195,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S isPublic() {
+  public SELF isPublic() {
     classes.assertIsPublic(info, actual);
     return myself;
   }
@@ -217,7 +217,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S isProtected() {
+  public SELF isProtected() {
     classes.assertIsProtected(info, actual);
     return myself;
   }
@@ -351,7 +351,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S hasMethods(String... methods) {
+  public SELF hasMethods(String... methods) {
     classes.assertHasMethods(info, actual, methods);
     return myself;
   }
@@ -376,7 +376,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S hasDeclaredMethods(String... methods) {
+  public SELF hasDeclaredMethods(String... methods) {
     classes.assertHasDeclaredMethods(info, actual, methods);
     return myself;
   }
@@ -404,7 +404,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S hasPublicMethods(String... methods) {
+  public SELF hasPublicMethods(String... methods) {
     classes.assertHasPublicMethods(info, actual, methods);
     return myself;
   }
@@ -432,7 +432,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @since 2.7.0 / 3.7.0
    */
-  public S hasDeclaredPublicMethods(String... methods) {
+  public SELF hasDeclaredPublicMethods(String... methods) {
     classes.assertHasDeclaredPublicMethods(info, actual, methods);
     return myself;
   }

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -12,34 +12,49 @@
  */
 package org.assertj.core.error;
 
+import java.lang.reflect.Modifier;
+
 /**
  * Creates an error message indicating that an assertion that verifies that a class is (or is not) final.
  *
  * @author Michal Kordas
  */
-public class ShouldBeFinal extends BasicErrorMessageFactory {
+public class ClassModifierShouldBe extends BasicErrorMessageFactory {
 
-  private ShouldBeFinal(Class<?> actual, boolean positive) {
-    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a final class.", actual);
+  private ClassModifierShouldBe(Class<?> actual, boolean positive, String modifier) {
+    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a %s class.", actual, modifier);
+  }
+
+  private ClassModifierShouldBe(Class<?> actual, String modifier) {
+    this(actual, true, modifier);
   }
 
   /**
-   * Creates a new {@link ShouldBeFinal}.
+   * Creates a new {@link ClassModifierShouldBe}.
    *
    * @param actual the actual value in the failed assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBeFinal(Class<?> actual) {
-    return new ShouldBeFinal(actual, true);
+    return new ClassModifierShouldBe(actual, true, Modifier.toString(Modifier.FINAL));
   }
 
   /**
-   * Creates a new {@link ShouldBeFinal}.
+   * Creates a new {@link ClassModifierShouldBe}.
    *
    * @param actual the actual value in the failed assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldNotBeFinal(Class<?> actual) {
-    return new ShouldBeFinal(actual, false);
+    return new ClassModifierShouldBe(actual, false, Modifier.toString(Modifier.FINAL));
   }
+
+  public static ErrorMessageFactory shouldBePublic(Class<?> actual) {
+    return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PUBLIC));
+  }
+
+  public static ErrorMessageFactory shouldBeProtected(Class<?> actual) {
+    return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PROTECTED));
+  }
+
 }

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -22,11 +22,7 @@ import java.lang.reflect.Modifier;
 public class ClassModifierShouldBe extends BasicErrorMessageFactory {
 
   private ClassModifierShouldBe(Class<?> actual, boolean positive, String modifier) {
-    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a %s class.", actual, modifier);
-  }
-
-  private ClassModifierShouldBe(Class<?> actual, String modifier) {
-    this(actual, true, modifier);
+    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a %s class, but was %s", actual, modifier, Modifier.toString(actual.getModifiers()));
   }
 
   /**
@@ -56,7 +52,7 @@ public class ClassModifierShouldBe extends BasicErrorMessageFactory {
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBePublic(Class<?> actual) {
-    return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PUBLIC));
+    return new ClassModifierShouldBe(actual, true, Modifier.toString(Modifier.PUBLIC));
   }
 
   /**
@@ -66,7 +62,7 @@ public class ClassModifierShouldBe extends BasicErrorMessageFactory {
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBeProtected(Class<?> actual) {
-    return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PROTECTED));
+    return new ClassModifierShouldBe(actual, true, Modifier.toString(Modifier.PROTECTED));
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Modifier;
 public class ClassModifierShouldBe extends BasicErrorMessageFactory {
 
   private ClassModifierShouldBe(Class<?> actual, boolean positive, String modifier) {
-    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a %s class, but was %s", actual, modifier, Modifier.toString(actual.getModifiers()));
+    super("%nExpecting:%n  <%s>%n" + (positive ? "to" : "not to") + " be a %s class but was %s.", actual, modifier, Modifier.toString(actual.getModifiers()));
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -49,10 +49,22 @@ public class ClassModifierShouldBe extends BasicErrorMessageFactory {
     return new ClassModifierShouldBe(actual, false, Modifier.toString(Modifier.FINAL));
   }
 
+  /**
+   * Creates a new {@link ClassModifierShouldBe}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
   public static ErrorMessageFactory shouldBePublic(Class<?> actual) {
     return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PUBLIC));
   }
 
+  /**
+   * Creates a new {@link ClassModifierShouldBe}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
   public static ErrorMessageFactory shouldBeProtected(Class<?> actual) {
     return new ClassModifierShouldBe(actual, Modifier.toString(Modifier.PROTECTED));
   }

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -55,7 +55,7 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String, String> nonMatching, boolean declared) {
     super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "") +  modifier + " "
-      + "methods:%n  <%s>%nbut the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
+      + "methods:%n  <%s>%nbut but the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
   }
 }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -46,18 +46,31 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
   }
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing, boolean declared) {
-    super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "")
-      + "methods:%n  <%s>%nbut it doesn't have:%n  <%s>", actual, expected, missing);
+    super("%n" +
+      "Expecting%n" +
+      "  <%s>%n" +
+      "to have " + (declared ? "declared " : "") + "methods:%n" +
+      "  <%s>%n" +
+      "but it doesn't have:%n" +
+      "  <%s>", actual, expected, missing);
   }
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String, String> nonMatching, boolean declared) {
-    super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "") +  modifier + " "
-      + "methods:%n  <%s>%nbut the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
+    super("%n" +
+      "Expecting%n" +
+      "  <%s>%n" +
+      "to have " + (declared ? "declared " : "") +  modifier + " " + "methods:%n" +
+      "  <%s>%n" +
+      "but the following are not " +modifier + ":%n" +
+      "  <%s>", actual, expected, nonMatching);
   }
 
   private ShouldHaveMethods(Class<?> actual, String modifier, boolean declared, Set<String> actualMethodsHavingModifier) {
-    super("%nExpecting%n  <%s>%nto have no " + (declared ? "declared " : "") +  ((modifier != null && modifier.length() > 0)  ?  modifier + " " : "")
-      + "methods but have the following:%n  <%s>", actual, actualMethodsHavingModifier);
+    super("%n" +
+      "Expecting%n" +
+      "  <%s>%n" +
+      "to have no " + (declared ? "declared " : "") +  ((modifier != null && modifier.length() > 0)  ?  modifier + " " : "") + "methods but have the following:%n" +
+      "  <%s>", actual, actualMethodsHavingModifier);
   }
 }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -33,8 +33,16 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
     return new ShouldHaveMethods(actual, expected, missing, declared);
   }
 
-  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String,String> nonMatching) {
-    return new ShouldHaveMethods(actual, expected, modifier, nonMatching, false);
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, Set<String> expected, String modifier, Map<String,String> nonMatching) {
+    return new ShouldHaveMethods(actual, expected, modifier, nonMatching, declared);
+  }
+
+  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, String modifier, boolean declared, Set<String> actualMethodsHavingModifier) {
+    return new ShouldHaveMethods(actual, modifier, declared, actualMethodsHavingModifier);
+  }
+
+  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, boolean declared, Set<String> actualMethodsHavingModifier) {
+    return new ShouldHaveMethods(actual, null, declared, actualMethodsHavingModifier);
   }
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing, boolean declared) {
@@ -45,6 +53,11 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String, String> nonMatching, boolean declared) {
     super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "") +  modifier + " "
       + "methods:%n  <%s>%nbut the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
+  }
+
+  private ShouldHaveMethods(Class<?> actual, String modifier, boolean declared, Set<String> actualMethodsHavingModifier) {
+    super("%nExpecting%n  <%s>%nto have no " + (declared ? "declared " : "") +  ((modifier != null && modifier.length() > 0)  ?  modifier + " " : "")
+      + "methods but have the following:%n  <%s>", actual, actualMethodsHavingModifier);
   }
 }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -55,7 +55,7 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String, String> nonMatching, boolean declared) {
     super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "") +  modifier + " "
-      + "methods:%n  <%s>%nbut but the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
+      + "methods:%n  <%s>%nbut the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
   }
 }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class have methods.
+ */
+public class ShouldHaveMethods extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link org.assertj.core.error.ShouldHaveMethods}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected expected methods for this class
+   * @param missing missing methods for this class
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing) {
+    return new ShouldHaveMethods(actual, expected, missing, false);
+  }
+
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String,String> nonMatching) {
+    return new ShouldHaveMethods(actual, expected, modifier, nonMatching, false);
+  }
+
+  /**
+   * Creates a new </code>{@link org.assertj.core.error.ShouldHaveMethods}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected expected methods for this class
+   * @param missing missing methods for this class
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveDeclaredMethods(Class<?> actual, Set<String> expected, Set<String> missing) {
+    return new ShouldHaveMethods(actual, expected, missing, true);
+  }
+
+  private ShouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing, boolean declared) {
+    super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "")
+      + "methods:%n  <%s>%nbut it doesn't have:%n  <%s>", actual, expected, missing);
+  }
+
+  private ShouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String, String> nonMatching, boolean declared) {
+    super("%nExpecting%n  <%s>%nto have " + (declared ? "declared " : "") +  modifier + " "
+      + "methods:%n  <%s>%nbut but the following are not " +modifier + ":%n  <%s>", actual, expected, nonMatching);
+  }
+}
+

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -14,6 +14,7 @@ package org.assertj.core.error;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a class have methods.
@@ -29,19 +30,19 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
    * @param missing missing methods for this class
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, Set<String> expected, Set<String> missing) {
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, SortedSet<String> expected, SortedSet<String> missing) {
     return new ShouldHaveMethods(actual, expected, missing, declared);
   }
 
-  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, Set<String> expected, String modifier, Map<String,String> nonMatching) {
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, SortedSet<String> expected, String modifier, Map<String,String> nonMatching) {
     return new ShouldHaveMethods(actual, expected, modifier, nonMatching, declared);
   }
 
-  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, String modifier, boolean declared, Set<String> actualMethodsHavingModifier) {
+  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, String modifier, boolean declared, SortedSet<String> actualMethodsHavingModifier) {
     return new ShouldHaveMethods(actual, modifier, declared, actualMethodsHavingModifier);
   }
 
-  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, boolean declared, Set<String> actualMethodsHavingModifier) {
+  public static ErrorMessageFactory shouldNotHaveMethods(Class<?> actual, boolean declared, SortedSet<String> actualMethodsHavingModifier) {
     return new ShouldHaveMethods(actual, null, declared, actualMethodsHavingModifier);
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveMethods.java
@@ -24,28 +24,17 @@ public class ShouldHaveMethods extends BasicErrorMessageFactory {
    * Creates a new </code>{@link org.assertj.core.error.ShouldHaveMethods}</code>.
    *
    * @param actual the actual value in the failed assertion.
+   * @param declared {@code true} if the expected methods are declared ones, {@code false} otherwise.
    * @param expected expected methods for this class
    * @param missing missing methods for this class
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing) {
-    return new ShouldHaveMethods(actual, expected, missing, false);
+  public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, boolean declared, Set<String> expected, Set<String> missing) {
+    return new ShouldHaveMethods(actual, expected, missing, declared);
   }
 
   public static ErrorMessageFactory shouldHaveMethods(Class<?> actual, Set<String> expected, String modifier, Map<String,String> nonMatching) {
     return new ShouldHaveMethods(actual, expected, modifier, nonMatching, false);
-  }
-
-  /**
-   * Creates a new </code>{@link org.assertj.core.error.ShouldHaveMethods}</code>.
-   *
-   * @param actual the actual value in the failed assertion.
-   * @param expected expected methods for this class
-   * @param missing missing methods for this class
-   * @return the created {@code ErrorMessageFactory}.
-   */
-  public static ErrorMessageFactory shouldHaveDeclaredMethods(Class<?> actual, Set<String> expected, Set<String> missing) {
-    return new ShouldHaveMethods(actual, expected, missing, true);
   }
 
   private ShouldHaveMethods(Class<?> actual, Set<String> expected, Set<String> missing, boolean declared) {

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -388,5 +388,4 @@ public class Classes {
   private static void classParameterIsNotNull(Class<?> clazz) {
     checkNotNull(clazz, "The class to compare actual with should not be null");
   }
-
 }

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -344,12 +344,10 @@ public class Classes {
     }
   }
 
-  private static boolean noNonMatchingModifier(Set<String> expectedMethodNames, Map<String, Integer> actualMethods, Map<String, String> nonMatchingModifiers, int modifier) {
-    for (String method : actualMethods.keySet()) {
-      if(expectedMethodNames.contains(method)) {
-        if ((actualMethods.get(method) & modifier) == 0) {
-          nonMatchingModifiers.put(method, Modifier.toString(actualMethods.get(method)));
-        }
+  private static boolean noNonMatchingModifier(Set<String> expectedMethodNames, Map<String, Integer> methodsModifier, Map<String, String> nonMatchingModifiers, int modifier) {
+    for (String method : methodsModifier.keySet()) {
+      if(expectedMethodNames.contains(method) && (methodsModifier.get(method) & modifier) == 0) {
+        nonMatchingModifiers.put(method, Modifier.toString(methodsModifier.get(method)));
       }
     }
     return nonMatchingModifiers.isEmpty();

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -26,15 +26,18 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Preconditions.checkNotNull;
+import static org.assertj.core.util.Sets.newTreeSet;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.LinkedHashMap;
+
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.Arrays;
@@ -293,9 +296,9 @@ public class Classes {
   }
 
   private void doAssertHasMethods(AssertionInfo info, Class<?> actual, Method[] methods, boolean declared, String... expectedMethods) {
-    Set<String> expectedMethodNames = newLinkedHashSet(expectedMethods);
-    Set<String> missingMethodNames = newLinkedHashSet();
-    Set<String> actualMethodNames = methodsToName(methods);
+    SortedSet<String> expectedMethodNames = newTreeSet(expectedMethods);
+    SortedSet<String> missingMethodNames = newTreeSet();
+    SortedSet<String> actualMethodNames = methodsToName(methods);
 
     if(isEmptyAndHasNoMethods(methods, expectedMethods)) {
       throw failures.failure(info, shouldNotHaveMethods(actual, declared, getMethodsWithModifier(methods, Modifier.methodModifiers())));
@@ -335,8 +338,8 @@ public class Classes {
   }
 
   private void doAssertHasPublicMethods(AssertionInfo info, Class<?> actual, Method[] methods, boolean declared, String... expectedMethods) {
-    Set<String> expectedMethodNames = newLinkedHashSet(expectedMethods);
-    Set<String> missingMethodNames = newLinkedHashSet();
+    SortedSet<String> expectedMethodNames = newTreeSet(expectedMethods);
+    SortedSet<String> missingMethodNames = newTreeSet();
     Map<String,Integer> actualMethods = methodsToNameAndModifier(methods);
 
     if(isEmptyAndHasNoMethodsWithModifier(Modifier.PUBLIC, methods, expectedMethods)) {
@@ -352,8 +355,8 @@ public class Classes {
     }
   }
 
-  private static Set<String> getMethodsWithModifier(Method[] methods, int modifier) {
-    Set<String> methodsWithModifier = newLinkedHashSet();
+  private static SortedSet<String> getMethodsWithModifier(Method[] methods, int modifier) {
+    SortedSet<String> methodsWithModifier = newTreeSet();
     for (Method method : methods) {
       if ((method.getModifiers() & modifier) != 0) {
         methodsWithModifier.add(method.getName());
@@ -386,8 +389,8 @@ public class Classes {
     return false;
   }
 
-  private static Set<String> methodsToName(Method[] methods) {
-    Set<String> methodsName = new LinkedHashSet<>(methods.length);
+  private static SortedSet<String> methodsToName(Method[] methods) {
+    SortedSet<String> methodsName = newTreeSet();
     for (Method method : methods) {
       methodsName.add(method.getName());
     }

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -274,7 +274,7 @@ public class Classes {
    */
   public void assertHasMethods(AssertionInfo info, Class<?> actual, String... methods) {
     assertNotNull(info, actual);
-    doAssertHasMethods(info,actual, actual.getMethods(), methods);
+    doAssertHasMethods(info,actual, actual.getMethods(), false, methods);
   }
 
   /**
@@ -288,16 +288,16 @@ public class Classes {
    */
   public void assertHasDeclaredMethods(AssertionInfo info, Class<?> actual, String... methods) {
     assertNotNull(info, actual);
-    doAssertHasMethods(info, actual, actual.getDeclaredMethods(), methods);
+    doAssertHasMethods(info, actual, actual.getDeclaredMethods(), true, methods);
   }
 
-  private void doAssertHasMethods(AssertionInfo info, Class<?> actual, Method[] methods, String... expectedMethods) {
+  private void doAssertHasMethods(AssertionInfo info, Class<?> actual, Method[] methods, boolean declared, String... expectedMethods) {
     Set<String> expectedMethodNames = newLinkedHashSet(expectedMethods);
     Set<String> missingMethodNames = newLinkedHashSet();
     Set<String> actualMethodNames = methodsToName(methods);
 
     if (!noMissingElement(actualMethodNames, expectedMethodNames, missingMethodNames)) {
-      throw failures.failure(info, shouldHaveMethods(actual, expectedMethodNames, missingMethodNames));
+      throw failures.failure(info, shouldHaveMethods(actual, declared, expectedMethodNames, missingMethodNames));
     }
   }
 
@@ -312,7 +312,7 @@ public class Classes {
    */
   public void assertHasPublicMethods(AssertionInfo info, Class<?> actual, String... methods) {
     assertNotNull(info, actual);
-    doAssertHasPublicMethods(info, actual, actual.getMethods(), methods);
+    doAssertHasPublicMethods(info, actual, actual.getMethods(), false, methods);
   }
 
   /**
@@ -326,16 +326,16 @@ public class Classes {
    */
   public void assertHasDeclaredPublicMethods(AssertionInfo info, Class<?> actual, String... methods) {
     assertNotNull(info, actual);
-    doAssertHasPublicMethods(info, actual, actual.getDeclaredMethods(), methods);
+    doAssertHasPublicMethods(info, actual, actual.getDeclaredMethods(), true, methods);
   }
 
-  private void doAssertHasPublicMethods(AssertionInfo info, Class<?> actual, Method[] methods, String... expectedMethods) {
+  private void doAssertHasPublicMethods(AssertionInfo info, Class<?> actual, Method[] methods, boolean declared, String... expectedMethods) {
     Set<String> expectedMethodNames = newLinkedHashSet(expectedMethods);
     Set<String> missingMethodNames = newLinkedHashSet();
     Map<String,Integer> actualMethods = methodsToNameAndModifier(methods);
 
     if (!noMissingElement(actualMethods.keySet(), expectedMethodNames, missingMethodNames)) {
-      throw failures.failure(info, shouldHaveMethods(actual, expectedMethodNames, missingMethodNames));
+      throw failures.failure(info, shouldHaveMethods(actual, declared, expectedMethodNames, missingMethodNames));
     }
     Map<String,String> nonMatchingModifiers= new LinkedHashMap<>();
     if(!noNonMatchingModifier(expectedMethodNames, actualMethods, nonMatchingModifiers, Modifier.PUBLIC)) {

--- a/src/main/java/org/assertj/core/util/Sets.java
+++ b/src/main/java/org/assertj/core/util/Sets.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Utility methods related to {@link Set}s.
@@ -73,6 +74,33 @@ public final class Sets {
       return null;
     }
     LinkedHashSet<T> set = newLinkedHashSet();
+    java.util.Collections.addAll(set, elements);
+    return set;
+  }
+
+  /**
+   * Creates a <em>mutable</em> {@link TreeSet}.
+   *
+   * @param <T> the generic type of the {@link TreeSet} to create.
+   * @return the created {@link TreeSet}.
+   */
+  public static <T> TreeSet<T> newTreeSet() {
+    return new TreeSet<>();
+  }
+
+  /**
+   * Creates a <em>mutable</em> {@link TreeSet} containing the given elements.
+   *
+   * @param <T> the generic type of the {@link TreeSet} to create.
+   * @param elements the elements to store in the {@link TreeSet}.
+   * @return the created {@link TreeSet}, or {@code null} if the given array of elements is {@code null}.
+   */
+  @SafeVarargs
+  public static <T> TreeSet<T> newTreeSet(T... elements) {
+    if (elements == null) {
+      return null;
+    }
+    TreeSet<T> set = newTreeSet();
     java.util.Collections.addAll(set, elements);
     return set;
   }

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasDeclaredMethods_Test.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasDeclaredMethods(String...)}</code>.
+ */
+public class ClassAssert_hasDeclaredMethods_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasDeclaredMethods("method");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasDeclaredMethods(getInfo(assertions), getActual(assertions), "method");
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasDeclaredPublicMethods_Test.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasDeclaredPublicMethods(String...)} </code>.
+ */
+public class ClassAssert_hasDeclaredPublicMethods_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasDeclaredPublicMethods("method");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasDeclaredPublicMethods(getInfo(assertions), getActual(assertions), "method");
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasMethods_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasMethods_Test.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasMethods(String...)}</code>.
+ */
+public class ClassAssert_hasMethods_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasMethods("method");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasMethods(getInfo(assertions), getActual(assertions), "method");
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasPublicMethods_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasPublicMethods(String...)} </code>.
+ */
+public class ClassAssert_hasPublicMethods_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasPublicMethods("method");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasPublicMethods(getInfo(assertions), getActual(assertions), "method");
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_isProtected_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_isProtected_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ClassAssert#isProtected()} ()}</code>.
+ */
+public class ClassAssert_isProtected_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.isProtected();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertIsProtected(getInfo(assertions), getActual(assertions));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_isPublic_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_isPublic_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ClassAssert#isPublic()}</code>.
+ */
+public class ClassAssert_isPublic_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.isPublic();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertIsPublic(getInfo(assertions), getActual(assertions));
+  }
+
+}
+

--- a/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
@@ -29,7 +29,7 @@ public class ClassModifierShouldBe_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.Object>%n" +
-                                       "to be a \"final\" class."));
+                                       "to be a \"final\" class, but was \"public\""));
   }
 
   @Test
@@ -39,6 +39,6 @@ public class ClassModifierShouldBe_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.String>%n" +
-                                       "not to be a \"final\" class."));
+                                       "not to be a \"final\" class, but was \"public final\""));
   }
 }

--- a/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
@@ -29,7 +29,7 @@ public class ClassModifierShouldBe_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.Object>%n" +
-                                       "to be a \"final\" class, but was \"public\""));
+                                       "to be a \"final\" class but was \"public\"."));
   }
 
   @Test
@@ -39,6 +39,6 @@ public class ClassModifierShouldBe_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.String>%n" +
-                                       "not to be a \"final\" class, but was \"public final\""));
+                                       "not to be a \"final\" class but was \"public final\"."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ClassModifierShouldBe_create_Test.java
@@ -14,13 +14,13 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.error.ShouldBeFinal.shouldBeFinal;
-import static org.assertj.core.error.ShouldBeFinal.shouldNotBeFinal;
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBeFinal;
+import static org.assertj.core.error.ClassModifierShouldBe.shouldNotBeFinal;
 
 import org.assertj.core.internal.TestDescription;
 import org.junit.Test;
 
-public class ShouldBeFinal_create_Test {
+public class ClassModifierShouldBe_create_Test {
 
   @Test
   public void should_create_error_message_for_is_final() {
@@ -29,7 +29,7 @@ public class ShouldBeFinal_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.Object>%n" +
-                                       "to be a final class."));
+                                       "to be a \"final\" class."));
   }
 
   @Test
@@ -39,6 +39,6 @@ public class ShouldBeFinal_create_Test {
     assertThat(error).isEqualTo(format("[TEST] %n" +
                                        "Expecting:%n" +
                                        "  <java.lang.String>%n" +
-                                       "not to be a final class."));
+                                       "not to be a \"final\" class."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveMethods_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveMethods_create_Test.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.test.Maps;
+import org.assertj.core.test.Person;
+import org.junit.Test;
+
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.util.Sets.newTreeSet;
+
+/**
+ * Tests for <code>{@link ShouldHaveMethods}</code>
+ */
+public class ShouldHaveMethods_create_Test {
+
+  @Test
+  public void should_create_error_message_for_methods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldHaveMethods(Person.class, false, newTreeSet("getName", "getAddress"), newTreeSet("getAddress"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have methods:%n"
+        + "  <[\"getAddress\", \"getName\"]>%n"
+        + "but it doesn't have:%n"
+        + "  <[\"getAddress\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_declared_methods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldHaveMethods(Person.class, true, newTreeSet("getName", "getAddress"), newTreeSet("getAddress"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have declared methods:%n"
+        + "  <[\"getAddress\", \"getName\"]>%n"
+        + "but it doesn't have:%n"
+        + "  <[\"getAddress\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_shouldNotHavePublicDeclaredMethods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldNotHaveMethods(Person.class, Modifier.toString(Modifier.PUBLIC),true, newTreeSet("getName"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have no declared public methods but have the following:%n"
+        + "  <[\"getName\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_shouldNotHavePublicMethods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldNotHaveMethods(Person.class, Modifier.toString(Modifier.PUBLIC),false, newTreeSet("getName"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have no public methods but have the following:%n"
+        + "  <[\"getName\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_shouldNotHaveDeclaredMethods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldNotHaveMethods(Person.class, true, newTreeSet("getName"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have no declared methods but have the following:%n"
+        + "  <[\"getName\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_shouldNotHaveMethods() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldNotHaveMethods(Person.class, false, newTreeSet("getName"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have no methods but have the following:%n"
+        + "  <[\"getName\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_shouldHaveMethodsNonMatchingModifier() {
+    ErrorMessageFactory factory = ShouldHaveMethods.shouldHaveMethods(Person.class, false,
+      newTreeSet("finalize"), Modifier.toString(Modifier.PUBLIC),
+      Maps.mapOf(entry("finalize", Modifier.toString(Modifier.PROTECTED))));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+        + "Expecting%n"
+        + "  <org.assertj.core.test.Person>%n"
+        + "to have public methods:%n"
+        + "  <[\"finalize\"]>%n"
+        +  "but the following are not public:%n"
+        + "  <{\"finalize\"=\"protected\"}>"));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
@@ -62,6 +62,15 @@ public abstract class ClassesBaseTest {
 
   }
 
+  protected static class MethodsClass {
+    public void publicMethod() {}
+
+    protected void protectedMethod() {}
+
+    private void privateMethod() {}
+
+  }
+
   @Before
   public void setUp() {
     failures = spy(new Failures());

--- a/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
@@ -62,10 +62,11 @@ public abstract class ClassesBaseTest {
   }
 
   protected static class MethodsClass {
+    @SuppressWarnings("unused")
     public void publicMethod() {}
-
+    @SuppressWarnings("unused")
     protected void protectedMethod() {}
-
+    @SuppressWarnings("unused")
     private void privateMethod() {}
 
   }

--- a/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,6 +75,7 @@ public abstract class ClassesBaseTest {
   @Before
   public void setUp() {
     failures = spy(new Failures());
+    Assertions.assertThat(failures).isNotNull();
     classes = new Classes();
     classes.failures = failures;
   }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -53,7 +53,7 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
   @Test()
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, true,
       newLinkedHashSet(expected),
       newLinkedHashSet("missingMethod")));
       classes.assertHasDeclaredMethods(someInfo(), actual, expected);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -21,7 +21,7 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.newTreeSet;
 
 /**
  * Tests for
@@ -49,7 +49,7 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_no_methods_are_expected_and_declared_methods_are_available() {
-    thrown.expectAssertionError(shouldNotHaveMethods(actual, true, newLinkedHashSet("publicMethod", "protectedMethod", "privateMethod")));
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, true, newTreeSet("publicMethod", "protectedMethod", "privateMethod")));
     classes.assertHasDeclaredMethods(someInfo(), actual);
   }
 
@@ -62,8 +62,8 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
     thrown.expectAssertionError(shouldHaveMethods(actual, true,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("missingMethod")));
+      newTreeSet(expected),
+      newTreeSet("missingMethod")));
       classes.assertHasDeclaredMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -41,7 +42,15 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_methods_are_expected() {
+  public void should_succeed_if_no_methods_are_expected_and_no_declared_methods_are_available() {
+    actual = Jedi.class;
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual);
+  }
+
+
+  @Test
+  public void should_fail_if_no_methods_are_expected_and_declared_methods_are_available() {
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, true, newLinkedHashSet("publicMethod")));
     classes.assertHasDeclaredMethods(someInfo(), actual);
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -19,10 +19,8 @@ import org.junit.Test;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Classes#assertHasDeclaredMethods(AssertionInfo, Class, String...)}</code>
+ */
+public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = MethodsClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasDeclaredMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_no_fields_are_expected() {
+    classes.assertHasDeclaredMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_fields_are_public() {
+    classes.assertHasDeclaredMethods(someInfo(), actual, "publicMethod");
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_missing() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "missingMethod", "publicMethod" };
+    try {
+      classes.assertHasDeclaredMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("missingMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -54,16 +54,10 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
 
   @Test()
   public void should_fail_if_methods_are_missing() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    try {
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("missingMethod")));
       classes.assertHasDeclaredMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("missingMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -43,12 +43,12 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_fields_are_expected() {
+  public void should_pass_if_no_methods_are_expected() {
     classes.assertHasDeclaredMethods(someInfo(), actual);
   }
 
   @Test
-  public void should_pass_if_fields_are_public() {
+  public void should_pass_if_methods_are_public() {
     classes.assertHasDeclaredMethods(someInfo(), actual, "publicMethod");
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -47,10 +47,9 @@ public class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
     classes.assertHasDeclaredPublicMethods(someInfo(), actual);
   }
 
-
   @Test
   public void should_fail_if_no_methods_are_expected_and_declared_methods_are_available() {
-    thrown.expectAssertionError(shouldNotHaveMethods(actual, true, newLinkedHashSet("publicMethod")));
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, true, newLinkedHashSet("publicMethod", "protectedMethod", "privateMethod")));
     classes.assertHasDeclaredMethods(someInfo(), actual);
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -72,7 +72,7 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
   @Test()
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, true,
       newLinkedHashSet(expected),
       newLinkedHashSet("missingMethod")));
     classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -48,12 +48,12 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
   }
 
   @Test
-  public void should_pass_if_no_fields_are_expected() {
+  public void should_pass_if_no_methods_are_expected() {
     classes.assertHasDeclaredPublicMethods(someInfo(), actual);
   }
 
   @Test
-  public void should_pass_if_fields_are_public() {
+  public void should_pass_if_methods_are_public() {
     classes.assertHasDeclaredPublicMethods(someInfo(), actual, "publicMethod");
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -59,36 +59,24 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
 
   @Test()
   public void should_fail_if_methods_are_protected_or_private() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    try {
-      classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      Map<String, String> nonMatching = new LinkedHashMap<>();
-      nonMatching.put("protectedMethod", "protected");
-      nonMatching.put("privateMethod", "private");
+    Map<String, String> nonMatching = new LinkedHashMap<>();
+    nonMatching.put("protectedMethod", "protected");
+    nonMatching.put("privateMethod", "private");
 
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        Modifier.toString(Modifier.PUBLIC),
-        nonMatching));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      Modifier.toString(Modifier.PUBLIC),
+      nonMatching));
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
   }
 
   @Test()
   public void should_fail_if_methods_are_missing() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    try {
-      classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("missingMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("missingMethod")));
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Classes#assertHasDeclaredPublicMethods(AssertionInfo, Class, String...)} </code>
+ */
+public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = MethodsClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_no_fields_are_expected() {
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_fields_are_public() {
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual, "publicMethod");
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_protected_or_private() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
+    try {
+      classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      Map<String, String> nonMatching = new LinkedHashMap<>();
+      nonMatching.put("protectedMethod", "protected");
+      nonMatching.put("privateMethod", "private");
+
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        Modifier.toString(Modifier.PUBLIC),
+        nonMatching));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_missing() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "missingMethod", "publicMethod" };
+    try {
+      classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("missingMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -46,7 +47,14 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
   }
 
   @Test
-  public void should_pass_if_no_methods_are_expected() {
+  public void should_succeed_if_no_methods_are_expected_and_no_declared_public_methods_are_available() {
+    actual = Jedi.class;
+    classes.assertHasDeclaredPublicMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_fail_if_no_methods_are_expected_and_declared_public_methods_are_available() {
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, Modifier.toString(Modifier.PUBLIC), true, newLinkedHashSet("publicMethod")));
     classes.assertHasDeclaredPublicMethods(someInfo(), actual);
   }
 
@@ -62,7 +70,7 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
     nonMatching.put("protectedMethod", "protected");
     nonMatching.put("privateMethod", "private");
 
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, true,
       newLinkedHashSet(expected),
       Modifier.toString(Modifier.PUBLIC),
       nonMatching));

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -26,7 +26,7 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.newTreeSet;
 
 /**
  * Tests for
@@ -54,7 +54,7 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
 
   @Test
   public void should_fail_if_no_methods_are_expected_and_declared_public_methods_are_available() {
-    thrown.expectAssertionError(shouldNotHaveMethods(actual, Modifier.toString(Modifier.PUBLIC), true, newLinkedHashSet("publicMethod")));
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, Modifier.toString(Modifier.PUBLIC), true, newTreeSet("publicMethod")));
     classes.assertHasDeclaredPublicMethods(someInfo(), actual);
   }
 
@@ -71,7 +71,7 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
     nonMatching.put("privateMethod", "private");
 
     thrown.expectAssertionError(shouldHaveMethods(actual, true,
-      newLinkedHashSet(expected),
+      newTreeSet(expected),
       Modifier.toString(Modifier.PUBLIC),
       nonMatching));
     classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
@@ -81,8 +81,8 @@ public class Classes_assertHasDeclaredPublicMethods_Test extends ClassesBaseTest
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
     thrown.expectAssertionError(shouldHaveMethods(actual, true,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("missingMethod")));
+      newTreeSet(expected),
+      newTreeSet("missingMethod")));
     classes.assertHasDeclaredPublicMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasDeclaredPublicMethods_Test.java
@@ -24,10 +24,8 @@ import java.util.Map;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -41,7 +42,9 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_methods_are_expected() {
+  public void should_fail_if_no_methods_are_expected_and_methods_are_available() {
+    thrown.expectAssertionError(shouldNotHaveMethods(actual,false,
+      newLinkedHashSet("publicMethod", "wait", "equals", "toString", "hashCode", "getClass", "notify", "notifyAll")));
     classes.assertHasMethods(someInfo(), actual);
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -44,7 +44,8 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   @Test
   public void should_fail_if_no_methods_are_expected_and_methods_are_available() {
     thrown.expectAssertionError(shouldNotHaveMethods(actual,false,
-      newLinkedHashSet("publicMethod", "wait", "equals", "toString", "hashCode", "getClass", "notify", "notifyAll")));
+      newLinkedHashSet("publicMethod",  "protectedMethod", "privateMethod", "finalize", "wait", "equals", "toString",
+        "hashCode", "getClass", "clone", "registerNatives", "notify", "notifyAll")));
     classes.assertHasMethods(someInfo(), actual);
   }
 
@@ -54,11 +55,14 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_fail_if_methods_are_protected_or_private() {
-    String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual, false,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("protectedMethod", "privateMethod")));
+  public void should_pass_if_methods_are_protected_or_private() {
+    String[] expected = new String[] { "protectedMethod", "privateMethod" };
+    classes.assertHasMethods(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_methods_are_inherited() {
+    String[] expected = new String[] { "notify", "notifyAll" };
     classes.assertHasMethods(someInfo(), actual, expected);
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ClassesBaseTest;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Classes#assertHasMethods(AssertionInfo, Class, String...)} </code>
+ */
+public class Classes_assertHasMethods_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = MethodsClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_no_fields_are_expected() {
+    classes.assertHasMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_fields_are_public() {
+    classes.assertHasMethods(someInfo(), actual, "publicMethod");
+  }
+
+  @Test
+  public void should_fail_if_methods_are_protected_or_private() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
+    try {
+      classes.assertHasMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("protectedMethod", "privateMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_missing() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "missingMethod", "publicMethod" };
+    try {
+      classes.assertHasMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("missingMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -56,31 +56,19 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_methods_are_protected_or_private() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    try {
-      classes.assertHasMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("protectedMethod", "privateMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("protectedMethod", "privateMethod")));
+    classes.assertHasMethods(someInfo(), actual, expected);
   }
 
   @Test()
   public void should_fail_if_methods_are_missing() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    try {
-      classes.assertHasMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("missingMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("missingMethod")));
+    classes.assertHasMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -12,19 +12,15 @@
  */
 package org.assertj.core.internal.classes;
 
-import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
-
-import static org.mockito.Mockito.verify;
-
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ClassesBaseTest;
+import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
 
 /**
  * Tests for

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -53,7 +53,7 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   @Test
   public void should_fail_if_methods_are_protected_or_private() {
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, false,
       newLinkedHashSet(expected),
       newLinkedHashSet("protectedMethod", "privateMethod")));
     classes.assertHasMethods(someInfo(), actual, expected);
@@ -62,7 +62,7 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   @Test()
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, false,
       newLinkedHashSet(expected),
       newLinkedHashSet("missingMethod")));
     classes.assertHasMethods(someInfo(), actual, expected);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -21,7 +21,7 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.newTreeSet;
 
 /**
  * Tests for
@@ -44,7 +44,7 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   @Test
   public void should_fail_if_no_methods_are_expected_and_methods_are_available() {
     thrown.expectAssertionError(shouldNotHaveMethods(actual,false,
-      newLinkedHashSet("publicMethod",  "protectedMethod", "privateMethod", "finalize", "wait", "equals", "toString",
+      newTreeSet("publicMethod",  "protectedMethod", "privateMethod", "finalize", "wait", "equals", "toString",
         "hashCode", "getClass", "clone", "registerNatives", "notify", "notifyAll")));
     classes.assertHasMethods(someInfo(), actual);
   }
@@ -70,8 +70,8 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
     thrown.expectAssertionError(shouldHaveMethods(actual, false,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("missingMethod")));
+      newTreeSet(expected),
+      newTreeSet("missingMethod")));
     classes.assertHasMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasMethods_Test.java
@@ -45,12 +45,12 @@ public class Classes_assertHasMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_fields_are_expected() {
+  public void should_pass_if_no_methods_are_expected() {
     classes.assertHasMethods(someInfo(), actual);
   }
 
   @Test
-  public void should_pass_if_fields_are_public() {
+  public void should_pass_if_methods_are_public() {
     classes.assertHasMethods(someInfo(), actual, "publicMethod");
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Maps.newHashMap;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Classes#assertHasMethods(AssertionInfo, Class, String...)} </code>
+ */
+public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = MethodsClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasPublicMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_no_fields_are_expected() {
+    classes.assertHasPublicMethods(someInfo(), actual);
+  }
+
+  @Test
+  public void should_pass_if_fields_are_public() {
+    classes.assertHasPublicMethods(someInfo(), actual, "publicMethod");
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_protected_or_private() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
+    try {
+      classes.assertHasPublicMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("protectedMethod", "privateMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test()
+  public void should_fail_if_methods_are_missing() {
+    AssertionInfo info = someInfo();
+    String[] expected = new String[] { "missingMethod", "publicMethod" };
+    try {
+      classes.assertHasPublicMethods(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveMethods(actual,
+        newLinkedHashSet(expected),
+        newLinkedHashSet("missingMethod")));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -19,10 +19,8 @@ import org.junit.Test;
 
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -53,7 +53,7 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   @Test()
   public void should_fail_if_methods_are_protected_or_private() {
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, false,
       newLinkedHashSet(expected),
       newLinkedHashSet("protectedMethod", "privateMethod")));
     classes.assertHasPublicMethods(someInfo(), actual, expected);
@@ -62,7 +62,7 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   @Test()
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    thrown.expectAssertionError(shouldHaveMethods(actual,
+    thrown.expectAssertionError(shouldHaveMethods(actual, false,
       newLinkedHashSet(expected),
       newLinkedHashSet("missingMethod")));
     classes.assertHasPublicMethods(someInfo(), actual, expected);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -23,7 +23,7 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.newTreeSet;
 
 /**
  * Tests for
@@ -46,7 +46,7 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   @Test
   public void should_fail_if_no_methods_are_expected_but_public_methods_are_available() {
     thrown.expectAssertionError(shouldNotHaveMethods(actual, Modifier.toString(Modifier.PUBLIC), false,
-      newLinkedHashSet("publicMethod", "wait", "equals", "toString", "hashCode", "getClass", "notify", "notifyAll")));
+      newTreeSet("publicMethod", "wait", "equals", "toString", "hashCode", "getClass", "notify", "notifyAll")));
     classes.assertHasPublicMethods(someInfo(), actual);
   }
 
@@ -59,8 +59,8 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   public void should_fail_if_methods_are_protected_or_private() {
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
     thrown.expectAssertionError(shouldHaveMethods(actual, false,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("protectedMethod", "privateMethod")));
+      newTreeSet(expected),
+      newTreeSet("protectedMethod", "privateMethod")));
     classes.assertHasPublicMethods(someInfo(), actual, expected);
   }
 
@@ -68,8 +68,8 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   public void should_fail_if_methods_are_missing() {
     String[] expected = new String[] { "missingMethod", "publicMethod" };
     thrown.expectAssertionError(shouldHaveMethods(actual, false,
-      newLinkedHashSet(expected),
-      newLinkedHashSet("missingMethod")));
+      newTreeSet(expected),
+      newTreeSet("missingMethod")));
     classes.assertHasPublicMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -17,7 +17,10 @@ import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Modifier;
+
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
+import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -41,7 +44,9 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_methods_are_expected() {
+  public void should_fail_if_no_methods_are_expected_but_public_methods_are_available() {
+    thrown.expectAssertionError(shouldNotHaveMethods(actual, Modifier.toString(Modifier.PUBLIC), false,
+      newLinkedHashSet("publicMethod", "wait", "equals", "toString", "hashCode", "getClass", "notify", "notifyAll")));
     classes.assertHasPublicMethods(someInfo(), actual);
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -54,31 +54,19 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
 
   @Test()
   public void should_fail_if_methods_are_protected_or_private() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "publicMethod", "protectedMethod", "privateMethod" };
-    try {
-      classes.assertHasPublicMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("protectedMethod", "privateMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("protectedMethod", "privateMethod")));
+    classes.assertHasPublicMethods(someInfo(), actual, expected);
   }
 
   @Test()
   public void should_fail_if_methods_are_missing() {
-    AssertionInfo info = someInfo();
     String[] expected = new String[] { "missingMethod", "publicMethod" };
-    try {
-      classes.assertHasPublicMethods(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMethods(actual,
-        newLinkedHashSet(expected),
-        newLinkedHashSet("missingMethod")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldHaveMethods(actual,
+      newLinkedHashSet(expected),
+      newLinkedHashSet("missingMethod")));
+    classes.assertHasPublicMethods(someInfo(), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -44,12 +44,12 @@ public class Classes_assertHasPublicMethods_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_no_fields_are_expected() {
+  public void should_pass_if_no_methods_are_expected() {
     classes.assertHasPublicMethods(someInfo(), actual);
   }
 
   @Test
-  public void should_pass_if_fields_are_public() {
+  public void should_pass_if_methods_are_public() {
     classes.assertHasPublicMethods(someInfo(), actual, "publicMethod");
   }
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasPublicMethods_Test.java
@@ -21,7 +21,6 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsNotFinal_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsNotFinal_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal.classes;
 
-import static org.assertj.core.error.ShouldBeFinal.shouldNotBeFinal;
+import static org.assertj.core.error.ClassModifierShouldBe.shouldNotBeFinal;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
@@ -13,15 +13,12 @@
 package org.assertj.core.internal.classes;
 
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Test;
 
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBeProtected;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.verify;
 
 public class Classes_assertIsProtected_Test extends ClassesBaseTest {
 

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
@@ -32,12 +32,12 @@ public class Classes_assertIsProtected_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_actual_is_a_final_class() {
+  public void should_pass_if_actual_is_a_protected_class() {
     classes.assertIsProtected(someInfo(), MethodsClass.class);
   }
 
   @Test
-  public void should_fail_if_actual_is_not_a_final_class() {
+  public void should_fail_if_actual_is_not_a_protected_class() {
     AssertionInfo info = someInfo();
     try {
       classes.assertIsProtected(someInfo(), Object.class);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
@@ -38,13 +38,7 @@ public class Classes_assertIsProtected_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_a_protected_class() {
-    AssertionInfo info = someInfo();
-    try {
-      classes.assertIsProtected(someInfo(), Object.class);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeProtected(Object.class));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBeProtected(Object.class));
+    classes.assertIsProtected(someInfo(), Object.class);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsProtected_Test.java
@@ -12,41 +12,37 @@
  */
 package org.assertj.core.internal.classes;
 
-import static org.assertj.core.error.ClassModifierShouldBe.shouldBeFinal;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Test;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Classes#assertIsFinal(AssertionInfo, Class)}</code>.
- *
- * @author Michal Kordas
- */
-public class Classes_assertIsFinal_Test extends ClassesBaseTest {
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBeProtected;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Classes_assertIsProtected_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    classes.assertIsAnnotation(someInfo(), null);
+    classes.assertIsProtected(someInfo(), null);
   }
 
   @Test
   public void should_pass_if_actual_is_a_final_class() {
-    classes.assertIsFinal(someInfo(), Math.class);
+    classes.assertIsProtected(someInfo(), MethodsClass.class);
   }
 
   @Test
   public void should_fail_if_actual_is_not_a_final_class() {
     AssertionInfo info = someInfo();
     try {
-      classes.assertIsFinal(someInfo(), Object.class);
+      classes.assertIsProtected(someInfo(), Object.class);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFinal(Object.class));
+      verify(failures).failure(info, shouldBeProtected(Object.class));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -13,16 +13,12 @@
 package org.assertj.core.internal.classes;
 
 
-import static org.assertj.core.error.ClassModifierShouldBe.shouldBePublic;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.verify;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Test;
+
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBePublic;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
 public class Classes_assertIsPublic_Test extends ClassesBaseTest {

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -40,14 +40,7 @@ public class Classes_assertIsPublic_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_a_public_class() {
-    AssertionInfo info = someInfo();
-    try {
-      classes.assertIsPublic(someInfo(), MethodsClass.class);
-    } catch (AssertionError e) {
-      Assertions.assertThat(failures).isNotNull();
-      verify(failures).failure(info, shouldBePublic(MethodsClass.class));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    thrown.expectAssertionError(shouldBePublic(MethodsClass.class));
+    classes.assertIsPublic(someInfo(), MethodsClass.class);
   }
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -32,12 +32,12 @@ public class Classes_assertIsPublic_Test extends ClassesBaseTest {
   }
 
   @Test
-  public void should_pass_if_actual_is_a_final_class() {
+  public void should_pass_if_actual_is_a_public_class() {
     classes.assertIsPublic(someInfo(), Math.class);
   }
 
   @Test
-  public void should_fail_if_actual_is_not_a_final_class() {
+  public void should_fail_if_actual_is_not_a_public_class() {
     AssertionInfo info = someInfo();
     try {
       classes.assertIsPublic(someInfo(), MethodsClass.class);

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -12,41 +12,37 @@
  */
 package org.assertj.core.internal.classes;
 
-import static org.assertj.core.error.ClassModifierShouldBe.shouldBeFinal;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Test;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Classes#assertIsFinal(AssertionInfo, Class)}</code>.
- *
- * @author Michal Kordas
- */
-public class Classes_assertIsFinal_Test extends ClassesBaseTest {
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBePublic;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+public class Classes_assertIsPublic_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    classes.assertIsAnnotation(someInfo(), null);
+    classes.assertIsPublic(someInfo(), null);
   }
 
   @Test
   public void should_pass_if_actual_is_a_final_class() {
-    classes.assertIsFinal(someInfo(), Math.class);
+    classes.assertIsPublic(someInfo(), Math.class);
   }
 
   @Test
   public void should_fail_if_actual_is_not_a_final_class() {
     AssertionInfo info = someInfo();
     try {
-      classes.assertIsFinal(someInfo(), Object.class);
+      classes.assertIsPublic(someInfo(), MethodsClass.class);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFinal(Object.class));
+      verify(failures).failure(info, shouldBePublic(MethodsClass.class));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal.classes;
 
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.Test;
 
@@ -42,6 +43,7 @@ public class Classes_assertIsPublic_Test extends ClassesBaseTest {
     try {
       classes.assertIsPublic(someInfo(), MethodsClass.class);
     } catch (AssertionError e) {
+      Assertions.assertThat(failures).isNotNull();
       verify(failures).failure(info, shouldBePublic(MethodsClass.class));
       return;
     }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPublic_Test.java
@@ -13,16 +13,17 @@
 package org.assertj.core.internal.classes;
 
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.internal.ClassesBaseTest;
-import org.junit.Test;
-
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBePublic;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.Test;
+
 
 public class Classes_assertIsPublic_Test extends ClassesBaseTest {
 


### PR DESCRIPTION
#### Check List:
* Fixes #888 (at least partially)
* Unit tests : YES
* Javadoc with a code example (API only) : YES 

a very first draft for class and method visibility.

e.g.

```
  @Test
  public void test1() {
    Assertions.assertThat(ArrayList.class).hasDeclaredPublicMethods("size", "grow", "add" , "fastRemove");
  }
```

would end up in:

```
java.lang.AssertionError: 
Expecting
  <java.util.ArrayList>
to have public methods:
  <["size", "grow", "add", "fastRemove"]>
but the following are not public:
  <{"fastRemove"="private", "grow"="private"}>
```