### PR TITLE
Make URI parameter checks use the raw query.

### DIFF
--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -135,7 +135,7 @@ public class Uris {
   public void assertHasParameter(AssertionInfo info, URI actual, String name) {
     assertNotNull(info, actual);
 
-    Map<String, List<String>> parameters = getParameters(actual.getQuery());
+    Map<String, List<String>> parameters = getParameters(actual.getRawQuery());
     if (!parameters.containsKey(name)) throw failures.failure(info, shouldHaveParameter(actual, name));
   }
 
@@ -143,7 +143,7 @@ public class Uris {
                                  String expectedParameterValue) {
     assertNotNull(info, actual);
 
-    Map<String, List<String>> parameters = getParameters(actual.getQuery());
+    Map<String, List<String>> parameters = getParameters(actual.getRawQuery());
 
     if (!parameters.containsKey(expectedParameterName))
       throw failures.failure(info, shouldHaveParameter(actual, expectedParameterName, expectedParameterValue));
@@ -156,14 +156,14 @@ public class Uris {
   public void assertHasNoParameters(AssertionInfo info, URI actual) {
     assertNotNull(info, actual);
 
-    Map<String, List<String>> parameters = getParameters(actual.getQuery());
+    Map<String, List<String>> parameters = getParameters(actual.getRawQuery());
     if (!parameters.isEmpty()) throw failures.failure(info, shouldHaveNoParameters(actual, parameters.keySet()));
   }
 
   public void assertHasNoParameter(AssertionInfo info, URI actual, String name) {
     assertNotNull(info, actual);
 
-    Map<String, List<String>> parameters = getParameters(actual.getQuery());
+    Map<String, List<String>> parameters = getParameters(actual.getRawQuery());
     if (parameters.containsKey(name))
       throw failures.failure(info, shouldHaveNoParameter(actual, name, parameters.get(name)));
   }
@@ -171,7 +171,7 @@ public class Uris {
   public void assertHasNoParameter(AssertionInfo info, URI actual, String name, String unwantedValue) {
     assertNotNull(info, actual);
 
-    Map<String, List<String>> parameters = getParameters(actual.getQuery());
+    Map<String, List<String>> parameters = getParameters(actual.getRawQuery());
 
     if (parameters.containsKey(name)) {
       List<String> values = parameters.get(name);

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasParameter_Test.java
@@ -178,4 +178,9 @@ public class Uris_assertHasParameter_Test extends UrisBaseTest {
   public void should_pass_if_parameter_with_value_is_found() throws URISyntaxException {
     uris.assertHasParameter(info, new URI("http://assertj.org/news?article=10"), "article", "10");
   }
+
+  @Test
+  public void should_correctly_unescape_values() throws URISyntaxException {
+    uris.assertHasParameter(info, new URI("http://assertj.org/news?article=abc%26page%3D5"), "article", "abc&page=5");
+  }
 }


### PR DESCRIPTION
Previously URI parameters would be parsed after being decoded, which led to some mishandling of escaped '&' and '='.

* Fixes: #1699
* Unit tests : YES