### PR TITLE
Extract ObjectAssert for value from OptionalAssert (#1021)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -405,6 +405,34 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
     return assertThat(actual.map(mapper));
   }
 
+  /**
+   * Verifies that the actual {@link Optional} is not {@code null} and not empty,
+   * and returns an Object assertion, to allow chaining of object-specific
+   * assertions from this call.
+   * <p>
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT);
+   * TolkienCharacter sam = new TolkienCharacter("Sam", 38, null);
+   *
+   * // assertion succeeds since all frodo's fields are set
+   * assertThat(Optional.of(frodo)).get().hasNoNullFields();
+   *
+   * // assertion does not succeed because sam does not have its race set
+   * assertThat(Optional.of(sam)).get().hasNoNullFields();</code></pre>
+   *
+   * @return a new {@link AbstractObjectAssert} for assertions chaining on the value of the Optional.
+   * @throws AssertionError if the actual {@link Optional} is null.
+   * @throws AssertionError if the actual {@link Optional} is empty.
+   * @since 3.9.0
+   */
+  @CheckReturnValue
+  public AbstractObjectAssert<?, VALUE> get() {
+    isPresent();
+    return assertThat(actual.get());
+  }
+
   private void checkNotNull(Object expectedValue) {
     checkArgument(expectedValue != null, "The expected value should not be <null>.");
   }

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.util.Optional;
+
+import org.assertj.core.api.BaseTest;
+import org.assertj.core.data.TolkienCharacter;
+import org.assertj.core.data.TolkienCharacter.Race;
+import org.junit.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class OptionalAssert_get_Test extends BaseTest {
+
+  @Test
+  public void should_fail_when_optional_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+
+    assertThat((Optional<String>) null).get();
+  }
+
+  @Test
+  public void should_fail_when_optional_is_empty() {
+    thrown.expectAssertionError(shouldBePresent(Optional.<String>empty()));
+    assertThat(Optional.<String>empty()).get();
+  }
+
+  @Test
+  public void should_pass_when_optional_contains_a_value() {
+    TolkienCharacter frodo = TolkienCharacter.of("Frodo", 33, Race.HOBBIT);
+    assertThat(Optional.of(frodo)).get().hasNoNullFieldsOrProperties();
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #1021
* Unit tests : YES 
* Javadoc with a code example (API only) : YES


