### PR TITLE
Add java 9 to master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ addons:
       - oracle-java8-installer
 
 jdk:  
-   - oraclejdk8
-   - openjdk8
+  - oraclejdk8
+  - openjdk8
+  - oraclejdk9

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -158,6 +158,7 @@ public class AbstractSoftAssertions {
     for (StackTraceElement element : stacktrace) {
       String className = element.getClassName();
       if (className.startsWith("sun.reflect")
+          || className.startsWith("jdk.internal.reflect")
           || className.startsWith("java.")
           || className.startsWith("javax.")
           || className.startsWith("org.junit.")

--- a/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
+++ b/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
@@ -35,34 +35,51 @@ public class XmlStringPrettyFormatter_prettyFormat_Test {
   @Rule
   public ExpectedException thrown = none();
 
+  private String expected_formatted_xml;
+
   @Before
   public void before() {
-	// Set locale to be able to check exception message in English.
-	Locale.setDefault(ENGLISH);
+    // Set locale to be able to check exception message in English.
+    Locale.setDefault(ENGLISH);
+    if (System.getProperty("java.specification.version").equals("9")) {
+      // seems to be a bug in java 9
+      expected_formatted_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\">\n"
+                               + "    <channel>\n"
+                               + "        <title>Java Tutorials and Examples 1</title>\n"
+                               + "        <language>en-us</language>\n"
+                               + "    </channel>\n"
+                               + "</rss>\n";
+    } else {
+      expected_formatted_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                               + "<rss version=\"2.0\">\n"
+                               + "    <channel>\n"
+                               + "        <title>Java Tutorials and Examples 1</title>\n"
+                               + "        <language>en-us</language>\n"
+                               + "    </channel>\n"
+                               + "</rss>\n";
+    }
   }
-
-  private static final String EXPECTED_FORMATTED_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss version=\"2.0\">\n    <channel>\n"
-      + "        <title>Java Tutorials and Examples 1</title>\n"
-      + "        <language>en-us</language>\n"
-      + "    </channel>\n</rss>\n";
 
   @Test
   public void should_format_xml_string_prettily() {
     String xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\"><channel><title>Java Tutorials and Examples 1</title><language>en-us</language></channel></rss>";
-    assertThat(xmlPrettyFormat(xmlString)).isEqualTo(EXPECTED_FORMATTED_XML);
+    assertThat(xmlPrettyFormat(xmlString)).isEqualTo(expected_formatted_xml);
   }
 
   @Test
   public void should_format_xml_string_without_xml_declaration_prettily() {
     String xmlString = "<rss version=\"2.0\"><channel><title>Java Tutorials and Examples 1</title><language>en-us</language></channel></rss>";
-    assertThat(xmlPrettyFormat(xmlString)).isEqualTo(
-        EXPECTED_FORMATTED_XML.substring("<?xml version='1.0' encoding='UTF-8'?>\n".length()));
+    if (System.getProperty("java.specification.version").equals("9")) {
+      assertThat(xmlPrettyFormat(xmlString)).isEqualTo(expected_formatted_xml.substring("<?xml version='1.0' encoding='UTF-8'?>".length()));
+    } else {
+      assertThat(xmlPrettyFormat(xmlString)).isEqualTo(expected_formatted_xml.substring("<?xml version='1.0' encoding='UTF-8'?>\n".length()));
+    }
   }
 
   @Test
   public void should_format_xml_string_with_space_and_newline_prettily() {
     String xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\"><channel>  <title>Java Tutorials and Examples 1</title>  \n\n<language>en-us</language>  </channel></rss>";
-    assertThat(xmlPrettyFormat(xmlString)).isEqualTo(EXPECTED_FORMATTED_XML);
+    assertThat(xmlPrettyFormat(xmlString)).isEqualTo(expected_formatted_xml);
   }
 
   @Test


### PR DESCRIPTION
Filtering the "jdk.internal.reflect" classes from the stacktraces is required to fix SoftAssertion error messages. Otherwise e.g. using SoftAssertions#fail will display an ugly error message (see below):

```
[ERROR]   SoftAssertionsTest.should_return_failure_after_fail
Expecting message:
 <"Should not reach here">
but was:
 <"Should not reach here
at NativeMethodAccessorImpl.invoke0(NativeMethodAccessorImpl.java:-2)">
```



