### PR TITLE
Fix ClassNotFoundError on OSGI when using SoftAssertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
                 <Export-Package>org.assertj.core.*</Export-Package>
                 <!-- Don't import what assertj-core exports -->
                 <Import-Package>!org.assertj.core.*</Import-Package>
-				<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+				        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                 <_removeheaders>Bnd-LastModified</_removeheaders>
               </instructions>
               <niceManifest>true</niceManifest>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,9 @@
             <configuration>
               <instructions>
                 <Export-Package>org.assertj.core.*</Export-Package>
-                <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                <!-- Don't import what assertj-core exports -->
+                <Import-Package>!org.assertj.core.*</Import-Package>
+				<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                 <_removeheaders>Bnd-LastModified</_removeheaders>
               </instructions>
               <niceManifest>true</niceManifest>

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -84,6 +84,9 @@ class SoftProxies {
                           .method(ElementMatchers.<MethodDescription> any().and(ElementMatchers.not(specialMethods)))
                           .intercept(MethodDelegation.to(collector))
                           .make()
+                          // Use ClassLoader of soft assertion class to allow ByteBuddy to always find it.
+                          // This is needed in OSGI runtime when custom soft assertion is defined outside of assertj
+                          // bundle.
                           .load(assertClass.getClassLoader())
                           .getLoaded();
   }

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -84,7 +84,7 @@ class SoftProxies {
                           .method(ElementMatchers.<MethodDescription> any().and(ElementMatchers.not(specialMethods)))
                           .intercept(MethodDelegation.to(collector))
                           .make()
-                          .load(getClass().getClassLoader())
+                          .load(assertClass.getClassLoader())
                           .getLoaded();
   }
 


### PR DESCRIPTION
* Fixes #1160
* Unit tests : NA This is related to OSGI runtime
* Javadoc with a code example (API only) : NA


