### PR TITLE
Allow overriding collected error list modification

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -101,7 +101,16 @@ public class AbstractSoftAssertions {
    * @return a copy of list of soft assertions collected errors.
    */
   public List<Throwable> errorsCollected() {
-    return addLineNumberToErrorMessages(proxies.errorsCollected());
+    return decorateErrorsCollected(proxies.errorsCollected());
+  }
+  
+  /**
+   * Modifies collected errors. Override to customize modification.
+   * @param errors list of errors to decorate
+   * @return decorated list
+  */
+  protected List<Throwable> decorateErrorsCollected(List<Throwable> errors) {
+    return addLineNumberToErrorMessages(errors);
   }
 
   /**


### PR DESCRIPTION
This is a suggestion of how to avoid error list modification for those who doesn't want it, and still retain this functionality for those who do. I am not sure about method names but this is the general idea anyway.

#### Check List:
* Fixes #1036
* Unit tests : NO
* Javadoc with a code example (API only) : NO


