### PR TITLE
When extracting a property using a String expression, I would find it…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -650,7 +650,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    */
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> extracting(String propertyOrField) {
     List<Object> values = FieldsOrPropertiesExtractor.extract(actual, byName(propertyOrField));
-    return newListAssertInstance(values);
+    return newListAssertInstance(values).as(propertyOrField);
   }
 
   /**


### PR DESCRIPTION
… very useful if that String expression was immediately shown in the description


