### PR TITLE
use @CheckReturnValue on "non-asserting" AssertX methods like using*,…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -26,6 +26,7 @@ import org.assertj.core.internal.Conditions;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.presentation.Representation;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -129,12 +130,14 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF as(String description, Object... args) {
     return describedAs(description, args);
   }
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF as(Description description) {
     return describedAs(description);
   }
@@ -165,6 +168,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   protected SELF inHexadecimal() {
     info.useHexadecimalRepresentation();
     return myself;
@@ -182,6 +186,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    * 
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   protected SELF inBinary() {
     info.useBinaryRepresentation();
     return myself;
@@ -189,6 +194,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF describedAs(String description, Object... args) {
     info.description(description, args);
     return myself;
@@ -196,6 +202,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF describedAs(Description description) {
     info.description(description);
     return myself;
@@ -378,6 +385,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   /** {@inheritDoc} */
   @SuppressWarnings("unchecked")
   @Override
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> asList() {
     objects.assertIsInstanceOf(info, actual, List.class);
     return Assertions.assertThat((List<Object>) actual);
@@ -385,6 +393,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public AbstractCharSequenceAssert<?, String> asString() {
     objects.assertIsInstanceOf(info, actual, String.class);
     return Assertions.assertThat((String) actual);
@@ -415,6 +424,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    * @return this assertion object.
    * @throws Exception see {@link String#format(String, Object...)} exception clause.
    */
+  @CheckReturnValue
   public SELF overridingErrorMessage(String newErrorMessage, Object... args) {
     info.overridingErrorMessage(formatIfArgs(newErrorMessage, args));
     return myself;
@@ -428,6 +438,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    * @return this assertion object.
    * @throws Exception see {@link String#format(String, Object...)} exception clause.
    */
+  @CheckReturnValue
   public SELF withFailMessage(String newErrorMessage, Object... args) {
     overridingErrorMessage(newErrorMessage, args);
     return myself;
@@ -435,6 +446,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     // using a specific strategy to compare actual with other objects.
     this.objects = new Objects(new ComparatorBasedComparisonStrategy(customComparator));
@@ -443,6 +455,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     // fall back to default strategy to compare actual with other objects.
     this.objects = Objects.instance();
@@ -451,6 +464,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF withThreadDumpOnError() {
     Failures.instance().enablePrintThreadDump();
     return myself;
@@ -458,6 +472,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF withRepresentation(Representation representation) {
     info.useRepresentation(representation);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -19,6 +19,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.BigDecimals;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -265,6 +266,7 @@ public abstract class AbstractBigDecimalAssert<SELF extends AbstractBigDecimalAs
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super BigDecimal> customComparator) {
     super.usingComparator(customComparator);
     this.bigDecimals = new BigDecimals(new ComparatorBasedComparisonStrategy(customComparator));
@@ -272,6 +274,7 @@ public abstract class AbstractBigDecimalAssert<SELF extends AbstractBigDecimalAs
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.bigDecimals = BigDecimals.instance();

--- a/src/main/java/org/assertj/core/api/AbstractBigIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBigIntegerAssert.java
@@ -19,6 +19,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.BigIntegers;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -401,6 +402,7 @@ public class AbstractBigIntegerAssert<S extends AbstractBigIntegerAssert<S>> ext
   }
 
   @Override
+  @CheckReturnValue
   public S usingComparator(Comparator<? super BigInteger> customComparator) {
     super.usingComparator(customComparator);
     this.bigIntegers = new BigIntegers(new ComparatorBasedComparisonStrategy(customComparator));
@@ -408,6 +410,7 @@ public class AbstractBigIntegerAssert<S extends AbstractBigIntegerAssert<S>> ext
   }
 
   @Override
+  @CheckReturnValue
   public S usingDefaultComparator() {
     super.usingDefaultComparator();
     this.bigIntegers = BigIntegers.instance();

--- a/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ByteArrays;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAssert<SELF>>
@@ -661,6 +662,7 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Byte> customComparator) {
     this.arrays = new ByteArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -668,6 +670,7 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = ByteArrays.instance();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractByteAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.Bytes;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -523,6 +524,7 @@ public abstract class AbstractByteAssert<SELF extends AbstractByteAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Byte> customComparator) {
     super.usingComparator(customComparator);
     this.bytes = new Bytes(new ComparatorBasedComparisonStrategy(customComparator));
@@ -530,6 +532,7 @@ public abstract class AbstractByteAssert<SELF extends AbstractByteAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.bytes = Bytes.instance();

--- a/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.CharArrays;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractCharArrayAssert<SELF extends AbstractCharArrayAssert<SELF>>
@@ -384,6 +385,7 @@ public abstract class AbstractCharArrayAssert<SELF extends AbstractCharArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Character> customComparator) {
     this.arrays = new CharArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -391,6 +393,7 @@ public abstract class AbstractCharArrayAssert<SELF extends AbstractCharArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = CharArrays.instance();
     return myself;
@@ -464,6 +467,7 @@ public abstract class AbstractCharArrayAssert<SELF extends AbstractCharArrayAsse
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF inUnicode() {
     info.useUnicodeRepresentation();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -22,6 +22,7 @@ import java.util.regex.PatternSyntaxException;
 
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Strings;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.IterableUtil;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -837,6 +838,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     super.usingComparator(customComparator);
     this.strings = new Strings(new ComparatorBasedComparisonStrategy(customComparator));
@@ -844,6 +846,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.strings = Strings.instance();
@@ -851,6 +854,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   @Override
+  @CheckReturnValue
   public SELF inHexadecimal() {
     return super.inHexadecimal();
   }
@@ -881,6 +885,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF inUnicode() {
     info.useUnicodeRepresentation();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 
 import org.assertj.core.internal.Characters;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -177,6 +178,7 @@ public abstract class AbstractCharacterAssert<SELF extends AbstractCharacterAsse
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF inUnicode() {
     info.useUnicodeRepresentation();
     return myself;
@@ -249,6 +251,7 @@ public abstract class AbstractCharacterAssert<SELF extends AbstractCharacterAsse
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Character> customComparator) {
     super.usingComparator(customComparator);
     this.characters = new Characters(new ComparatorBasedComparisonStrategy(customComparator));
@@ -256,6 +259,7 @@ public abstract class AbstractCharacterAssert<SELF extends AbstractCharacterAsse
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.characters = Characters.instance();

--- a/src/main/java/org/assertj/core/api/AbstractComparableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractComparableAssert.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 
 import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -96,6 +97,7 @@ public abstract class AbstractComparableAssert<SELF extends AbstractComparableAs
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     super.usingComparator(customComparator);
     this.comparables = new Comparables(new ComparatorBasedComparisonStrategy(customComparator));
@@ -103,6 +105,7 @@ public abstract class AbstractComparableAssert<SELF extends AbstractComparableAs
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.comparables = Comparables.instance();
@@ -110,11 +113,13 @@ public abstract class AbstractComparableAssert<SELF extends AbstractComparableAs
   }
 
   @Override
+  @CheckReturnValue
   public SELF inHexadecimal() {
     return super.inHexadecimal();
   }
 
   @Override
+  @CheckReturnValue
   public SELF inBinary() {
     return super.inBinary();
   }

--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Dates;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -2305,6 +2306,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    * @param userCustomDateFormat the new Date format used for String based Date assertions.
    * @return this assertion object.
    */
+  @CheckReturnValue
   public SELF withDateFormat(DateFormat userCustomDateFormat) {
     registerCustomDateFormat(userCustomDateFormat);
     return myself;
@@ -2331,6 +2333,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    * @param userCustomDateFormatPattern the new Date format string pattern used for String based Date assertions.
    * @return this assertion object.
    */
+  @CheckReturnValue
   public SELF withDateFormat(String userCustomDateFormatPattern) {
     checkNotNull(userCustomDateFormatPattern, DATE_FORMAT_PATTERN_SHOULD_NOT_BE_NULL);
     return withDateFormat(new SimpleDateFormat(userCustomDateFormatPattern));
@@ -2511,6 +2514,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    *
    * @return this assertion
    */
+  @CheckReturnValue
   public SELF withDefaultDateFormatsOnly() {
     useDefaultDateFormatsOnly();
     return myself;
@@ -2564,6 +2568,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Date> customComparator) {
     super.usingComparator(customComparator);
     this.dates = new Dates(new ComparatorBasedComparisonStrategy(customComparator));
@@ -2571,6 +2576,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     this.dates = Dates.instance();

--- a/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.DoubleArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractDoubleArrayAssert<SELF extends AbstractDoubleArrayAssert<SELF>>
@@ -771,6 +772,7 @@ public abstract class AbstractDoubleArrayAssert<SELF extends AbstractDoubleArray
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Double> customComparator) {
     this.arrays = new DoubleArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -778,6 +780,7 @@ public abstract class AbstractDoubleArrayAssert<SELF extends AbstractDoubleArray
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = DoubleArrays.instance();
     return myself;
@@ -877,6 +880,7 @@ public abstract class AbstractDoubleArrayAssert<SELF extends AbstractDoubleArray
    * @param precision precisin used to compare {@link Double}.
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingComparatorWithPrecision(Double precision) {
     return usingElementComparator(doubleComparator.doubleComparatorWithPrecision(precision));
   }

--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Doubles;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -519,6 +520,7 @@ public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SEL
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Double> customComparator) {
     super.usingComparator(customComparator);
     doubles = new Doubles(new ComparatorBasedComparisonStrategy(customComparator));
@@ -526,6 +528,7 @@ public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SEL
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     doubles = Doubles.instance();

--- a/src/main/java/org/assertj/core/api/AbstractEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractEnumerableAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static org.assertj.core.internal.Arrays.assertIsArray;
 
 import org.assertj.core.internal.Arrays;
+import org.assertj.core.util.CheckReturnValue;
 
 /**
  * Base implementation for Enumerable class assertions.
@@ -78,11 +79,13 @@ public abstract class AbstractEnumerableAssert<SELF extends AbstractEnumerableAs
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public SELF inHexadecimal() {
     return super.inHexadecimal();
   }
 
   @Override
+  @CheckReturnValue
   public SELF inBinary() {
     return super.inBinary();
   }

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -17,6 +17,7 @@ import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.internal.Files;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 import java.io.File;
@@ -340,6 +341,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @return {@code this} assertion object.
    * @throws IllegalArgumentException if the given encoding is not supported on this platform.
    */
+  @CheckReturnValue
   public SELF usingCharset(String charsetName) {
     checkArgument(Charset.isSupported(charsetName), "Charset:<'%s'> is not supported on this system", charsetName);
     return usingCharset(Charset.forName(charsetName));
@@ -352,6 +354,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given charset is {@code null}.
    */
+  @CheckReturnValue
   public SELF usingCharset(Charset charset) {
     this.charset = checkNotNull(charset, "The charset should not be null");
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.FloatArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractFloatArrayAssert<SELF extends AbstractFloatArrayAssert<SELF>>
@@ -755,6 +756,7 @@ public abstract class AbstractFloatArrayAssert<SELF extends AbstractFloatArrayAs
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Float> customComparator) {
     this.arrays = new FloatArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -762,6 +764,7 @@ public abstract class AbstractFloatArrayAssert<SELF extends AbstractFloatArrayAs
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = FloatArrays.instance();
     return myself;
@@ -860,6 +863,7 @@ public abstract class AbstractFloatArrayAssert<SELF extends AbstractFloatArrayAs
    * @param precision precisin used to compare {@link Float}.
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingComparatorWithPrecision(Float precision) {
     return usingElementComparator(floatComparator.floatComparatorWithPrecision(precision));
   }

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Floats;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -527,6 +528,7 @@ public abstract class AbstractFloatAssert<SELF extends AbstractFloatAssert<SELF>
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Float> customComparator) {
     super.usingComparator(customComparator);
     floats = new Floats(new ComparatorBasedComparisonStrategy(customComparator));
@@ -534,6 +536,7 @@ public abstract class AbstractFloatAssert<SELF extends AbstractFloatAssert<SELF>
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     floats = Floats.instance();

--- a/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.IntArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractIntArrayAssert<SELF extends AbstractIntArrayAssert<SELF>>
@@ -340,6 +341,7 @@ public abstract class AbstractIntArrayAssert<SELF extends AbstractIntArrayAssert
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Integer> customComparator) {
     this.arrays = new IntArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -347,6 +349,7 @@ public abstract class AbstractIntArrayAssert<SELF extends AbstractIntArrayAssert
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = IntArrays.instance();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntegerAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Integers;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -452,6 +453,7 @@ public abstract class AbstractIntegerAssert<SELF extends AbstractIntegerAssert<S
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Integer> customComparator) {
     super.usingComparator(customComparator);
     integers = new Integers(new ComparatorBasedComparisonStrategy(customComparator));
@@ -459,6 +461,7 @@ public abstract class AbstractIntegerAssert<SELF extends AbstractIntegerAssert<S
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     integers = Integers.instance();

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -52,6 +52,7 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.OnFieldsComparator;
 import org.assertj.core.internal.RecursiveFieldByFieldComparator;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.IterableUtil;
 import org.assertj.core.util.Preconditions;
 import org.assertj.core.util.Strings;
@@ -485,6 +486,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * {@inheritDoc}
    */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super ELEMENT> elementComparator) {
     this.iterables = new Iterables(new ComparatorBasedComparisonStrategy(elementComparator));
     // to have the same semantics on base assertions like isEqualTo, we need to use an iterable comparator comparing
@@ -497,6 +499,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * {@inheritDoc}
    */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     usingDefaultComparator();
     this.iterables = Iterables.instance();
@@ -584,6 +587,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IntrospectionError if no field or property exists with the given name in one of the initial
    *         Iterable's element.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> extracting(String propertyOrField) {
     List<Object> values = FieldsOrPropertiesExtractor.extract(actual, byName(propertyOrField));
     return newListAssertInstance(values);
@@ -628,6 +632,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IllegalArgumentException if no method exists with the given name, or method is not public, or method does
    *           return void, or method accepts arguments.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> extractingResultOf(String method) {
     List<Object> values = FieldsOrPropertiesExtractor.extract(actual, resultOf(method));
     return newListAssertInstance(values);
@@ -673,6 +678,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IllegalArgumentException if no method exists with the given name, or method is not public, or method does
    *           return void or method accepts arguments.
    */
+  @CheckReturnValue
   public <P> AbstractListAssert<?, List<? extends P>, P, ObjectAssert<P>> extractingResultOf(String method,
                                                                                              Class<P> extractedType) {
     @SuppressWarnings("unchecked")
@@ -760,6 +766,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IntrospectionError if no field or property exists with the given name in one of the initial
    *         Iterable's element.
    */
+  @CheckReturnValue
   public <P> AbstractListAssert<?, List<? extends P>, P, ObjectAssert<P>> extracting(String propertyOrField,
                                                                                      Class<P> extractingType) {
     @SuppressWarnings("unchecked")
@@ -851,6 +858,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IntrospectionError if one of the given name does not match a field or property in one of the initial
    *         Iterable's element.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(String... propertiesOrFields) {
     List<Tuple> values = FieldsOrPropertiesExtractor.extract(actual, byName(propertiesOrFields));
     return newListAssertInstance(values);
@@ -895,6 +903,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @param extractor the object transforming input object to desired one
    * @return a new assertion object whose object under test is the list of values extracted
    */
+  @CheckReturnValue
   public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> extracting(Extractor<? super ELEMENT, V> extractor) {
     List<V> values = FieldsOrPropertiesExtractor.extract(actual, extractor);
     return newListAssertInstance(values);
@@ -935,6 +944,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @param extractor the object transforming input object to an Iterable of desired ones
    * @return a new assertion object whose object under test is the list of values extracted
    */
+  @CheckReturnValue
   public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> flatExtracting(Extractor<? super ELEMENT, ? extends Collection<V>> extractor) {
     List<V> result = newArrayList();
     final List<? extends Collection<V>> extractedValues = FieldsOrPropertiesExtractor.extract(actual, extractor);
@@ -975,6 +985,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object whose object under test is the list of values extracted
    * @throws IllegalArgumentException if one of the extracted property value was not an array or an iterable.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(String fieldOrPropertyName) {
     List<Object> extractedValues = newArrayList();
     List<?> extractedGroups = FieldsOrPropertiesExtractor.extract(actual, byName(fieldOrPropertyName));
@@ -1020,6 +1031,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IllegalArgumentException if fieldOrPropertyNames vararg is null or empty
    * @since 2.5.0
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(String... fieldOrPropertyNames) {
     List<Object> extractedValues = newArrayList();
     for (Tuple tuple : FieldsOrPropertiesExtractor.extract(actual, Extractors.byName(fieldOrPropertyNames))) {
@@ -1113,6 +1125,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return {@code this} assertions object
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public <T> SELF usingComparatorForElementFieldsWithNames(Comparator<T> comparator,
                                                            String... elementPropertyOrFieldNames) {
     for (String elementPropertyOrField : elementPropertyOrFieldNames) {
@@ -1181,6 +1194,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return {@code this} assertions object
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public <T> SELF usingComparatorForElementFieldsWithType(Comparator<T> comparator, Class<T> type) {
     comparatorsForElementPropertyOrFieldTypes.put(type, comparator);
     return myself;
@@ -1212,6 +1226,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingFieldByFieldElementComparator() {
     return usingElementComparator(new FieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                              comparatorsForElementPropertyOrFieldTypes));
@@ -1261,6 +1276,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return {@code this} assertion object.
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public SELF usingRecursiveFieldByFieldElementComparator() {
     return usingElementComparator(new RecursiveFieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                                       comparatorsForElementPropertyOrFieldTypes));
@@ -1293,6 +1309,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingElementComparatorOnFields(String... fields) {
     return usingElementComparator(new OnFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                          comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1330,6 +1347,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingElementComparatorIgnoringFields(String... fields) {
     return usingElementComparator(new IgnoringFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                                comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1366,6 +1384,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public SELF inHexadecimal() {
     return super.inHexadecimal();
   }
@@ -1399,6 +1418,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public SELF inBinary() {
     return super.inBinary();
   }
@@ -1460,6 +1480,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws IllegalArgumentException if the given propertyOrFieldName is {@code null} or empty.
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the iterable elements.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> filteredOn(String propertyOrFieldName,
                                                                                                    Object expectedValue) {
     Filters<? extends ELEMENT> filter = filter((Iterable<? extends ELEMENT>) actual);
@@ -1506,6 +1527,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object with the filtered iterable under test
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the iterable elements.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> filteredOnNull(String propertyOrFieldName) {
     // need to cast nulll to Object otherwise it calls :
     // filteredOn(String propertyOrFieldName, FilterOperation<?> filterOperation)
@@ -1577,6 +1599,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object with the filtered iterable under test
    * @throws IllegalArgumentException if the given propertyOrFieldName is {@code null} or empty.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> filteredOn(String propertyOrFieldName,
                                                                                                    FilterOperator<?> filterOperator) {
     checkNotNull(filterOperator);
@@ -1617,6 +1640,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object with the filtered iterable under test
    * @throws IllegalArgumentException if the given condition is {@code null}.
    */
+  @CheckReturnValue
   public AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> filteredOn(Condition<? super ELEMENT> condition) {
     Filters<? extends ELEMENT> filter = filter((Iterable<? extends ELEMENT>) actual);
     Iterable<? extends ELEMENT> filteredIterable = filter.being(condition).get();
@@ -1666,6 +1690,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws AssertionError if the actual {@link Iterable} is empty.
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public ELEMENT_ASSERT first() {
     isNotEmpty();
     return toAssert(actual.iterator().next(), navigationDescription("check first element")); // TOD better description
@@ -1712,6 +1737,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws AssertionError if the actual {@link Iterable} is empty.
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public ELEMENT_ASSERT last() {
     isNotEmpty();
     return toAssert(lastElement(), navigationDescription("check last element"));
@@ -1771,6 +1797,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws AssertionError if the given index is out of bound.
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public ELEMENT_ASSERT element(int index) {
     isNotEmpty();
     assertThat(index).describedAs(navigationDescription("check index validity"))
@@ -1808,21 +1835,25 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   // one on raw types.
 
   @Override
+  @CheckReturnValue
   public SELF as(String description, Object... args) {
     return super.as(description, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF as(Description description) {
     return super.as(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(Description description) {
     return super.describedAs(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(String description, Object... args) {
     return super.describedAs(description, args);
   }
@@ -1948,26 +1979,31 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   }
 
   @Override
+  @CheckReturnValue
   public SELF overridingErrorMessage(String newErrorMessage, Object... args) {
     return super.overridingErrorMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     return super.usingDefaultComparator();
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     return super.usingComparator(customComparator);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withFailMessage(String newErrorMessage, Object... args) {
     return super.withFailMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withThreadDumpOnError() {
     return super.withThreadDumpOnError();
   }
@@ -1994,6 +2030,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws NullPointerException if the given {@code Iterable} is {@code null}.
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @CheckReturnValue
   public AbstractIterableSizeAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> size() {
     Preconditions.checkNotNull(actual, "Can not perform assertions on the size of a null iterable.");
     return new IterableSizeAssert(this, IterableUtil.sizeOf(actual));

--- a/src/main/java/org/assertj/core/api/AbstractListAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractListAssert.java
@@ -20,6 +20,7 @@ import org.assertj.core.description.Description;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.Lists;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -146,6 +147,7 @@ public abstract class AbstractListAssert<SELF extends AbstractListAssert<SELF, A
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super ELEMENT> customComparator) {
     super.usingElementComparator(customComparator);
     lists = new Lists(new ComparatorBasedComparisonStrategy(customComparator));
@@ -153,6 +155,7 @@ public abstract class AbstractListAssert<SELF extends AbstractListAssert<SELF, A
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     super.usingDefaultElementComparator();
     lists = Lists.instance();
@@ -173,21 +176,25 @@ public abstract class AbstractListAssert<SELF extends AbstractListAssert<SELF, A
   // raw types :(
 
   @Override
+  @CheckReturnValue
   public SELF as(String description, Object... args) {
     return super.as(description, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF as(Description description) {
     return super.as(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(Description description) {
     return super.describedAs(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(String description, Object... args) {
     return super.describedAs(description, args);
   }
@@ -313,26 +320,31 @@ public abstract class AbstractListAssert<SELF extends AbstractListAssert<SELF, A
   }
 
   @Override
+  @CheckReturnValue
   public SELF overridingErrorMessage(String newErrorMessage, Object... args) {
     return super.overridingErrorMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     return super.usingDefaultComparator();
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     return super.usingComparator(customComparator);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withFailMessage(String newErrorMessage, Object... args) {
     return super.withFailMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withThreadDumpOnError() {
     return super.withThreadDumpOnError();
   }

--- a/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.LongArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAssert<SELF>>
@@ -340,6 +341,7 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Long> customComparator) {
     this.arrays = new LongArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -347,6 +349,7 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = LongArrays.instance();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Longs;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -448,6 +449,7 @@ public abstract class AbstractLongAssert<SELF extends AbstractLongAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Long> customComparator) {
     super.usingComparator(customComparator);
     longs = new Longs(new ComparatorBasedComparisonStrategy(customComparator));
@@ -455,6 +457,7 @@ public abstract class AbstractLongAssert<SELF extends AbstractLongAssert<SELF>> 
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     longs = Longs.instance();

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Maps;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Preconditions;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -747,21 +748,25 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   // this is pretty sad, a better fix for that would be welcome
 
   @Override
+  @CheckReturnValue
   public SELF as(String description, Object... args) {
     return super.as(description, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF as(Description description) {
     return super.as(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(Description description) {
     return super.describedAs(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF describedAs(String description, Object... args) {
     return super.describedAs(description, args);
   }
@@ -887,26 +892,31 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   @Override
+  @CheckReturnValue
   public SELF overridingErrorMessage(String newErrorMessage, Object... args) {
     return super.overridingErrorMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     return super.usingDefaultComparator();
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super ACTUAL> customComparator) {
     return super.usingComparator(customComparator);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withFailMessage(String newErrorMessage, Object... args) {
     return super.withFailMessage(newErrorMessage, args);
   }
 
   @Override
+  @CheckReturnValue
   public SELF withThreadDumpOnError() {
     return super.withThreadDumpOnError();
   }
@@ -935,6 +945,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws NullPointerException if the given map is {@code null}.
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @CheckReturnValue
   public AbstractMapSizeAssert<SELF, ACTUAL, K, V> size() {
     Preconditions.checkNotNull(actual, "Can not perform assertions on the size of a null map.");
     return new MapSizeAssert(this, actual.size());

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -47,6 +47,7 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.OnFieldsComparator;
 import org.assertj.core.internal.RecursiveFieldByFieldComparator;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.IterableUtil;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.IntrospectionError;
@@ -1092,6 +1093,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws NullPointerException if the given comparator is {@code null}.
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super ELEMENT> elementComparator) {
     this.arrays = new ObjectArrays(new ComparatorBasedComparisonStrategy(elementComparator));
     // to have the same semantics on base assertions like isEqualTo, we need to use an iterable comparator comparing
@@ -1102,6 +1104,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = ObjectArrays.instance();
     return myself;
@@ -1171,6 +1174,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return {@code this} assertions object
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public <C> SELF usingComparatorForElementFieldsWithNames(Comparator<C> comparator,
                                                            String... elementPropertyOrFieldNames) {
     for (String elementPropertyOrField : elementPropertyOrFieldNames) {
@@ -1248,6 +1252,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return {@code this} assertions object
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public <C> SELF usingComparatorForElementFieldsWithType(Comparator<C> comparator, Class<C> type) {
     comparatorsForElementPropertyOrFieldTypes.put(type, comparator);
     return myself;
@@ -1279,6 +1284,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingFieldByFieldElementComparator() {
     return usingElementComparator(new FieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                              comparatorsForElementPropertyOrFieldTypes));
@@ -1327,6 +1333,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return {@code this} assertion object.
    * @since 2.5.0 / 3.5.0
    */
+  @CheckReturnValue
   public SELF usingRecursiveFieldByFieldElementComparator() {
     return usingElementComparator(new RecursiveFieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                                       comparatorsForElementPropertyOrFieldTypes));
@@ -1359,6 +1366,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingElementComparatorOnFields(String... fields) {
     return usingElementComparator(new OnFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                          comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1391,6 +1399,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public SELF usingElementComparatorIgnoringFields(String... fields) {
     return usingElementComparator(new IgnoringFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                                comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1438,6 +1447,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the array of extracted field/property values.
    * @throws IntrospectionError if no field or property exists with the given name
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> extracting(String fieldOrProperty) {
     Object[] values = FieldsOrPropertiesExtractor.extract(actual, byName(fieldOrProperty));
     return new ObjectArrayAssert<>(values);
@@ -1486,6 +1496,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the array of extracted field/property values.
    * @throws IntrospectionError if no field or property exists with the given name
    */
+  @CheckReturnValue
   public <P> ObjectArrayAssert<P> extracting(String fieldOrProperty, Class<P> extractingType) {
     @SuppressWarnings("unchecked")
     P[] values = (P[]) FieldsOrPropertiesExtractor.extract(actual, byName(fieldOrProperty));
@@ -1544,6 +1555,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IntrospectionError if one of the given name does not match a field or property in one of the initial
    *         Iterable's element.
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Tuple> extracting(String... propertiesOrFields) {
     Object[] values = FieldsOrPropertiesExtractor.extract(actual, byName(propertiesOrFields));
     Tuple[] result = Arrays.copyOf(values, values.length, Tuple[].class);
@@ -1591,6 +1603,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @param extractor the object transforming input object to desired one
    * @return a new assertion object whose object under test is the list of values extracted
    */
+  @CheckReturnValue
   public <U> ObjectArrayAssert<U> extracting(Extractor<? super ELEMENT, U> extractor) {
     U[] extracted = FieldsOrPropertiesExtractor.extract(actual, extractor);
 
@@ -1632,6 +1645,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @param extractor the object transforming input object to an Iterable of desired ones
    * @return a new assertion object whose object under test is the list of values extracted
    */
+  @CheckReturnValue
   public <U, C extends Collection<U>> ObjectArrayAssert<U> flatExtracting(Extractor<? super ELEMENT, C> extractor) {
     final List<C> extractedValues = FieldsOrPropertiesExtractor.extract(Arrays.asList(actual), extractor);
 
@@ -1672,6 +1686,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the list of values extracted
    * @throws IllegalArgumentException if one of the extracted property value was not an array or an iterable.
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> flatExtracting(String propertyName) {
     List<Object> extractedValues = newArrayList();
     List<?> extractedGroups = FieldsOrPropertiesExtractor.extract(Arrays.asList(actual), byName(propertyName));
@@ -1731,6 +1746,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IllegalArgumentException if no method exists with the given name, or method is not public, or method does
    *           return void, or method accepts arguments.
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> extractingResultOf(String method) {
     Object[] values = FieldsOrPropertiesExtractor.extract(actual, resultOf(method));
     return new ObjectArrayAssert<>(values);
@@ -1774,6 +1790,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IllegalArgumentException if no method exists with the given name, or method is not public, or method does
    *           return void, or method accepts arguments.
    */
+  @CheckReturnValue
   public <P> ObjectArrayAssert<P> extractingResultOf(String method, Class<P> extractingType) {
     @SuppressWarnings("unchecked")
     P[] values = (P[]) FieldsOrPropertiesExtractor.extract(actual, resultOf(method));
@@ -1808,11 +1825,13 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public SELF inHexadecimal() {
     return super.inHexadecimal();
   }
 
   @Override
+  @CheckReturnValue
   public SELF inBinary() {
     return super.inBinary();
   }
@@ -1874,6 +1893,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the array elements.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public SELF filteredOn(String propertyOrFieldName, Object expectedValue) {
     Iterable<? extends ELEMENT> filteredIterable = filter(actual).with(propertyOrFieldName, expectedValue).get();
     return (SELF) new ObjectArrayAssert<>(toArray(filteredIterable));
@@ -1917,6 +1937,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object with the filtered array under test
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the array elements.
    */
+  @CheckReturnValue
   public SELF filteredOnNull(String propertyOrFieldName) {
     // need to cast nulll to Object otherwise it calls :
     // filteredOn(String propertyOrFieldName, FilterOperation<?> filterOperation)
@@ -1989,6 +2010,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IllegalArgumentException if the given propertyOrFieldName is {@code null} or empty.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public SELF filteredOn(String propertyOrFieldName, FilterOperator<?> filterOperator) {
     checkNotNull(filterOperator);
     Filters<? extends ELEMENT> filter = filter(actual).with(propertyOrFieldName);
@@ -2029,6 +2051,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws IllegalArgumentException if the given condition is {@code null}.
    */
   @SuppressWarnings("unchecked")
+  @CheckReturnValue
   public SELF filteredOn(Condition<? super ELEMENT> condition) {
     Iterable<? extends ELEMENT> filteredIterable = filter(actual).being(condition).get();
     return (SELF) new ObjectArrayAssert<>(toArray(filteredIterable));

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.internal.TypeComparators;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.DoubleComparator;
 import org.assertj.core.util.FloatComparator;
 import org.assertj.core.util.introspection.IntrospectionError;
@@ -60,11 +61,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   }
 
   @Override
+  @CheckReturnValue
   public SELF as(Description description) {
     return super.as(description);
   }
 
   @Override
+  @CheckReturnValue
   public SELF as(String description, Object... args) {
     return super.as(description, args);
   }
@@ -337,6 +340,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @param propertiesOrFields the names of the properties and/or fields the comparator should be used for
    * @return {@code this} assertions object
    */
+  @CheckReturnValue
   public <T> SELF usingComparatorForFields(Comparator<T> comparator, String... propertiesOrFields) {
     for (String propertyOrField : propertiesOrFields) {
       comparatorByPropertyOrField.put(propertyOrField, comparator);
@@ -398,6 +402,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @param type the {@link java.lang.Class} of the type the comparator should be used for
    * @return {@code this} assertions object
    */
+  @CheckReturnValue
   public <T> SELF usingComparatorForType(Comparator<T> comparator, Class<T> type) {
     comparatorByType.put(type, comparator);
     return myself;
@@ -522,6 +527,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @return a new assertion object whose object under test is the array containing the extracted properties/fields values
    * @throws IntrospectionError if one of the given name does not match a field or property
    */
+  @CheckReturnValue
   public AbstractObjectArrayAssert<?, Object> extracting(String... propertiesOrFields) {
     Tuple values = byName(propertiesOrFields).extract(actual);
     return new ObjectArrayAssert<Object>(values.toArray());

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -28,6 +28,7 @@ import java.nio.file.spi.FileSystemProvider;
 import org.assertj.core.api.exception.PathsException;
 import org.assertj.core.api.exception.RuntimeIOException;
 import org.assertj.core.internal.Paths;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -204,6 +205,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * @return {@code this} assertion object.
    * @throws IllegalArgumentException if the given encoding is not supported on this platform.
    */
+  @CheckReturnValue
   public SELF usingCharset(String charsetName) {
     checkArgument(Charset.isSupported(charsetName), "Charset:<'%s'> is not supported on this system", charsetName);
     return usingCharset(Charset.forName(charsetName));
@@ -223,6 +225,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given charset is {@code null}.
    */
+  @CheckReturnValue
   public SELF usingCharset(Charset charset) {
 	this.charset = checkNotNull(charset, "The charset should not be null");
 	return myself;

--- a/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ShortArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractShortArrayAssert<SELF extends AbstractShortArrayAssert<SELF>>
@@ -340,6 +341,7 @@ public abstract class AbstractShortArrayAssert<SELF extends AbstractShortArrayAs
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingElementComparator(Comparator<? super Short> customComparator) {
     this.arrays = new ShortArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -347,6 +349,7 @@ public abstract class AbstractShortArrayAssert<SELF extends AbstractShortArrayAs
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public SELF usingDefaultElementComparator() {
     this.arrays = ShortArrays.instance();
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractShortAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Shorts;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -443,6 +444,7 @@ public abstract class AbstractShortAssert<SELF extends AbstractShortAssert<SELF>
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingComparator(Comparator<? super Short> customComparator) {
     super.usingComparator(customComparator);
     shorts = new Shorts(new ComparatorBasedComparisonStrategy(customComparator));
@@ -450,6 +452,7 @@ public abstract class AbstractShortAssert<SELF extends AbstractShortAssert<SELF>
   }
 
   @Override
+  @CheckReturnValue
   public SELF usingDefaultComparator() {
     super.usingDefaultComparator();
     shorts = Shorts.instance();

--- a/src/main/java/org/assertj/core/api/AtomicIntegerArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicIntegerArrayAssert.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.IntArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public class AtomicIntegerArrayAssert
@@ -504,6 +505,7 @@ public class AtomicIntegerArrayAssert
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public AtomicIntegerArrayAssert usingElementComparator(Comparator<? super Integer> customComparator) {
     this.arrays = new IntArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
@@ -511,6 +513,7 @@ public class AtomicIntegerArrayAssert
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public AtomicIntegerArrayAssert usingDefaultElementComparator() {
     this.arrays = IntArrays.instance();
     return myself;

--- a/src/main/java/org/assertj/core/api/AtomicIntegerAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicIntegerAssert.java
@@ -23,6 +23,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Integers;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public class AtomicIntegerAssert extends AbstractAssert<AtomicIntegerAssert, AtomicInteger> {
@@ -365,6 +366,7 @@ public class AtomicIntegerAssert extends AbstractAssert<AtomicIntegerAssert, Ato
   }
 
   @Override
+  @CheckReturnValue
   public AtomicIntegerAssert usingComparator(Comparator<? super AtomicInteger> customComparator) {
     super.usingComparator(customComparator);
     integers = new Integers(new ComparatorBasedComparisonStrategy(customComparator));
@@ -372,6 +374,7 @@ public class AtomicIntegerAssert extends AbstractAssert<AtomicIntegerAssert, Ato
   }
 
   @Override
+  @CheckReturnValue
   public AtomicIntegerAssert usingDefaultComparator() {
     super.usingDefaultComparator();
     integers = Integers.instance();

--- a/src/main/java/org/assertj/core/api/AtomicLongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicLongArrayAssert.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.LongArrays;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public class AtomicLongArrayAssert
@@ -504,6 +505,7 @@ public class AtomicLongArrayAssert
    * @return {@code this} assertion object.
    */
   @Override
+  @CheckReturnValue
   public AtomicLongArrayAssert usingElementComparator(Comparator<? super Long> customComparator) {
     this.arrays = new LongArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/assertj/core/api/AtomicLongAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicLongAssert.java
@@ -23,6 +23,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.Longs;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public class AtomicLongAssert extends AbstractAssert<AtomicLongAssert, AtomicLong> {
@@ -365,6 +366,7 @@ public class AtomicLongAssert extends AbstractAssert<AtomicLongAssert, AtomicLon
   }
 
   @Override
+  @CheckReturnValue
   public AtomicLongAssert usingComparator(Comparator<? super AtomicLong> customComparator) {
     super.usingComparator(customComparator);
     longs = new Longs(new ComparatorBasedComparisonStrategy(customComparator));
@@ -372,6 +374,7 @@ public class AtomicLongAssert extends AbstractAssert<AtomicLongAssert, AtomicLon
   }
 
   @Override
+  @CheckReturnValue
   public AtomicLongAssert usingDefaultComparator() {
     super.usingDefaultComparator();
     longs = Longs.instance();

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -49,6 +49,7 @@ import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.OnFieldsComparator;
 import org.assertj.core.internal.RecursiveFieldByFieldComparator;
 import org.assertj.core.internal.TypeComparators;
+import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.IterableUtil;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.IntrospectionError;
@@ -71,11 +72,13 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   @Override
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> as(Description description) {
     return super.as(description);
   }
 
   @Override
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> as(String description, Object... args) {
     return super.as(description, args);
   }
@@ -1206,6 +1209,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws NullPointerException if the given comparator is {@code null}.
    * @return {@code this} assertion object.
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingElementComparator(Comparator<? super T> elementComparator) {
     this.arrays = new ObjectArrays(new ComparatorBasedComparisonStrategy(elementComparator));
     objects = new Objects(new AtomicReferenceArrayElementComparisonStrategy<>(elementComparator));
@@ -1214,6 +1218,7 @@ public class AtomicReferenceArrayAssert<T>
 
   /** {@inheritDoc} */
   @Override
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingDefaultElementComparator() {
     this.arrays = ObjectArrays.instance();
     return myself;
@@ -1283,6 +1288,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertions object
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <C> AtomicReferenceArrayAssert<T> usingComparatorForElementFieldsWithNames(Comparator<C> comparator,
                                                         String... elementPropertyOrFieldNames) {
     for (String elementPropertyOrField : elementPropertyOrFieldNames) {
@@ -1360,6 +1366,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertions object
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <C> AtomicReferenceArrayAssert<T> usingComparatorForElementFieldsWithType(Comparator<C> comparator, Class<C> type) {
     comparatorsForElementPropertyOrFieldTypes.put(type, comparator);
     return myself;
@@ -1392,6 +1399,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertion object.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingFieldByFieldElementComparator() {
     return usingElementComparator(new FieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                              comparatorsForElementPropertyOrFieldTypes));
@@ -1440,6 +1448,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertion object.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingRecursiveFieldByFieldElementComparator() {
     return usingElementComparator(new RecursiveFieldByFieldComparator(comparatorsForElementPropertyOrFieldNames,
                                                                       comparatorsForElementPropertyOrFieldTypes));
@@ -1473,6 +1482,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertion object.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingElementComparatorOnFields(String... fields) {
     return usingElementComparator(new OnFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                          comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1506,6 +1516,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return {@code this} assertion object.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingElementComparatorIgnoringFields(String... fields) {
     return usingElementComparator(new IgnoringFieldsComparator(comparatorsForElementPropertyOrFieldNames,
                                                                comparatorsForElementPropertyOrFieldTypes, fields));
@@ -1554,6 +1565,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IntrospectionError if no field or property exists with the given name
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> extracting(String fieldOrProperty) {
     Object[] values = FieldsOrPropertiesExtractor.extract(array, byName(fieldOrProperty));
     return new ObjectArrayAssert<>(values);
@@ -1603,6 +1615,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IntrospectionError if no field or property exists with the given name
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <P> ObjectArrayAssert<P> extracting(String fieldOrProperty, Class<P> extractingType) {
     @SuppressWarnings("unchecked")
     P[] values = (P[]) FieldsOrPropertiesExtractor.extract(array, byName(fieldOrProperty));
@@ -1661,6 +1674,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IntrospectionError if one of the given name does not match a field or property in one of the initial
    *         Iterable's element.
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Tuple> extracting(String... propertiesOrFields) {
     Object[] values = FieldsOrPropertiesExtractor.extract(array, byName(propertiesOrFields));
     Tuple[] result = Arrays.copyOf(values, values.length, Tuple[].class);
@@ -1709,6 +1723,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return a new assertion object whose object under test is the list of values extracted
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <U> ObjectArrayAssert<U> extracting(Extractor<? super T, U> extractor) {
     U[] extracted = FieldsOrPropertiesExtractor.extract(array, extractor);
 
@@ -1751,6 +1766,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return a new assertion object whose object under test is the list of values extracted
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <U, C extends Collection<U>> ObjectArrayAssert<U> flatExtracting(Extractor<? super T, C> extractor) {
     final List<C> extractedValues = FieldsOrPropertiesExtractor.extract(Arrays.asList(array), extractor);
 
@@ -1792,6 +1808,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IllegalArgumentException if one of the extracted property value was not an array or an iterable.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> flatExtracting(String propertyName) {
     List<Object> extractedValues = newArrayList();
     List<?> extractedGroups = FieldsOrPropertiesExtractor.extract(Arrays.asList(array), byName(propertyName));
@@ -1855,6 +1872,7 @@ public class AtomicReferenceArrayAssert<T>
    *           return void, or method accepts arguments.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public ObjectArrayAssert<Object> extractingResultOf(String method) {
     Object[] values = FieldsOrPropertiesExtractor.extract(array, resultOf(method));
     return new ObjectArrayAssert<>(values);
@@ -1902,6 +1920,7 @@ public class AtomicReferenceArrayAssert<T>
    *           return void, or method accepts arguments.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public <P> ObjectArrayAssert<P> extractingResultOf(String method, Class<P> extractingType) {
     @SuppressWarnings("unchecked")
     P[] values = (P[]) FieldsOrPropertiesExtractor.extract(array, resultOf(method));
@@ -1939,11 +1958,13 @@ public class AtomicReferenceArrayAssert<T>
    * @since 2.7.0 / 3.7.0
    */
   @Override
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> inHexadecimal() {
     return super.inHexadecimal();
   }
 
   @Override
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> inBinary() {
     return super.inBinary();
   }
@@ -2005,6 +2026,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the array elements.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> filteredOn(String propertyOrFieldName, Object expectedValue) {
     Iterable<? extends T> filteredIterable = filter(array).with(propertyOrFieldName, expectedValue).get();
     return new AtomicReferenceArrayAssert<>(new AtomicReferenceArray<T>(toArray(filteredIterable)));
@@ -2049,6 +2071,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IntrospectionError if the given propertyOrFieldName can't be found in one of the array elements.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> filteredOnNull(String propertyOrFieldName) {
     // need to cast nulll to Object otherwise it calls :
     // filteredOn(String propertyOrFieldName, FilterOperation<?> filterOperation)
@@ -2121,6 +2144,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IllegalArgumentException if the given propertyOrFieldName is {@code null} or empty.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> filteredOn(String propertyOrFieldName, FilterOperator<?> filterOperator) {
     checkNotNull(filterOperator);
     Filters<? extends T> filter = filter(array).with(propertyOrFieldName);
@@ -2161,6 +2185,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws IllegalArgumentException if the given condition is {@code null}.
    * @since 2.7.0 / 3.7.0
    */
+  @CheckReturnValue
   public AtomicReferenceArrayAssert<T> filteredOn(Condition<? super T> condition) {
     Iterable<? extends T> filteredIterable = filter(array).being(condition).get();
     return new AtomicReferenceArrayAssert<>(new AtomicReferenceArray<T>(toArray(filteredIterable)));

--- a/src/main/java/org/assertj/core/api/IterableSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableSizeAssert.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 //@format:off
 public class IterableSizeAssert<T> extends AbstractIterableSizeAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> {
 //@format:on
@@ -24,6 +26,7 @@ public class IterableSizeAssert<T> extends AbstractIterableSizeAssert<IterableAs
     this.source = source;
   }
 
+  @CheckReturnValue
   public AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> returnToIterable() {
     return source;
   }

--- a/src/main/java/org/assertj/core/api/MapSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/MapSizeAssert.java
@@ -14,6 +14,8 @@ package org.assertj.core.api;
 
 import java.util.Map;
 
+import org.assertj.core.util.CheckReturnValue;
+
 public class MapSizeAssert<KEY, VALUE> extends AbstractMapSizeAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
 
   private AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> source;
@@ -24,6 +26,7 @@ public class MapSizeAssert<KEY, VALUE> extends AbstractMapSizeAssert<MapAssert<K
   }
 
   @Override
+  @CheckReturnValue
   public AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> returnToMap() {
     return source;
   }


### PR DESCRIPTION
… with* and as/describedAs (closes #914)
