### PR TITLE
[ci] Fix relativePath from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <groupId>org.assertj</groupId>
     <artifactId>assertj-parent-pom</artifactId>
     <version>2.1.6</version>
+    <relativePath />
   </parent>
   <mailingLists>
     <mailingList>


### PR DESCRIPTION
Restores a fix added previously.  RelativePath needs to be set unless this project is nexted within parent.  It is not so it needs set.  I believe I did this once before but some merged from origin/2.x wrote over it.  The same fix would need over on 2.x branch as well if you agree I can submit a PR there too.


