### PR TITLE
Added catchThrowableOfType() assertion to do type-safe downcast.

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1117,7 +1117,7 @@ public class Assertions {
   }
 
   /**
-   * Allows to catch an {@link Throwable} more easily when used with Java 8 lambdas.
+   * Allows catching a {@link Throwable} more easily when used with Java 8 lambdas.
    *
    * <p>
    * This caught {@link Throwable} can then be asserted.
@@ -1146,12 +1146,13 @@ public class Assertions {
   }
 
   /**
-   * Allows catching an {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
+   * Allows catching a {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
    *
    * <p>
-   * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught {@link Throwable} to ensure it is of the specified type. If
-   * the assertion passes, then the caught {@link Throwable} is cast to the correct subtype before
-   * being returned, making it convenient to perform subtype-specific assertions on the result.
+   * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught
+   * {@link Throwable} to ensure it is of the specified type. If the assertion passes, then the caught
+   * {@link Throwable} is cast to the correct subtype before being returned, making it convenient to
+   * perform subtype-specific assertions on the result.
    * </p>
    *
    * <p>
@@ -1159,15 +1160,39 @@ public class Assertions {
    * </p>
    *
    * <pre><code class='java'>{@literal @}Test
+   * 
+   * class CustomParseException extends Exception {
+   *   final private int line;
+   *   final private int column;
+   *   
+   *   public CustomParseException(String msg, int l, int c) {
+   *     super(msg);
+   *     line = l;
+   *     column = c;
+   *   }
+   *   
+   *   public int getLine() {return line;}
+   *   public int getColumn() {return column;}
+   * }
+   * 
    * public void testException() {
-   *   // when
+   *   // when (assertion will pass)
    *   CustomParseException e = catchThrowableOfType(() -&gt; { throw new CustomParseException("boom!", 1, 5); },
    *                                                 CustomParseException.class);
    *
    *   // then
-   *   assertThat(e).as("message").hasMessageContaining("boom");
-   *   assertThat(e.getLine()).as("line").isEqualTo(1);
-   *   assertThat(e.getColumn()).as("column").isEqualTo(5);
+   *   assertThat(e).hasMessageContaining("boom");
+   *   assertThat(e.getLine()).isEqualTo(1);
+   *   assertThat(e.getColumn()).isEqualTo(5);
+   * }
+   * 
+   * public void testRuntimeException() {
+   *   // when (assertion will fail)
+   *   RuntimeException e = catchThrowableOfType(() -&gt; { throw new IOException("boom!", 1, 5); },
+   *                                             RuntimeException.class);
+   *
+   *   // then
+   *   assertThat(e).hasMessageContaining("boom");
    * } </code></pre>
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1139,9 +1139,45 @@ public class Assertions {
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see #catchThrowableOfType(ThrowingCallable, Class)
    */
   public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
     return AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
+  }
+
+  /**
+   * Allows catching an {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught {@link Throwable} to ensure it is of the specified type. If
+   * the assertion passes, then the caught {@link Throwable} is cast to the correct subtype before
+   * being returned, making it convenient to perform subtype-specific assertions on the result.
+   * </p>
+   *
+   * <p>
+   * Example:
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   // when
+   *   CustomParseException e = catchThrowableOfType(() -&gt; { throw new CustomParseException("boom!", 1, 5); },
+   *                                                 CustomParseException.class);
+   *
+   *   // then
+   *   assertThat(e).as("message").hasMessageContaining("boom");
+   *   assertThat(e.getLine()).as("line").isEqualTo(1);
+   *   assertThat(e.getColumn()).as("column").isEqualTo(5);
+   * } </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @param type The type of exception that the code is expected to raise.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see #catchThrowable(ThrowingCallable)
+   * @since 3.9.0
+   */
+  public static <E extends Throwable> E catchThrowableOfType(ThrowingCallable shouldRaiseThrowable, Class<E> type) {
+    return AssertionsForClassTypes.catchThrowableOfType(shouldRaiseThrowable, type);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -587,7 +587,6 @@ public class AssertionsForClassTypes {
     return new InstantAssert(instant);
   }
 
-
   /**
    * Creates a new instance of <code>{@link ThrowableAssert}</code>.
    *
@@ -641,7 +640,7 @@ public class AssertionsForClassTypes {
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return new ThrowableTypeAssert<>(exceptionType);
   }
-  
+
   /**
    * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
    *
@@ -711,9 +710,46 @@ public class AssertionsForClassTypes {
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see AssertionsForClassTypes#catchThrowableOfType(ThrowingCallable, Class)
    */
   public static Throwable catchThrowable(ThrowingCallable shouldRaiseThrowable) {
     return ThrowableAssert.catchThrowable(shouldRaiseThrowable);
+  }
+
+  /**
+   * Allows catching an {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught
+   * {@link Throwable} to ensure it is of the specified type. If the assertion passes, then the caught
+   * {@link Throwable} is cast to the correct subtype before being returned, making it convenient to
+   * perform subtype-specific assertions on the result.
+   * </p>
+   *
+   * <p>
+   * Example:
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   // when
+   *   CustomParseException e = catchThrowableOfType(() -&gt; { throw new CustomParseException("boom!", 1, 5); },
+   *                                                 CustomParseException.class);
+   *
+   *   // then
+   *   assertThat(e).as("message").hasMessageContaining("boom");
+   *   assertThat(e.getLine()).as("line").isEqualTo(1);
+   *   assertThat(e.getColumn()).as("column").isEqualTo(5);
+   * } </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @param type The type of exception that the code is expected to raise.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see #catchThrowable(ThrowingCallable)
+   * @since 3.9.0
+   */
+  public static <E extends Throwable> E catchThrowableOfType(ThrowingCallable shouldRaiseThrowable, Class<E> type) {
+    return ThrowableAssert.catchThrowableOfType(shouldRaiseThrowable, type);
   }
 
   // -------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -688,7 +688,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Allows to catch an {@link Throwable} more easily when used with Java 8 lambdas.
+   * Allows catching a {@link Throwable} more easily when used with Java 8 lambdas.
    *
    * <p>
    * This caught {@link Throwable} can then be asserted.
@@ -717,7 +717,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Allows catching an {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
+   * Allows catching a {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
    *
    * <p>
    * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught
@@ -731,15 +731,39 @@ public class AssertionsForClassTypes {
    * </p>
    *
    * <pre><code class='java'>{@literal @}Test
+   * 
+   * class CustomParseException extends Exception {
+   *   final private int line;
+   *   final private int column;
+   *   
+   *   public CustomParseException(String msg, int l, int c) {
+   *     super(msg);
+   *     line = l;
+   *     column = c;
+   *   }
+   *   
+   *   public int getLine() {return line;}
+   *   public int getColumn() {return column;}
+   * }
+   * 
    * public void testException() {
-   *   // when
+   *   // when (assertion will pass)
    *   CustomParseException e = catchThrowableOfType(() -&gt; { throw new CustomParseException("boom!", 1, 5); },
    *                                                 CustomParseException.class);
    *
    *   // then
-   *   assertThat(e).as("message").hasMessageContaining("boom");
-   *   assertThat(e.getLine()).as("line").isEqualTo(1);
-   *   assertThat(e.getColumn()).as("column").isEqualTo(5);
+   *   assertThat(e).hasMessageContaining("boom");
+   *   assertThat(e.getLine()).isEqualTo(1);
+   *   assertThat(e.getColumn()).isEqualTo(5);
+   * }
+   * 
+   * public void testRuntimeException() {
+   *   // when (assertion will fail)
+   *   RuntimeException e = catchThrowableOfType(() -&gt; { throw new IOException("boom!", 1, 5); },
+   *                                             RuntimeException.class);
+   *
+   *   // then
+   *   assertThat(e).hasMessageContaining("boom");
    * } </code></pre>
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.

--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -63,4 +63,11 @@ public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Th
     }
     return null;
   }
+
+  @SuppressWarnings("unchecked")
+  public static <E extends Throwable> E catchThrowableOfType(ThrowingCallable shouldRaiseThrowable, Class<E> type) {
+    Throwable t = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
+    new ThrowableAssert(t).isInstanceOf(type);
+    return (E)t;
+  }
 }

--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -67,7 +67,10 @@ public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Th
   @SuppressWarnings("unchecked")
   public static <E extends Throwable> E catchThrowableOfType(ThrowingCallable shouldRaiseThrowable, Class<E> type) {
     Throwable t = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
-    new ThrowableAssert(t).isInstanceOf(type);
+    if (t == null) {
+      return null;
+    }
+    new ThrowableAssert(t).overridingErrorMessage("Expecting code to throw <%s>, but threw <%s> instead", type, t.getClass()).isInstanceOf(type);
     return (E)t;
   }
 }

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -2219,9 +2219,46 @@ public interface WithAssertions {
    *
    * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see #catchThrowableOfType(ThrowingCallable, Class)
    */
   default Throwable catchThrowable(final ThrowingCallable shouldRaiseThrowable) {
     return Assertions.catchThrowable(shouldRaiseThrowable);
+  }
+
+  /**
+   * Allows catching an {@link Throwable} of a specific type more easily when used with Java 8 lambdas.
+   *
+   * <p>
+   * A call is made to {@link #catchThrowable(ThrowingCallable)}, and an assertion is made on the caught
+   * {@link Throwable} to ensure it is of the specified type. If the assertion passes, then the caught
+   * {@link Throwable} is cast to the correct subtype before being returned, making it convenient to
+   * perform subtype-specific assertions on the result.
+   * </p>
+   *
+   * <p>
+   * Example:
+   * </p>
+   *
+   * <pre><code class='java'>{@literal @}Test
+   * public void testException() {
+   *   // when
+   *   CustomParseException e = catchThrowableOfType(() -&gt; { throw new CustomParseException("boom!", 1, 5); },
+   *                                                 CustomParseException.class);
+   *
+   *   // then
+   *   assertThat(e).as("message").hasMessageContaining("boom");
+   *   assertThat(e.getLine()).as("line").isEqualTo(1);
+   *   assertThat(e.getColumn()).as("column").isEqualTo(5);
+   * } </code></pre>
+   *
+   * @param shouldRaiseThrowable The lambda with the code that should raise the exception.
+   * @param type The type of exception that the code is expected to raise.
+   * @return The captured exception or <code>null</code> if none was raised by the callable.
+   * @see #catchThrowable(ThrowingCallable)
+   * @since 3.9.0
+   */
+  default <E extends Throwable> E catchThrowableOfType(final ThrowingCallable shouldRaiseThrowable, final Class<E> type) {
+    return Assertions.catchThrowableOfType(shouldRaiseThrowable, type);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.Fail.fail;
+import static org.assertj.core.api.Fail.shouldHaveThrown;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -61,6 +63,15 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
+  public void catchThrowable_returns_null_when_no_exception_thrown() {
+    // when
+    Throwable boom = catchThrowable(() -> {});
+
+    // then
+    assertThat(boom).isNull();
+  }
+
+  @Test
   public void catchThrowableOfType_should_fail_with_good_message_if_wrong_type() {
     boolean failed = false;
     try {
@@ -72,7 +83,7 @@ public class Assertions_assertThat_with_Throwable_Test {
         .hasMessageContaining(Exception.class.getName());
     }
     if (failed) {
-      Fail.shouldHaveThrown(AssertionError.class);
+      shouldHaveThrown(AssertionError.class);
     }
   }
 
@@ -83,9 +94,21 @@ public class Assertions_assertThat_with_Throwable_Test {
     try {
       actual = catchThrowableOfType(raisingException(expected), Exception.class);
     } catch (AssertionError a) {
-      Fail.fail("catchThrowableOfType should not have asserted", a);
+      fail("catchThrowableOfType should not have asserted", a);
     }
     assertThat(actual).isSameAs(expected);
+  }
+
+  @Test
+  public void catchThrowableOfType_should_succeed_and_return_null_if_no_exception_thrown() {
+    final Exception initial = new Exception("boom!");
+    Exception actual = initial;
+    try {
+      actual = catchThrowableOfType(() -> {}, Exception.class);
+    } catch (AssertionError a) {
+      fail("catchThrowableOfType should not have asserted", a);
+    }
+    assertThat(actual).isNull();
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Adds a new feature
* Unit tests : YES 
* Javadoc with a code example (API only) : YES

During my testing using the new catchThrowable() syntax, I frequently found myself wanting to catch a Throwable of a particular subtype, and then run further assertions on the specific subtype. The new function `catchThrowableOfType()` facilitates this.

Before:
````
Throwable t = catchThrowable(() -> { functionThatThrowsParseException(); });
assertThat(t).isInstanceOf(ParseException.class);
ParseException p = (ParseException)t;
assertThat(p.getErrorOffset()).isEqualTo(10);
````
Now:
````
ParseException p = catchThrowableOfType(() -> { functionThatThrowsParseException(); }, 
                                                                     ParseException.class );
assertThat(p.getErrorOffset()).isEqualTo(10);
````
`catchThrowableOfType()` does the `isInstanceOf()` assertion and down-casting for you. The resulting code is not only shorter, it also removes the need for ugly casts in your test code and enforces type safety at compile time.