### PR TITLE
[Issue #1140]Modify the IterableDiff class and rework assertContainsOnly Iterable/Array assertion

### DIFF
--- a/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/src/main/java/org/assertj/core/internal/Arrays.java
@@ -208,11 +208,22 @@ public class Arrays {
 
   void assertContainsOnly(AssertionInfo info, Failures failures, Object actual, Object values) {
     if (commonChecks(info, actual, values)) return;
-    IterableDiff diff = diff(asList(actual), asList(values), comparisonStrategy);
-    if (diff.differencesFound())
-      throw failures.failure(info, shouldContainOnly(actual, values,
-                                                     diff.missing, diff.unexpected,
-                                                     comparisonStrategy));
+    List<Object> notExpected = asList(actual);
+    List<Object> notFound = asList(values);
+
+    for (Object value : asList(values)) {
+      if (iterableContains(notExpected, value)) {
+        iterableRemoves(notExpected, value);
+        iterableRemoves(notFound, value);
+      }
+    }
+
+    if (notExpected.isEmpty() && notFound.isEmpty()) return;
+
+    throw failures.failure(info, shouldContainOnly(actual, values,
+                                                   notFound, notExpected,
+                                                   comparisonStrategy));
+
   }
 
   void assertContainsOnlyNulls(AssertionInfo info, Failures failures, Object[] actual) {
@@ -298,6 +309,13 @@ public class Arrays {
 
   private void iterablesRemoveFirst(Collection<?> actual, Object value) {
     comparisonStrategy.iterablesRemoveFirst(actual, value);
+  }
+
+  /**
+   * Delegates to {@link ComparisonStrategy#iterableRemoves(Iterable, Object)}
+   */
+  private void iterableRemoves(Collection<?> actual, Object value) {
+    comparisonStrategy.iterableRemoves(actual, value);
   }
 
   void assertContainsSequence(AssertionInfo info, Failures failures, Object actual, Object sequence) {

--- a/src/main/java/org/assertj/core/internal/IterableDiff.java
+++ b/src/main/java/org/assertj/core/internal/IterableDiff.java
@@ -12,47 +12,54 @@
  */
 package org.assertj.core.internal;
 
-import static java.util.Collections.unmodifiableList;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Collections.*;
+import static org.assertj.core.util.Lists.*;
+
 class IterableDiff {
-  
+
   private final ComparisonStrategy comparisonStrategy;
 
   List<Object> unexpected;
   List<Object> missing;
 
-  static IterableDiff diff(Iterable<Object> actual, Iterable<Object> expected, ComparisonStrategy comparisonStrategy) {
-    return new IterableDiff(actual, expected, comparisonStrategy);
-  }
-  
-  IterableDiff(Iterable<Object> actual, Iterable<Object> expected, ComparisonStrategy comparisonStrategy) {
+  <T> IterableDiff(Iterable<T> actual, Iterable<T> expected, ComparisonStrategy comparisonStrategy) {
     this.comparisonStrategy = comparisonStrategy;
     this.unexpected = unmodifiableList(unexpectedElements(actual, expected));
     this.missing = unmodifiableList(missingElements(actual, expected));
   }
-  
+
+  static <T> IterableDiff diff(Iterable<T> actual, Iterable<T> expected, ComparisonStrategy comparisonStrategy) {
+    return new IterableDiff(actual, expected, comparisonStrategy);
+  }
+
   boolean differencesFound() {
     return !unexpected.isEmpty() || !missing.isEmpty();
   }
-  
-  private List<Object> missingElements(Iterable<Object> actual, Iterable<Object> expected) {
+
+  private <T> List<Object> missingElements(Iterable<T> actual, Iterable<T> expected) {
     List<Object> missing = new ArrayList<>();
+    List<T> copyOfActual = newArrayList(actual);
     for (Object element : expected) {
-      if (!iterableContains(actual, element)) {
+      if (!iterableContains(copyOfActual, element)) {
         missing.add(element);
+      } else {
+        iterablesRemoveFirst(copyOfActual, element);
       }
     }
     return missing;
   }
 
-  private List<Object> unexpectedElements(Iterable<Object> actual, Iterable<Object> expected) {
+  private <T> List<Object> unexpectedElements(Iterable<T> actual, Iterable<T> expected) {
     List<Object> unexpected = new ArrayList<>();
+    List<T> copyOfExpected = newArrayList(expected);
     for (Object actualElement : actual) {
-      if (!iterableContains(expected, actualElement)) {
+      if (!iterableContains(copyOfExpected, actualElement)) {
         unexpected.add(actualElement);
+      } else {
+        iterablesRemoveFirst(copyOfExpected, actualElement);
       }
     }
     return unexpected;
@@ -61,5 +68,8 @@ class IterableDiff {
   private boolean iterableContains(Iterable<?> actual, Object value) {
     return comparisonStrategy.iterableContains(actual, value);
   }
-  
+
+  private void iterablesRemoveFirst(Iterable<?> actual, Object value) {
+    comparisonStrategy.iterablesRemoveFirst(actual, value);
+  }
 }

--- a/src/test/java/org/assertj/core/internal/IterableDiff_Test.java
+++ b/src/test/java/org/assertj/core/internal/IterableDiff_Test.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
+package org.assertj.core.internal;
+
+import org.assertj.core.test.ExpectedException;
+import org.assertj.core.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.test.ExpectedException.*;
+import static org.assertj.core.util.Lists.*;
+
+/**
+ * Class for testing <code>{@link IterableDiff}</code>
+ *
+ * @author Billy Yuan
+ */
+
+public class IterableDiff_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  private List<String> actual;
+  private ComparisonStrategy comparisonStrategy;
+  private List<String> expected;
+
+  @Before
+  public void setUp() {
+    comparisonStrategy = StandardComparisonStrategy.instance();
+  }
+
+  @Test
+  public void no_difference_found_between_two_same_iterables() {
+    actual = newArrayList("#", "$");
+    expected = newArrayList("#", "$");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isFalse();
+    assertThat(diff.missing.isEmpty()).isTrue();
+    assertThat(diff.unexpected.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void no_difference_found_between_two_same_iterables_without_same_order() {
+    actual = newArrayList("#", "$");
+    expected = newArrayList("$", "#");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isFalse();
+    assertThat(diff.missing.isEmpty()).isTrue();
+    assertThat(diff.unexpected.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void no_difference_found_between_two_same_iterables_with_duplicate_elements() {
+    actual = newArrayList("#", "#", "$", "$");
+    expected = newArrayList("$", "$", "#", "#");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isFalse();
+    assertThat(diff.missing.isEmpty()).isTrue();
+    assertThat(diff.unexpected.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void difference_found_between_two_different_iterables() {
+    actual = newArrayList("A", "B", "C");
+    expected = newArrayList("X", "Y", "Z");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isTrue();
+    assertThat(diff.missing).isEqualTo(newArrayList("X", "Y", "Z"));
+    assertThat(diff.unexpected).isEqualTo(newArrayList("A", "B", "C"));
+  }
+
+  @Test
+  public void difference_found_between_two_different_iterables_with_duplicate_elements() {
+    actual = newArrayList("#", "#", "$");
+    expected = newArrayList("$", "$", "#");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isTrue();
+    assertThat(diff.missing).isEqualTo(newArrayList("$"));
+    assertThat(diff.unexpected).isEqualTo(newArrayList("#"));
+  }
+
+  @Test
+  public void no_difference_found_between_two_case_sensitive_iterables_according_to_custom_comparison_strategy() {
+    comparisonStrategy = new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance);
+    actual = newArrayList("a", "b", "C", "D");
+    expected = newArrayList("A", "B", "C", "D");
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isFalse();
+    assertThat(diff.missing.isEmpty()).isTrue();
+    assertThat(diff.unexpected.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void no_difference_found_between_two_same_iterables_with_custom_objects() {
+    Foo foo1 = new Foo();
+    Foo foo2 = new Foo();
+    Foo foo3 = new Foo();
+
+    List<Foo> actual = newArrayList(foo1, foo2, foo3);
+    List<Foo> expected = newArrayList(foo1, foo2, foo3);
+
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isFalse();
+    assertThat(diff.missing.isEmpty()).isTrue();
+    assertThat(diff.unexpected.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void difference_found_between_two_iterables_with_duplicate_objects() {
+    Foo foo1 = new Foo();
+    Foo foo2 = new Foo();
+
+    List<Foo> actual = newArrayList(foo1, foo1, foo2);
+    List<Foo> expected = newArrayList(foo1, foo2, foo2);
+
+    IterableDiff diff = IterableDiff.diff(actual, expected, comparisonStrategy);
+    assertThat(diff.differencesFound()).isTrue();
+    assertThat(diff.missing).isEqualTo(newArrayList(foo2));
+    assertThat(diff.unexpected).isEqualTo(newArrayList(foo1));
+  }
+
+  @SuppressWarnings("unused")
+  private class Foo {
+  }
+}

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
@@ -88,7 +88,7 @@ public class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseT
 	try {
 	  arrays.assertContainsExactly(info, actual, expected);
 	} catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, expected, newArrayList(), newArrayList(false)));
+      verify(failures).failure(info, shouldContainExactly(actual, expected, newArrayList(true), newArrayList(false)));
 	  return;
 	}
 	failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION
#### Check List:
* Fixes #1140 
* Unit tests : NO
* Javadoc with a code example (API only) : NO

Modify the `IterableDiff ` class to make it aware of the differences even if there are **duplicate** elements.

Besides, `assertContainsOnly` iterable/array assertion used to be implemented with the `IterableDiff ` class which has an unexpected intention, so I rework impl of both assertions.

