### PR TITLE
#1069 Add isStrictlyBlank and isNotStrictlyBlank

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -180,6 +180,60 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} is {@code null} or blank, i.e. consists of one or more whitespace characters.
+   * <p>
+   * The whitespace definition used by this assertion follows the latest Unicode standard (which is not the same as Java whitespace definition)
+   * and is based on Guava <a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/CharMatcher.html#whitespace()"> CharMatcher#whitespace</a>.
+   * <p>
+   * It uses the same whitespace definition as the {@link #isBlank()} assertion.
+   * <p>
+   * These assertions will succeed:
+   * <pre><code class='java'> assertThat(" ").isStrictlyBlank();
+   * assertThat("     ").isStrictlyBlank();
+   * String nullString = null;
+   * assertThat(nullString).isStrictlyBlank();</code></pre>
+   *
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat("a").isStrictlyBlank();
+   * assertThat(" b").isStrictlyBlank();
+   * assertThat("").isStrictlyBlank();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not blank.
+   * @since 2.6.0 / 3.6.0
+   */
+  public SELF isStrictlyBlank() {
+    strings.assertStrictlyBlank(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is not blank, i.e. either is empty or contains at least one non-whitespace characters.
+   * <p>
+   * It uses the same whitespace definition as the {@link #isBlank()} assertion.
+   * <p>
+   * These assertions will succeed:
+   * <pre><code class='java'> assertThat("a").isNotStrictlyBlank();
+   * assertThat(" b").isNotStrictlyBlank();
+   * assertThat(" c ").isNotStrictlyBlank();
+   * assertThat("").isNotStrictlyBlank();</code></pre>
+   *
+   * Whereas these assertions will fail:
+   * <pre><code class='java'> assertThat(" ").isNotStrictlyBlank();
+   * assertThat("    ").isNotStrictlyBlank();
+   * String nullString = null;
+   * assertThat(nullString).isNotStrictlyBlank();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is blank.
+   * @since 2.6.0 / 3.6.0
+   */
+  public SELF isNotStrictlyBlank() {
+    strings.assertNotStrictlyBlank(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} is blank, i.e. consists of one or more whitespace characters
    * (according to {@link Character#isWhitespace(char)}).
    * <p>

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -160,7 +160,7 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence} is not blank.
    */
   public void assertBlank(AssertionInfo info, CharSequence actual) {
-    if (!isBlank(actual)) throw failures.failure(info, shouldBeBlank(actual));
+    if (isNull(actual) || !isBlank(actual)) throw failures.failure(info, shouldBeBlank(actual));
   }
 
   /**
@@ -171,11 +171,37 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence} is blank.
    */
   public void assertNotBlank(AssertionInfo info, CharSequence actual) {
-    if (isBlank(actual)) throw failures.failure(info, shouldNotBeBlank(actual));
+    if (!isNull(actual) && isBlank(actual)) throw failures.failure(info, shouldNotBeBlank(actual));
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is {@code Null} or consists of one or more whitespace characters.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is not strictly blank.
+   */
+  public void assertStrictlyBlank(AssertionInfo info, CharSequence actual) {
+    if (!isNull(actual) && !isBlank(actual)) throw failures.failure(info, shouldBeBlank(actual));
+  }
+
+  /**
+   * Asserts that the given {@code CharSequence} is empty or contains at least one non-whitespace character.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @throws AssertionError if the given {@code CharSequence} is strictly blank.
+   */
+  public void assertNotStrictlyBlank(AssertionInfo info, CharSequence actual) {
+    if (isNull(actual) || isBlank(actual)) throw failures.failure(info, shouldNotBeBlank(actual));
+  }
+
+  private boolean isNull(CharSequence actual) {
+    return actual == null;
   }
 
   private boolean isBlank(CharSequence actual) {
-    if (actual == null || actual.length() == 0) return false;
+    if (actual.length() == 0) return false;
     for (int i = 0; i < actual.length(); i++) {
       if (!Whitespace.isWhitespace(actual.charAt(i))) return false;
     }

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotStrictlyBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isNotStrictlyBlank_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isNotStrictlyBlank()}</code>.
+ * 
+ * @author Chris Arnott
+ */
+public class CharSequenceAssert_isNotStrictlyBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isNotStrictlyBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertNotStrictlyBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isStrictlyBlank_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isStrictlyBlank_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#isStrictlyBlank()}</code>.
+ * 
+ * @author Chris Arnott
+ */
+public class CharSequenceAssert_isStrictlyBlank_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.isStrictlyBlank();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertStrictlyBlank(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotStrictlyBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotStrictlyBlank_Test.java
@@ -12,35 +12,35 @@
  */
 package org.assertj.core.internal.strings;
 
-import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.mockito.Mockito.verify;
-
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.StringsBaseTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
+import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.verify;
 
 @RunWith(DataProviderRunner.class)
-public class Strings_assertNotBlank_Test extends StringsBaseTest {
+public class Strings_assertNotStrictlyBlank_Test extends StringsBaseTest {
 
   @Test
   @DataProvider(value = {
-      "null",
       "",
       "a",
       " bc "
   }, trimValues=false)
   public void should_pass_string_is_not_blank(String actual) {
-    strings.assertNotBlank(someInfo(), actual);
+    strings.assertNotStrictlyBlank(someInfo(), actual);
   }
 
   @Test
   @DataProvider(value = {
+      "null",
       " ",
       "\u005Ct", // tab
       "\u005Cn", // line feed
@@ -52,6 +52,6 @@ public class Strings_assertNotBlank_Test extends StringsBaseTest {
   }, trimValues=false)
   public void should_fail_if_string_is_blank(String actual) {
     thrown.expectAssertionError(shouldNotBeBlank(actual));
-    strings.assertNotBlank(someInfo(), actual);
+    strings.assertNotStrictlyBlank(someInfo(), actual);
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertStrictlyBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertStrictlyBlank_Test.java
@@ -12,35 +12,21 @@
  */
 package org.assertj.core.internal.strings;
 
-import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-import static org.mockito.Mockito.verify;
-
-import org.assertj.core.api.AssertionInfo;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.assertj.core.internal.StringsBaseTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
+import static org.assertj.core.test.TestData.someInfo;
 
 @RunWith(DataProviderRunner.class)
-public class Strings_assertNotBlank_Test extends StringsBaseTest {
+public class Strings_assertStrictlyBlank_Test extends StringsBaseTest {
 
   @Test
   @DataProvider(value = {
       "null",
-      "",
-      "a",
-      " bc "
-  }, trimValues=false)
-  public void should_pass_string_is_not_blank(String actual) {
-    strings.assertNotBlank(someInfo(), actual);
-  }
-
-  @Test
-  @DataProvider(value = {
       " ",
       "\u005Ct", // tab
       "\u005Cn", // line feed
@@ -50,8 +36,18 @@ public class Strings_assertNotBlank_Test extends StringsBaseTest {
       "\u202F", // non-breaking space
       " \u005Cn\u005Cr  "
   }, trimValues=false)
-  public void should_fail_if_string_is_blank(String actual) {
-    thrown.expectAssertionError(shouldNotBeBlank(actual));
-    strings.assertNotBlank(someInfo(), actual);
+  public void should_pass_string_is_blank(String actual) {
+    strings.assertStrictlyBlank(someInfo(), actual);
+  }
+
+  @Test
+  @DataProvider(value = {
+      "",
+      "a",
+      " bc "
+  }, trimValues=false)
+  public void should_fail_if_string_is_not_blank(String actual) {
+    thrown.expectAssertionError(shouldBeBlank(actual));
+    strings.assertStrictlyBlank(someInfo(), actual);
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1069
* Unit tests : Yes
* Javadoc with a code example (API only) : Yes

Adds isStrictlyBlank and isNotStrictlyBlank methods (which work the same as isBlank and isNotBlank, but with null counting as blank).


