### PR TITLE
Use an SPI for registering a custom Representation (#1016)

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.data.Percentage.withPercentage;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.io.File;
 import java.io.InputStream;
@@ -2126,7 +2126,7 @@ public class Assertions {
    * @since 2.5.0 / 3.5.0
    */
   public static void useDefaultRepresentation() {
-    AbstractAssert.setCustomRepresentation(STANDARD_REPRESENTATION);
+    AbstractAssert.setCustomRepresentation(CONFIGURATION_PROVIDER.representation());
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/WritableAssertionInfo.java
+++ b/src/main/java/org/assertj/core/api/WritableAssertionInfo.java
@@ -13,7 +13,7 @@
 package org.assertj.core.api;
 
 import static java.lang.String.format;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
 import static org.assertj.core.util.Strings.quote;
@@ -40,11 +40,11 @@ public class WritableAssertionInfo implements AssertionInfo {
   private Representation representation;
 
   public WritableAssertionInfo(Representation customRepresentation) {
-    useRepresentation(customRepresentation == null ? STANDARD_REPRESENTATION : customRepresentation);
+    useRepresentation(customRepresentation == null ? CONFIGURATION_PROVIDER.representation() : customRepresentation);
   }
 
   public WritableAssertionInfo() {
-    useRepresentation(STANDARD_REPRESENTATION);
+    useRepresentation(CONFIGURATION_PROVIDER.representation());
   }
 
   /**

--- a/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.configuration;
+
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+
+/**
+ * Provider for all the configuration settings / parameters within AssertJ.
+ * <p>
+ * All the configuration possibilities are registered via an SPI.
+ *
+ * @author Filip Hrisafov
+ * @since 2.9.0 / 3.9.0
+ */
+public final class ConfigurationProvider {
+
+  public static final ConfigurationProvider CONFIGURATION_PROVIDER = new ConfigurationProvider();
+
+  private final Representation defaultRepresentation;
+
+  public ConfigurationProvider() {
+    defaultRepresentation = Services.get(Representation.class, new StandardRepresentation());
+  }
+
+  /**
+   * @return the default {@link Representation} that needs to be used within AssertJ
+   * @since 2.9.0 / 3.9.0
+   */
+  public Representation representation() {
+    return defaultRepresentation;
+  }
+}

--- a/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
@@ -1,13 +1,13 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
+ *
  * Copyright 2012-2017 the original author or authors.
  */
 package org.assertj.core.configuration;

--- a/src/main/java/org/assertj/core/configuration/Services.java
+++ b/src/main/java/org/assertj/core/configuration/Services.java
@@ -14,6 +14,8 @@ package org.assertj.core.configuration;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A simple locator for SPI implementations.
@@ -21,6 +23,8 @@ import java.util.ServiceLoader;
  * @author Filip Hrisafov
  */
 class Services {
+
+  private static final Logger logger = Logger.getLogger(Services.class.getCanonicalName());
 
   private Services() {
   }
@@ -36,8 +40,10 @@ class Services {
       result = defaultValue;
     }
     if (services.hasNext()) {
-      throw new IllegalStateException(
-        "Multiple implementations have been found for the service provider interface");
+      result = defaultValue;
+      logger
+        .log(Level.WARNING, "Found multiple implementations for the service provider {0}. Using the default: {1}",
+             new Object[] { serviceType, result.getClass() });
     }
     return result;
   }

--- a/src/main/java/org/assertj/core/configuration/Services.java
+++ b/src/main/java/org/assertj/core/configuration/Services.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.configuration;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * A simple locator for SPI implementations.
+ *
+ * @author Filip Hrisafov
+ */
+class Services {
+
+  private Services() {
+  }
+
+  public static <T> T get(Class<T> serviceType, T defaultValue) {
+
+    Iterator<T> services = ServiceLoader.load(serviceType, Services.class.getClassLoader()).iterator();
+
+    T result;
+    if (services.hasNext()) {
+      result = services.next();
+    } else {
+      result = defaultValue;
+    }
+    if (services.hasNext()) {
+      throw new IllegalStateException(
+        "Multiple implementations have been found for the service provider interface");
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.data;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
 import java.util.Map;
 import java.util.Objects;
@@ -63,7 +63,7 @@ public class MapEntry<K, V> implements Map.Entry<K, V> {
 
   @Override
   public String toString() {
-    return STANDARD_REPRESENTATION.toStringOf(this);
+    return CONFIGURATION_PROVIDER.representation().toStringOf(this);
   }
 
   @Override

--- a/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
+++ b/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
@@ -13,8 +13,8 @@
 package org.assertj.core.error;
 
 import static java.lang.String.format;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.description.EmptyTextDescription.emptyDescription;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Objects.HASH_CODE_PRIME;
 import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Objects.hashCodeFor;
@@ -25,7 +25,6 @@ import java.util.Arrays;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.presentation.Representation;
-import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -113,13 +112,13 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
   /** {@inheritDoc} */
   @Override
   public String create(Description d) {
-    return formatter.format(d, STANDARD_REPRESENTATION, format, arguments);
+    return formatter.format(d, CONFIGURATION_PROVIDER.representation(), format, arguments);
   }
 
   /** {@inheritDoc} */
   @Override
   public String create() {
-    return formatter.format(emptyDescription(), STANDARD_REPRESENTATION, format, arguments);
+    return formatter.format(emptyDescription(), CONFIGURATION_PROVIDER.representation(), format, arguments);
   }
 
   /**
@@ -160,7 +159,7 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
   @Override
   public String toString() {
     return format("%s[format=%s, arguments=%s]", getClass().getSimpleName(), quote(format),
-        StandardRepresentation.STANDARD_REPRESENTATION.toStringOf(arguments));
+                  CONFIGURATION_PROVIDER.representation().toStringOf(arguments));
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldOnlyHaveElementsOfTypes.java
+++ b/src/main/java/org/assertj/core/error/ShouldOnlyHaveElementsOfTypes.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.error;
 
-import org.assertj.core.presentation.StandardRepresentation;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
 /**
  * Creates an error message indicating that an assertion that verifies a group of elements contains elements that
@@ -54,7 +54,7 @@ public class ShouldOnlyHaveElementsOfTypes extends BasicErrorMessageFactory {
         builder.append(", ");
       }
 
-      String formatted = StandardRepresentation.STANDARD_REPRESENTATION.toStringOf(element);
+      String formatted = CONFIGURATION_PROVIDER.representation().toStringOf(element);
       builder.append(formatted);
 
       if (element != null && !formatted.contains(element.getClass().getName())) {

--- a/src/main/java/org/assertj/core/groups/Tuple.java
+++ b/src/main/java/org/assertj/core/groups/Tuple.java
@@ -13,7 +13,7 @@
 package org.assertj.core.groups;
 
 import static java.util.Collections.addAll;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Objects.areEqual;
 
@@ -55,7 +55,7 @@ public class Tuple {
 
   @Override
   public String toString() {
-    return STANDARD_REPRESENTATION.toStringOf(this);
+    return CONFIGURATION_PROVIDER.representation().toStringOf(this);
   }
 
   public static Tuple tuple(Object... values) {

--- a/src/main/java/org/assertj/core/internal/AtomicReferenceArrayElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/AtomicReferenceArrayElementComparisonStrategy.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.Arrays.isArray;
 
 import java.util.Comparator;
@@ -46,12 +46,14 @@ public class AtomicReferenceArrayElementComparisonStrategy<T> extends StandardCo
 
   @Override
   public String toString() {
-    return "AtomicReferenceArrayElementComparisonStrategy using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "AtomicReferenceArrayElementComparisonStrategy using " + CONFIGURATION_PROVIDER.representation()
+                                                                                          .toStringOf(
+                                                                                            elementComparator);
   }
 
   @Override
   public String asText() {
-    return "when comparing elements using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "when comparing elements using " + CONFIGURATION_PROVIDER.representation().toStringOf(elementComparator);
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 
 import java.util.Comparator;
@@ -135,13 +135,13 @@ public class ComparatorBasedComparisonStrategy extends AbstractComparisonStrateg
 
   @Override
   public String asText() {
-	return "when comparing values using " + STANDARD_REPRESENTATION.toStringOf(comparator);
+    return "when comparing values using " + CONFIGURATION_PROVIDER.representation().toStringOf(comparator);
 	// return "according to " + this;
   }
 
   @Override
   public String toString() {
-	return STANDARD_REPRESENTATION.toStringOf(comparator);
+    return CONFIGURATION_PROVIDER.representation().toStringOf(comparator);
   }
 
   public Comparator<?> getComparator() {

--- a/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/IgnoringFieldsComparator.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -53,6 +53,6 @@ public class IgnoringFieldsComparator extends FieldByFieldComparator {
   @Override
   public String toString() {
     return "field/property by field/property comparator on all fields/properties except "
-           + STANDARD_REPRESENTATION.toStringOf(fields);
+           + CONFIGURATION_PROVIDER.representation().toStringOf(fields);
   }
 }

--- a/src/main/java/org/assertj/core/internal/IterableElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/IterableElementComparisonStrategy.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.IterableUtil.sizeOf;
 
 import java.util.Comparator;
@@ -49,12 +49,13 @@ public class IterableElementComparisonStrategy<T> extends StandardComparisonStra
 
   @Override
   public String toString() {
-	return "IterableElementComparisonStrategy using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "IterableElementComparisonStrategy using " + CONFIGURATION_PROVIDER.representation()
+                                                                              .toStringOf(elementComparator);
   }
   
   @Override
   public String asText() {
-    return "when comparing elements using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "when comparing elements using " + CONFIGURATION_PROVIDER.representation().toStringOf(elementComparator);
   }
   
   @Override

--- a/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.Arrays.isArray;
 
 import java.util.Comparator;
@@ -45,12 +45,13 @@ public class ObjectArrayElementComparisonStrategy<T> extends StandardComparisonS
 
   @Override
   public String toString() {
-    return "ObjectArrayElementComparisonStrategy using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "ObjectArrayElementComparisonStrategy using " + CONFIGURATION_PROVIDER.representation()
+                                                                                 .toStringOf(elementComparator);
   }
   
   @Override
   public String asText() {
-    return "when comparing elements using " + STANDARD_REPRESENTATION.toStringOf(elementComparator);
+    return "when comparing elements using " + CONFIGURATION_PROVIDER.representation().toStringOf(elementComparator);
   }
   
   @Override

--- a/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
+++ b/src/main/java/org/assertj/core/internal/OnFieldsComparator.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.util.Arrays.isNullOrEmpty;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
@@ -35,7 +35,7 @@ public class OnFieldsComparator extends FieldByFieldComparator {
     for (String field : fields) {
       checkArgument(!isNullOrEmpty(field) && !isNullOrEmpty(field.trim()),
                     "Null/blank fields/properties are invalid, fields/properties were %s",
-                    STANDARD_REPRESENTATION.toStringOf(fields));
+                    CONFIGURATION_PROVIDER.representation().toStringOf(fields));
     }
     this.fields = fields;
   }
@@ -62,10 +62,12 @@ public class OnFieldsComparator extends FieldByFieldComparator {
 
   @Override
   public String toString() {
-    if (fields.length == 1)
-      return "single field/property comparator on field/property " + STANDARD_REPRESENTATION.toStringOf(fields[0]);
+    if (fields.length == 1) {
+      return "single field/property comparator on field/property " + CONFIGURATION_PROVIDER.representation()
+                                                                                           .toStringOf(fields[0]);
+    }
     return "field/property by field/property comparator on fields/properties "
-           + STANDARD_REPRESENTATION.toStringOf(fields);
+           + CONFIGURATION_PROVIDER.representation().toStringOf(fields);
   }
 
 }

--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -57,6 +57,10 @@ import org.assertj.core.util.DateUtil;
  */
 public class StandardRepresentation implements Representation {
 
+  /**
+   * @deprecated use {@link org.assertj.core.configuration.ConfigurationProvider#representation()} instead
+   */
+  @Deprecated
   // can share this as StandardRepresentation has no state
   public static final StandardRepresentation STANDARD_REPRESENTATION = new StandardRepresentation();
 
@@ -138,13 +142,24 @@ public class StandardRepresentation implements Representation {
     if (object instanceof Map<?, ?>) return toStringOf((Map<?, ?>) object);
     if (object instanceof Tuple) return toStringOf((Tuple) object);
     if (object instanceof MapEntry) return toStringOf((MapEntry<?, ?>) object);
-    return object == null ? null : object.toString();
+    return object == null ? null : fallbackToStringOf(object);
   }
 
   @Override
   public String unambiguousToStringOf(Object obj) {
     return obj == null ? null
         : String.format("%s (%s@%s)", toStringOf(obj), obj.getClass().getSimpleName(), toHexString(obj.hashCode()));
+  }
+
+  /**
+   * Returns the {@code String} representation of the given object. This method is used as a last resort if none of
+   * the {@link StandardRepresentation} predefined string representations were not called.
+   *
+   * @param object the object to represent (never {@code null}
+   * @return to {@code toString} representation for the given object
+   */
+  protected String fallbackToStringOf(Object object) {
+    return object.toString();
   }
 
   protected String toStringOf(Number number) {

--- a/src/main/java/org/assertj/core/util/Maps.java
+++ b/src/main/java/org/assertj/core/util/Maps.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.util;
 
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +40,7 @@ public class Maps {
    */
   @Deprecated
   public static String format(Map<?, ?> map) {
-    return STANDARD_REPRESENTATION.toStringOf(map);
+    return CONFIGURATION_PROVIDER.representation().toStringOf(map);
   }
 
   /**
@@ -53,7 +53,7 @@ public class Maps {
    */
   @Deprecated
   public static String format(Representation p, Map<?, ?> map) {
-    return STANDARD_REPRESENTATION.toStringOf(map);
+    return CONFIGURATION_PROVIDER.representation().toStringOf(map);
   }
 
   public static <K, V> Map<K, V> newHashMap(K key, V value) {

--- a/src/main/java/org/assertj/core/util/diff/Delta.java
+++ b/src/main/java/org/assertj/core/util/diff/Delta.java
@@ -136,6 +136,7 @@ public abstract class Delta<T> {
   }
 
   String formatLines(List<T> lines) {
+    //TODO see what we should use here
     return STANDARD_REPRESENTATION.format(lines, DEFAULT_START, DEFAULT_END, ELEMENT_SEPARATOR_WITH_NEWLINE, "   ");
   }
 

--- a/src/test/java/org/assertj/core/error/BasicErrorMessageFactory_create_Test.java
+++ b/src/test/java/org/assertj/core/error/BasicErrorMessageFactory_create_Test.java
@@ -13,8 +13,10 @@
 package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
+import static org.assertj.core.description.EmptyTextDescription.emptyDescription;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,10 +55,20 @@ public class BasicErrorMessageFactory_create_Test {
   }
 
   @Test
-  public void should_create_error_with_StandardRepresentation() {
+  public void should_create_error_with_configured_representation() {
     Description description = new TestDescription("Test");
     String formattedMessage = "[Test] Hello Yoda";
-    when(formatter.format(eq(description), any(StandardRepresentation.class), eq("Hello %s"), eq("Yoda"))).thenReturn(formattedMessage);
+    when(formatter.format(eq(description), same(CONFIGURATION_PROVIDER.representation()), eq("Hello %s"), eq("Yoda")))
+      .thenReturn(formattedMessage);
     assertThat(factory.create(description)).isEqualTo(formattedMessage);
+  }
+
+  @Test
+  public void should_create_error_with_empty_description_and_configured_representation() {
+    Description description = emptyDescription();
+    String formattedMessage = "[] Hello Yoda";
+    when(formatter.format(eq(description), same(CONFIGURATION_PROVIDER.representation()), eq("Hello %s"), eq("Yoda")))
+      .thenReturn(formattedMessage);
+    assertThat(factory.create()).isEqualTo(formattedMessage);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
@@ -15,8 +15,8 @@ package org.assertj.core.error;
 import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldBeEqualByComparingFieldByFieldRecursively.shouldBeEqualByComparingFieldByFieldRecursive;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -47,8 +47,8 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
     String message = shouldBeEqualByComparingFieldByFieldRecursive(withSortedSet,
                                                                    withHashSet,
                                                                    differences,
-                                                                   STANDARD_REPRESENTATION)
-        .create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+                                                                   CONFIGURATION_PROVIDER.representation())
+        .create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     // @format:on
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +
@@ -79,8 +79,8 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
     String message = shouldBeEqualByComparingFieldByFieldRecursive(withTreeMap,
                                                                    withLinkedHashMap,
                                                                    differences,
-                                                                   STANDARD_REPRESENTATION)
-                                                          .create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+                                                                   CONFIGURATION_PROVIDER.representation())
+                                                          .create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     // @format:on
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +

--- a/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainEntry_create_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.test.Maps.mapOf;
 
 import java.util.Map;
@@ -34,7 +34,7 @@ public class ShouldContainEntry_create_Test {
   public void should_create_error_message_with_entry_condition() {
     Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
     ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test condition"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(String.format("[Test] %n" +
                                                 "Expecting:%n" +
                                                 " <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +
@@ -47,7 +47,7 @@ public class ShouldContainEntry_create_Test {
     Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
     ErrorMessageFactory factory = shouldContainEntry(map, new TestCondition<>("test key condition"),
                                                      new TestCondition<>("test value condition"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(String.format("[Test] %n" +
                                                 "Expecting:%n" +
                                                 " <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n" +

--- a/src/test/java/org/assertj/core/error/ShouldContainsAnyOf_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainsAnyOf_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Lists.newArrayList;
 
 import org.assertj.core.description.TextDescription;
@@ -35,7 +35,7 @@ public class ShouldContainsAnyOf_create_Test {
 
   @Test
   public void should_create_error_message() {
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting:%n" +
                                          "  <[\"Yoda\", \"Han\", \"Han\"]>%n" +
@@ -48,7 +48,7 @@ public class ShouldContainsAnyOf_create_Test {
   public void should_create_error_message_with_custom_comparison_strategy() {
     ErrorMessageFactory factory = shouldContainAnyOf(newArrayList("Yoda", "Han", "Han"), newArrayList("Vador", "Leia"),
                                                      new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting:%n" +
                                          "  <[\"Yoda\", \"Han\", \"Han\"]>%n" +

--- a/src/test/java/org/assertj/core/error/ShouldHaveContent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveContent_create_Test.java
@@ -15,8 +15,8 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +41,7 @@ public class ShouldHaveContent_create_Test {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
 
     ErrorMessageFactory factory = shouldHaveContent(file, defaultCharset(), diffs);
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n"
                                          + "File:%n"
                                          + "  <xyz>%n"

--- a/src/test/java/org/assertj/core/error/ShouldHaveMethods_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveMethods_create_Test.java
@@ -14,10 +14,10 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.util.Sets.newTreeSet;
 
@@ -37,7 +37,7 @@ public class ShouldHaveMethods_create_Test {
     ErrorMessageFactory factory = shouldHaveMethods(Person.class, false,
                                                     newTreeSet("getName", "getAddress"),
                                                     newTreeSet("getAddress"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -52,7 +52,7 @@ public class ShouldHaveMethods_create_Test {
     ErrorMessageFactory factory = shouldHaveMethods(Person.class, true,
                                                     newTreeSet("getName", "getAddress"),
                                                     newTreeSet("getAddress"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -67,7 +67,7 @@ public class ShouldHaveMethods_create_Test {
     ErrorMessageFactory factory = shouldNotHaveMethods(Person.class,
                                                        Modifier.toString(Modifier.PUBLIC), true,
                                                        newTreeSet("getName"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -80,7 +80,7 @@ public class ShouldHaveMethods_create_Test {
     ErrorMessageFactory factory = shouldNotHaveMethods(Person.class,
                                                        Modifier.toString(Modifier.PUBLIC), false,
                                                        newTreeSet("getName"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -91,7 +91,7 @@ public class ShouldHaveMethods_create_Test {
   @Test
   public void should_create_error_message_for_shouldNotHave_Declared_Methods() {
     ErrorMessageFactory factory = shouldNotHaveMethods(Person.class, true, newTreeSet("getName"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -102,7 +102,7 @@ public class ShouldHaveMethods_create_Test {
   @Test
   public void should_create_error_message_for_shouldNotHaveMethods() {
     ErrorMessageFactory factory = shouldNotHaveMethods(Person.class, false, newTreeSet("getName"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +
@@ -116,7 +116,7 @@ public class ShouldHaveMethods_create_Test {
                                                     newTreeSet("finalize"),
                                                     Modifier.toString(Modifier.PUBLIC),
                                                     mapOf(entry("finalize", Modifier.toString(Modifier.PROTECTED))));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting%n" +
                                          "  <org.assertj.core.test.Person>%n" +

--- a/src/test/java/org/assertj/core/error/ShouldHaveReference_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveReference_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldHaveReference.shouldHaveReference;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.concurrent.atomic.AtomicMarkableReference;
 import java.util.concurrent.atomic.AtomicStampedReference;
@@ -33,7 +33,7 @@ public class ShouldHaveReference_create_Test {
     AtomicMarkableReference<String> actual = new AtomicMarkableReference<>("foo", true);
     // WHEN
     String message = shouldHaveReference(actual, actual.getReference(), "bar").create(TEST_DESCRIPTION,
-                                                                                      STANDARD_REPRESENTATION);
+                                                                                      CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting%n" +
@@ -50,7 +50,7 @@ public class ShouldHaveReference_create_Test {
     AtomicStampedReference<String> actual = new AtomicStampedReference<>("foo", 123);
     // WHEN
     String message = shouldHaveReference(actual, actual.getReference(), "bar").create(TEST_DESCRIPTION,
-                                                                                      STANDARD_REPRESENTATION);
+                                                                                      CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting%n" +

--- a/src/test/java/org/assertj/core/error/ShouldHaveStamp_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveStamp_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldHaveStamp.shouldHaveStamp;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.concurrent.atomic.AtomicStampedReference;
 
@@ -29,7 +29,7 @@ public class ShouldHaveStamp_create_Test {
     // GIVEN
     AtomicStampedReference<String> actual = new AtomicStampedReference<>("foo", 1234);
     // WHEN
-    String message = shouldHaveStamp(actual, 5678).create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
+    String message = shouldHaveStamp(actual, 5678).create(new TestDescription("TEST"), CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting%n" +

--- a/src/test/java/org/assertj/core/error/ShouldHaveSuppressedException_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSuppressedException_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldHaveSuppressedException.shouldHaveSuppressedException;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.description.TextDescription;
 import org.junit.Test;
@@ -30,7 +30,7 @@ public class ShouldHaveSuppressedException_create_Test {
 
     ErrorMessageFactory factory = shouldHaveSuppressedException(actual,
                                                                new IllegalArgumentException("foo"));
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting:%n" +
                                          "  <java.lang.Throwable>%n" +

--- a/src/test/java/org/assertj/core/error/ShouldHaveValue_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveValue_create_Test.java
@@ -15,8 +15,8 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldHaveValue.shouldHaveValue;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -44,7 +44,7 @@ public class ShouldHaveValue_create_Test {
     // GIVEN
     AtomicIntegerFieldUpdater<Person> updater = AtomicIntegerFieldUpdater.newUpdater(Person.class, "age");
     // WHEN
-    String message = shouldHaveValue(updater, 33, 20, joe).create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
+    String message = shouldHaveValue(updater, 33, 20, joe).create(TEST_DESCRIPTION, CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting <AtomicIntegerFieldUpdater> to have value:%n" +
@@ -60,7 +60,7 @@ public class ShouldHaveValue_create_Test {
     // GIVEN
     AtomicLongFieldUpdater<Person> updater = AtomicLongFieldUpdater.newUpdater(Person.class, "account");
     // WHEN
-    String message = shouldHaveValue(updater, 123456789L, 0L, joe).create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
+    String message = shouldHaveValue(updater, 123456789L, 0L, joe).create(TEST_DESCRIPTION, CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting <AtomicLongFieldUpdater> to have value:%n" +
@@ -76,7 +76,7 @@ public class ShouldHaveValue_create_Test {
     // GIVEN
     AtomicReferenceFieldUpdater<Person, String> updater = newUpdater(Person.class, String.class, "name");
     // WHEN
-    String message = shouldHaveValue(updater, "Joe", "Jack", joe).create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
+    String message = shouldHaveValue(updater, "Joe", "Jack", joe).create(TEST_DESCRIPTION, CONFIGURATION_PROVIDER.representation());
     // THEN
     assertThat(message).isEqualTo(format("[TEST] %n" +
                                          "Expecting <AtomicReferenceFieldUpdater> to have value:%n" +

--- a/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.description.TextDescription;
 import org.junit.Before;
@@ -32,7 +32,7 @@ public class ShouldNotContainPattern_create_Test {
 
   @Test
   public void should_create_error_message() {
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting:%n" +
                                          "  \"Frodo\"%n" +

--- a/src/test/java/org/assertj/core/error/ShouldNotHaveAnyElementsOfTypes_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotHaveAnyElementsOfTypes_create_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldNotHaveAnyElementsOfTypes.shouldNotHaveAnyElementsOfTypes;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class ShouldNotHaveAnyElementsOfTypes_create_Test {
                                                                                                       unexpectedTypes,
                                                                                                       nonMatchingElementsByType);
     // WHEN
-    String message = shouldNotHaveAnyElementsOfTypes.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    String message = shouldNotHaveAnyElementsOfTypes.create(new TestDescription("Test"), CONFIGURATION_PROVIDER.representation());
 
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
@@ -15,8 +15,8 @@ package org.assertj.core.internal.objects;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.error.ShouldBeEqualByComparingFieldByFieldRecursively.shouldBeEqualByComparingFieldByFieldRecursive;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_TIMESTAMP;
 import static org.assertj.core.test.NeverEqualComparator.NEVER_EQUALS;
@@ -162,7 +162,7 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
                                                                                    asList(new Difference(asList("name"),
                                                                                                          "John",
                                                                                                          "Jack")),
-                                                                                   STANDARD_REPRESENTATION));
+                                                                                   CONFIGURATION_PROVIDER.representation()));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -189,7 +189,7 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
                                                                              asList(new Difference(asList("home.address.number"),
                                                                                                    1,
                                                                                                    2)),
-                                                                             STANDARD_REPRESENTATION));
+                                                                             CONFIGURATION_PROVIDER.representation()));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -261,7 +261,7 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
                                                                              asList(new Difference(asList("home.address.number"),
                                                                                                    1,
                                                                                                    2)),
-                                                                             STANDARD_REPRESENTATION));
+                                                                             CONFIGURATION_PROVIDER.representation()));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
@@ -14,7 +14,6 @@ package org.assertj.core.presentation;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Strings.quote;
 
 import org.junit.Test;
@@ -23,6 +22,8 @@ import org.junit.Test;
  * Tests for <code>{@link StandardRepresentation#formatArray(Object)}</code>.
  */
 public class StandardRepresentation_array_format_Test extends AbstractBaseRepresentationTest {
+
+  private static final StandardRepresentation STANDARD_REPRESENTATION = new StandardRepresentation();
 
   @Test
   public void should_return_null_if_array_is_null() {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -15,7 +15,6 @@ package org.assertj.core.presentation;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +22,8 @@ import java.util.List;
 import org.junit.Test;
 
 public class StandardRepresentation_iterable_format_Test extends AbstractBaseRepresentationTest {
+
+  private static final StandardRepresentation STANDARD_REPRESENTATION = new StandardRepresentation();
 
   @Test
   public void should_return_null_if_iterable_is_null() {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
@@ -13,14 +13,12 @@
 package org.assertj.core.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
 
 /**
@@ -31,6 +29,7 @@ import org.junit.Test;
  * @author gabga
  */
 public class StandardRepresentation_map_format_Test extends AbstractBaseRepresentationTest {
+  private static final StandardRepresentation STANDARD_REPRESENTATION = new StandardRepresentation();
 
   @Test
   public void should_return_null_if_Map_is_null() {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_Test.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -51,6 +50,8 @@ import org.junit.Test;
  * @author Joel Costigliola
  */
 public class StandardRepresentation_toStringOf_Test extends AbstractBaseRepresentationTest {
+
+  private static final StandardRepresentation STANDARD_REPRESENTATION = new StandardRepresentation();
 
   @Test
   public void should_return_null_if_object_is_null() {

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.test;
 
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
+
 import static java.lang.String.format;
 
 import java.util.ArrayList;
@@ -19,7 +21,6 @@ import java.util.List;
 
 import org.assertj.core.error.AssertionErrorFactory;
 import org.assertj.core.error.ErrorMessageFactory;
-import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.introspection.IntrospectionError;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -65,7 +66,7 @@ public class ExpectedException implements TestRule {
   }
 
   public void expectAssertionError(AssertionErrorFactory assertionErrorFactory) {
-    AssertionError assertionError = assertionErrorFactory.newAssertionError(null, StandardRepresentation.STANDARD_REPRESENTATION);
+    AssertionError assertionError = assertionErrorFactory.newAssertionError(null, CONFIGURATION_PROVIDER.representation());
     delegate.expect(new ThrowableMatcher<>(AssertionError.class, assertionError.getMessage()));
   }
 


### PR DESCRIPTION
#### Check List:
* Fixes #1016 
* Unit tests : YES
* Javadoc with a code example (API only):  NA

I added `ConfigurationProvider` that could potentially be a single entry place for SPI / default configuration within AssertJ. 

We need to find a way to test the `ConfigurationProvider` better. We need to test that we use the `StandardRepresentation` when nothing is registered or we use the registered configuration when something is registered. In [mapstruct](https://github.com/mapstruct/mapstruct) another project I am working on we have a nice way of testing such SPIs. There is a custom JUnit 4 runner that does some "magic" with the classloaders and registers SPIs if needed (via annotation). We want to extract this testing infrastructure into a separate module / project, but we haven't had the time yet.

I am open to discussion for everything in the PR.


