### PR TITLE
Custom error processor

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -101,7 +101,16 @@ public class AbstractSoftAssertions {
    * @return a copy of list of soft assertions collected errors.
    */
   public List<Throwable> errorsCollected() {
-    return addLineNumberToErrorMessages(proxies.errorsCollected());
+    return decorateErrorsCollected(proxies.errorsCollected());
+  }
+  
+  /**
+   * Modifies collected errors. Override to customize modification.
+   * @param errors list of errors to decorate
+   * @return decorated list
+  */
+  protected List<Throwable> decorateErrorsCollected(List<Throwable> errors) {
+    return addLineNumberToErrorMessages(errors);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -16,6 +16,7 @@ import static java.lang.String.format;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.assertj.core.internal.Failures;
 
@@ -24,7 +25,7 @@ public class AbstractSoftAssertions {
   protected final SoftProxies proxies;
 
   public AbstractSoftAssertions() {
-    proxies = new SoftProxies();
+    proxies = new SoftProxies(errorProcessor());
   }
 
   public <T, V> V proxy(Class<V> assertClass, Class<T> actualClass, T actual) {
@@ -111,6 +112,10 @@ public class AbstractSoftAssertions {
   */
   protected List<Throwable> decorateErrorsCollected(List<Throwable> errors) {
     return addLineNumberToErrorMessages(errors);
+  }
+  
+  protected Consumer<Throwable> errorProcessor() {
+	  return t -> {};
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/ErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/ErrorCollector.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
@@ -31,6 +32,16 @@ public class ErrorCollector implements MethodInterceptor {
   private final List<Throwable> errors = new ArrayList<>();
   // scope : the last assertion call (might be nested)
   private final LastResult lastResult = new LastResult();
+  
+  private final Consumer<Throwable> errorProcessor;
+  
+  public ErrorCollector() {
+	  this(t -> {});
+  }
+  
+  public ErrorCollector(Consumer<Throwable> errorProcessor) {
+	  this.errorProcessor = errorProcessor;
+  }
 
   @Override
   public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
@@ -45,6 +56,7 @@ public class ErrorCollector implements MethodInterceptor {
       }
       lastResult.setSuccess(false);
       errors.add(e);
+      errorProcessor.accept(e);
     }
     return result;
   }

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -16,14 +16,18 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.function.Consumer;
 
 import net.sf.cglib.proxy.Callback;
 import net.sf.cglib.proxy.CallbackFilter;
 import net.sf.cglib.proxy.Enhancer;
 
 class SoftProxies {
-
-  private final ErrorCollector collector = new ErrorCollector();
+  private final ErrorCollector collector;
+  
+  SoftProxies(Consumer<Throwable> errorProcessor) {
+	  collector = new ErrorCollector(errorProcessor);
+  }
 
   void collectError(Throwable error) {
     collector.addError(error);


### PR DESCRIPTION
Here is another PR with a possible implementation of pluggable and customizable error processing hook which hopefully does not break existing API and does not expose much of the internals. This is basically what I was trying to achieve when encountered issue #1036.

Unfortunately this PR it contains changes from my previous PR #1038 as well. I should have kept them separate.

