### PR TITLE
New map assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -482,6 +482,94 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   /**
+   * Verifies that the actual map contains an entry with key satisfying {@code keyCondition}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * Map&lt;TolkienCharacter, Ring&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(galadriel, nenya);
+   * ringBearers.put(gandalf, narya);
+   * ringBearers.put(elrond, vilya);
+   * ringBearers.put(frodo, oneRing);
+   *
+   * Condition&lt;TolkienCharacter&gt; isMan =
+   *   new Condition&lt;TolkienCharacter&gt;("is man") {
+   *     public boolean matches(TolkienCharacter value) {
+   *       return value.getRace() == MAN;
+   *     }
+   *   };
+   *
+   * Condition&lt;TolkienCharacter&gt; isOrc =
+   *   new Condition&lt;TolkienCharacter&gt;("is orc") {
+   *     public boolean matches(TolkienCharacter value) {
+   *       return value.getRace() == ORC;
+   *     }
+   *   };
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).hasKeySatisfying(isOrc);
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).hasKeySatisfying(isMan);
+   * </code></pre>
+   *
+   * @param keyCondition the condition for key search.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no key matching given {@code keyCondition}.
+   * @since 2.8.0
+   */
+  public SELF hasKeySatisfying(Condition<? super K> keyCondition) {
+    maps.assertHasKeySatisfying(info, actual, keyCondition);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual map contains an entry with value satisfying {@code valueCondition}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap<>();
+   * ringBearers.put(nenya, galadriel);
+   * ringBearers.put(narya, gandalf);
+   * ringBearers.put(vilya, elrond);
+   * ringBearers.put(oneRing, frodo);
+   *
+   * Condition&lt;TolkienCharacter&gt; isMan =
+   *   new Condition&lt;TolkienCharacter&gt;("is man") {
+   *     public boolean matches(TolkienCharacter value) {
+   *       return value.getRace() == MAN;
+   *     }
+   *   };
+   *
+   * Condition&lt;TolkienCharacter&gt; isOrc =
+   *   new Condition&lt;TolkienCharacter&gt;("is orc") {
+   *     public boolean matches(TolkienCharacter value) {
+   *       return value.getRace() == ORC;
+   *     }
+   *   };
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).hasValueSatisfying(isOrc);
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).hasValueSatisfying(isMan);
+   * </code></pre>
+   *
+   * @param valueCondition the condition for value search.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no value matching given {@code valueCondition}.
+   * @since 2.8.0
+   */
+  public SELF hasValueSatisfying(Condition<? super V> valueCondition) {
+    maps.assertHasValueSatisfying(info, actual, valueCondition);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual map does not contain the given entries.
    * <p>
    * Example :

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -396,6 +396,92 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   /**
+   * Verifies that the actual map contains an entry satisfying given {@code entryCondition}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * Map&lt;TolkienCharacter, Ring&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(galadriel, nenya);
+   * ringBearers.put(gandalf, narya);
+   * ringBearers.put(elrond, vilya);
+   * ringBearers.put(frodo, oneRing);
+   *
+   * Condition&lt;Map.Entry&lt;TolkienCharacter, Ring&gt;&gt; oneRingManBearer =
+   *   new Condition&lt;Map.Entry&lt;TolkienCharacter, Ring&gt;&gt;("One ring man bearer") {
+   *     public boolean matches(Map.Entry&lt;TolkienCharacter, Ring&gt; entry) {
+   *       return entry.getKey().getRace() == MAN && entry.getValue() == oneRing;
+   *     }
+   *   };
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).hasEntrySatisfying(oneRingManBearer);
+   *
+   * ringBearers.put(isildur, oneRing);
+   *
+   * // now assertion will pass
+   * assertThat(ringBearers).hasEntrySatisfying(oneRingManBearer);
+   * </code></pre>
+   *
+   * @param entryCondition the condition for searching entry.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no entry matching given {@code entryCondition}.
+   * @since 2.8.0
+   */
+  public SELF hasEntrySatisfying(Condition<? super Map.Entry<K, V>> entryCondition) {
+    maps.assertHasEntrySatisfying(info, actual, entryCondition);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual map contains an entry with key satisfying {@code keyCondition} and value satisfying {@code valueCondition}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * Map&lt;TolkienCharacter, Ring&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(galadriel, nenya);
+   * ringBearers.put(gandalf, narya);
+   * ringBearers.put(elrond, vilya);
+   * ringBearers.put(frodo, oneRing);
+   *
+   * Condition&lt;TolkienCharacter&gt; isMan =
+   *   new Condition&lt;TolkienCharacter&gt;("is man") {
+   *     public boolean matches(TolkienCharacter value) {
+   *       return value.getRace() == MAN;
+   *     }
+   *   };
+   *
+   * Condition&lt;Ring&gt; oneRingBearer =
+   *   new Condition&lt;Ring&gt;("One ring bearer") {
+   *     public boolean matches(Ring value) {
+   *       return value == oneRing;
+   *     }
+   *   };
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).hasEntrySatisfying(isMan, oneRingBearer);
+   *
+   * ringBearers.put(isildur, oneRing);
+   *
+   * // now assertion will pass
+   * assertThat(ringBearers).hasEntrySatisfying(isMan, oneRingBearer);
+   * </code></pre>
+   *
+   * @param keyCondition the condition for entry key.
+   * @param valueCondition the condition for entry value.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if any of the given conditions is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no entry matching given {@code keyCondition} and {@code valueCondition}.
+   * @since 2.8.0
+   */
+  public SELF hasEntrySatisfying(Condition<? super K> keyCondition, Condition<? super V> valueCondition) {
+    maps.assertHasEntrySatisfyingConditions(info, actual, keyCondition, valueCondition);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual map does not contain the given entries.
    * <p>
    * Example :

--- a/src/main/java/org/assertj/core/error/ShouldContainEntry.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainEntry.java
@@ -24,7 +24,7 @@ public class ShouldContainEntry extends BasicErrorMessageFactory {
   /**
    * Creates a new </code>{@link ShouldContainEntry}</code>.
    *
-   * @param actual the actual value in the failed assertion.
+   * @param actual the actual map in the failed assertion.
    * @param entryCondition entry condition.
    * @return the created {@code ErrorMessageFactory}.
    */
@@ -35,7 +35,7 @@ public class ShouldContainEntry extends BasicErrorMessageFactory {
   /**
    * Creates a new </code>{@link ShouldContainEntry}</code>.
    *
-   * @param actual the actual value in the failed assertion.
+   * @param actual the actual map in the failed assertion.
    * @param keyCondition key condition.
    * @param valueCondition value condition.
    * @return the created {@code ErrorMessageFactory}.
@@ -46,11 +46,11 @@ public class ShouldContainEntry extends BasicErrorMessageFactory {
   }
 
   private <K, V> ShouldContainEntry(Map<K, V> actual, Condition<?> entryCondition) {
-    super("%nExpecting%n <%s>%nto have an entry satisfying%n <%s>", actual, entryCondition);
+    super("%nExpecting:%n <%s>%nto contain an entry satisfying:%n <%s>", actual, entryCondition);
   }
 
   private <K, V> ShouldContainEntry(Map<K, V> actual, Condition<? super K> keyCondition, Condition<? super V> valueCondition) {
-    super("%nExpecting%n <%s>%nto have an entry satisfying%nkey condition%n <%s>%nand value condition%n <%s>",
+    super("%nExpecting:%n <%s>%nto contain an entry satisfying:%nkey condition%n <%s>%nand value condition%n <%s>",
           actual, keyCondition, valueCondition);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldContainEntry.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainEntry.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.Map;
+
+import org.assertj.core.api.Condition;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a map contains an entry..
+ */
+public class ShouldContainEntry extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link ShouldContainEntry}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param entryCondition entry condition.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static <K, V> ErrorMessageFactory shouldContainEntry(Map<K, V> actual, Condition<?> entryCondition) {
+    return new ShouldContainEntry(actual, entryCondition);
+  }
+
+  /**
+   * Creates a new </code>{@link ShouldContainEntry}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param keyCondition key condition.
+   * @param valueCondition value condition.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static <K, V> ErrorMessageFactory shouldContainEntry(Map<K, V> actual, Condition<? super K> keyCondition,
+                                                              Condition<? super V> valueCondition) {
+    return new ShouldContainEntry(actual, keyCondition, valueCondition);
+  }
+
+  private <K, V> ShouldContainEntry(Map<K, V> actual, Condition<?> entryCondition) {
+    super("%nExpecting%n <%s>%nto have an entry satisfying%n <%s>", actual, entryCondition);
+  }
+
+  private <K, V> ShouldContainEntry(Map<K, V> actual, Condition<? super K> keyCondition, Condition<? super V> valueCondition) {
+    super("%nExpecting%n <%s>%nto have an entry satisfying%nkey condition%n <%s>%nand value condition%n <%s>",
+          actual, keyCondition, valueCondition);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldContainKey.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainKey.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.Condition;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a map contains a key..
+ */
+public class ShouldContainKey extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link ShouldContainKey}</code>.
+   *
+   * @param actual the actual map in the failed assertion.
+   * @param keyCondition key condition.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainKey(Object actual, Condition<?> keyCondition) {
+    return new ShouldContainKey(actual, keyCondition);
+  }
+
+  private ShouldContainKey(Object actual, Condition<?> keyCondition) {
+    super("%nExpecting:%n <%s>%nto contain key satisfying:%n <%s>", actual, keyCondition);
+  }
+
+}

--- a/src/main/java/org/assertj/core/error/ShouldContainValue.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainValue.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.api.Condition;
+
 /**
  * Creates an error message indicating that an assertion that verifies a map contains a value.
  * 
@@ -28,7 +30,22 @@ public class ShouldContainValue extends BasicErrorMessageFactory {
     return new ShouldContainValue(actual, value);
   }
 
+  /**
+   * Creates a new </code>{@link ShouldContainValue}</code>.
+   *
+   * @param actual the actual map in the failed assertion.
+   * @param valueCondition value condition.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainValue(Object actual, Condition<?> valueCondition) {
+    return new ShouldContainValue(actual, valueCondition);
+  }
+
   private ShouldContainValue(Object actual, Object value) {
     super("%nExpecting:%n  <%s>%nto contain value:%n  <%s>", actual, value);
+  }
+
+  private ShouldContainValue(Object actual, Condition<?> valueCondition) {
+    super("%nExpecting:%n <%s>%nto contain value satisfying:%n <%s>", actual, valueCondition);
   }
 }

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.error.ShouldContainOnlyKeys.shouldContainOnlyKeys;
@@ -260,7 +261,8 @@ public class Maps {
   }
 
   /**
-   * Verifies that the given {@code Map} contains an entry with key satisfying {@code keyCondition} and value satisfying {@code valueCondition}.
+   * Verifies that the given {@code Map} contains an entry with key satisfying {@code keyCondition}
+   * and value satisfying {@code valueCondition}.
    *
    * @param info contains information about the assertion.
    * @param actual the given {@code Map}.
@@ -285,6 +287,54 @@ public class Maps {
     }
 
     throw failures.failure(info, shouldContainEntry(actual, keyCondition, valueCondition));
+  }
+
+  /**
+   * Verifies that the given {@code Map} contains an entry with key satisfying {@code keyCondition}.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param keyCondition the condition for key search.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no key matching given {@code keyCondition}.
+   * @since 2.8.0
+   */
+  public <K> void assertHasKeySatisfying(AssertionInfo info, Map<K, ?> actual, Condition<? super K> keyCondition) {
+    assertNotNull(info, actual);
+    conditions.assertIsNotNull(keyCondition);
+
+    for (K key : actual.keySet()) {
+      if (keyCondition.matches(key)) {
+        return;
+      }
+    }
+
+    throw failures.failure(info, shouldContainKey(actual, keyCondition));
+  }
+
+  /**
+   * Verifies that the given {@code Map} contains an entry with value satisfying {@code valueCondition}.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param valueCondition the condition for value search.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no value matching given {@code valueCondition}.
+   * @since 2.8.0
+   */
+  public <V> void assertHasValueSatisfying(AssertionInfo info, Map<?, V> actual, Condition<? super V> valueCondition) {
+    assertNotNull(info, actual);
+    conditions.assertIsNotNull(valueCondition);
+
+    for (V value : actual.values()) {
+      if (valueCondition.matches(value)) {
+        return;
+      }
+    }
+
+    throw failures.failure(info, shouldContainValue(actual, valueCondition));
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -17,6 +17,7 @@ import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
@@ -232,6 +233,58 @@ public class Maps {
     conditions.assertIsNotNull(valueCondition);
     V value = actual.get(key);
     if (!valueCondition.matches(value)) throw failures.failure(info, elementsShouldBe(actual, value, valueCondition));
+  }
+
+  /**
+   * Verifies that the given {@code Map} contains an entry satisfying given {@code entryCondition}.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param entryCondition the condition for searching entry.
+   * @throws NullPointerException if the given condition is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no entry matching given {@code entryCondition}.
+   * @since 2.8.0
+   */
+  public <K, V> void assertHasEntrySatisfying(AssertionInfo info, Map<K, V> actual,
+                                              Condition<? super Map.Entry<K, V>> entryCondition) {
+    assertNotNull(info, actual);
+    conditions.assertIsNotNull(entryCondition);
+    for (Map.Entry<K, V> entry : actual.entrySet()) {
+      if (entryCondition.matches(entry)) {
+        return;
+      }
+    }
+
+    throw failures.failure(info, shouldContainEntry(actual, entryCondition));
+  }
+
+  /**
+   * Verifies that the given {@code Map} contains an entry with key satisfying {@code keyCondition} and value satisfying {@code valueCondition}.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param keyCondition the condition for entry key.
+   * @param valueCondition the condition for entry value.
+   * @throws NullPointerException if any of the given conditions is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if there is no entry matching given {@code keyCondition} and {@code valueCondition}.
+   * @since 2.8.0
+   */
+  public <K, V> void assertHasEntrySatisfyingConditions(AssertionInfo info, Map<K, V> actual,
+                                                        Condition<? super K> keyCondition,
+                                                        Condition<? super V> valueCondition) {
+    assertNotNull(info, actual);
+    conditions.assertIsNotNull(keyCondition);
+    conditions.assertIsNotNull(valueCondition);
+
+    for (Map.Entry<K, V> entry : actual.entrySet()) {
+      if (keyCondition.matches(entry.getKey()) && valueCondition.matches(entry.getValue())) {
+        return;
+      }
+    }
+
+    throw failures.failure(info, shouldContainEntry(actual, keyCondition, valueCondition));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_condition_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_condition_Test.java
@@ -12,23 +12,17 @@
  */
 package org.assertj.core.api.map;
 
-import static org.assertj.core.data.MapEntry.entry;
-import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
-import org.assertj.core.data.MapEntry;
 
 /**
- * Tests for <code>{@link MapAssert#hasEntrySatisfying(Object, Condition)}</code>.
- *
- * @author Filip Hrisafov
+ * Tests for <code>{@link MapAssert#hasEntrySatisfying(Condition)}</code>.
  */
-public class MapAssert_hasEntrySatisfying_Test extends MapAssertBaseTest {
+public class MapAssert_hasEntrySatisfying_with_condition_Test extends MapAssertBaseTest {
 
-  final MapEntry<String, String>[] entries = array(entry("key1", "value1"));
 
   private final Condition<Object> condition = new Condition<Object>() {
     @Override
@@ -40,11 +34,11 @@ public class MapAssert_hasEntrySatisfying_Test extends MapAssertBaseTest {
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.hasEntrySatisfying("key1", condition);
+    return assertions.hasEntrySatisfying(condition);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(maps).assertHasEntrySatisfying(getInfo(assertions), getActual(assertions), "key1", condition);
+    verify(maps).assertHasEntrySatisfying(getInfo(assertions), getActual(assertions), condition);
   }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_key_and_condition_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_key_and_condition_Test.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+
+/**
+ * Tests for <code>{@link MapAssert#hasEntrySatisfying(Object, Condition)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class MapAssert_hasEntrySatisfying_with_key_and_condition_Test extends MapAssertBaseTest {
+
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"));
+
+  private final Condition<Object> condition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.hasEntrySatisfying("key1", condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertHasEntrySatisfying(getInfo(assertions), getActual(assertions), "key1", condition);
+  }
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_key_and_value_conditions_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasEntrySatisfying_with_key_and_value_conditions_Test.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+
+/**
+ * Tests for <code>{@link MapAssert#hasEntrySatisfying(Condition, Condition)}</code>.
+ */
+public class MapAssert_hasEntrySatisfying_with_key_and_value_conditions_Test extends MapAssertBaseTest {
+
+  private final Condition<Object> keyCondition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  private final Condition<Object> valueCondition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.hasEntrySatisfying(keyCondition, valueCondition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertHasEntrySatisfyingConditions(getInfo(assertions), getActual(assertions), keyCondition, valueCondition);
+  }
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasKeySatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasKeySatisfying_Test.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+
+/**
+ * Tests for <code>{@link MapAssert#hasKeySatisfying(Condition)}</code>.
+ */
+public class MapAssert_hasKeySatisfying_Test extends MapAssertBaseTest {
+
+  private final Condition<Object> condition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.hasKeySatisfying(condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertHasKeySatisfying(getInfo(assertions), getActual(assertions), condition);
+  }
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_hasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_hasValueSatisfying_Test.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+
+/**
+ * Tests for <code>{@link MapAssert#hasValueSatisfying(Condition)}</code>.
+ */
+public class MapAssert_hasValueSatisfying_Test extends MapAssertBaseTest {
+
+  private final Condition<Object> condition = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      //return is not important as we are testing the invoking and the internal effects
+      return false;
+    }
+  };
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.hasValueSatisfying(condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertHasValueSatisfying(getInfo(assertions), getActual(assertions), condition);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
@@ -12,6 +12,11 @@
  */
 package org.assertj.core.error;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.test.Maps.mapOf;
+
 import org.assertj.core.api.TestCondition;
 import org.assertj.core.description.Description;
 import org.assertj.core.description.TextDescription;
@@ -19,11 +24,6 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
 
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
-import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
-import static org.assertj.core.test.Maps.mapOf;
 
 /**
  * Tests for <code>{@link ShouldContainEntry#create(Description)}</code>.
@@ -35,8 +35,10 @@ public class ShouldContainEntry_create_Test {
     Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
     ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test condition"));
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo(String.format("[Test] %nExpecting%n <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n"
-                                                  + "to have an entry satisfying%n <test condition>"));
+    assertThat(message).isEqualTo(String.format("[Test] %nExpecting:%n" +
+                                                  " <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
+                                                  "to contain an entry satisfying:%n" +
+                                                  " <test condition>"));
   }
 
   @Test
@@ -45,8 +47,11 @@ public class ShouldContainEntry_create_Test {
     ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test key condition"),
                                                      new TestCondition<>("test value condition"));
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-    assertThat(message).isEqualTo(String.format("[Test] %nExpecting%n <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n"
-                                                  + "to have an entry satisfying%nkey condition%n <test key condition>%n"
-                                                  + "and value condition%n <test value condition>"));
+    assertThat(message).isEqualTo(String.format("[Test] %nExpecting:%n <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
+                                                  "to contain an entry satisfying:%n" +
+                                                  "key condition%n" +
+                                                  " <test key condition>%n" +
+                                                  "and value condition%n" +
+                                                  " <test value condition>"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.TestCondition;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.test.Maps.mapOf;
+
+/**
+ * Tests for <code>{@link ShouldContainEntry#create(Description)}</code>.
+ */
+public class ShouldContainEntry_create_Test {
+
+  @Test
+  public void should_create_error_message_with_entry_condition() {
+    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test condition"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %nExpecting%n <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n"
+                                                  + "to have an entry satisfying%n <test condition>"));
+  }
+
+  @Test
+  public void should_create_error_message_with_key_and_value_conditions() {
+    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test key condition"),
+                                                     new TestCondition<>("test value condition"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %nExpecting%n <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n"
+                                                  + "to have an entry satisfying%nkey condition%n <test key condition>%n"
+                                                  + "and value condition%n <test value condition>"));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainKey_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainKey_create_Test.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
+import static org.assertj.core.test.Maps.mapOf;
+
+import java.util.Map;
+
+import org.assertj.core.api.TestCondition;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import static org.assertj.core.data.MapEntry.entry;
+
+/**
+ * Tests for <code>{@link ShouldContainKey#create(Description)}</code>.
+ */
+public class ShouldContainKey_create_Test {
+
+  @Test
+  public void should_create_error_message_with_key_condition() {
+    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainKey(map, new TestCondition<>("test condition"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %nExpecting:%n" +
+                                                  " <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
+                                                  "to contain key satisfying:%n" +
+                                                  " <test condition>"));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainValue_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainValue_create_Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.test.Maps.mapOf;
 
 import java.util.Map;
 
+import org.assertj.core.api.TestCondition;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
@@ -34,14 +35,25 @@ public class ShouldContainValue_create_Test {
 
   @Test
   public void should_create_error_message() {
-	Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
-	ErrorMessageFactory factory = shouldContainValue(map, "VeryOld");
-	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo(String.format("[Test] %n" +
-	                              "Expecting:%n" +
-	                              "  <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
-	                              "to contain value:%n" +
-	                              "  <\"VeryOld\">"));
+    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainValue(map, "VeryOld");
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %n" +
+                                                  "Expecting:%n" +
+                                                  "  <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
+                                                  "to contain value:%n" +
+                                                  "  <\"VeryOld\">"));
   }
 
+  @Test
+  public void should_create_error_message_with_value_condition() {
+    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainValue(map, new TestCondition<>("test condition"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format("[Test] %n" +
+                                                  "Expecting:%n" +
+                                                  " <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
+                                                  "to contain value satisfying:%n" +
+                                                  " <test condition>"));
+  }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_condition_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_condition_Test.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Condition;
+import org.assertj.core.internal.Maps;
+import org.assertj.core.internal.MapsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Maps#assertHasEntrySatisfying(AssertionInfo, Map, Condition)}</code>.
+ */
+public class Maps_assertHasEntrySatisfying_with_condition_Test extends MapsBaseTest {
+
+  private Condition<Map.Entry<String, String>> greenColorCondition = new Condition<Map.Entry<String, String>>("greenColorCondition") {
+    @Override
+    public boolean matches(Map.Entry<String, String> entry) {
+      return entry.getKey().equals("color") && entry.getValue().equals("green");
+    }
+  };
+
+  private Condition<Map.Entry<String, String>> blackColorCondition = new Condition<Map.Entry<String, String>>("greenColorCondition") {
+    @Override
+    public boolean matches(Map.Entry<String, String> entry) {
+      return entry.getKey().equals("color") && entry.getValue().equals("black");
+    }
+  };
+
+  @Test
+  public void should_fail_if_condition_is_null() {
+    thrown.expectNullPointerException("The condition to evaluate should not be null");
+    maps.assertHasEntrySatisfying(someInfo(), actual, null);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    maps.assertHasEntrySatisfying(someInfo(), null, greenColorCondition);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_entry_matching_condition() {
+    AssertionInfo info = someInfo();
+    try {
+      maps.assertHasEntrySatisfying(info, actual, blackColorCondition);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldContainEntry(actual, blackColorCondition));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_entry_matching_condition() {
+    maps.assertHasEntrySatisfying(someInfo(), actual, greenColorCondition);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_condition_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_condition_Test.java
@@ -38,7 +38,7 @@ import org.junit.Test;
  *
  * @author Valeriy Vyrva
  */
-public class Maps_assertHasEntrySatisfying_Test extends MapsBaseTest {
+public class Maps_assertHasEntrySatisfying_with_key_and_condition_Test extends MapsBaseTest {
 
   private static final Pattern IS_DIGITS = Pattern.compile("^\\d+$");
 

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
@@ -52,7 +52,7 @@ public class Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test ex
     }
   };
 
-  private Condition<Object> isBlack = new Condition<Object>("greenColorCondition") {
+  private Condition<Object> isBlack = new Condition<Object>("black color condition") {
     @Override
     public boolean matches(Object value) {
       return "black".equals(value);

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Condition;
+import org.assertj.core.internal.Maps;
+import org.assertj.core.internal.MapsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Maps#assertHasEntrySatisfyingConditions(AssertionInfo, Map, Condition, Condition)}</code>.
+ */
+public class Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test extends MapsBaseTest {
+
+  private Condition<String> isColor = new Condition<String>("is color condition") {
+    @Override
+    public boolean matches(String value) {
+      return "color".equals(value);
+    }
+  };
+
+  private Condition<String> isGreen = new Condition<String>("green color condition") {
+    @Override
+    public boolean matches(String value) {
+      return "green".equals(value);
+    }
+  };
+
+  private Condition<Object> isAge = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      return "age".equals(value);
+    }
+  };
+
+  private Condition<Object> isBlack = new Condition<Object>("greenColorCondition") {
+    @Override
+    public boolean matches(Object value) {
+      return "black".equals(value);
+    }
+  };
+
+  @Test
+  public void should_fail_if_key_condition_is_null() {
+    thrown.expectNullPointerException("The condition to evaluate should not be null");
+    maps.assertHasEntrySatisfyingConditions(someInfo(), actual, null, isGreen);
+  }
+
+  @Test
+  public void should_fail_if_value_condition_is_null() {
+    thrown.expectNullPointerException("The condition to evaluate should not be null");
+    maps.assertHasEntrySatisfyingConditions(someInfo(), actual, isColor, null);
+  }
+
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    maps.assertHasEntrySatisfyingConditions(someInfo(), null, isColor, isGreen);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_entry_matching_key_condition() {
+    AssertionInfo info = someInfo();
+    try {
+      maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isGreen);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldContainEntry(actual, isAge, isGreen));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_entry_matching_value_condition() {
+    AssertionInfo info = someInfo();
+    try {
+      maps.assertHasEntrySatisfyingConditions(info, actual, isColor, isBlack);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldContainEntry(actual, isColor, isBlack));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_entry_matching_both_key_and_value_conditions() {
+    AssertionInfo info = someInfo();
+    try {
+      maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isBlack);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldContainEntry(actual, isAge, isBlack));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_entry_matching_conditions() {
+    maps.assertHasEntrySatisfyingConditions(someInfo(), actual, isColor, isGreen);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasKeySatisfying_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasKeySatisfying_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal.maps;
 
-import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -27,52 +27,50 @@ import org.assertj.core.internal.MapsBaseTest;
 import org.junit.Test;
 
 /**
- * Tests for <code>{@link Maps#assertHasEntrySatisfying(AssertionInfo, Map, Condition)}</code>.
+ * Tests for <code>{@link Maps#assertHasKeySatisfying(AssertionInfo, Map, Condition)}</code>.
  */
-public class Maps_assertHasEntrySatisfying_with_condition_Test extends MapsBaseTest {
+public class Maps_assertHasKeySatisfying_Test extends MapsBaseTest {
 
-  private Condition<Map.Entry<String, String>> greenColorCondition =
-    new Condition<Map.Entry<String, String>>("green color condition") {
-      @Override
-      public boolean matches(Map.Entry<String, String> entry) {
-        return entry.getKey().equals("color") && entry.getValue().equals("green");
-      }
-    };
+  private Condition<String> isColor = new Condition<String>("is color condition") {
+    @Override
+    public boolean matches(String value) {
+      return "color".equals(value);
+    }
+  };
 
-  private Condition<Map.Entry<String, String>> blackColorCondition =
-    new Condition<Map.Entry<String, String>>("black color condition") {
-      @Override
-      public boolean matches(Map.Entry<String, String> entry) {
-        return entry.getKey().equals("color") && entry.getValue().equals("black");
-      }
-    };
+  private Condition<Object> isAge = new Condition<Object>() {
+    @Override
+    public boolean matches(Object value) {
+      return "age".equals(value);
+    }
+  };
 
   @Test
   public void should_fail_if_condition_is_null() {
     thrown.expectNullPointerException("The condition to evaluate should not be null");
-    maps.assertHasEntrySatisfying(someInfo(), actual, null);
+    maps.assertHasKeySatisfying(someInfo(), actual, null);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    maps.assertHasEntrySatisfying(someInfo(), null, greenColorCondition);
+    maps.assertHasKeySatisfying(someInfo(), null, isColor);
   }
 
   @Test
-  public void should_fail_if_actual_does_not_contain_entry_matching_condition() {
+  public void should_fail_if_actual_does_not_contain_key_matching_condition() {
     AssertionInfo info = someInfo();
     try {
-      maps.assertHasEntrySatisfying(info, actual, blackColorCondition);
+      maps.assertHasKeySatisfying(info, actual, isAge);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, blackColorCondition));
+      verify(failures).failure(info, shouldContainKey(actual, isAge));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
-  public void should_pass_if_actual_contains_entry_matching_condition() {
-    maps.assertHasEntrySatisfying(someInfo(), actual, greenColorCondition);
+  public void should_pass_if_actual_contains_key_matching_condition() {
+    maps.assertHasKeySatisfying(someInfo(), actual, isColor);
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasValueSatisfying_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal.maps;
 
-import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
+import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -27,52 +27,51 @@ import org.assertj.core.internal.MapsBaseTest;
 import org.junit.Test;
 
 /**
- * Tests for <code>{@link Maps#assertHasEntrySatisfying(AssertionInfo, Map, Condition)}</code>.
+ * Tests for <code>{@link Maps#assertHasValueSatisfying(AssertionInfo, Map, Condition)} (AssertionInfo, Map, Condition)}</code>.
  */
-public class Maps_assertHasEntrySatisfying_with_condition_Test extends MapsBaseTest {
+public class Maps_assertHasValueSatisfying_Test extends MapsBaseTest {
 
-  private Condition<Map.Entry<String, String>> greenColorCondition =
-    new Condition<Map.Entry<String, String>>("green color condition") {
-      @Override
-      public boolean matches(Map.Entry<String, String> entry) {
-        return entry.getKey().equals("color") && entry.getValue().equals("green");
-      }
-    };
+  private Condition<String> isGreen = new Condition<String>("green color condition") {
+    @Override
+    public boolean matches(String value) {
+      return "green".equals(value);
+    }
+  };
 
-  private Condition<Map.Entry<String, String>> blackColorCondition =
-    new Condition<Map.Entry<String, String>>("black color condition") {
-      @Override
-      public boolean matches(Map.Entry<String, String> entry) {
-        return entry.getKey().equals("color") && entry.getValue().equals("black");
-      }
-    };
+  private Condition<Object> isBlack = new Condition<Object>("black color condition") {
+    @Override
+    public boolean matches(Object value) {
+      return "black".equals(value);
+    }
+  };
 
   @Test
   public void should_fail_if_condition_is_null() {
     thrown.expectNullPointerException("The condition to evaluate should not be null");
-    maps.assertHasEntrySatisfying(someInfo(), actual, null);
+    maps.assertHasValueSatisfying(someInfo(), actual, null);
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     thrown.expectAssertionError(actualIsNull());
-    maps.assertHasEntrySatisfying(someInfo(), null, greenColorCondition);
+    maps.assertHasValueSatisfying(someInfo(), null, isGreen);
   }
 
+
   @Test
-  public void should_fail_if_actual_does_not_contain_entry_matching_condition() {
+  public void should_fail_if_actual_does_not_contain_value_matching_condition() {
     AssertionInfo info = someInfo();
     try {
-      maps.assertHasEntrySatisfying(info, actual, blackColorCondition);
+      maps.assertHasValueSatisfying(info, actual, isBlack);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, blackColorCondition));
+      verify(failures).failure(info, shouldContainValue(actual, isBlack));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
-  public void should_pass_if_actual_contains_entry_matching_condition() {
-    maps.assertHasEntrySatisfying(someInfo(), actual, greenColorCondition);
+  public void should_pass_if_actual_contains_value_matching_condition() {
+    maps.assertHasValueSatisfying(someInfo(), actual, isGreen);
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #944 
* Unit tests : YES
* Javadoc with a code example (API only) : YES

Added:

    hasEntrySatisfying(Condition<? super Map.Entry<K, V>> entryCondition)
    hasEntrySatisfying(Condition<? super K> keyCondition, Condition<? super V> valueCondition)
    hasKeySatisfying(Condition<? super K> keyCondition)
    hasValueSatisfying(Condition<? super V> valueCondition)




