### PR TITLE
Implemented assertEqualsToIgnoringNewLines

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -40,6 +40,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  * @author Nicolas Francois
+ * @author Daniel Weber
  */
 public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequenceAssert<SELF, ACTUAL>, ACTUAL extends CharSequence>
     extends AbstractAssert<SELF, ACTUAL> implements EnumerableAssert<SELF, Character> {
@@ -1143,6 +1144,35 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    */
   public SELF isEqualToNormalizingNewlines(CharSequence expected) {
     strings.assertIsEqualToNormalizingNewlines(info, actual, expected);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is equal to the given one, after the new lines
+   * of both strings has been removed.<br>
+   * To be exact, the following rules are applied:
+   * <ul>
+   * <li>all new lines of both actual and expected strings are ignored</li>
+   * <li>any remaining new lines, appearing within either string, are removed before comparison</li>
+   * </ul>
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertions will pass
+   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewLines("Some text\nWith new lines")
+   *                              .isEqualToIgnoringNewLines("Some text\r\nWith new lines")
+   *                              .isEqualToIgnoringNewLines("Some text\n\nWith new lines");
+   *
+   * // assertions will fail
+   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewLines("Some text With new lines");
+   * assertThat("Some text\r\nWith new lines").isEqualToIgnoringNewLines("Some text With new lines");</code></pre>
+   *
+   * @param expected the given {@code CharSequence} to compare the actual {@code CharSequence} to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not equal to the given one
+   *           after new lines has been removed.
+   */
+  public SELF isEqualToIgnoringNewLines(CharSequence expected) {
+    strings.assertIsEqualToIgnoringNewLines(info, actual, expected);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
@@ -6,7 +6,7 @@ public class ShouldBeEqualIgnoringNewLines  extends BasicErrorMessageFactory {
 	 }
 
 	  private ShouldBeEqualIgnoringNewLines(CharSequence actual, CharSequence expected) {
-	    super("%nExpecting:%n  <%s>%nto be equal to:%n  <%s>%nignoring newline (\n, \r\n) in acutal.",
+	    super("%nExpecting:%n  <%s>%nto be equal to:%n  <%s>%nignoring newlines (\n, \r\n).",
 	          actual, expected);
 	  }
 

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
@@ -1,0 +1,14 @@
+package org.assertj.core.error;
+
+public class ShouldBeEqualIgnoringNewLines  extends BasicErrorMessageFactory {
+	 public static ErrorMessageFactory shouldBeEqualIgnoringNewLines(CharSequence actual, CharSequence expected) {
+	    return new ShouldBeEqualIgnoringNewLines(actual, expected);
+	 }
+
+	  private ShouldBeEqualIgnoringNewLines(CharSequence actual, CharSequence expected) {
+	    super("%nExpecting:%n  <%s>%nto be equal to:%n  <%s>%nignoring newline (\n, \r\n) in acutal.",
+	          actual, expected);
+	  }
+
+}
+

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNewLineDifferences.shouldBeEqualIgnoringNewLineDifferences;
+import static org.assertj.core.error.ShouldBeEqualIgnoringNewLines.shouldBeEqualIgnoringNewLines;
 import static org.assertj.core.error.ShouldBeEqualIgnoringWhitespace.shouldBeEqualIgnoringWhitespace;
 import static org.assertj.core.error.ShouldBeEqualNormalizingWhitespace.shouldBeEqualNormalizingWhitespace;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
@@ -883,4 +884,20 @@ public class Strings {
     }
   }
 
+  /***
+   * Verifies that actual is equal to expected ignoring new lines
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence} (newlines will be ignored).
+   * @param expected the expected {@code CharSequence}.
+   */
+  public void assertIsEqualToIgnoringNewLines(AssertionInfo info, CharSequence actual, CharSequence expected) {
+    String actualWithoutNewLines = removeNewLines(actual);
+    if (!actualWithoutNewLines.equals(expected))
+      throw failures.failure(info, shouldBeEqualIgnoringNewLines(actual, expected));
+  }
+
+  private static String removeNewLines(CharSequence actual) {
+    String modified = normalizeNewlines(actual);
+    return modified.toString().replace("\n", "");
+  }
 }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -887,8 +887,8 @@ public class Strings {
   /***
    * Verifies that actual is equal to expected ignoring new lines
    * @param info contains information about the assertion.
-   * @param actual the actual {@code CharSequence} (newlines will be ignored).
-   * @param expected the expected {@code CharSequence}.
+   * @param actual the actual {@code CharSequence} (new lines will be ignored).
+   * @param expected the expected {@code CharSequence} (new lines will be ignored).
    */
   public void assertIsEqualToIgnoringNewLines(AssertionInfo info, CharSequence actual, CharSequence expected) {
     String actualWithoutNewLines = removeNewLines(actual);

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -892,12 +892,13 @@ public class Strings {
    */
   public void assertIsEqualToIgnoringNewLines(AssertionInfo info, CharSequence actual, CharSequence expected) {
     String actualWithoutNewLines = removeNewLines(actual);
-    if (!actualWithoutNewLines.equals(expected))
+    String expectedWithoutNewLines = removeNewLines(expected);
+    if (!actualWithoutNewLines.equals(expectedWithoutNewLines))
       throw failures.failure(info, shouldBeEqualIgnoringNewLines(actual, expected));
   }
 
-  private static String removeNewLines(CharSequence actual) {
-    String modified = normalizeNewlines(actual);
-    return modified.toString().replace("\n", "");
+  private static String removeNewLines(CharSequence text) {
+    String normalizedText = normalizeNewlines(text);
+    return normalizedText.toString().replace("\n", "");
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsToIgnoringNewLines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsToIgnoringNewLines_Test.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.error.ShouldBeEqualIgnoringNewLines.shouldBeEqualIgnoringNewLines;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Strings#assertIsEqualToIgnoringNewLines(AssertionInfo, CharSequence, CharSequence)}</code>.
+ *
+ * @author Daniel Weber
+ */
+public class Strings_assertEqualsToIgnoringNewLines_Test extends StringsBaseTest {
+
+  @Test
+  public void should_pass_if_actual_contains_new_lines_and_expected_has_no_new_lines() {
+    String expected = "Some textWith new lines";
+    strings.assertIsEqualToIgnoringNewLines(someInfo(), "Some text\nWith new lines", expected);
+    strings.assertIsEqualToIgnoringNewLines(someInfo(), "Some text\r\nWith new lines", expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_new_lines_and_expected_has_no_new_lines() {
+    String expected = "Some text With new lines";
+    VerifyThatAssertationErrorWasThrown("Some text\nWith new lines", expected);
+    VerifyThatAssertationErrorWasThrown("Some text\r\nWith new lines", expected);
+  }
+
+  private void VerifyThatAssertationErrorWasThrown(String actual, String expected) {
+    try {
+      strings.assertIsEqualToIgnoringNewLines(someInfo(), actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLines(actual, expected));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsToIgnoringNewLines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsToIgnoringNewLines_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNewLines.shouldBeEqualIgnoringNewLines;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -30,10 +31,15 @@ import org.junit.Test;
 public class Strings_assertEqualsToIgnoringNewLines_Test extends StringsBaseTest {
 
   @Test
-  public void should_pass_if_actual_contains_new_lines_and_expected_has_no_new_lines() {
-    String expected = "Some textWith new lines";
-    strings.assertIsEqualToIgnoringNewLines(someInfo(), "Some text\nWith new lines", expected);
-    strings.assertIsEqualToIgnoringNewLines(someInfo(), "Some text\r\nWith new lines", expected);
+  public void should_pass_if_both_texts_contain_new_lines_of_any_kind() {
+    String actual = "Some text\nWith new lines";
+    String expectedOnLinux = "Some text\nWith new lines";
+    String expectedOnWindows = "Some text\r\nWith new lines";
+    String expectedWithConsecutiveNewlines= "Some text\n\nWith new lines";
+
+    assertThat(actual).isEqualToIgnoringNewLines(expectedOnLinux)
+      .isEqualToIgnoringNewLines(expectedOnWindows)
+      .isEqualToIgnoringNewLines(expectedWithConsecutiveNewlines);
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes Implemented assertEqualsToIgnoringNewLines
* Unit tests : YES
* Javadoc with a code example (API only) : YES


