### PR TITLE
Have AbstractInstantAssertions implement ComparableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
@@ -32,7 +32,7 @@ import org.assertj.core.internal.Objects;
  * @since 3.7.0
  */
 public class AbstractInstantAssert<SELF extends AbstractInstantAssert<SELF>>
-    extends AbstractTemporalAssert<SELF, Instant> {
+    extends AbstractTemporalAssert<SELF, Instant> implements ComparableAssert<SELF, Instant> {
 
   /**
    * Creates a new <code>{@link org.assertj.core.api.AbstractInstantAssert}</code>.
@@ -326,6 +326,42 @@ public class AbstractInstantAssert<SELF extends AbstractInstantAssert<SELF>>
   public SELF isNotIn(String... instantsAsString) {
     checkIsNotNullAndNotEmpty(instantsAsString);
     return isNotIn(convertToInstantArray(instantsAsString));
+  }
+
+  @Override
+  public SELF isEqualByComparingTo(Instant other) {
+    comparables.assertEqualByComparison(info, actual, other);
+    return myself;
+  }
+
+  @Override
+  public SELF isNotEqualByComparingTo(Instant other) {
+    comparables.assertNotEqualByComparison(info, actual, other);
+    return myself;
+  }
+
+  @Override
+  public SELF isLessThan(Instant other) {
+    comparables.assertLessThan(info, actual, other);
+    return myself;
+  }
+
+  @Override
+  public SELF isLessThanOrEqualTo(Instant other) {
+    comparables.assertLessThanOrEqualTo(info, actual, other);
+    return myself;
+  }
+
+  @Override
+  public SELF isGreaterThan(Instant other) {
+    comparables.assertGreaterThan(info, actual, other);
+    return myself;
+  }
+
+  @Override
+  public SELF isGreaterThanOrEqualTo(Instant other) {
+    comparables.assertGreaterThanOrEqualTo(info, actual, other);
+    return myself;
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
@@ -33,6 +33,8 @@ public class InstantAssert_IsBeforeOrEqualTo_Test extends InstantAssertBaseTest 
     // WHEN
     assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
     assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
+    assertThat(dateBefore).isLessThanOrEqualTo(referenceDate);
+    assertThat(referenceDate).isLessThanOrEqualTo(referenceDate);
     // THEN
     verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
   }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
@@ -34,6 +34,8 @@ public class InstantAssert_isAfterOrEqual_Test extends InstantAssertBaseTest {
     // WHEN
     assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
     assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
+    assertThat(dateAfter).isGreaterThanOrEqualTo(referenceDate);
+    assertThat(referenceDate).isGreaterThanOrEqualTo(referenceDate);
     // THEN
     verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
   }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
@@ -34,6 +34,7 @@ public class InstantAssert_isAfter_Test extends InstantAssertBaseTest {
     // WHEN
     assertThat(dateAfter).isAfter(referenceDate);
     assertThat(dateAfter).isAfter(referenceDate.toString());
+    assertThat(dateAfter).isGreaterThan(referenceDate);
     // THEN
     verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
     verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
@@ -33,6 +33,7 @@ public class InstantAssert_isBefore_Test extends InstantAssertBaseTest {
     testAssumptions(referenceDate, dateBefore, dateAfter);
     // WHEN
     assertThat(dateBefore).isBefore(referenceDate);
+    assertThat(dateBefore).isLessThan(referenceDate);
     // THEN
     verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
     verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
@@ -29,6 +29,7 @@ public class InstantAssert_isEqualTo_Test extends InstantAssertBaseTest {
   public void test_isEqualTo_assertion(Instant referenceDate) {
     // WHEN
     assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    assertThat(referenceDate).isEqualByComparingTo(referenceDate);
     // THEN
     verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
   }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
@@ -29,6 +29,7 @@ public class InstantAssert_isNotEqualTo_Test extends InstantAssertBaseTest {
   public void test_isNotEqualTo_assertion(Instant referenceDate) {
     // WHEN
     assertThat(referenceDate).isNotEqualTo(referenceDate.plusSeconds(1).toString());
+    assertThat(referenceDate).isNotEqualByComparingTo(referenceDate.plusSeconds(1));
     // THEN
     verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
   }


### PR DESCRIPTION
Using an older assert/j, we have a bunch of assertions that
work using ComparableAssertions on Instant objects.  With the
addition of native Instant assertions, these currently fail to
compile.