### PR TITLE
.travis.yml: run javadoc:javadoc to detect javadoc errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ jdk:
   - oraclejdk9
 
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean verify; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.login=651ffb3dd32bdbb12acfc60dcb4a48a768609830; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean verify javadoc:javadoc; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install javadoc:javadoc sonar:sonar -Dsonar.login=651ffb3dd32bdbb12acfc60dcb4a48a768609830; fi'
 


### PR DESCRIPTION
Currently the javadoc is in pristine state (no warnings or errors). 😄 

Let's make sure it stays that way and let travis create javadoc so javadoc errors of pull requests are detected early on.

What do you think?

