### PR TITLE
Use correct SELF class for SoftAssertionPredicateAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/SoftAssertionPredicateAssert.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionPredicateAssert.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
  * @since 3.5.2
  */
 public class SoftAssertionPredicateAssert<T>
-    extends AbstractPredicateAssert<PredicateAssert<T>, T> {
+    extends AbstractPredicateAssert<SoftAssertionPredicateAssert<T>, T> {
 
   public SoftAssertionPredicateAssert(Predicate<T> actual) {
     super(actual, SoftAssertionPredicateAssert.class);


### PR DESCRIPTION
While fiddling with the proxies I noticed that the `SoftAssertionPredicate` has wrong class in it's extends clause

#### Check List:
* Unit tests : NA
* Javadoc with a code example (API only) : NA


