### PR TITLE
Make configurable if AbstractAssert#equals throws an exception

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -50,6 +50,9 @@ import org.assertj.core.util.VisibleForTesting;
  */
 public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, ACTUAL> implements Assert<SELF, ACTUAL> {
 
+  // https://github.com/joel-costigliola/assertj-core/issues/1128
+  public static boolean throwUnsupportedExceptionOnEquals = true;
+
   private static final String ORG_ASSERTJ = "org.assert";
 
   @VisibleForTesting
@@ -540,7 +543,10 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   @Override
   @Deprecated
   public boolean equals(Object obj) {
-    throw new UnsupportedOperationException("'equals' is not supported...maybe you intended to call 'isEqualTo'");
+    if (throwUnsupportedExceptionOnEquals) {
+      throw new UnsupportedOperationException("'equals' is not supported...maybe you intended to call 'isEqualTo'");
+    }
+    return super.equals(obj);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
@@ -42,6 +42,14 @@ public class AbstractAssert_equal_hashCode_Test {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
+  public void should_not_fail_when_equals_exceptions_is_deactivated() {
+    AbstractAssert.throwUnsupportedExceptionOnEquals = false;
+    assertions.equals("anotherString");
+  }
+
+
+  @Test
   public void shouldReturnOneAsHashCode() {
     assertThat(assertions.hashCode()).isEqualTo(1);
   }


### PR DESCRIPTION
#### Check List:
* Fixes #1128 
* Unit tests : YES
* Javadoc with a code example (API only) : NO


