### PR TITLE
Fixes: #1145 - `isEqualToComparingFieldByFieldRecursively` throws Nul…

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
@@ -17,6 +17,7 @@ import static org.assertj.core.util.Strings.join;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.internal.DeepDifference.Difference;
 import org.assertj.core.presentation.Representation;
@@ -52,20 +53,20 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorM
 
     boolean sameRepresentation = Objects.areEqual(actualFieldValue, otherFieldValue);
 
-    String actualFieldValueRepresentation = sameRepresentation
+    Optional<String> actualFieldValueRepresentation = Optional.ofNullable(sameRepresentation
         ? representation.unambiguousToStringOf(difference.getActual())
-        : actualFieldValue;
+        : actualFieldValue);
 
-    String otherFieldValueRepresentation = sameRepresentation
+    Optional<String> otherFieldValueRepresentation = Optional.ofNullable(sameRepresentation
         ? representation.unambiguousToStringOf(difference.getOther())
-        : otherFieldValue;
+        : otherFieldValue);
 
     return format("%nPath to difference: <%s>%n" +
                   "- expected: <%s>%n" +
                   "- actual  : <%s>",
                   join(difference.getPath()).with("."),
-                  otherFieldValueRepresentation.replace("%", "%%"),
-                  actualFieldValueRepresentation.replace("%", "%%"));
+                  otherFieldValueRepresentation.map(s -> s.replace("%", "%%")).orElse(null),
+                  actualFieldValueRepresentation.map(s -> s.replace("%", "%%")).orElse(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.DeepDifference;
 import org.assertj.core.internal.DeepDifference.Difference;
@@ -32,6 +33,27 @@ import org.assertj.core.internal.objects.Objects_assertIsEqualToComparingFieldBy
 import org.junit.Test;
 
 public class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
+
+  @Test
+  public void should_throw_assertion_error_rather_than_null_pointer_when_one_nested_member_is_null() {
+    TestValue actual = new TestValue(null);
+    TestValue expected = new TestValue("value");
+    try {
+      Assertions.assertThat(expected).isEqualToComparingFieldByFieldRecursively(actual);
+    } catch (Throwable throwable) {
+      assertThat(throwable).isInstanceOf(AssertionError.class);
+      assertThat(throwable).isNotInstanceOf(NullPointerException.class);
+    }
+
+  }
+
+  class TestValue {
+    private final String v;
+
+    public TestValue(String v) {
+      this.v = v;
+    }
+  }
 
   @Test
   public void should_use_unambiguous_fields_description_when_standard_description_of_actual_and_expected_collection_fields_values_are_identical() {


### PR DESCRIPTION
…lPointerException while comparing null values

#### Check List:
* Fixes #1145
* Unit tests : YES
* Javadoc with a code example (API only) : NA


