### PR TITLE
Print stack trace information for `AbstractThrowableAssert.doesNotThr…

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldNotHaveThrown.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotHaveThrown.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.error;
 
+import static org.assertj.core.util.Throwables.getStackTrace;
+
 public class ShouldNotHaveThrown extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldNotHaveThrown(Throwable throwable) {
@@ -19,7 +21,7 @@ public class ShouldNotHaveThrown extends BasicErrorMessageFactory {
   }
 
   private ShouldNotHaveThrown(Throwable throwable) {
-    super("%nExpecting code not to raise a throwable but caught a%n  <%s>%nwith message :%n  %s",
-          throwable.getClass(), throwable.getMessage());
+    super("%nExpecting code to not raise a throwable but caught%n  <%s>",
+          getStackTrace(throwable));
   }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.error.ShouldNotHaveThrown;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,17 +40,14 @@ public class Assertions_assertThatCode_Test {
   @Test
   public void should_fail_when_asserting_no_exception_raised_but_exception_occurs() {
     // Given
-    ThrowingCallable boom = raisingException("boom");
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
 
     // Expect
-    thrown.expectAssertionError(format("[Test] %n" +
-                                       "Expecting code not to raise a throwable but caught a%n" +
-                                       "  <java.lang.Exception>%n" +
-                                       "with message :%n" +
-                                       "  \"boom\""));
+    thrown.expectAssertionError(ShouldNotHaveThrown.shouldNotHaveThrown(exception));
 
     // When
-    assertThatCode(boom).as("Test").doesNotThrowAnyException();
+    assertThatCode(boom).doesNotThrowAnyException();
   }
 
   @Test
@@ -63,8 +61,12 @@ public class Assertions_assertThatCode_Test {
   }
 
   private ThrowingCallable raisingException(final String reason) {
+    return raisingException(new Exception(reason));
+  }
+
+  private ThrowingCallable raisingException(final Exception exception) {
     return () -> {
-      throw new Exception(reason);
+      throw exception;
     };
   }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 import static org.assertj.core.test.ExpectedException.none;

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -14,10 +14,10 @@ package org.assertj.core.api;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.error.ShouldNotHaveThrown;
 import org.assertj.core.test.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +44,7 @@ public class Assertions_assertThatCode_Test {
     ThrowingCallable boom = raisingException(exception);
 
     // Expect
-    thrown.expectAssertionError(ShouldNotHaveThrown.shouldNotHaveThrown(exception));
+    thrown.expectAssertionError(shouldNotHaveThrown(exception));
 
     // When
     assertThatCode(boom).doesNotThrowAnyException();

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -51,6 +51,34 @@ public class Assertions_assertThatCode_Test {
   }
 
   @Test
+  public void can_use_description_in_error_message() {
+    // Given
+    ThrowingCallable boom = raisingException("boom");
+
+    // Expect
+    thrown.expectWithMessageStartingWith(AssertionError.class, "[Test]");
+
+    // When
+    assertThatCode(boom).as("Test").doesNotThrowAnyException();
+  }
+
+  @Test
+  public void error_message_contains_stacktrace() {
+    // Given
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+
+    // Expect
+    thrown.expectAssertionErrorWithMessageContaining(
+      "java.lang.Exception: boom",
+      "at org.assertj.core.api.Assertions_assertThatCode_Test.error_message_contains_stacktrace"
+    );
+
+    // When
+    assertThatCode(boom).doesNotThrowAnyException();
+  }
+
+  @Test
   public void should_succeed_when_asserting_no_exception_raised_and_no_exception_occurs() {
     // Given
     ThrowingCallable silent = () -> {

--- a/src/test/java/org/assertj/core/error/ShouldNotHaveThrown_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotHaveThrown_create_Test.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+import static org.assertj.core.util.Throwables.getStackTrace;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+public class ShouldNotHaveThrown_create_Test {
+
+  @Test
+  public void should_create_error_message_with_stacktrace_of_exception() {
+    Exception exception = new Exception("boom");
+    ErrorMessageFactory factory = shouldNotHaveThrown(exception);
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertThat(message).isEqualTo(String.format(
+      "[Test] %nExpecting code to not raise a throwable but caught%n  <\"%s\">"
+    , getStackTrace(exception)));
+  }
+}


### PR DESCRIPTION
…owAnyException()`

closes https://github.com/joel-costigliola/assertj-core/issues/1118

#### Check List:

* Fixes https://github.com/joel-costigliola/assertj-core/issues/1118
* Unit tests : YES
* Javadoc with a code example (API only) : YES / NO / NA


