### PR TITLE
add brittle test with race condition

### DIFF
--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
@@ -18,17 +18,37 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCompletedExceptionally.shouldHaveCompletedExceptionally;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class CompletableFutureAssert_isCompletedExceptionally_Test extends BaseTest {
+
+  /**
+   * Run these tests 100 times because they are prone to Race Conditions.
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[100][0]);
+  }
 
   @Test
   public void should_pass_if_completable_future_is_completed_exceptionally() {
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException());
+
+    assertThat(future).isCompletedExceptionally();
+  }
+
+  @Test
+  public void should_pass_if_completable_future_will_complete_exceptionally() {
+    CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {throw new RuntimeException();});
 
     assertThat(future).isCompletedExceptionally();
   }


### PR DESCRIPTION
reproducing #1011 

Run the changed test. It repeats the same test 100 times. This fails for me like this:
```
mvn test -Dtest=CompletableFutureAssert_isCompletedExceptionally_Test

[ERROR]   CompletableFutureAssert_isCompletedExceptionally_Test.should_pass_if_completable_future_will_complete_exceptionally[88] 
Expecting
  <CompletableFuture[Incomplete]>
to be completed exceptionally


[ERROR]   CompletableFutureAssert_isCompletedExceptionally_Test.should_pass_if_completable_future_will_complete_exceptionally[89] 
Expecting
  <CompletableFuture[Failed: java.lang.RuntimeException]>
to be completed exceptionally
```

As you can see the first message makes sense, the future is incomplete. In the second case, the error says "expecting ... to be completed exceptionally, but it shows [Failed: java.lang.RuntimeException]"

Not sure if or how this can best be fixed, probably just a hint in the message might work.