### PR TITLE
remove unnecessary optional ASM dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>5.2</version>
-      <optional>true</optional>
-    </dependency>
     <!-- NEEDED! Unlike File, a Path is not linked to the JRE's filesystem. In order to accurately test assertions, we need 
       a decent JSR 203 implementation which lets us test our assertions. Right now, this is memoryfilesystem (https://github.com/marschall/memoryfilesystem). 
       Another choice would be jimfs from Google (https://github.com/google/jimfs), but its support for reading/writing file attributes 


### PR DESCRIPTION
No idea why we had this dependency (as we were using cg-lib-nodep with embeds ASM).

Byte-Buddy also embeds AMS, so this should be necessary. If it is for some reason, we should update to 6.0 because this is the version used by Byte-Buddy.



