### PR TITLE
get rid of deprecated Tuple#addData

### DIFF
--- a/src/main/java/org/assertj/core/groups/Tuple.java
+++ b/src/main/java/org/assertj/core/groups/Tuple.java
@@ -19,20 +19,12 @@ import static org.assertj.core.util.Objects.areEqual;
 
 import java.util.List;
 
-/**
- * Will be immutable when {@link #addData(Object)} is removed.
- */
 public class Tuple {
 
   private final List<Object> datas = newArrayList();
 
   public Tuple(Object... values) {
 	addAll(datas, values);
-  }
-
-  @Deprecated
-  public void addData(Object data) {
-	datas.add(data);
   }
 
   public Object[] toArray() {

--- a/src/test/java/org/assertj/core/api/Tuple_Test.java
+++ b/src/test/java/org/assertj/core/api/Tuple_Test.java
@@ -43,14 +43,6 @@ public class Tuple_Test {
     assertThat(tuple).isEqualTo(new Tuple());
   }
 
-  @SuppressWarnings("deprecation")
-  @Test
-  public void add_an_element_to_a_tuple() {
-    Tuple tuple = new Tuple("Yoda", 800);
-    tuple.addData("Jedi");
-    assertThat(tuple).isEqualTo(new Tuple("Yoda", 800, "Jedi"));
-  }
-
   @Test
   public void convert_tuple_to_an_array() {
     Tuple tuple = new Tuple("Yoda", 800, "Jedi");


### PR DESCRIPTION
What about getting rid of deprecated Tuple#addData?
It is not used by the assertj-core project and seems to be deprecated for > 1.5 years now.


