### PR TITLE
Small cleanups

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2146,7 +2146,7 @@ public class Assertions {
    * <p>
    * An alternative way of using a different representation is to register one as a service, 
    * this approach is described in {@link Representation}, it requires more work than this method 
-   * but has the advantage of not having to do do anything in your tests. 
+   * but has the advantage of not having to do anything in your tests and it would be applied to all the tests globally
    * <p>
    * Example :
    * <pre><code class='java'> private class Example {}

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -50,7 +50,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 /**
  * Entry point for assumption methods for different types, which allow to skip test execution on failed assumptions.
- * @since 2.9.0
+ * @since 2.9.0 / 3.9.0
  */
 public class Assumptions {
 

--- a/src/main/java/org/assertj/core/api/HamcrestCondition.java
+++ b/src/main/java/org/assertj/core/api/HamcrestCondition.java
@@ -28,6 +28,7 @@ import org.hamcrest.StringDescription;
  * 
  * // assertion will fail
  * assertThat(&quot;bc&quot;).is(aStringContainingA);</code></pre>
+ * @since 2.9.0 / 3.9.0
 */
 public class HamcrestCondition<T> extends Condition<T> {
 

--- a/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/assertj/core/configuration/ConfigurationProvider.java
@@ -30,7 +30,7 @@ public final class ConfigurationProvider {
 
   private final Representation defaultRepresentation;
 
-  public ConfigurationProvider() {
+  private ConfigurationProvider() {
     defaultRepresentation = Services.get(Representation.class, STANDARD_REPRESENTATION);
   }
 

--- a/src/main/java/org/assertj/core/presentation/Representation.java
+++ b/src/main/java/org/assertj/core/presentation/Representation.java
@@ -28,9 +28,11 @@ import org.assertj.core.api.Assertions;
  * <p>
  * To register a {@link Representation}, you need to do several things:
  * <ul>
- * <li>create a file named in {@code org.assertj.core.presentation.Representation} file in META-INF/services directory</li>
+ * <li>create a file named {@code org.assertj.core.presentation.Representation} file in META-INF/services directory</li>
  * <li>put the fully qualified class name of your {@link Representation} in it</li>   
- * <li>make sure {@code META-INF/services/org.assertj.core.presentation.Representation} is in the runtime classpath, usually putting it in {@code src/main/resources} is enough</li>  
+ * <li>make sure {@code META-INF/services/org.assertj.core.presentation.Representation} is in the runtime classpath, usually putting it in {@code src/test/resources} is enough</li>
+ * <li>we recommend that you extend from the {@link StandardRepresentation} and override the
+ * {@link StandardRepresentation#fallbackToStringOf(Object)}. By doing this all the defaults of AssertJ would be applied and you can apply your own customization</li>
  * </ul>
  * <p>
  * The <a href="https://github.com/joel-costigliola/assertj-examples/tree/master/assertions-examples">assertj-examples</a> project provides a working example of registering a custom representation.


### PR DESCRIPTION
This is some small Javadoc changes and cleanups:

* Add some missing since tags
* Make the ConfigurationProvider constructor private
* Do some rewording and fix some typos around the new SPI Representation

I think that the most important change here is that the `META-INF/services` folder needs to be in `src/test/resources` and not `src/main/resources`. Users usually have a test scoped dependency of AssertJ.

I've also fixed some small typos that I saw and I added the recommended way of writing a custom `Representation`. I think it is much easier for the users if they just extend the `StandardRepresentation` and override `fallbackToStringOf(Object)` method, this way they won't mess with all the defaults from AssertJ.

