### PR TITLE
Add hasExactlyFields and hasExactlyDeclaredFields

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -299,10 +299,37 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * @see Class#getField(String)
    * @param fields the fields who must be in the class.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} doesn't contains all of the field.
+   * @throws AssertionError if the actual {@code Class} doesn't contain all of the fields.
    */
   public SELF hasFields(String... fields) {
     classes.assertHasFields(info, actual, fields);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the exactly the {@code fields} and nothing more. <b>in any order</b>.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public String fieldOne;
+   *     public String fieldTwo;
+   *     private String fieldThree;
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasExactlyFields("fieldOne", "fieldTwo");
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasExactlyFields("fieldOne");</code></pre>
+   *
+   * @see Class#getField(String)
+   * @param fields all the fields that are expected to be in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if fields are not all the fields of the actual {@code Class}.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public SELF hasExactlyFields(String... fields) {
+    classes.assertHasExactlyFields(info, actual, fields);
     return myself;
   }
 
@@ -327,6 +354,34 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    */
   public SELF hasDeclaredFields(String... fields) {
     classes.assertHasDeclaredFields(info, actual, fields);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has the exactly the declared {@code fields} and nothing more. <b>in any order</b>.
+   *
+   * <pre><code class='java'> class MyClass {
+   *     public String fieldOne;
+   *     public String fieldTwo;
+   *     private String fieldThree;
+   *     private String fieldFour;
+   * }
+   *
+   * // This one should pass :
+   * assertThat(MyClass.class).hasExactlyDeclaredFields("fieldOne", "fieldTwo", "fieldThree", "fieldFour:);
+   *
+   * // This one should fail :
+   * assertThat(MyClass.class).hasExactlyDeclaredFields("fieldOne", "fieldThree");</code></pre>
+   *
+   * @see Class#getField(String)
+   * @param fields all the fields that are expected to be in the class.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if fields are not all the declared fields of the actual {@code Class}.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public SELF hasExactlyDeclaredFields(String... fields) {
+    classes.assertHasExactlyDeclaredFields(info, actual, fields);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveExactlyFields.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveExactlyFields.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.error.ShouldHaveExactlyFields.ErrorType.NOT_EXPECTED_ONLY;
+import static org.assertj.core.error.ShouldHaveExactlyFields.ErrorType.NOT_FOUND_ONLY;
+import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class has exactly the fields.
+ *
+ * @author Filip Hrisafov
+ */
+public class ShouldHaveExactlyFields extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new </code>{@link ShouldHaveExactlyFields}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected expected fields for this class
+   * @param notFound fields in {@code expected} not found in the {@code actual}.
+   * @param notExpected fields in the {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveExactlyFields(Class<?> actual, Collection<String> expected, Collection<String> notFound,
+                                                            Collection<String> notExpected) {
+    return create(actual, expected, notFound, notExpected, false);
+  }
+
+  /**
+   * Creates a new </code>{@link ShouldHaveExactlyFields}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected expected fields for this class
+   * @param notFound fields in {@code expected} not found in the {@code actual}.
+   * @param notExpected fields in the {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveExactlyDeclaredFields(Class<?> actual, Collection<String> expected,
+                                                                    Collection<String> notFound, Collection<String> notExpected) {
+    return create(actual, expected, notFound, notExpected, true);
+  }
+
+  private static ErrorMessageFactory create(Class<?> actual, Collection<String> expected, Collection<String> notFound,
+                                            Collection<String> notExpected, boolean declared) {
+    if (isNullOrEmpty(notExpected)) {
+      return new ShouldHaveExactlyFields(actual, expected, notFound, NOT_FOUND_ONLY, declared);
+    }
+
+    if (isNullOrEmpty(notFound)) {
+      return new ShouldHaveExactlyFields(actual, expected, notExpected, NOT_EXPECTED_ONLY, declared);
+    }
+
+    return new ShouldHaveExactlyFields(actual, expected, notFound, notExpected, declared);
+  }
+
+  private ShouldHaveExactlyFields(Class<?> actual, Collection<String> expected, Collection<String> notFound, Collection<String> notExpected,
+                                  boolean declared) {
+    super("%n" +
+          "Expecting%n" +
+          "  <%s>%n" +
+          "to have exactly " + (declared ? "declared " : "") + "fields:%n" +
+          "  <%s>%n" +
+          "fields not found:%n" +
+          "  <%s>%n" +
+          "and fields not expected:%n" +
+          "  <%s>", actual, expected, notFound, notExpected);
+  }
+
+  private ShouldHaveExactlyFields(Class<?> actual, Collection<String> expected, Collection<String> notFoundOrNotExpected,
+                                  ErrorType errorType, boolean declared) {
+    super("%n" +
+          "Expecting%n" +
+          "  <%s>%n" +
+          "to have exactly " + (declared ? "declared " : "") + "fields:%n" +
+          "  <%s>%n" + (errorType == NOT_FOUND_ONLY ?
+            "but could not find the following fields:%n" : "but the following fields were unexpected:%n") +
+          "  <%s>",
+          actual, expected, notFoundOrNotExpected);
+  }
+
+  enum ErrorType {
+    NOT_FOUND_ONLY, NOT_EXPECTED_ONLY
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasExactlyDeclaredFields_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasExactlyDeclaredFields_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasExactlyDeclaredFields(String...)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class ClassAssert_hasExactlyDeclaredFields_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasExactlyDeclaredFields("field");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasExactlyDeclaredFields(getInfo(assertions), getActual(assertions), "field");
+  }
+}

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasExactlyFields_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasExactlyFields_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasFields(String...)}</code>.
+ *
+ * @author Filip Hrisafoc
+ */
+public class ClassAssert_hasExactlyFields_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasExactlyFields("field");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasExactlyFields(getInfo(assertions), getActual(assertions), "field");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveExactlyFields_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveExactlyFields_create_Test.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveExactlyFields.shouldHaveExactlyDeclaredFields;
+import static org.assertj.core.error.ShouldHaveExactlyFields.shouldHaveExactlyFields;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.test.Player;
+import org.assertj.core.util.Sets;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * <code>{@link ShouldHaveExactlyFields#create(Description, Representation)}</code>
+ *
+ * @author Filip Hrisafov
+ */
+public class ShouldHaveExactlyFields_create_Test {
+
+  @Test
+  public void should_create_error_message_for_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyFields(Player.class, newLinkedHashSet("name", "team"),
+                                                          newLinkedHashSet("nickname"),
+                                                          newLinkedHashSet("address"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "fields not found:%n"
+      + "  <[\"nickname\"]>%n"
+      + "and fields not expected:%n"
+      + "  <[\"address\"]>"));
+  }
+
+  @Test
+  public void should_not_display_unexpected_fields_when_there_are_none_for_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyFields(Player.class, newLinkedHashSet("name", "team"),
+                                                          newLinkedHashSet("nickname"),
+                                                          Sets.<String>newLinkedHashSet());
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "but could not find the following fields:%n"
+      + "  <[\"nickname\"]>"));
+  }
+
+  @Test
+  public void should_not_display_fields_not_found_when_there_are_none_for_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyFields(Player.class, newLinkedHashSet("name", "team"),
+                                                          Sets.<String>newLinkedHashSet(),
+                                                          newLinkedHashSet("address"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "but the following fields were unexpected:%n"
+      + "  <[\"address\"]>"));
+  }
+
+  @Test
+  public void should_create_error_message_for_declared_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyDeclaredFields(Player.class, newLinkedHashSet("name", "team"),
+                                                          newLinkedHashSet("nickname"),
+                                                          newLinkedHashSet("address"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly declared fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "fields not found:%n"
+      + "  <[\"nickname\"]>%n"
+      + "and fields not expected:%n"
+      + "  <[\"address\"]>"));
+  }
+
+  @Test
+  public void should_not_display_unexpected_fields_when_there_are_none_for_declared_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyDeclaredFields(Player.class, newLinkedHashSet("name", "team"),
+                                                                  newLinkedHashSet("nickname"),
+                                                                  Sets.<String>newLinkedHashSet());
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly declared fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "but could not find the following fields:%n"
+      + "  <[\"nickname\"]>"));
+  }
+
+  @Test
+  public void should_not_display_fields_not_found_when_there_are_none_for_declared_fields() {
+    ErrorMessageFactory factory = shouldHaveExactlyDeclaredFields(Player.class, newLinkedHashSet("name", "team"),
+                                                                  Sets.<String>newLinkedHashSet(),
+                                                                  newLinkedHashSet("address"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %n"
+      + "Expecting%n"
+      + "  <org.assertj.core.test.Player>%n"
+      + "to have exactly declared fields:%n"
+      + "  <[\"name\", \"team\"]>%n"
+      + "but the following fields were unexpected:%n"
+      + "  <[\"address\"]>"));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ClassesBaseTest.java
@@ -48,6 +48,7 @@ public abstract class ClassesBaseTest {
   @MyAnnotation
   protected static class AnnotatedClass {
     public String publicField;
+    public String public2Field;
     protected String protectedField;
     @SuppressWarnings("unused")
     private String privateField;

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasExactlyDeclaredFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasExactlyDeclaredFields_Test.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import static org.assertj.core.error.ShouldHaveExactlyFields.shouldHaveExactlyDeclaredFields;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import org.assertj.core.internal.ClassesBaseTest;
+import org.assertj.core.util.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * <code
+ * >{@link org.assertj.core.internal.Classes#assertHasExactlyDeclaredFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
+ * .
+ *
+ * @author Filip Hrisafov
+ */
+public class Classes_assertHasExactlyDeclaredFields_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = AnnotatedClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual);
+  }
+
+  @Test
+  public void should_fail_if_no_fields_are_expected() {
+    thrown.expectAssertionError(shouldHaveExactlyDeclaredFields(actual,
+                                                                newLinkedHashSet("publicField", "public2Field",
+                                                                                 "protectedField", "privateField"),
+                                                                Sets.<String>newLinkedHashSet(),
+                                                                newLinkedHashSet("publicField", "public2Field",
+                                                                                 "protectedField", "privateField")));
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual);
+  }
+
+  @Test
+  public void should_fail_if_not_all_fields_are_expected() {
+    thrown.expectAssertionError(shouldHaveExactlyDeclaredFields(actual,
+                                                                newLinkedHashSet("publicField", "public2Field",
+                                                                                 "protectedField", "privateField"),
+                                                                Sets.<String>newLinkedHashSet(),
+                                                                newLinkedHashSet("public2Field")));
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual, "publicField", "protectedField", "privateField");
+  }
+
+  @Test
+  public void should_fail_if_fields_are_missing() {
+    String[] expected = new String[] { "missingField", "publicField", "public2Field", "protectedField",
+      "privateField" };
+    thrown.expectAssertionError(shouldHaveExactlyDeclaredFields(actual,
+                                                                newLinkedHashSet("publicField", "public2Field",
+                                                                                 "protectedField", "privateField"),
+                                                                newLinkedHashSet("missingField"),
+                                                                Sets.<String>newLinkedHashSet()));
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_all_fields_are_expected() {
+    String[] expected = new String[] { "publicField", "public2Field", "protectedField", "privateField" };
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_public_all_fields_are_reversed_expected() {
+    String[] expected = new String[] { "protectedField", "privateField", "public2Field", "publicField" };
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual, expected);
+  }
+
+  @Test()
+  public void should_fail_if_fields_are_not_expected_and_not_found() {
+    String[] expected = new String[] { "publicField", "public2Field", "missing", "privateField" };
+    thrown.expectAssertionError(shouldHaveExactlyDeclaredFields(actual,
+                                                                newLinkedHashSet("publicField", "public2Field",
+                                                                                 "protectedField", "privateField"),
+                                                                newLinkedHashSet("missing"),
+                                                                newLinkedHashSet("protectedField")));
+    classes.assertHasExactlyDeclaredFields(someInfo(), actual, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasExactlyFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasExactlyFields_Test.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import static org.assertj.core.error.ShouldHaveExactlyFields.shouldHaveExactlyFields;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import org.assertj.core.internal.ClassesBaseTest;
+import org.assertj.core.util.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * <code
+ * >{@link org.assertj.core.internal.Classes#assertHasExactlyFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
+ * .
+ *
+ * @author Filip Hrisafov
+ */
+public class Classes_assertHasExactlyFields_Test extends ClassesBaseTest {
+
+  @Before
+  public void setupActual() {
+    actual = AnnotatedClass.class;
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    actual = null;
+    thrown.expectAssertionError(actualIsNull());
+    classes.assertHasExactlyFields(someInfo(), actual);
+  }
+
+  @Test
+  public void should_fail_if_no_fields_are_expected() {
+    thrown.expectAssertionError(shouldHaveExactlyFields(actual,
+                                                        newLinkedHashSet("publicField", "public2Field"),
+                                                        Sets.<String>newLinkedHashSet(),
+                                                        newLinkedHashSet("publicField", "public2Field")));
+    classes.assertHasExactlyFields(someInfo(), actual);
+  }
+
+  @Test
+  public void should_fail_if_not_all_public_fields_are_expected() {
+    thrown.expectAssertionError(shouldHaveExactlyFields(actual,
+                                                        newLinkedHashSet("publicField", "public2Field"),
+                                                        Sets.<String>newLinkedHashSet(),
+                                                        newLinkedHashSet("public2Field")));
+    classes.assertHasExactlyFields(someInfo(), actual, "publicField");
+  }
+
+  @Test
+  public void should_fail_if_public_fields_are_missing() {
+    String[] expected = new String[] { "missingField", "publicField", "public2Field" };
+    thrown.expectAssertionError(shouldHaveExactlyFields(actual,
+                                                        newLinkedHashSet("publicField", "public2Field"),
+                                                        newLinkedHashSet("missingField"),
+                                                        Sets.<String>newLinkedHashSet()));
+    classes.assertHasExactlyFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_public_all_fields_are_expected() {
+    String[] expected = new String[] { "publicField", "public2Field" };
+    classes.assertHasExactlyFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_public_all_fields_are_reversed_expected() {
+    String[] expected = new String[] { "public2Field", "publicField" };
+    classes.assertHasExactlyFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_fail_if_fields_are_protected_or_private() {
+    String[] expected = new String[] { "publicField", "public2Field", "protectedField", "privateField" };
+    thrown.expectAssertionError(shouldHaveExactlyFields(actual,
+                                                        newLinkedHashSet("publicField", "public2Field"),
+                                                        newLinkedHashSet("protectedField", "privateField"),
+                                                        Sets.<String>newLinkedHashSet()));
+    classes.assertHasExactlyFields(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_fail_if_fields_are_not_found_and_not_expected() {
+    String[] expected = new String[] { "publicField", "protectedField", "privateField" };
+    thrown.expectAssertionError(shouldHaveExactlyFields(actual,
+                                                        newLinkedHashSet("publicField", "public2Field"),
+                                                        newLinkedHashSet("protectedField", "privateField"),
+                                                        newLinkedHashSet("public2Field")));
+    classes.assertHasExactlyFields(someInfo(), actual, expected);
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #953 
* Unit tests : YES
* Javadoc with a code example (API only) : YES

I additionally modified the `filterSyntheticMembers` to be generic and I am using it for all the field extractions (new and old).


