### PR TITLE
Use Opentest4j assertion failed error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>1.3</version>

--- a/src/main/java/org/assertj/core/error/ConstructorInvoker.java
+++ b/src/main/java/org/assertj/core/error/ConstructorInvoker.java
@@ -23,7 +23,7 @@ import java.security.*;
  */
 class ConstructorInvoker {
 
-  Object newInstance(String className, Class<?>[] parameterTypes, Object[] parameterValues) throws Exception {
+  Object newInstance(String className, Class<?>[] parameterTypes, Object... parameterValues) throws Exception {
     Class<?> targetType = Class.forName(className);
     Constructor<?> constructor = targetType.getConstructor(parameterTypes);
     boolean accessible = constructor.isAccessible();

--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -148,8 +148,10 @@ public class ShouldBeEqual implements AssertionErrorFactory {
    *          of object
    * @return the error message from description using {@link #expected} and {@link #actual} basic representation.
    */
-  protected String defaultErrorMessage(Description description, Representation representation) {
+  private String defaultErrorMessage(Description description, Representation representation) {
     if (actualAndExpectedHaveSameStringRepresentation()) {
+      // Example : actual = 42f and expected = 42d gives actual : "42" and expected : "42" therefore we need
+      // to create a detailed error message`
       return defaultDetailedErrorMessage(description, representation);
     }
     return comparisonStrategy.isStandard()
@@ -180,7 +182,10 @@ public class ShouldBeEqual implements AssertionErrorFactory {
   private AssertionError assertionFailedError(String message) {
     try {
       Object o = constructorInvoker
-        .newInstance("org.opentest4j.AssertionFailedError", MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR, message, expected,
+        .newInstance("org.opentest4j.AssertionFailedError",
+                     MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR,
+                     message,
+                     expected,
                      actual);
       if (o instanceof AssertionError) {
         return (AssertionError) o;

--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -43,6 +43,8 @@ public class ShouldBeEqual implements AssertionErrorFactory {
   private static final String EXPECTED_BUT_WAS_MESSAGE_USING_COMPARATOR = "%nExpecting:%n <%s>%nto be equal to:%n " +
                                                                           "<%s>%n%s but was not.";
   private static final Class<?>[] MSG_ARG_TYPES = new Class<?>[] { String.class, String.class, String.class };
+  private static final Class<?>[] MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR = new Class<?>[] { String.class,
+    Object.class, Object.class };
   protected final Object actual;
   protected final Object expected;
   @VisibleForTesting
@@ -97,6 +99,9 @@ public class ShouldBeEqual implements AssertionErrorFactory {
    * {@link #expected} string representation were different), this method will instead create a
    * org.junit.ComparisonFailure that highlights the difference(s) between the expected and actual objects.
    * </p>
+   * <p>
+   *   If opentest4j is on the classpath then {@code org.opentest4j.AssertionFailedError} would be used.
+   * </p>
    * {@link AssertionError} stack trace won't show AssertJ related elements if {@link Failures} is configured to filter
    * them (see {@link Failures#setRemoveAssertJRelatedElementsFromStackTrace(boolean)}).
    *
@@ -106,25 +111,28 @@ public class ShouldBeEqual implements AssertionErrorFactory {
    */
   @Override
   public AssertionError newAssertionError(Description description, Representation representation) {
-    if (actualAndExpectedHaveSameStringRepresentation()) {
+    // only use JUnit error message if comparison strategy was standard, otherwise we need to mention it in the
+    // assertion error message to make it clear to the user it was used.
+    if (comparisonStrategy.isStandard() && !actualAndExpectedHaveSameStringRepresentation()) {
       // Example : actual = 42f and expected = 42d gives actual : "42" and expected : "42" and
       // JUnit 4 manages this case even worst, it will output something like :
       // "java.lang.String expected:java.lang.String<42.0> but was: java.lang.String<42.0>"
       // which does not solve the problem and makes things even more confusing since we lost the fact that 42 was a
       // float or a double, it is then better to built our own description, with the drawback of not using a
       // ComparisonFailure (which looks nice in eclipse)
-      return Failures.instance().failure(defaultDetailedErrorMessage(description, representation));
-    }
-    // only use JUnit error message if comparison strategy was standard, otherwise we need to mention it in the
-    // assertion error message to make it clear to the user it was used.
-    if (comparisonStrategy.isStandard()) {
       // comparison strategy is standard -> try to build a JUnit ComparisonFailure that is nicely displayed in IDE.
       AssertionError error = comparisonFailure(description);
-      // error ==null means that JUnit was not in the classpath
+      // error ==null means that JUnit 4 was not in the classpath
       if (error != null) return error;
     }
+
+    String message = defaultErrorMessage(description, representation);
+    AssertionError assertionFailedError = assertionFailedError(message);
+    if (assertionFailedError != null) {
+      return assertionFailedError;
+    }
     // No JUnit in the classpath => fall back to default error message
-    return Failures.instance().failure(defaultErrorMessage(description, representation));
+    return Failures.instance().failure(message);
   }
 
   private boolean actualAndExpectedHaveSameStringRepresentation() {
@@ -140,7 +148,10 @@ public class ShouldBeEqual implements AssertionErrorFactory {
    *          of object
    * @return the error message from description using {@link #expected} and {@link #actual} basic representation.
    */
-  private String defaultErrorMessage(Description description, Representation representation) {
+  protected String defaultErrorMessage(Description description, Representation representation) {
+    if (actualAndExpectedHaveSameStringRepresentation()) {
+      return defaultDetailedErrorMessage(description, representation);
+    }
     return comparisonStrategy.isStandard()
         ? messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, actual, expected)
         : messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE_USING_COMPARATOR,
@@ -164,6 +175,20 @@ public class ShouldBeEqual implements AssertionErrorFactory {
                                      detailedExpected(), comparisonStrategy);
     return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, detailedActual(),
                                    detailedExpected());
+  }
+
+  private AssertionError assertionFailedError(String message) {
+    try {
+      Object o = constructorInvoker
+        .newInstance("org.opentest4j.AssertionFailedError", MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR, message, expected,
+                     actual);
+      if (o instanceof AssertionError) {
+        return (AssertionError) o;
+      }
+      return null;
+    } catch (Throwable e) {
+      return null;
+    }
   }
 
   private AssertionError comparisonFailure(Description description) {

--- a/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
+++ b/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
@@ -20,57 +20,6 @@ import java.util.List;
 public class ClassUtils {
 
   /**
-   * Determine whether the {@link Class} identified by the supplied name is present
-   * and can be loaded. Will return {@code false} if either the class or
-   * one of its dependencies is not present or cannot be loaded.
-   *
-   * @param className   the name of the class to check
-   * @param classLoader the class loader to use
-   *                    (may be {@code null}, which indicates the default class loader)
-   * @return whether the specified class is present
-   */
-  public static boolean isPresent(String className, ClassLoader classLoader) {
-    ClassLoader classLoaderToUse = classLoader;
-    if (classLoaderToUse == null) {
-      classLoaderToUse = getDefaultClassLoader();
-    }
-
-    try {
-      classLoaderToUse.loadClass(className);
-      return true;
-    } catch (Throwable e) {
-      return false;
-    }
-  }
-
-  /**
-   * Return the default ClassLoader to use: typically the thread context
-   * ClassLoader, if available; the ClassLoader that loaded the ClassUtils
-   * class will be used as fallback.
-   * <p>Call this method if you intend to use the thread context ClassLoader
-   * in a scenario where you absolutely need a non-null ClassLoader reference:
-   * for example, for class path resource loading (but not necessarily for
-   * {@code Class.forName}, which accepts a {@code null} ClassLoader
-   * reference as well).
-   *
-   * @return the default ClassLoader (never {@code null})
-   * @see Thread#getContextClassLoader()
-   */
-  private static ClassLoader getDefaultClassLoader() {
-    ClassLoader cl = null;
-    try {
-      cl = Thread.currentThread().getContextClassLoader();
-    } catch (Throwable ex) {
-      // Cannot access thread context ClassLoader - falling back to system class loader...
-    }
-    if (cl == null) {
-      // No thread context class loader -> use class loader of this class.
-      cl = ClassUtils.class.getClassLoader();
-    }
-    return cl;
-  }
-
-  /**
    * <p>Gets a {@code List} of superclasses for the given class.</p>
    *
    * @param cls the class to look up, may be {@code null}

--- a/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
+++ b/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
@@ -20,6 +20,57 @@ import java.util.List;
 public class ClassUtils {
 
   /**
+   * Determine whether the {@link Class} identified by the supplied name is present
+   * and can be loaded. Will return {@code false} if either the class or
+   * one of its dependencies is not present or cannot be loaded.
+   *
+   * @param className   the name of the class to check
+   * @param classLoader the class loader to use
+   *                    (may be {@code null}, which indicates the default class loader)
+   * @return whether the specified class is present
+   */
+  public static boolean isPresent(String className, ClassLoader classLoader) {
+    ClassLoader classLoaderToUse = classLoader;
+    if (classLoaderToUse == null) {
+      classLoaderToUse = getDefaultClassLoader();
+    }
+
+    try {
+      classLoaderToUse.loadClass(className);
+      return true;
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+
+  /**
+   * Return the default ClassLoader to use: typically the thread context
+   * ClassLoader, if available; the ClassLoader that loaded the ClassUtils
+   * class will be used as fallback.
+   * <p>Call this method if you intend to use the thread context ClassLoader
+   * in a scenario where you absolutely need a non-null ClassLoader reference:
+   * for example, for class path resource loading (but not necessarily for
+   * {@code Class.forName}, which accepts a {@code null} ClassLoader
+   * reference as well).
+   *
+   * @return the default ClassLoader (never {@code null})
+   * @see Thread#getContextClassLoader()
+   */
+  private static ClassLoader getDefaultClassLoader() {
+    ClassLoader cl = null;
+    try {
+      cl = Thread.currentThread().getContextClassLoader();
+    } catch (Throwable ex) {
+      // Cannot access thread context ClassLoader - falling back to system class loader...
+    }
+    if (cl == null) {
+      // No thread context class loader -> use class loader of this class.
+      cl = ClassUtils.class.getClassLoader();
+    }
+    return cl;
+  }
+
+  /**
    * <p>Gets a {@code List} of superclasses for the given class.</p>
    *
    * @param cls the class to look up, may be {@code null}

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
@@ -76,11 +76,11 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     assertThat(error)
       .isInstanceOf(AssertionFailedError.class)
       .hasMessage("[my test] %n" +
-                                 "Expecting:%n" +
-                                 " <\"Person[name=Jake] (Person@%s)\">%n" +
-                                 "to be equal to:%n" +
-                                 " <\"Person[name=Jake] (Person@%s)\">%n"
-                                 + "but was not.", toHexString(actual.hashCode()), toHexString(expected.hashCode()));
+                  "Expecting:%n" +
+                  " <\"Person[name=Jake] (Person@%s)\">%n" +
+                  "to be equal to:%n" +
+                  " <\"Person[name=Jake] (Person@%s)\">%n"
+                  + "but was not.", toHexString(actual.hashCode()), toHexString(expected.hashCode()));
   }
 
   @Test
@@ -98,12 +98,12 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     assertThat(error)
       .isInstanceOf(AssertionFailedError.class)
       .hasMessage("[my test] %n" +
-                                 "Expecting:%n" +
-                                 " <\"Person[name=Jake] (Person@%s)\">%n" +
-                                 "to be equal to:%n" +
-                                 " <\"Person[name=Jake] (Person@%s)\">%n" +
-                                 "when comparing values using 'PersonComparator'" +
-                                 " but was not.", toHexString(actual.hashCode()), toHexString(expected.hashCode()));
+                  "Expecting:%n" +
+                  " <\"Person[name=Jake] (Person@%s)\">%n" +
+                  "to be equal to:%n" +
+                  " <\"Person[name=Jake] (Person@%s)\">%n" +
+                  "when comparing values using 'PersonComparator'" +
+                  " but was not.", toHexString(actual.hashCode()), toHexString(expected.hashCode()));
   }
 
   @Test
@@ -119,11 +119,11 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     assertThat(error)
       .isInstanceOf(AssertionFailedError.class)
       .hasMessage("[my test] %n" +
-                                 "Expecting:%n" +
-                                 " <null>%n" +
-                                 "to be equal to:%n" +
-                                 " <\"null (ToStringIsNull@%s)\">%n" +
-                                 "but was not.", toHexString(expected.hashCode()));
+                  "Expecting:%n" +
+                  " <null>%n" +
+                  "to be equal to:%n" +
+                  " <\"null (ToStringIsNull@%s)\">%n" +
+                  "but was not.", toHexString(expected.hashCode()));
   }
 
   @Test
@@ -139,11 +139,11 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     assertThat(error)
       .isInstanceOf(AssertionFailedError.class)
       .hasMessage("[my test] %n" +
-                                 "Expecting:%n" +
-                                 " <\"null (ToStringIsNull@%s)\">%n" +
-                                 "to be equal to:%n" +
-                                 " <null>%n" +
-                                 "but was not.", toHexString(actual.hashCode()));
+                  "Expecting:%n" +
+                  " <\"null (ToStringIsNull@%s)\">%n" +
+                  "to be equal to:%n" +
+                  " <null>%n" +
+                  "but was not.", toHexString(actual.hashCode()));
   }
 
   private static class Person {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
@@ -27,7 +27,9 @@ import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Before;
+import org.junit.ComparisonFailure;
 import org.junit.Test;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * Tests for
@@ -56,7 +58,9 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
 
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
 
-    assertThat(error).hasMessage("[my test] expected:<42.0[]> but was:<42.0[f]>");
+    assertThat(error)
+      .isInstanceOf(ComparisonFailure.class)
+      .hasMessage("[my test] expected:<42.0[]> but was:<42.0[f]>");
   }
 
   @Test
@@ -69,7 +73,9 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
 
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
 
-    assertThat(error).hasMessage("[my test] %n" +
+    assertThat(error)
+      .isInstanceOf(AssertionFailedError.class)
+      .hasMessage("[my test] %n" +
                                  "Expecting:%n" +
                                  " <\"Person[name=Jake] (Person@%s)\">%n" +
                                  "to be equal to:%n" +
@@ -89,7 +95,9 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
 
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
 
-    assertThat(error).hasMessage("[my test] %n" +
+    assertThat(error)
+      .isInstanceOf(AssertionFailedError.class)
+      .hasMessage("[my test] %n" +
                                  "Expecting:%n" +
                                  " <\"Person[name=Jake] (Person@%s)\">%n" +
                                  "to be equal to:%n" +
@@ -108,7 +116,9 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
 
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
 
-    assertThat(error).hasMessage("[my test] %n" +
+    assertThat(error)
+      .isInstanceOf(AssertionFailedError.class)
+      .hasMessage("[my test] %n" +
                                  "Expecting:%n" +
                                  " <null>%n" +
                                  "to be equal to:%n" +
@@ -126,7 +136,9 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
 
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
 
-    assertThat(error).hasMessage("[my test] %n" +
+    assertThat(error)
+      .isInstanceOf(AssertionFailedError.class)
+      .hasMessage("[my test] %n" +
                                  "Expecting:%n" +
                                  " <\"null (ToStringIsNull@%s)\">%n" +
                                  "to be equal to:%n" +

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
@@ -76,13 +76,13 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_Test {
   private void check(AssertionError error) throws Exception {
     verify(constructorInvoker)
       .newInstance(ComparisonFailure.class.getName(), new Class<?>[] { String.class, String.class, String.class },
-                   array("[Jedi]", "\"Yoda\"", "\"Luke\""));
+                   "[Jedi]", "\"Yoda\"", "\"Luke\"");
     verify(constructorInvoker)
       .newInstance(AssertionFailedError.class.getName(), new Class<?>[] { String.class, Object.class, Object.class },
-                   array(String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."),
-                         "Yoda", "Luke"));
-    assertThat(error).isNotInstanceOf(ComparisonFailure.class);
-    assertThat(error).isInstanceOf(AssertionFailedError.class);
+                   String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."),
+                   "Yoda", "Luke");
+    assertThat(error).isNotInstanceOf(ComparisonFailure.class)
+                     .isInstanceOf(AssertionFailedError.class);
     AssertionFailedError assertionFailedError = (AssertionFailedError) error;
     assertThat(assertionFailedError.getActual().getValue()).isEqualTo("Luke");
     assertThat(assertionFailedError.getExpected().getValue()).isEqualTo("Yoda");

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
@@ -14,14 +14,11 @@ package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
-import static org.assertj.core.util.Arrays.array;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyVararg;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Failures;
@@ -63,14 +60,14 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test {
   @Test
   public void should_create_AssertionError_if_created_ComparisonFailure_and_AssertionFailedError_is_null()
     throws Exception {
-    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), anyVararg())).thenReturn(null);
+    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), any(Object[].class))).thenReturn(null);
     AssertionError error = factory.newAssertionError(description, new StandardRepresentation());
     check(error);
   }
 
   @Test
   public void should_create_AssertionError_if_error_is_thrown_when_creating_ComparisonFailure() throws Exception {
-    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), anyVararg()))
+    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), any(Object[].class)))
       .thenThrow(new AssertionError("Thrown on purpose"));
     AssertionError error = factory.newAssertionError(description, new StandardRepresentation());
     check(error);
@@ -79,11 +76,11 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test {
   private void check(AssertionError error) throws Exception {
     verify(constructorInvoker)
       .newInstance(ComparisonFailure.class.getName(), new Class<?>[] { String.class, String.class, String.class },
-                   array("[Jedi]", "\"Yoda\"", "\"Luke\""));
+                   "[Jedi]", "\"Yoda\"", "\"Luke\"");
     verify(constructorInvoker)
       .newInstance(AssertionFailedError.class.getName(), new Class<?>[] { String.class, Object.class, Object.class },
-                   array(String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."),
-                         "Yoda", "Luke"));
+                   String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."),
+                   "Yoda", "Luke");
     assertThat(error).isNotInstanceOf(ComparisonFailure.class);
     assertThat(error).isNotInstanceOf(AssertionFailedError.class);
     assertThat(error.getMessage())

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
@@ -12,6 +12,17 @@
  */
 package org.assertj.core.error;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyVararg;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.TestDescription;
@@ -25,19 +36,13 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 import org.opentest4j.AssertionFailedError;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
-import static org.assertj.core.util.Arrays.array;
-import static org.mockito.Mockito.*;
-
-
 /**
- * Tests for <code>{@link ShouldBeEqual#newAssertionError(Description, org.assertj.core.presentation.Representation)}</code>.
- * 
- * @author Alex Ruiz
- * @author Yvonne Wang
+ * Tests for
+ * <code>{@link ShouldBeEqual#newAssertionError(Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Filip Hrisafov
  */
-public class ShouldBeEqual_newAssertionError_without_JUnit_Test {
+public class ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test {
 
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
@@ -51,26 +56,24 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_Test {
     Failures.instance().setRemoveAssertJRelatedElementsFromStackTrace(false);
     description = new TestDescription("Jedi");
     factory = (ShouldBeEqual) shouldBeEqual("Luke", "Yoda", new StandardRepresentation());
-    constructorInvoker = mock(ConstructorInvoker.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    constructorInvoker = mock(ConstructorInvoker.class);
     factory.constructorInvoker = constructorInvoker;
   }
 
   @Test
-  public void should_create_AssertionFailedError_if_created_ComparisonFailure_is_null() throws Exception {
-    when(createComparisonFailure()).thenReturn(null);
+  public void should_create_AssertionError_if_created_ComparisonFailure_and_AssertionFailedError_is_null()
+    throws Exception {
+    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), anyVararg())).thenReturn(null);
     AssertionError error = factory.newAssertionError(description, new StandardRepresentation());
     check(error);
   }
 
   @Test
-  public void should_create_AssertionFailedError_if_error_is_thrown_when_creating_ComparisonFailure() throws Exception {
-    when(createComparisonFailure()).thenThrow(new AssertionError("Thrown on purpose"));
+  public void should_create_AssertionError_if_error_is_thrown_when_creating_ComparisonFailure() throws Exception {
+    when(constructorInvoker.newInstance(any(String.class), any(Class[].class), anyVararg()))
+      .thenThrow(new AssertionError("Thrown on purpose"));
     AssertionError error = factory.newAssertionError(description, new StandardRepresentation());
     check(error);
-  }
-
-  private Object createComparisonFailure() throws Exception {
-    return createComparisonFailure(constructorInvoker);
   }
 
   private void check(AssertionError error) throws Exception {
@@ -82,16 +85,8 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_Test {
                    array(String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."),
                          "Yoda", "Luke"));
     assertThat(error).isNotInstanceOf(ComparisonFailure.class);
-    assertThat(error).isInstanceOf(AssertionFailedError.class);
-    AssertionFailedError assertionFailedError = (AssertionFailedError) error;
-    assertThat(assertionFailedError.getActual().getValue()).isEqualTo("Luke");
-    assertThat(assertionFailedError.getExpected().getValue()).isEqualTo("Yoda");
+    assertThat(error).isNotInstanceOf(AssertionFailedError.class);
     assertThat(error.getMessage())
-        .isEqualTo(String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."));
-  }
-
-  private static Object createComparisonFailure(ConstructorInvoker invoker) throws Exception {
-    return invoker.newInstance(ComparisonFailure.class.getName(), new Class<?>[] { String.class, String.class, String.class },
-        array("[Jedi]", "\"Yoda\"", "\"Luke\""));
+      .isEqualTo(String.format("[Jedi] %nExpecting:%n <\"Luke\">%nto be equal to:%n <\"Yoda\">%nbut was not."));
   }
 }


### PR DESCRIPTION
As I wrote in the issue. We are defaulting to the `ComparisonFailure` from JUnit 4 if both are on the classpath. Otherwise we use `AssertionFailedError`. Best would be to default to the one from opentest4j. However, for now at least IntelliJ does not show a nice diff when the test is not a JUnit 5 test.

#### Check List:
* Fixes #1072
* Unit tests : YES
* Javadoc with a code example (API only) : NA


