### PR TITLE
Add a new AssertionMatcher that reuses AssertJ assertions

### DIFF
--- a/src/main/java/org/assertj/core/matcher/AssertionMatcher.java
+++ b/src/main/java/org/assertj/core/matcher/AssertionMatcher.java
@@ -27,7 +27,7 @@ import org.hamcrest.Matcher;
  *
  * <p>
  * Example with Mockito use case:
- * <pre><code class='java'>verify(customerRepository).save(argThat(new AssertionMatcher&lt;Customer&gt;() {
+ * <pre><code class='java'> verify(customerRepository).save(argThat(new AssertionMatcher&lt;Customer&gt;() {
  *   &#64;Override
  *   public void assertion(Customer actual) throws AssertionError {
  *     assertThat(actual)
@@ -76,7 +76,7 @@ public abstract class AssertionMatcher<T> extends BaseMatcher<T> {
     if (lastError != null) {
       description.appendText("AssertionError with message: ");
       description.appendText(lastError.getMessage());
-      description.appendText("\n\nStacktrace was: ");
+      description.appendText(String.format("%n%nStacktrace was: "));
       description.appendText(Throwables.getStackTrace(lastError));
     }
   }

--- a/src/main/java/org/assertj/core/matcher/AssertionMatcher.java
+++ b/src/main/java/org/assertj/core/matcher/AssertionMatcher.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.matcher;
+
+import org.assertj.core.util.Throwables;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+/**
+ * Generic Hamcrest {@link Matcher} that reuses AssertJ assertions.
+ *
+ * Overriding classes should only override {@link AssertionMatcher#assertion(Object)}
+ * method. {@link Matcher#matches(Object)} and {@link Matcher#describeTo(Description)}
+ * are provided. If matcher fails it will provide description that contains
+ * stacktrace of a failed assertion.
+ *
+ * <p>
+ * Example with Mockito use case:
+ * <pre><code class='java'>verify(customerRepository).save(argThat(new AssertionMatcher&lt;Customer&gt;() {
+ *   &#64;Override
+ *   public void assertion(Customer actual) throws AssertionError {
+ *     assertThat(actual)
+ *       .hasName(&quot;John&quot;)
+ *       .hasAge(30);
+ *   }
+ * }));</code></pre>
+ * </p>
+ *
+ * @author Tomasz Kalkosiński
+ */
+public abstract class AssertionMatcher<T> extends BaseMatcher<T> {
+  private AssertionError lastError;
+
+  /**
+   * {@inheritDoc}
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public boolean matches(Object argument) {
+    T actual = (T) argument;
+    try {
+      assertion(actual);
+      return true;
+    } catch (AssertionError e) {
+      lastError = e;
+      return false;
+    }
+  }
+
+  /**
+   * Use assertions with <val>actual</val>.
+   *
+   * If any assertion fails matcher will also fail.
+   *
+   * @param actual assertion object
+   * @throws AssertionError if the assertion object fails assertion
+   */
+  public abstract void assertion(T actual) throws AssertionError;
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void describeTo(Description description) {
+    if (lastError != null) {
+      description.appendText("AssertionError with message: ");
+      description.appendText(lastError.getMessage());
+      description.appendText("\n\nStacktrace was: ");
+      description.appendText(Throwables.getStackTrace(lastError));
+    }
+  }
+}

--- a/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
+++ b/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
@@ -74,10 +74,9 @@ public class AssertionMatcher_matches_Test {
     verify(description).appendText(argThat(new ArgumentMatcher<String>() {
       @Override public boolean matches(String s) {
         return s.contains("org.junit.ComparisonFailure: expected:<[0]> but was:<[1]>")
-            && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:20)")
-            && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:17)")
-            && s.contains("at org.assertj.core.matcher.AssertionMatcher.matches(AssertionMatcher.java:53)")
-            && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test.should_fill_description_when_assertion_fails(AssertionMatcher_matches_Test.java:68)");
+            && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:")
+            && s.contains("at org.assertj.core.matcher.AssertionMatcher.matches(AssertionMatcher.java:")
+            && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test.should_fill_description_when_assertion_fails(AssertionMatcher_matches_Test.java:");
       }
     }));
   }

--- a/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
+++ b/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
@@ -1,0 +1,70 @@
+package org.assertj.core.matcher;
+
+import org.assertj.core.internal.Failures;
+import org.assertj.core.util.Throwables;
+import org.hamcrest.Description;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AssertionMatcher_matches_Test {
+  private static final Integer ZERO = 0;
+  private static final Integer ONE = 1;
+
+  private final AssertionMatcher<Integer> isZeroMatcher = new AssertionMatcher<Integer>() {
+    @Override
+    public void assertion(Integer actual) throws AssertionError {
+      assertThat(actual).isZero();
+    }
+  };
+
+  @Test
+  public void should_pass_when_assertion_passes() {
+    assertThat(isZeroMatcher.matches(ZERO)).isTrue();
+  }
+
+  @Test
+  public void should_not_fill_description_when_assertion_passes() {
+    Description description = mock(Description.class);
+
+    assertThat(isZeroMatcher.matches(ZERO)).isTrue();
+
+    isZeroMatcher.describeTo(description);
+    verifyZeroInteractions(description);
+  }
+
+  @Test
+  public void should_fail_when_assertion_fails() {
+    assertThat(isZeroMatcher.matches(ONE)).isFalse();
+  }
+
+  /**
+   * Stacktrace is not complete here in this test, because {@link Failures} filters out
+   * all stacktrace frames that contain {@link Throwables#ORG_ASSERTJ} package name.
+   *
+   * These are lines filtered out by {@link Failures}:
+   *
+   * at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:19)
+   * at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:15)
+   * at org.assertj.core.matcher.AssertionMatcher.matches(AssertionMatcher.java:54)
+   * at org.assertj.core.matcher.AssertionMatcher_matches_Test.should_fill_description_when_assertion_fails(AssertionMatcher_matches_Test.java:53)
+   */
+  @Test
+  public void should_fill_description_when_assertion_fails() {
+    Description description = mock(Description.class);
+
+    assertThat(isZeroMatcher.matches(ONE)).isFalse();
+
+    isZeroMatcher.describeTo(description);
+    verify(description).appendText("AssertionError with message: ");
+    verify(description).appendText("expected:<[0]> but was:<[1]>");
+    verify(description).appendText("\n\nStacktrace was: ");
+    verify(description).appendText(argThat(new ArgumentMatcher<String>() {
+      @Override public boolean matches(String s) {
+        return s.contains("org.junit.ComparisonFailure: expected:<[0]> but was:<[1]>");
+      }
+    }));
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #926 - AssertionMatcher implementation proposal
* Unit tests : YES
* Javadoc with a code example (API only) : YES

I'm not quite happy with a test AssertionMatcher_matches_Test#should_fill_description_when_assertion_fails. I've explained in code comments. I feel like I can't alter static Failures instance in this test because it would alter other tests.

Please review my contribution. Thanks!


