### PR TITLE
Fixes: #1164 AbstractZonedDateTimeAssert.isEqualTo(ZonedDateTime expe…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
@@ -414,10 +414,14 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
+   * @throws IllegalArgumentException if other {@code ZonedDateTime} is {@code null}.
    * @throws AssertionError if the actual {@code ZonedDateTime} is not equal to the {@link ZonedDateTime} in the actual
    *           ZonedDateTime's java.time.ZoneId.
    */
   public SELF isEqualTo(ZonedDateTime expected) {
+    Objects.instance().assertNotNull(info, actual);
+    assertDateTimeParameterIsNotNull(expected);
     return super.isEqualTo(sameInstantInActualTimeZone(expected));
   }
 
@@ -447,6 +451,7 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *           given String.
    */
   public SELF isEqualTo(String dateTimeAsString) {
+    Objects.instance().assertNotNull(info, actual);
     assertDateTimeAsStringParameterIsNotNull(dateTimeAsString);
     return super.isEqualTo(parse(dateTimeAsString));
   }
@@ -459,10 +464,14 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
+   * @throws IllegalArgumentException if other {@code ZonedDateTime} is {@code null}.
    * @throws AssertionError if the actual {@code ZonedDateTime} is equal to the {@link ZonedDateTime} in the actual
    *           ZonedDateTime's java.time.ZoneId.
    */
   public SELF isNotEqualTo(ZonedDateTime expected) {
+    Objects.instance().assertNotNull(info, actual);
+    assertDateTimeParameterIsNotNull(expected);
     return super.isNotEqualTo(sameInstantInActualTimeZone(expected));
   }
 
@@ -487,6 +496,7 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *           String.
    */
   public SELF isNotEqualTo(String dateTimeAsString) {
+    Objects.instance().assertNotNull(info, actual);
     assertDateTimeAsStringParameterIsNotNull(dateTimeAsString);
     return super.isNotEqualTo(parse(dateTimeAsString));
   }

--- a/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
@@ -414,14 +414,10 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
-   * @throws IllegalArgumentException if other {@code ZonedDateTime} is {@code null}.
    * @throws AssertionError if the actual {@code ZonedDateTime} is not equal to the {@link ZonedDateTime} in the actual
    *           ZonedDateTime's java.time.ZoneId.
    */
   public SELF isEqualTo(ZonedDateTime expected) {
-    Objects.instance().assertNotNull(info, actual);
-    assertDateTimeParameterIsNotNull(expected);
     return super.isEqualTo(sameInstantInActualTimeZone(expected));
   }
 
@@ -451,7 +447,6 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *           given String.
    */
   public SELF isEqualTo(String dateTimeAsString) {
-    Objects.instance().assertNotNull(info, actual);
     assertDateTimeAsStringParameterIsNotNull(dateTimeAsString);
     return super.isEqualTo(parse(dateTimeAsString));
   }
@@ -464,14 +459,10 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *
    * @param expected the given value to compare the actual value to.
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
-   * @throws IllegalArgumentException if other {@code ZonedDateTime} is {@code null}.
    * @throws AssertionError if the actual {@code ZonedDateTime} is equal to the {@link ZonedDateTime} in the actual
    *           ZonedDateTime's java.time.ZoneId.
    */
   public SELF isNotEqualTo(ZonedDateTime expected) {
-    Objects.instance().assertNotNull(info, actual);
-    assertDateTimeParameterIsNotNull(expected);
     return super.isNotEqualTo(sameInstantInActualTimeZone(expected));
   }
 
@@ -496,7 +487,6 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
    *           String.
    */
   public SELF isNotEqualTo(String dateTimeAsString) {
-    Objects.instance().assertNotNull(info, actual);
     assertDateTimeAsStringParameterIsNotNull(dateTimeAsString);
     return super.isNotEqualTo(parse(dateTimeAsString));
   }
@@ -749,6 +739,9 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
   }
 
   private ZonedDateTime sameInstantInActualTimeZone(ZonedDateTime zonedDateTime) {
+    if (actual == null && zonedDateTime == null) return null;
+    if (actual == null || zonedDateTime == null) return zonedDateTime;
+
     return zonedDateTime.withZoneSameInstant(actual.getZone());
   }
 

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_Test.java
@@ -38,4 +38,10 @@ public class ZonedDateTimeAssert_isEqualTo_Test extends ZonedDateTimeAssertBaseT
     assertThat(utcDateTime).as("in UTC time zone").isEqualTo(cestDateTime);
     assertThat(cestDateTime).as("in CEST time zone").isEqualTo(utcDateTime);
   }
+
+  @Test
+  public void should_pass_if_both_are_null() {
+    assertThat((ZonedDateTime) null).isEqualTo((ZonedDateTime) null);
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
@@ -48,13 +48,13 @@ public class ZonedDateTimeAssert_isEqualTo_errors_Test extends ZonedDateTimeAsse
 
   @Test
   public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime() {
-    thrown.expectAssertionError("\nExpecting actual not to be null");
-    assertThat((ZonedDateTime) null).isEqualTo(ZonedDateTime.now());
+    thrown.expectAssertionError("expected:<2000-01-05T03:00:05Z> but was:<null>");
+    assertThat((ZonedDateTime) null).isEqualTo(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC));
   }
 
   @Test
   public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime_as_string() {
-    thrown.expectAssertionError("\nExpecting actual not to be null");
+    thrown.expectAssertionError("expected:<2000-01-01T01:00+01:00> but was:<null>");
     assertThat((ZonedDateTime) null).isEqualTo("2000-01-01T01:00:00+01:00");
   }
 
@@ -67,9 +67,8 @@ public class ZonedDateTimeAssert_isEqualTo_errors_Test extends ZonedDateTimeAsse
 
   @Test
   public void should_fail_if_dateTime_as_ZoneDateTime_is_null() {
-    expectException(IllegalArgumentException.class,
-                    "The ZonedDateTime to compare actual with should not be null");
-    assertThat(ZonedDateTime.now()).isEqualTo((ZonedDateTime) null);
+    thrown.expectAssertionError("expected:<null> but was:<2000-01-05T03:00:05Z>");
+    assertThat(ZonedDateTime.of(2000, 1, 5, 3, 0, 5, 0, UTC)).isEqualTo((ZonedDateTime) null);
   }
 
   private static void verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(ZonedDateTime reference) {

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
@@ -47,10 +47,29 @@ public class ZonedDateTimeAssert_isEqualTo_errors_Test extends ZonedDateTimeAsse
   }
 
   @Test
+  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime() {
+    thrown.expectAssertionError("\nExpecting actual not to be null");
+    assertThat((ZonedDateTime) null).isEqualTo(ZonedDateTime.now());
+  }
+
+  @Test
+  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime_as_string() {
+    thrown.expectAssertionError("\nExpecting actual not to be null");
+    assertThat((ZonedDateTime) null).isEqualTo("2000-01-01T01:00:00+01:00");
+  }
+
+  @Test
   public void should_fail_if_dateTime_as_string_parameter_is_null() {
     expectException(IllegalArgumentException.class,
         "The String representing the ZonedDateTime to compare actual with should not be null");
     assertThat(ZonedDateTime.now()).isEqualTo((String) null);
+  }
+
+  @Test
+  public void should_fail_if_dateTime_as_ZoneDateTime_is_null() {
+    expectException(IllegalArgumentException.class,
+                    "The ZonedDateTime to compare actual with should not be null");
+    assertThat(ZonedDateTime.now()).isEqualTo((ZonedDateTime) null);
   }
 
   private static void verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(ZonedDateTime reference) {

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_Test.java
@@ -39,4 +39,19 @@ public class ZonedDateTimeAssert_isNotEqualTo_Test extends ZonedDateTimeAssertBa
     assertThat(cestDateTime).as("in CEST time zone").isNotEqualTo(utcDateTime);
   }
 
+  @Test
+  public void should_pass_if_actual_dateTime_is_null_and_parameter_is_dateTime_as_string() {
+    assertThat((ZonedDateTime) null).isNotEqualTo("2000-01-01T01:00:00+01:00");
+  }
+
+  @Test
+  public void should_pass_if_actual_dateTimes_is_null_and_parameter_is_dateTime() {
+    assertThat((ZonedDateTime) null).isNotEqualTo(ZonedDateTime.now());
+  }
+
+  @Test
+  public void should_pass_if_dateTime_as_ZoneDateTime_is_null() {
+    assertThat(ZonedDateTime.now()).isNotEqualTo((ZonedDateTime) null);
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
@@ -48,10 +48,29 @@ public class ZonedDateTimeAssert_isNotEqualTo_errors_Test extends ZonedDateTimeA
   }
 
   @Test
+  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime() {
+    thrown.expectAssertionError("\nExpecting actual not to be null");
+    assertThat((ZonedDateTime) null).isNotEqualTo(ZonedDateTime.now());
+  }
+
+  @Test
+  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime_as_string() {
+    thrown.expectAssertionError("\nExpecting actual not to be null");
+    assertThat((ZonedDateTime) null).isNotEqualTo("2000-01-01T01:00:00+01:00");
+  }
+
+  @Test
   public void should_fail_if_dateTime_as_string_parameter_is_null() {
     expectException(IllegalArgumentException.class,
-        "The String representing the ZonedDateTime to compare actual with should not be null");
+                    "The String representing the ZonedDateTime to compare actual with should not be null");
     assertThat(ZonedDateTime.now()).isNotEqualTo((String) null);
+  }
+
+  @Test
+  public void should_fail_if_dateTime_as_ZoneDateTime_is_null() {
+    expectException(IllegalArgumentException.class,
+                    "The ZonedDateTime to compare actual with should not be null");
+    assertThat(ZonedDateTime.now()).isNotEqualTo((ZonedDateTime) null);
   }
 
   private static void verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(ZonedDateTime reference) {

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
@@ -48,29 +48,10 @@ public class ZonedDateTimeAssert_isNotEqualTo_errors_Test extends ZonedDateTimeA
   }
 
   @Test
-  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime() {
-    thrown.expectAssertionError("\nExpecting actual not to be null");
-    assertThat((ZonedDateTime) null).isNotEqualTo(ZonedDateTime.now());
-  }
-
-  @Test
-  public void should_fail_if_actual_dateTime_is_null_and_parameter_is_dateTime_as_string() {
-    thrown.expectAssertionError("\nExpecting actual not to be null");
-    assertThat((ZonedDateTime) null).isNotEqualTo("2000-01-01T01:00:00+01:00");
-  }
-
-  @Test
   public void should_fail_if_dateTime_as_string_parameter_is_null() {
     expectException(IllegalArgumentException.class,
                     "The String representing the ZonedDateTime to compare actual with should not be null");
     assertThat(ZonedDateTime.now()).isNotEqualTo((String) null);
-  }
-
-  @Test
-  public void should_fail_if_dateTime_as_ZoneDateTime_is_null() {
-    expectException(IllegalArgumentException.class,
-                    "The ZonedDateTime to compare actual with should not be null");
-    assertThat(ZonedDateTime.now()).isNotEqualTo((ZonedDateTime) null);
   }
 
   private static void verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(ZonedDateTime reference) {


### PR DESCRIPTION
…cted) throws NPE

#### Check List:
* Fixes #1164 
* Unit tests : YES
* Javadoc with a code example (API only) : YES


