### PR TITLE
Add doesNotContainPattern to String assertions as counterpart to containsPattern

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -570,6 +570,51 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} does not contain the given regular expression.
+   * <p>
+   * Example :
+   * <pre><code class='java'>
+   * // assertion will pass
+   * assertThat(&quot;Frodo&quot;).doesNotContainPattern(&quot;Fr.ud&quot;);
+   *
+   * // assertion will fail
+   * assertThat(&quot;Freud&quot;).doesNotContainPattern(&quot;Fr.ud&quot;);</code></pre>
+   *
+   * @param pattern the regular expression to find in the actual {@code CharSequence}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws PatternSyntaxException if the regular expression's syntax is invalid.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given regular expression can be found in the actual {@code CharSequence}.
+   */
+  public SELF doesNotContainPattern(CharSequence pattern) {
+    strings.assertDoesNotContainPattern(info, actual, pattern);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} does not contain the given regular expression.
+   * <p>
+   * Example :
+   * <pre><code class='java'>
+   * // assertion will pass
+   * assertThat(&quot;Frodo&quot;).doesNotContainPattern(Pattern.compile(&quot;Fr.ud&quot;));
+   *
+   * // assertion will fail
+   * assertThat(&quot;Freud&quot;).doesNotContainPattern(Pattern.compile(&quot;Fr.ud&quot;));</code></pre>
+   *
+   * @param pattern the regular expression to find in the actual {@code CharSequence}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given regular expression can be found in the actual {@code CharSequence}.
+   */
+  public SELF doesNotContainPattern(Pattern pattern) {
+    strings.assertDoesNotContainPattern(info, actual, pattern);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} starts with the given prefix.
    * <p>
    * Example :

--- a/src/main/java/org/assertj/core/error/ShouldNotContainPattern.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotContainPattern.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@code CharSequence} does not contain
+ * a regular expression failed.
+ */
+public class ShouldNotContainPattern extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotContainPattern}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param pattern a regular expression pattern.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainPattern(CharSequence actual, CharSequence pattern) {
+    return new ShouldNotContainPattern(actual, pattern);
+  }
+
+  private ShouldNotContainPattern(CharSequence actual, CharSequence pattern) {
+    super("%nExpecting:%n  %s%nnot to contain pattern:%n  %s", actual, pattern);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -35,6 +35,7 @@ import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringCase.shouldNotBeEqualIgnoringCase;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace.shouldNotBeEqualIgnoringWhitespace;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
 import static org.assertj.core.error.ShouldNotEndWith.shouldNotEndWith;
 import static org.assertj.core.error.ShouldNotMatchPattern.shouldNotMatch;
 import static org.assertj.core.error.ShouldNotStartWith.shouldNotStartWith;
@@ -772,6 +773,46 @@ public class Strings {
     assertNotNull(info, actual);
     Matcher matcher = pattern.matcher(actual);
     if (!matcher.find()) throw failures.failure(info, shouldContainPattern(actual, pattern.pattern()));
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} does not contain the given regular expression.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @param regex the regular expression to find in the actual {@code CharSequence}.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws PatternSyntaxException if the regular expression's syntax is invalid.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} contains the given regular expression.
+   */
+  public void assertDoesNotContainPattern(AssertionInfo info, CharSequence actual, CharSequence regex) {
+    checkRegexIsNotNull(regex);
+    assertNotNull(info, actual);
+    Pattern pattern = Pattern.compile(regex.toString());
+    Matcher matcher = pattern.matcher(actual);
+    if (matcher.find()) {
+      throw failures.failure(info, shouldNotContainPattern(actual, pattern.pattern()));
+    }
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} does not contain the given regular expression.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @param pattern the regular expression to find in the actual {@code CharSequence}.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} contains the given regular expression.
+   */
+  public void assertDoesNotContainPattern(AssertionInfo info, CharSequence actual, Pattern pattern) {
+    checkIsNotNull(pattern);
+    assertNotNull(info, actual);
+    Matcher matcher = pattern.matcher(actual);
+    if (matcher.find()) {
+      throw failures.failure(info, shouldNotContainPattern(actual, pattern.pattern()));
+    }
   }
 
   private void checkCharSequenceArrayDoesNotHaveNullElements(CharSequence[] values) {

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainPattern_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainPattern_Pattern_Test.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+import org.junit.BeforeClass;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.test.TestData.matchAnything;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotContainPattern(Pattern)}</code>.
+ */
+public class CharSequenceAssert_doesNotContainPattern_Pattern_Test extends CharSequenceAssertBaseTest {
+
+  private static Pattern pattern;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    pattern = matchAnything();
+  }
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainPattern(pattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainPattern(getInfo(assertions), getActual(assertions), pattern);
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainPattern_String_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainPattern_String_Test.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+import org.junit.BeforeClass;
+
+import static org.assertj.core.test.TestData.matchAnything;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotContainPattern(CharSequence)}</code>.
+ */
+public class CharSequenceAssert_doesNotContainPattern_String_Test extends CharSequenceAssertBaseTest {
+
+  private static CharSequence regex;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    regex = matchAnything().pattern();
+  }
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainPattern(regex);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainPattern(getInfo(assertions), getActual(assertions), regex);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
+
+public class ShouldNotContainPattern_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldNotContainPattern("Frodo", "Fr.do");
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(format("[Test] %nExpecting:%n  \"Frodo\"%nnot to contain pattern:%n  \"Fr.do\""));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
@@ -26,7 +26,7 @@ import org.assertj.core.internal.StringsBaseTest;
 import org.junit.Test;
 
 /**
- * Tests for <code>{@link Strings#assertMatches(AssertionInfo, CharSequence, CharSequence)}</code>.
+ * Tests for <code>{@link Strings#assertContainsPattern(AssertionInfo, CharSequence, CharSequence)}</code>.
  * 
  * @author Pierre Templier
  */

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_Pattern_Test.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Strings#assertContains(AssertionInfo, CharSequence, Pattern)}</code>.
+ * Tests for <code>{@link Strings#assertContainsPattern(AssertionInfo, CharSequence, Pattern)}</code>.
  * 
  * @author Pierre Templier
  */

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+import java.util.regex.PatternSyntaxException;
+
+import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
+import static org.assertj.core.test.ErrorMessages.regexPatternIsNull;
+import static org.assertj.core.test.TestData.matchAnything;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * Tests for <code>{@link Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, CharSequence)}</code>.
+ */
+public class Strings_assertDoesNotContainPattern_CharSequence_Test extends StringsBaseTest {
+
+  private static final String CONTAINED_PATTERN = "y.*u?";
+  private static final String NOT_CONTAINED_PATTERN = "Y.*U?";
+  private static final String ACTUAL = "No soup for you!";
+
+  @Test
+  public void should_throw_error_if_regular_expression_is_null() {
+    thrown.expectNullPointerException(regexPatternIsNull());
+    final String nullRegex = null;
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, nullRegex);
+  }
+
+  @Test
+  public void should_throw_error_if_syntax_of_regular_expression_is_invalid() {
+    thrown.expect(PatternSyntaxException.class);
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, "*...");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertDoesNotContainPattern(someInfo(), null, matchAnything().pattern());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_regular_expression() {
+    thrown.expectAssertionError(shouldNotContainPattern(ACTUAL, CONTAINED_PATTERN));
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, CONTAINED_PATTERN);
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_regular_expression() {
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, NOT_CONTAINED_PATTERN);
+  }
+
+  @Test
+  public void should_throw_error_if_regular_expression_is_null_whatever_custom_comparison_strategy_is() {
+    thrown.expectNullPointerException(regexPatternIsNull());
+    String nullRegex = null;
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, nullRegex);
+  }
+
+  @Test
+  public void should_throw_error_if_syntax_of_regular_expression_is_invalid_whatever_custom_comparison_strategy_is() {
+    thrown.expect(PatternSyntaxException.class);
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, "*...");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError(actualIsNull());
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), null,
+                                                                             matchAnything().pattern());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_regular_expression_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError(shouldNotContainPattern(ACTUAL, CONTAINED_PATTERN));
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, CONTAINED_PATTERN);
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_regular_expression_whatever_custom_comparison_strategy_is() {
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, NOT_CONTAINED_PATTERN);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_Pattern_Test.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
+import static org.assertj.core.test.ErrorMessages.regexPatternIsNull;
+import static org.assertj.core.test.TestData.matchAnything;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+/**
+ * Tests for <code>{@link Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, Pattern)}</code>.
+ */
+public class Strings_assertDoesNotContainPattern_Pattern_Test extends StringsBaseTest {
+
+  private static final String CONTAINED_PATTERN = "y.*u?";
+  private static final String NOT_CONTAINED_PATTERN = "Y.*U?";
+  private static final String ACTUAL = "No soup for you!";
+
+  @Test
+  public void should_throw_error_if_pattern_is_null() {
+    thrown.expectNullPointerException(regexPatternIsNull());
+    Pattern nullPattern = null;
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, nullPattern);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertDoesNotContainPattern(someInfo(), null, matchAnything());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_pattern() {
+    thrown.expectAssertionError(shouldNotContainPattern(ACTUAL, CONTAINED_PATTERN));
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, Pattern.compile(CONTAINED_PATTERN));
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_pattern() {
+    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, Pattern.compile(NOT_CONTAINED_PATTERN));
+  }
+
+  @Test
+  public void should_throw_error_if_pattern_is_null_whatever_custom_comparison_strategy_is() {
+    thrown.expectNullPointerException(regexPatternIsNull());
+    Pattern nullPattern = null;
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, nullPattern);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError(actualIsNull());
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), null, matchAnything());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_pattern_whatever_custom_comparison_strategy_is() {
+    thrown.expectAssertionError(shouldNotContainPattern(ACTUAL, CONTAINED_PATTERN));
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL,
+                                                                             Pattern.compile(CONTAINED_PATTERN));
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_pattern_whatever_custom_comparison_strategy_is() {
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL,
+                                                                             Pattern.compile(NOT_CONTAINED_PATTERN));
+  }
+}


### PR DESCRIPTION
The containsPattern String assertion lacks a negated version, which this pull requests adds.
Rationale - users tend to expect having both negative and positive assertion versions,
I was surprised to not find a matching negative version myself and had to use 
doesNotMatch(".*<pattern>.*"), which does the job of course, but is not as descriptive
and elegant.
Based on Pierre Templier's original work on containsPattern.

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES /


