### PR TITLE
[#1102] Improve the method doesNotContain in CharSequenceAssert for accepting varargs

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -603,24 +603,48 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} does not contain the given sequence.
+   * Verifies that the actual {@code CharSequence} does not contain any one of the given values.
    * <p>
    * Example :
    * <pre><code class='java'> // assertion will pass
-   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;fro&quot;);
+   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;fro&quot;, &quot;sam&quot;);
    * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;gandalf&quot;);
-   * 
+   *
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;Fro&quot;);</code></pre>
-   * 
-   * @param sequence the sequence to search for.
+   * assertThat(&quot;Frodo&quot;).doesNotContain(&quot;Fro&quot;, &quot;Aragorn&quot;, &quot;Legolas&quot;);</code></pre>
+   *
+   * @param values the CharSequences to search for.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
-   * @throws AssertionError if the actual {@code CharSequence} contains the given one.
+   * @throws AssertionError if the actual {@code CharSequence} contains any one of the given values.
    */
-  public SELF doesNotContain(CharSequence sequence) {
-    strings.assertDoesNotContain(info, actual, sequence);
+  public SELF doesNotContain(CharSequence... values) {
+    strings.assertDoesNotContain(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} does not contain any one of the given Iterable.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).doesNotContain(Arrays.asList(&quot;fro&quot;, &quot;sam&quot;));
+   * assertThat(&quot;Frodo&quot;).doesNotContain(Arrays.asList(&quot;gandalf&quot;));
+   *
+   * // assertion will fail
+   * assertThat(&quot;Frodo&quot;).doesNotContain(Arrays.asList(&quot;Fro&quot;, &quot;Aragorn&quot;, &quot;Legolas&quot;));</code></pre>
+   *
+   * @param values the CharSequences to search for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} contains any one of the given values.
+   */
+  public SELF doesNotContain(Iterable<? extends CharSequence> values) {
+    strings.assertDoesNotContain(info, actual, IterableUtil.toArray(values, CharSequence.class));
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
@@ -12,40 +12,80 @@
  */
 package org.assertj.core.error;
 
-import org.assertj.core.internal.*;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+
+import java.util.Set;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a {@code CharSequence} does not contain another
  * {@code CharSequence} failed.
- * 
+ *
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  */
 public class ShouldNotContainCharSequence extends BasicErrorMessageFactory {
 
+  private ShouldNotContainCharSequence(String format, CharSequence actual, CharSequence sequence,
+                                       ComparisonStrategy comparisonStrategy) {
+    super(format, actual, sequence, comparisonStrategy);
+  }
+
+  private ShouldNotContainCharSequence(String format, CharSequence actual, CharSequence[] values,
+                                       Set<? extends CharSequence> found,
+                                       ComparisonStrategy comparisonStrategy) {
+    super(format, actual, values, found, comparisonStrategy);
+  }
+
   /**
    * Creates a new <code>{@link ShouldNotContainCharSequence}</code>.
    * @param actual the actual value in the failed assertion.
-   * @param sequence the sequence of values expected not to be in {@code actual}.
+   * @param sequence the charsequence expected not to be in {@code actual}.
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence sequence) {
-    return new ShouldNotContainCharSequence(actual, sequence, StandardComparisonStrategy.instance());
+    return new ShouldNotContainCharSequence("%nExpecting:%n <%s>%nnot to contain:%n <%s> %s", actual, sequence,
+                                            StandardComparisonStrategy.instance());
   }
 
   /**
    * Creates a new <code>{@link ShouldNotContainCharSequence}</code>.
    * @param actual the actual value in the failed assertion.
-   * @param sequence the sequence of values expected not to be in {@code actual}.
+   * @param sequence the charsequence expected not to be in {@code actual}.
    * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence sequence, ComparisonStrategy comparisonStrategy) {
-    return new ShouldNotContainCharSequence(actual, sequence, comparisonStrategy);
+  public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence sequence,
+                                                     ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotContainCharSequence("%nExpecting:%n <%s>%nnot to contain:%n <%s> %s", actual, sequence,
+                                            comparisonStrategy);
   }
 
-  private ShouldNotContainCharSequence(CharSequence actual, CharSequence sequence, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting:%n <%s>%nnot to contain:%n <%s> %s", actual, sequence, comparisonStrategy);
+  /**
+   * Creates a new <code>{@link ShouldNotContainCharSequence}</code>
+   * @param actual the actual value in the failed assertion.
+   * @param values the charsequences expected not to be in {@code actual}.
+   * @param found the charsequences unexpectedly in {@code actual}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence[] values,
+                                                     Set<? extends CharSequence> found,
+                                                     ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotContainCharSequence("%nExpecting:%n <%s>%nnot to contain:%n <%s>%nbut find:%n <%s>%n %s", actual,
+                                            values, found, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldNotContainCharSequence}</code>
+   * @param actual the actual value in the failed assertion.
+   * @param values the charsequences expected not to be in {@code actual}.
+   * @param found the charsequences unexpectedly in {@code actual}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence[] values,
+                                                     Set<? extends CharSequence> found) {
+    return shouldNotContain(actual, values, found, StandardComparisonStrategy.instance());
   }
 }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -362,20 +362,30 @@ public class Strings {
   }
 
   /**
-   * Verifies that the given {@code CharSequence} does not contain the given sequence.
+   * Verifies that the given {@code CharSequence} does not contain any one of the given values.
    * 
    * @param info contains information about the assertion.
    * @param actual the actual {@code CharSequence}.
-   * @param sequence the sequence to search for.
-   * @throws NullPointerException if the given sequence is {@code null}.
-   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
-   * @throws AssertionError if the actual {@code CharSequence} contains the given sequence.
+   * @param values the values to search for.
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws NullPointerException if any one of the given values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} contains any one of the given values.
    */
-  public void assertDoesNotContain(AssertionInfo info, CharSequence actual, CharSequence sequence) {
-    checkCharSequenceIsNotNull(sequence);
-    assertNotNull(info, actual);
-    if (stringContains(actual, sequence))
-      throw failures.failure(info, shouldNotContain(actual, sequence, comparisonStrategy));
+  public void assertDoesNotContain(AssertionInfo info, CharSequence actual, CharSequence... values) {
+    doCommonCheckForCharSequence(info, actual, values);
+    Set<CharSequence> found = new LinkedHashSet<>();
+    for (CharSequence value : values) {
+      if (stringContains(actual, value)) {
+        found.add(value);
+      }
+    }
+    if (found.isEmpty()) return;
+    if (found.size() == 1 && values.length == 1) {
+      throw failures.failure(info, shouldNotContain(actual, values[0], comparisonStrategy));
+    }
+    throw failures.failure(info, shouldNotContain(actual, values, found, comparisonStrategy));
   }
 
   private void checkCharSequenceIsNotNull(CharSequence sequence) {

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_CharSequence_Test.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotContain(CharSequence)}</code>.
+ *
+ * @author Alex Ruiz
+ */
+public class CharSequenceAssert_doesNotContain_CharSequence_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContain("Luke");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContain(getInfo(assertions), getActual(assertions), "Luke");
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_several_String_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_several_String_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -10,6 +10,7 @@
  *
  * Copyright 2012-2017 the original author or authors.
  */
+
 package org.assertj.core.api.charsequence;
 
 import org.assertj.core.api.CharSequenceAssert;
@@ -17,21 +18,20 @@ import org.assertj.core.api.CharSequenceAssertBaseTest;
 
 import static org.mockito.Mockito.verify;
 
-
 /**
- * Tests for <code>{@link CharSequenceAssert#doesNotContain(CharSequence)}</code>.
- * 
- * @author Alex Ruiz
+ * Tests for <code>{@link CharSequenceAssert#doesNotContain(CharSequence...)}</code>.
+ *
+ * @author Billy Yuan
  */
-public class CharSequenceAssert_doesNotContain_Test extends CharSequenceAssertBaseTest {
 
+public class CharSequenceAssert_doesNotContain_several_String_Test extends CharSequenceAssertBaseTest {
   @Override
   protected CharSequenceAssert invoke_api_method() {
-    return assertions.doesNotContain("Luke");
+    return assertions.doesNotContain("od", "do");
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(strings).assertDoesNotContain(getInfo(assertions), getActual(assertions), "Luke");
+    verify(strings).assertDoesNotContain(getInfo(assertions), getActual(assertions), "od", "do");
   }
 }

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_several_String_as_Iterable_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContain_several_String_as_Iterable_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotContain(Iterable<CharSequence>)}</code>.
+ *
+ * @author Billy Yuan
+ */
+
+public class CharSequenceAssert_doesNotContain_several_String_as_Iterable_Test extends CharSequenceAssertBaseTest {
+  @Override protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContain(Arrays.<CharSequence>asList("od", "do"));
+  }
+
+  @Override protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContain(getInfo(assertions), getActual(assertions), "od", "do");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
@@ -14,6 +14,8 @@ package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.internal.util.collections.Sets.newSet;
 
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
@@ -46,5 +48,13 @@ public class ShouldNotContainString_create_Test {
     assertThat(message).isEqualTo(String.format(
         "[Test] %nExpecting:%n <\"Yoda\">%nnot to contain:%n <\"od\"> when comparing values using 'CaseInsensitiveStringComparator'"
     ));
+  }
+
+  @Test
+  public void should_create_error_message_with_several_string_values() {
+    ErrorMessageFactory factory = shouldNotContain("Yoda", array("od", "ya"), newSet("ya"));
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    assertThat(message).isEqualTo(
+      String.format("[Test] %nExpecting:%n <\"Yoda\">%nnot to contain:%n <[\"od\", \"ya\"]>%nbut find:%n <[\"ya\"]>%n "));
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContain_Test.java
@@ -12,34 +12,41 @@
  */
 package org.assertj.core.internal.strings;
 
-import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
-import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNull;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Strings;
 import org.assertj.core.internal.StringsBaseTest;
 import org.junit.Test;
 
+import static org.assertj.core.error.ShouldNotContainCharSequence.*;
+import static org.assertj.core.internal.ErrorMessages.*;
+import static org.assertj.core.test.TestData.*;
+import static org.assertj.core.util.FailureMessages.*;
+import static org.mockito.internal.util.collections.Sets.*;
 
 /**
- * Tests for <code>{@link Strings#assertDoesNotContain(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
+ * Tests for <code>{@link Strings#assertDoesNotContain(AssertionInfo, CharSequence, CharSequence...)}</code>.
+ *
  * @author Alex Ruiz
  */
 public class Strings_assertDoesNotContain_Test extends StringsBaseTest {
 
   @Test
-  public void should_fail_if_actual_contains_sequence() {
+  public void should_fail_if_actual_contains_any_of_values() {
     thrown.expectAssertionError(shouldNotContain("Yoda", "oda"));
     strings.assertDoesNotContain(someInfo(), "Yoda", "oda");
   }
 
   @Test
-  public void should_throw_error_if_sequence_is_null() {
-    thrown.expectNullPointerException(charSequenceToLookForIsNull());
+  public void should_throw_error_if_list_of_values_is_null() {
+    thrown.expectNullPointerException(arrayOfValuesToLookForIsNull());
     strings.assertDoesNotContain(someInfo(), "Yoda", null);
+  }
+
+  @Test
+  public void should_throw_error_if_any_element_of_values_is_null() {
+    String[] values = { "author", null };
+    thrown.expectNullPointerException("Expecting CharSequence elements not to be null but found one at index 1");
+    strings.assertDoesNotContain(someInfo(), "Yoda", values);
   }
 
   @Test
@@ -64,4 +71,30 @@ public class Strings_assertDoesNotContain_Test extends StringsBaseTest {
     stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(someInfo(), "Yoda", "yoda");
   }
 
+  @Test
+  public void should_pass_if_actual_does_not_contain_all_of_given_values() {
+    String[] values = { "practice", "made", "good" };
+    strings.assertDoesNotContain(someInfo(), "Practice makes perfect", values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_any_of_given_values() {
+    String[] values = { "practice", "make", "good" };
+    thrown.expectAssertionError(shouldNotContain("Practice makes perfect", values, newSet("make")));
+    strings.assertDoesNotContain(someInfo(), "Practice makes perfect", values);
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_all_of_given_values_according_to_custom_comparison_strategy() {
+    String[] values = { "p1ractice", "made", "good" };
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(someInfo(), "Practice makes perfect", values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_any_of_given_values_according_to_custom_comparison_strategy() {
+    String[] values = { "practice", "made", "good" };
+    thrown
+      .expectAssertionError(shouldNotContain("Practice makes perfect", values, newSet("practice"), comparisonStrategy));
+    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(someInfo(), "Practice makes perfect", values);
+  }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1102 
* Unit tests : YES
* Javadoc with a code example (API only) : YES


