### PR TITLE
#1197 fix of extracting/flatExtracting method not having proper description if set (for 2.x branch)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -1110,7 +1110,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   @CheckReturnValue
   public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> extracting(Extractor<? super ELEMENT, V> extractor) {
     List<V> values = FieldsOrPropertiesExtractor.extract(actual, extractor);
-    return newListAssertInstance(values);
+    return newListAssertInstance(values).as(info.description());
   }
 
   /**
@@ -1139,7 +1139,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *
    * List&lt;CartoonCharacter&gt; parents = newArrayList(homer, fred);
    * // check children
-   * assertThat(parent).flatExtracting(childrenOf)
+   * assertThat(parents).flatExtracting(childrenOf)
    *                   .containsOnly(bart, lisa, maggie, pebbles);</code></pre>
    *
    * The order of extracted values is consisted with both the order of the collection itself, as well as the extracted
@@ -1157,7 +1157,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
       result.addAll(iterable);
     }
 
-    return newListAssertInstance(result);
+    return newListAssertInstance(result).as(info.description());
   }
 
   /**
@@ -1209,7 +1209,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
         CommonErrors.wrongElementTypeForFlatExtracting(group);
       }
     }
-    return newListAssertInstance(extractedValues);
+    return newListAssertInstance(extractedValues).as(info.description());
   }
 
   /**
@@ -1241,7 +1241,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     for (Tuple tuple : FieldsOrPropertiesExtractor.extract(actual, Extractors.byName(fieldOrPropertyNames))) {
       extractedValues.addAll(tuple.toList());
     }
-    return newListAssertInstance(extractedValues);
+    return newListAssertInstance(extractedValues).as(info.description());
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -1938,7 +1938,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   public <U> ObjectArrayAssert<U> extracting(Extractor<? super ELEMENT, U> extractor) {
     U[] extracted = FieldsOrPropertiesExtractor.extract(actual, extractor);
 
-    return new ObjectArrayAssert<>(extracted);
+    return new ObjectArrayAssert<>(extracted).as(info.description());
   }
 
   /**
@@ -1985,7 +1985,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
       result.addAll(e);
     }
 
-    return new ObjectArrayAssert<>(IterableUtil.toArray(result));
+    return new ObjectArrayAssert<>(IterableUtil.toArray(result)).as(info.description());
   }
 
   /**
@@ -2037,7 +2037,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
         CommonErrors.wrongElementTypeForFlatExtracting(group);
       }
     }
-    return new ObjectArrayAssert<>(extractedValues.toArray());
+    return new ObjectArrayAssert<>(extractedValues.toArray()).as(info.description());
   }
 
   /**
@@ -2350,7 +2350,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
     checkNotNull(filterOperator);
     Filters<? extends ELEMENT> filter = filter(actual).with(propertyOrFieldName);
     filterOperator.applyOn(filter);
-    return (SELF) new ObjectArrayAssert<>(toArray(filter.get()));
+    return (SELF) new ObjectArrayAssert<>(toArray(filter.get())).as(info.description());
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -219,4 +219,18 @@ public class IterableAssert_extracting_Test {
 
     assertThat(employees).as("check employees first name").extracting("name.first").isEmpty();
   }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
+    thrown.expectAssertionErrorWithMessageContaining("[check employees first name]");
+
+    assertThat(employees).as("check employees first name").extracting(new Extractor<Employee, String>() {
+      @Override
+      public String extract(Employee input) {
+        return input.getName().getFirst();
+      }
+    }).isEmpty();
+  }
+
+
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
@@ -77,4 +77,27 @@ public class IterableAssert_flatExtracting_Test {
     thrown.expectNullPointerException();
     assertThat(newArrayList(homer, null)).flatExtracting(children);
   }
+
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
+    thrown.expectAssertionErrorWithMessageContaining("[expected description]");
+
+    assertThat(newArrayList(homer)).as("check children names").flatExtracting(children).isEmpty();
+  }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_single_field_name() {
+    thrown.expectAssertionErrorWithMessageContaining("[expected description]");
+
+    assertThat(newArrayList(homer)).as("expected description").flatExtracting("children").isEmpty();
+  }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_multiple_field_names() {
+    thrown.expectAssertionErrorWithMessageContaining("[expected description]");
+
+    assertThat(newArrayList(homer)).as("expected description").flatExtracting("children","name").isEmpty();
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
@@ -83,7 +83,7 @@ public class IterableAssert_flatExtracting_Test {
   public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
     thrown.expectAssertionErrorWithMessageContaining("[expected description]");
 
-    assertThat(newArrayList(homer)).as("check children names").flatExtracting(children).isEmpty();
+    assertThat(newArrayList(homer)).as("expected description").flatExtracting(children).isEmpty();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
@@ -138,4 +138,16 @@ public class ObjectArrayAssert_extracting_Test {
 
     assertThat(employees).as("check employees first name").extracting("name.first").isEmpty();
   }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
+    thrown.expectAssertionErrorWithMessageContaining("[check employees first name]");
+
+    assertThat(employees).as("check employees first name").extracting(new Extractor<Employee, String>() {
+      @Override
+      public String extract(Employee input) {
+        return input.getName().getFirst();
+      }
+    }).isEmpty();
+  }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
@@ -72,4 +72,18 @@ public class ObjectArrayAssert_flatExtracting_Test {
     assertThat(new CartoonCharacter[] { homer, null }).flatExtracting(children);
   }
 
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_property() {
+    thrown.expectAssertionErrorWithMessageContaining("[expected description]");
+
+    assertThat(new CartoonCharacter[] { homer }).as("expected description").flatExtracting("children").isEmpty();
+  }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
+    thrown.expectAssertionErrorWithMessageContaining("[expected description]");
+
+    assertThat(new CartoonCharacter[] { homer }).as("expected description").flatExtracting(children).isEmpty();
+  }
+
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1197 fix of extracting/flatExtracting method not having proper description if set (for 2.x branch)
* Unit tests : YES
* Javadoc with a code example (API only) : NA


