### PR TITLE
Fixes #1052 by overloading endsWith assertion

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -424,7 +424,16 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * {@inheritDoc}
    */
   @Override
-  public SELF endsWith(@SuppressWarnings("unchecked") ELEMENT... sequence) {
+  public SELF endsWith(ELEMENT first, @SuppressWarnings("unchecked") ELEMENT... rest) {
+    iterables.assertEndsWith(info, actual, first, rest);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF endsWith(@SuppressWarnings("unchecked") ELEMENT[] sequence) {
     iterables.assertEndsWith(info, actual, sequence);
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -890,22 +890,49 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * Example :
    * <pre><code class='java'> String[] abc = {"a", "b", "c"};
    *
+   * // assertions will pass
+   * assertThat(abc).endsWith(new String[0])
+   *                .endsWith(new String[] {"b", "c"});
+   *
+   * // assertion will fail
+   * assertThat(abc).endsWith(new String[] {"a"});</code></pre>
+   *
+   * @param sequence the sequence of objects to look for.
+   * @return this assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not end with the given sequence of objects.
+   */
+  @Override
+  public SELF endsWith(ELEMENT[] sequence) {
+    arrays.assertEndsWith(info, actual, sequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array ends with the given sequence of objects, without any other objects between them.
+   * Similar to <code>{@link #containsSequence(Object...)}</code>, but it also verifies that the last element in the
+   * sequence is also last element of the actual array.
+   * <p>
+   * Example :
+   * <pre><code class='java'> String[] abc = {"a", "b", "c"};
+   *
    * // assertion will pass
    * assertThat(abc).endsWith("b", "c");
    *
    * // assertion will fail
    * assertThat(abc).endsWith("a");</code></pre>
    *
-   * @param sequence the sequence of objects to look for.
+   * @param first the first element of the end sequence of objects to look for.
+   * @param sequence the rest of the end sequence of objects to look for.
    * @return this assertion object.
    * @throws NullPointerException if the given argument is {@code null}.
-   * @throws IllegalArgumentException if the given argument is an empty array.
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not end with the given sequence of objects.
    */
   @Override
-  public SELF endsWith(@SuppressWarnings("unchecked") ELEMENT... sequence) {
-    arrays.assertEndsWith(info, actual, sequence);
+  public SELF endsWith(ELEMENT first, @SuppressWarnings("unchecked") ELEMENT... sequence) {
+    arrays.assertEndsWith(info, actual, first, sequence);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -22,6 +22,7 @@ import static org.assertj.core.internal.CommonValidations.checkSequenceIsNotNull
 import static org.assertj.core.internal.CommonValidations.checkSubsequenceIsNotNull;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.isArray;
+import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.IterableUtil.toArray;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Preconditions.checkNotNull;
@@ -917,15 +918,42 @@ public class AtomicReferenceArrayAssert<T>
    * // assertion will fail
    * assertThat(abc).endsWith("a");</code></pre>
    *
-   * @param sequence the sequence of objects to look for.
+   * @param first the first element of the end sequence of objects to look for.
+   * @param sequence the rest of the end sequence of objects to look for.
    * @return this assertion object.
    * @throws NullPointerException if the given argument is {@code null}.
-   * @throws IllegalArgumentException if the given argument is an empty array.
    * @throws AssertionError if the actual AtomicReferenceArray is {@code null}.
    * @throws AssertionError if the actual AtomicReferenceArray does not end with the given sequence of objects.
    */
   @Override
-  public AtomicReferenceArrayAssert<T> endsWith(@SuppressWarnings("unchecked") T... sequence) {
+  public AtomicReferenceArrayAssert<T> endsWith(T first, @SuppressWarnings("unchecked") T... sequence) {
+    arrays.assertEndsWith(info, array, first, sequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual AtomicReferenceArray ends with the given sequence of objects, without any other objects between them.
+   * Similar to <code>{@link #containsSequence(Object...)}</code>, but it also verifies that the last element in the
+   * sequence is also last element of the actual AtomicReferenceArray.
+   * <p>
+   * Example :
+   * <pre><code class='java'> AtomicReferenceArray&lt;String&gt; abc = new AtomicReferenceArray&lt;&gt;(new String[]{"a", "b", "c"});
+   *
+   * // assertions will pass
+   * assertThat(abc).endsWith(new String[0])
+   *                .endsWith(new String[] {"b", "c"});
+   *
+   * // assertion will fail
+   * assertThat(abc).endsWith(new String[] {"a"});</code></pre>
+   *
+   * @param sequence the (possibly empty) sequence of objects to look for.
+   * @return this assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual AtomicReferenceArray is {@code null}.
+   * @throws AssertionError if the actual AtomicReferenceArray does not end with the given sequence of objects.
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> endsWith(T[] sequence) {
     arrays.assertEndsWith(info, array, sequence);
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
  * @author Mikhail Mazursky
  * @author Joel Costigliola
  * @author Nicolas François
+ * @author Florent Biville
  */
 public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF, ELEMENT>, ELEMENT>
     extends EnumerableAssert<SELF, ELEMENT> {
@@ -462,7 +463,33 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not end with the given sequence of objects.
    */
-  SELF endsWith(@SuppressWarnings("unchecked") ELEMENT... sequence);
+  SELF endsWith(ELEMENT first, @SuppressWarnings("unchecked") ELEMENT... sequence);
+
+  /**
+   * Verifies that the actual group ends with the given sequence of objects, without any other objects between them.
+   * Similar to <code>{@link #containsSequence(Object...)}</code>, but it also verifies that the last element in the
+   * sequence is also last element of the actual group.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // an Iterable is used in the example but it would also work with an array
+   * Iterable&lt;String&gt; abc = newArrayList("a", "b", "c");
+   *
+   * // assertions will pass
+   * assertThat(abc).endsWith(new String[0])
+   *                .endsWith(new String[] {"c"})
+   *                .endsWith(new String[] {"b", "c"});
+   *
+   * // assertions will fail
+   * assertThat(abc).endsWith(new String[] {"a"});
+   * assertThat(abc).endsWith(new String[] {"a", "b"});</code></pre>
+   *
+   * @param sequence the sequence of objects to look for.
+   * @return this assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not end with the given sequence of objects.
+   */
+  SELF endsWith(@SuppressWarnings("unchecked") ELEMENT[] sequence);
 
   /**
    * Verifies that the actual group contains at least a null element.

--- a/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/src/main/java/org/assertj/core/internal/Arrays.java
@@ -64,6 +64,7 @@ import static org.assertj.core.internal.CommonValidations.hasSameSizeAsCheck;
 import static org.assertj.core.internal.IterableDiff.diff;
 import static org.assertj.core.util.ArrayWrapperList.wrap;
 import static org.assertj.core.util.Arrays.isArray;
+import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Preconditions.checkArgument;
@@ -90,6 +91,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Nicolas François
+ * @author Florent Biville
  */
 public class Arrays {
 
@@ -441,12 +443,17 @@ public class Arrays {
   }
 
   private static boolean commonChecks(AssertionInfo info, Object actual, Object sequence) {
-    checkIsNotNull(sequence);
-    assertNotNull(info, actual);
+    checkNulls(info, actual, sequence);
     // if both actual and values are empty arrays, then assertion passes.
     if (isArrayEmpty(actual) && isArrayEmpty(sequence)) return true;
     failIfEmptySinceActualIsNotEmpty(sequence);
     return false;
+
+  }
+
+  private static void checkNulls(AssertionInfo info, Object actual, Object sequence) {
+    checkIsNotNull(sequence);
+    assertNotNull(info, actual);
   }
 
   private AssertionError arrayDoesNotStartWithSequence(AssertionInfo info, Failures failures, Object array,
@@ -454,8 +461,13 @@ public class Arrays {
     return failures.failure(info, shouldStartWith(array, sequence, comparisonStrategy));
   }
 
+  void assertEndsWith(AssertionInfo info, Failures failures, Object actual, Object first, Object rest) {
+    Object[] sequence = prepend(first, rest);
+    assertEndsWith(info, failures, actual, sequence);
+  }
+
   void assertEndsWith(AssertionInfo info, Failures failures, Object actual, Object sequence) {
-    if (commonChecks(info, actual, sequence)) return;
+    checkNulls(info, actual, sequence);
     int sequenceSize = sizeOf(sequence);
     int arraySize = sizeOf(actual);
     if (arraySize < sequenceSize) throw arrayDoesNotEndWithSequence(info, failures, actual, sequence);

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -65,6 +65,7 @@ import static org.assertj.core.internal.ErrorMessages.emptySubsequence;
 import static org.assertj.core.internal.ErrorMessages.nullSequence;
 import static org.assertj.core.internal.ErrorMessages.nullSubsequence;
 import static org.assertj.core.internal.IterableDiff.diff;
+import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -93,6 +94,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Maciej Jaskowski
  * @author Nicolas François
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class Iterables {
 
@@ -584,6 +586,25 @@ public class Iterables {
    *
    * @param info contains information about the assertion.
    * @param actual the given {@code Iterable}.
+   * @param first the first element of the end sequence.
+   * @param rest the optional next elements of the end sequence.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the given {@code Iterable} is {@code null}.
+   * @throws AssertionError if the given {@code Iterable} does not end with the given sequence of objects.
+   */
+  public void assertEndsWith(AssertionInfo info, Iterable<?> actual, Object first, Object[] rest) {
+    Object[] sequence = prepend(first, rest);
+    assertEndsWith(info, actual, sequence);
+  }
+
+  /**
+   * Verifies that the given {@code Iterable} ends with the given sequence of objects, without any other objects between
+   * them. Similar to <code>{@link #assertContainsSequence(AssertionInfo, Iterable, Object[])}</code>, but it also
+   * verifies that the last element in the sequence is also the last element of the given {@code Iterable}.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Iterable}.
    * @param sequence the sequence of objects to look for.
    * @throws NullPointerException if the given argument is {@code null}.
    * @throws IllegalArgumentException if the given argument is an empty array.
@@ -591,7 +612,7 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not end with the given sequence of objects.
    */
   public void assertEndsWith(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, sequence)) return;
+    checkNotNullIterables(info, actual, sequence);
 
     int sizeOfActual = sizeOf(actual);
     if (sizeOfActual < sequence.length) throw actualDoesNotEndWithSequence(info, actual, sequence);
@@ -606,12 +627,16 @@ public class Iterables {
   }
 
   private boolean commonCheckThatIterableAssertionSucceeds(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
-    checkIsNotNull(sequence);
-    assertNotNull(info, actual);
+    checkNotNullIterables(info, actual, sequence);
     // if both actual and values are empty, then assertion passes.
     if (!actual.iterator().hasNext() && sequence.length == 0) return true;
     failIfEmptySinceActualIsNotEmpty(sequence);
     return false;
+  }
+
+  private void checkNotNullIterables(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
+    checkIsNotNull(sequence);
+    assertNotNull(info, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/ObjectArrays.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrays.java
@@ -364,12 +364,28 @@ public class ObjectArrays {
    * Verifies that the given array ends with the given sequence of objects, without any other objects between them.
    * Similar to <code>{@link #assertContainsSequence(AssertionInfo, Object[], Object[])}</code>, but it also verifies
    * that the last element in the sequence is also the last element of the given array.
-   * 
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param first the first element of the end sequence of objects to look for.
+   * @param sequence the rest of the end sequence of objects to look for.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the given array is {@code null}.
+   * @throws AssertionError if the given array does not end with the given sequence of objects.
+   */
+  public void assertEndsWith(AssertionInfo info, Object[] actual, Object first, Object[] sequence) {
+    arrays.assertEndsWith(info, failures, actual, first, sequence);
+  }
+
+  /**
+   * Verifies that the given array ends with the given sequence of objects, without any other objects between them.
+   * Similar to <code>{@link #assertContainsSequence(AssertionInfo, Object[], Object[])}</code>, but it also verifies
+   * that the last element in the sequence is also the last element of the given array.
+   *
    * @param info contains information about the assertion.
    * @param actual the given array.
    * @param sequence the sequence of objects to look for.
    * @throws NullPointerException if the given argument is {@code null}.
-   * @throws IllegalArgumentException if the given argument is an empty array.
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the given array does not end with the given sequence of objects.
    */

--- a/src/main/java/org/assertj/core/util/Arrays.java
+++ b/src/main/java/org/assertj/core/util/Arrays.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class Arrays {
 
@@ -161,6 +162,14 @@ public class Arrays {
 
   public static IllegalArgumentException notAnArrayOfPrimitives(Object o) {
     return new IllegalArgumentException(String.format("<%s> is not an array of primitives", o));
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T[] prepend(T first, T... rest) {
+    T[] result = (T[]) new Object[1 + rest.length];
+    result[0] = first;
+    System.arraycopy(rest, 0, result, 1, rest.length);
+    return result;
   }
 
   private Arrays() {}

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_endsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_endsWith_Test.java
@@ -28,6 +28,6 @@ public class AtomicReferenceArrayAssert_endsWith_Test extends AtomicReferenceArr
 
   @Override
   protected void verify_internal_effects() {
-    verify(arrays).assertEndsWith(info(), internalArray(), array("Luke", "Yoda"));
+    verify(arrays).assertEndsWith(info(), internalArray(), "Luke", array("Yoda"));
   }
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_endsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_endsWith_Test.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class IterableAssert_endsWith_Test extends IterableAssertBaseTest {
 
@@ -36,6 +37,6 @@ public class IterableAssert_endsWith_Test extends IterableAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(iterables).assertEndsWith(getInfo(assertions), getActual(assertions), array("Luke", "Yoda"));
+    verify(iterables).assertEndsWith(getInfo(assertions), getActual(assertions), "Luke", array("Yoda"));
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_endsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_endsWith_Test.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
  * 
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Florent Biville
  */
 public class ObjectArrayAssert_endsWith_Test extends ObjectArrayAssertBaseTest {
 
@@ -35,6 +36,6 @@ public class ObjectArrayAssert_endsWith_Test extends ObjectArrayAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(arrays).assertEndsWith(getInfo(assertions), getActual(assertions), array("Luke", "Yoda"));
+    verify(arrays).assertEndsWith(getInfo(assertions), getActual(assertions), "Luke", array("Yoda"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEndsWith_Test.java
@@ -34,6 +34,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class BooleanArrays_assertEndsWith_Test extends BooleanArraysBaseTest {
 
@@ -57,8 +58,7 @@ public class BooleanArrays_assertEndsWith_Test extends BooleanArraysBaseTest {
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_Test.java
@@ -33,6 +33,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class ByteArrays_assertEndsWith_Test extends ByteArraysBaseTest {
 
@@ -54,8 +55,7 @@ public class ByteArrays_assertEndsWith_Test extends ByteArraysBaseTest {
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -121,8 +121,7 @@ public class ByteArrays_assertEndsWith_Test extends ByteArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_with_Integer_Arguments_Test.java
@@ -52,8 +52,7 @@ public class ByteArrays_assertEndsWith_with_Integer_Arguments_Test extends ByteA
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, IntArrays.emptyArray());
   }
 
@@ -116,8 +115,7 @@ public class ByteArrays_assertEndsWith_with_Integer_Arguments_Test extends ByteA
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, IntArrays.emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEndsWith_Test.java
@@ -33,6 +33,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class CharArrays_assertEndsWith_Test extends CharArraysBaseTest {
 
@@ -54,8 +55,7 @@ public class CharArrays_assertEndsWith_Test extends CharArraysBaseTest {
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -121,8 +121,7 @@ public class CharArrays_assertEndsWith_Test extends CharArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertEndsWith_Test.java
@@ -30,6 +30,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class DoubleArrays_assertEndsWith_Test extends DoubleArraysBaseTest {
 
@@ -51,8 +52,7 @@ public class DoubleArrays_assertEndsWith_Test extends DoubleArraysBaseTest {
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -100,8 +100,7 @@ public class DoubleArrays_assertEndsWith_Test extends DoubleArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEndsWith_Test.java
@@ -31,6 +31,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class FloatArrays_assertEndsWith_Test extends FloatArraysBaseTest {
 
@@ -52,8 +53,7 @@ public class FloatArrays_assertEndsWith_Test extends FloatArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -119,8 +119,7 @@ public class FloatArrays_assertEndsWith_Test extends FloatArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEndsWith_Test.java
@@ -33,6 +33,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class IntArrays_assertEndsWith_Test extends IntArraysBaseTest {
 
@@ -54,8 +55,7 @@ public class IntArrays_assertEndsWith_Test extends IntArraysBaseTest {
   }
   
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -121,8 +121,7 @@ public class IntArrays_assertEndsWith_Test extends IntArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWith_Test.java
@@ -32,10 +32,11 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Iterables#assertEndsWith(AssertionInfo, Collection, Object[])}</code>.
- * 
+ * Tests for <code>{@link Iterables#assertEndsWith(AssertionInfo, Iterable, Object[])}</code>.
+ *
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class Iterables_assertEndsWith_Test extends IterablesBaseTest {
 
@@ -59,8 +60,7 @@ public class Iterables_assertEndsWith_Test extends IterablesBaseTest {
   }
   
   @Test
-  public void should_fail_if_sequence_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_sequence_to_look_for_is_empty_and_actual_is_not() {
     iterables.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEndsWith_Test.java
@@ -33,6 +33,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class LongArrays_assertEndsWith_Test extends LongArraysBaseTest {
 
@@ -54,8 +55,7 @@ public class LongArrays_assertEndsWith_Test extends LongArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -121,8 +121,7 @@ public class LongArrays_assertEndsWith_Test extends LongArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
@@ -34,6 +34,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Florent Biville
  */
 public class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
 
@@ -55,8 +56,7 @@ public class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -120,8 +120,7 @@ public class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
@@ -32,6 +32,7 @@ import org.junit.Test;
  * Tests for <code>{@link ShortArrays#assertEndsWith(AssertionInfo, short[], short[])}</code>.
  * 
  * @author Alex Ruiz
+ * @author Florent Biville
  */
 public class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
 
@@ -53,8 +54,7 @@ public class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     arrays.assertEndsWith(someInfo(), actual, emptyArray());
   }
 
@@ -120,8 +120,7 @@ public class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
   }
 
   @Test
-  public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
+  public void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
     arraysWithCustomComparisonStrategy.assertEndsWith(someInfo(), actual, emptyArray());
   }
 


### PR DESCRIPTION
The new `endsWith(T[])` allows empty arrays whereas the former
`endsWith(T...)` has been changed to `endsWith(T, T...)` to
explicitly prevent empty varargs.

#### Check List:
* Fixes #1052
* Unit tests : YES
* Javadoc with a code example (API only) : YES


