### PR TITLE
[Path|File|InputStream]Assert#hasDigest

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -583,21 +583,141 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link File} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, byte[] expected) {
     files.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link File} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, String expected) {
     files.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link File} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest("SHA1", new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(tested).hasDigest("MD5", new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest("SHA1", new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(tested).hasDigest("MD5", new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, byte[] expected) {
     files.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link File} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest("SHA1", "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(tested).hasDigest("MD5", "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest("SHA1", "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(tested).hasDigest("MD5", "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, String expected) {
     files.assertHasDigest(info, actual, algorithm, expected);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -18,6 +18,8 @@ import static org.assertj.core.util.Preconditions.checkNotNull;
 import java.io.File;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
+import java.security.MessageDigest;
+
 import org.assertj.core.internal.Files;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
@@ -578,6 +580,26 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    */
   public SELF hasNoParent() {
     files.assertHasNoParent(info, actual);
+    return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, byte[] expected) {
+    files.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, String expected) {
+    files.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, byte[] expected) {
+    files.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, String expected) {
+    files.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import java.io.InputStream;
+import java.security.MessageDigest;
 
 import org.assertj.core.internal.InputStreams;
 import org.assertj.core.internal.InputStreamsException;
@@ -76,6 +77,26 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    */
   public SELF hasSameContentAs(InputStream expected) {
     inputStreams.assertSameContentAs(info, actual, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, byte[] expected) {
+    inputStreams.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, String expected) {
+    inputStreams.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, byte[] expected) {
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, String expected) {
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -12,12 +12,12 @@
  */
 package org.assertj.core.api;
 
-import java.io.InputStream;
-import java.security.MessageDigest;
-
 import org.assertj.core.internal.InputStreams;
 import org.assertj.core.internal.InputStreamsException;
 import org.assertj.core.util.VisibleForTesting;
+
+import java.io.InputStream;
+import java.security.MessageDigest;
 
 /**
  * Base class for all implementations of assertions for {@link InputStream}s.
@@ -80,21 +80,141 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link InputStream} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException  if the given algorithm is {@code null}.
+   * @throws NullPointerException  if the given digest is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is not exist.
+   * @throws AssertionError        if the actual {@code File} is not an file.
+   * @throws AssertionError        if the actual {@code File} is not readable.
+   * @throws InputStreamsException if an I/O error occurs.
+   * @throws AssertionError        if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, byte[] expected) {
     inputStreams.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link InputStream} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("SHA1"), "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("MD5"), "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("SHA1"), "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(new FileInputStream(tested)).hasDigest(MessageDigest.getInstance("MD5"), "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException  if the given algorithm is {@code null}.
+   * @throws NullPointerException  if the given digest is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is not exist.
+   * @throws AssertionError        if the actual {@code File} is not an file.
+   * @throws AssertionError        if the actual {@code File} is not readable.
+   * @throws InputStreamsException if an I/O error occurs.
+   * @throws AssertionError        if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, String expected) {
     inputStreams.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link InputStream} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(new FileInputStream(tested)).hasDigest("SHA1", new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(new FileInputStream(tested)).hasDigest("MD5", new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(new FileInputStream(tested)).hasDigest("SHA1", new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(new FileInputStream(tested)).hasDigest("MD5", new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException  if the given algorithm is {@code null}.
+   * @throws NullPointerException  if the given digest is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is not exist.
+   * @throws AssertionError        if the actual {@code File} is not an file.
+   * @throws AssertionError        if the actual {@code File} is not readable.
+   * @throws InputStreamsException if an I/O error occurs.
+   * @throws AssertionError        if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, byte[] expected) {
     inputStreams.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link InputStream} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final File tested = new File("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(new FileInputStream(tested)).hasDigest("SHA1", "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(new FileInputStream(tested)).hasDigest("MD5", "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(new FileInputStream(tested)).hasDigest("SHA1", "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(new FileInputStream(tested)).hasDigest("MD5", "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException  if the given algorithm is {@code null}.
+   * @throws NullPointerException  if the given digest is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is {@code null}.
+   * @throws AssertionError        if the actual {@code File} is not exist.
+   * @throws AssertionError        if the actual {@code File} is not an file.
+   * @throws AssertionError        if the actual {@code File} is not readable.
+   * @throws InputStreamsException if an I/O error occurs.
+   * @throws AssertionError        if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, String expected) {
     inputStreams.assertHasDigest(info, actual, algorithm, expected);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1172,21 +1172,145 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
 	return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link Path} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // fs is a filesystem
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final Path tested = fs.getPath("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, byte[] expected) {
     paths.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link Path} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // fs is a filesystem
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final Path tested = fs.getPath("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("SHA1"), "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(tested).hasDigest(MessageDigest.getInstance("MD5"), "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(MessageDigest digest, String expected) {
     paths.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link Path} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // fs is a filesystem
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final Path tested = fs.getPath("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest("SHA1", new byte[]{92, 90, -28, 91, 88, -15, 32, 35, -127, 122, -66, 73, 36, 71, -51, -57, -111, 44, 26, 44});
+   * assertThat(tested).hasDigest("MD5", new byte[]{-36, -77, 1, 92, -46, -124, 71, 100, 76, -127, 10, -13, 82, -125, 44, 25});
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest("SHA1", new byte[]{-109, -71, -50, -46, -18, 91, 63, 15, 76, -114, 100, 14, 119, 71, 13, -85, 3, 29, 76, -83});
+   * assertThat(tested).hasDigest("MD5", new byte[]{55, 53, -33, -8, -31, -7, -33, 4, -110, -93, 78, -16, 117, 32, 91, -113});
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, byte[] expected) {
     paths.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 
+  /**
+   * Verifies that the content of the tested {@link Path} (which must be a readable file) has digest calculated
+   * by given algorithm equal to the given one.
+   * <p>
+   * Examples:
+   * <pre><code class="java">
+   * // fs is a filesystem
+   * // the current directory is supposed to have file downloaded from 'https://repo1.maven.org/maven2/org/assertj/assertj-core/2.9.0/assertj-core-2.9.0.jar'.
+   * final Path tested = fs.getPath("assertj-core-2.9.0.jar");
+   *
+   * // The following assertion succeeds:
+   * assertThat(tested).hasDigest("SHA1", "5c5ae45b58f12023817abe492447cdc7912c1a2c");
+   * assertThat(tested).hasDigest("MD5", "dcb3015cd28447644c810af352832c19");
+   *
+   * // The following assertion fails:
+   * assertThat(tested).hasDigest("SHA1", "93b9ced2ee5b3f0f4c8e640e77470dab031d4cad");
+   * assertThat(tested).hasDigest("MD5", "3735dff8e1f9df0492a34ef075205b8f");
+   * </code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given algorithm is {@code null}.
+   * @throws NullPointerException if the given digest is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is not exist.
+   * @throws AssertionError       if the actual {@code File} is not an file.
+   * @throws AssertionError       if the actual {@code File} is not readable.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws AssertionError       if the content of the tested {@code File} has digest which is not equal to the given one.
+   * @since 3.10.0
+   */
   public SELF hasDigest(String algorithm, String expected) {
     paths.assertHasDigest(info, actual, algorithm, expected);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -24,6 +24,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
 import java.nio.file.spi.FileSystemProvider;
+import java.security.MessageDigest;
 
 import org.assertj.core.api.exception.PathsException;
 import org.assertj.core.internal.Paths;
@@ -1169,5 +1170,25 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
   public SELF endsWithRaw(final Path other) {
 	paths.assertEndsWithRaw(info, actual, other);
 	return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, byte[] expected) {
+    paths.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(MessageDigest digest, String expected) {
+    paths.assertHasDigest(info, actual, digest, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, byte[] expected) {
+    paths.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
+  }
+
+  public SELF hasDigest(String algorithm, String expected) {
+    paths.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.DigestDiff;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that file/inputStream/path have digest failed.
+ *
+ * @author Valeriy Vyrva
+ */
+public class ShouldHaveDigest extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHaveDigest(String actualSource, DigestDiff diff) {
+    return new ShouldHaveDigest(actualSource, diff);
+  }
+
+  private ShouldHaveDigest(String actualSource, DigestDiff diff) {
+    super("%nPath:%n  <%s>%n  expected to have %s-digest <%s>%n  but have <%s>"
+      , actualSource, diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
+    );
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
@@ -14,6 +14,7 @@ package org.assertj.core.error;
 
 import org.assertj.core.internal.DigestDiff;
 
+import java.io.File;
 import java.nio.file.Path;
 
 /**
@@ -29,6 +30,16 @@ public class ShouldHaveDigest extends BasicErrorMessageFactory {
 
   private ShouldHaveDigest(Path actualSource, DigestDiff diff) {
     super("%nPath:%n  <%s>%n  expected to have %s-digest <%s>%n  but have <%s>"
+      , actualSource, diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
+    );
+  }
+
+  public static ErrorMessageFactory shouldHaveDigest(File actualSource, DigestDiff diff) {
+    return new ShouldHaveDigest(actualSource, diff);
+  }
+
+  private ShouldHaveDigest(File actualSource, DigestDiff diff) {
+    super("%nFile:%n  <%s>%n  expected to have %s-digest <%s>%n  but have <%s>"
       , actualSource, diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
     );
   }

--- a/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
@@ -14,6 +14,8 @@ package org.assertj.core.error;
 
 import org.assertj.core.internal.DigestDiff;
 
+import java.nio.file.Path;
+
 /**
  * Creates an error message indicating that an assertion that verifies that file/inputStream/path have digest failed.
  *
@@ -21,11 +23,11 @@ import org.assertj.core.internal.DigestDiff;
  */
 public class ShouldHaveDigest extends BasicErrorMessageFactory {
 
-  public static ErrorMessageFactory shouldHaveDigest(String actualSource, DigestDiff diff) {
+  public static ErrorMessageFactory shouldHaveDigest(Path actualSource, DigestDiff diff) {
     return new ShouldHaveDigest(actualSource, diff);
   }
 
-  private ShouldHaveDigest(String actualSource, DigestDiff diff) {
+  private ShouldHaveDigest(Path actualSource, DigestDiff diff) {
     super("%nPath:%n  <%s>%n  expected to have %s-digest <%s>%n  but have <%s>"
       , actualSource, diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
     );

--- a/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDigest.java
@@ -15,6 +15,7 @@ package org.assertj.core.error;
 import org.assertj.core.internal.DigestDiff;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Path;
 
 /**
@@ -41,6 +42,16 @@ public class ShouldHaveDigest extends BasicErrorMessageFactory {
   private ShouldHaveDigest(File actualSource, DigestDiff diff) {
     super("%nFile:%n  <%s>%n  expected to have %s-digest <%s>%n  but have <%s>"
       , actualSource, diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
+    );
+  }
+
+  public static ErrorMessageFactory shouldHaveDigest(InputStream actualSource, DigestDiff diff) {
+    return new ShouldHaveDigest(actualSource, diff);
+  }
+
+  public ShouldHaveDigest(@SuppressWarnings("unused") InputStream actualSource, DigestDiff diff) {
+    super("%nInputStream:%n  expected to have %s-digest <%s>%n  but have <%s>"
+      , diff.getDigest().getAlgorithm(), diff.getExpected(), diff.getActual()
     );
   }
 }

--- a/src/main/java/org/assertj/core/internal/DigestDiff.java
+++ b/src/main/java/org/assertj/core/internal/DigestDiff.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import java.security.MessageDigest;
+
+/**
+ * Compares the digest values
+ *
+ * @author Valeriy Vyrva
+ */
+public class DigestDiff {
+  private final MessageDigest digest;
+  private final String expected;
+  private final String actual;
+  private final boolean equals;
+
+  public DigestDiff(MessageDigest digest, String expected, String actual) {
+    this.digest = digest;
+    this.expected = expected;
+    this.actual = actual;
+    this.equals = expected.equals(actual);
+  }
+
+  public MessageDigest getDigest() {
+    return digest;
+  }
+
+  public String getExpected() {
+    return expected;
+  }
+
+  public String getActual() {
+    return actual;
+  }
+
+  public boolean isEquals() {
+    return equals;
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Digests.java
+++ b/src/main/java/org/assertj/core/internal/Digests.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.util.Hexadecimals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+
+import static org.assertj.core.util.Preconditions.checkNotNull;
+
+/**
+ * Reusable utils for digest processing
+ *
+ * @author Valeriy Vyrva
+ */
+public final class Digests {
+
+  /**
+   * @see Files#BUFFER_SIZE
+   */
+  private static final int BUFFER_SIZE = 1024 * 8;
+
+  private Digests() {
+  }
+
+  public static String toHex(byte[] digest) {
+    checkNotNull(digest, "The digest should not be null");
+    StringBuilder str = new StringBuilder(digest.length * 2);
+    for (byte b : digest) {
+      str.append(Hexadecimals.byteToHexString(b));
+    }
+    return str.toString();
+  }
+
+  public static byte[] fromHex(String digest) {
+    checkNotNull(digest, "The digest should not be null");
+    byte[] bytes = new byte[digest.length() / 2];
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = Integer.valueOf(digest.substring(i * 2, (i + 1) * 2), 16).byteValue();
+    }
+    return bytes;
+  }
+
+  public static DigestDiff digestDiff(InputStream stream, MessageDigest digest, byte[] expected) throws IOException {
+    checkNotNull(stream, "The stream should not be null");
+    checkNotNull(digest, "The digest should not be null");
+    checkNotNull(expected, "The expected should not be null");
+    digest.reset();
+    byte[] buffer = new byte[BUFFER_SIZE];
+    int len;
+    while ((len = stream.read(buffer)) > 0) {
+      digest.update(buffer, 0, len);
+    }
+    byte[] actualDigest = digest.digest();
+    String expectedHex = toHex(expected);
+    String actualHex = toHex(actualDigest);
+    return new DigestDiff(digest, expectedHex, actualHex);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -13,11 +13,14 @@
 package org.assertj.core.internal;
 
 import static java.lang.String.format;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
@@ -76,5 +79,38 @@ public class InputStreams {
 
   private static void assertNotNull(AssertionInfo info, InputStream stream) {
     Objects.instance().assertNotNull(info, stream);
+  }
+
+  public void assertHasDigest(AssertionInfo info, InputStream actual, MessageDigest digest, byte[] expected) {
+    checkNotNull(digest, "The message digest algorithm should not be null");
+    checkNotNull(expected, "The binary representation of digest to compare to should not be null");
+    assertNotNull(info, actual);
+    try {
+      DigestDiff diff = Digests.digestDiff(actual, digest, expected);
+      if (diff.isEquals()) return;
+      throw failures.failure(info, shouldHaveDigest(actual, diff));
+    } catch (IOException e) {
+      String msg = format("Unable to calculate digest of InputStream:%n  <%s>", actual);
+      throw new InputStreamsException(msg, e);
+    }
+  }
+
+  public void assertHasDigest(AssertionInfo info, InputStream actual, MessageDigest digest, String expected) {
+    checkNotNull(expected, "The string representation of digest to compare to should not be null");
+    assertHasDigest(info, actual, digest, Digests.fromHex(expected));
+  }
+
+  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, byte[] expected) {
+    checkNotNull(algorithm, "The message digest algorithm should not be null");
+    try {
+      assertHasDigest(info, actual, MessageDigest.getInstance(algorithm), expected);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException(format("Unable to find digest implementation for: <%s>", algorithm), e);
+    }
+  }
+
+  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) {
+    checkNotNull(expected, "The string representation of digest to compare to should not be null");
+    assertHasDigest(info, actual, algorithm, Digests.fromHex(expected));
   }
 }

--- a/src/main/java/org/assertj/core/internal/NioFilesWrapper.java
+++ b/src/main/java/org/assertj/core/internal/NioFilesWrapper.java
@@ -12,8 +12,11 @@
  */
 package org.assertj.core.internal;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 
 import org.assertj.core.util.VisibleForTesting;
@@ -68,6 +71,9 @@ public class NioFilesWrapper {
   public boolean isExecutable(Path path) {
 	return Files.isExecutable(path);
   }
-  
+
+  public InputStream newInputStream(Path path, OpenOption... options) throws IOException {
+    return Files.newInputStream(path, options);
+  }
 }
 

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -316,6 +316,7 @@ public class Paths {
   public void assertHasDigest(AssertionInfo info, Path actual, MessageDigest digest, byte[] expected) {
     checkNotNull(digest, "The message digest algorithm should not be null");
     checkNotNull(expected, "The binary representation of digest to compare to should not be null");
+    assertIsRegularFile(info, actual);
     assertIsReadable(info, actual);
     try (
       InputStream actualStream = nioFilesWrapper.newInputStream(actual)

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -28,6 +28,7 @@ import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldExist.shouldExistNoFollowLinks;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
@@ -38,10 +39,13 @@ import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
@@ -309,4 +313,37 @@ public class Paths {
 	}
   }
 
+  public void assertHasDigest(AssertionInfo info, Path actual, MessageDigest digest, byte[] expected) {
+    checkNotNull(digest, "The message digest algorithm should not be null");
+    checkNotNull(expected, "The binary representation of digest to compare to should not be null");
+    assertIsReadable(info, actual);
+    try (
+      InputStream actualStream = nioFilesWrapper.newInputStream(actual)
+    ) {
+      DigestDiff diff = Digests.digestDiff(actualStream, digest, expected);
+      if (diff.isEquals()) return;
+      throw failures.failure(info, shouldHaveDigest(actual, diff));
+    } catch (IOException e) {
+      throw new UncheckedIOException(format("Unable to calculate digest of path:<%s>", actual), e);
+    }
+  }
+
+  public void assertHasDigest(AssertionInfo info, Path actual, MessageDigest digest, String expected) {
+    checkNotNull(expected, "The string representation of digest to compare to should not be null");
+    assertHasDigest(info, actual, digest, Digests.fromHex(expected));
+  }
+
+  public void assertHasDigest(AssertionInfo info, Path actual, String algorithm, byte[] expected) {
+    checkNotNull(algorithm, "The message digest algorithm should not be null");
+    try {
+      assertHasDigest(info, actual, MessageDigest.getInstance(algorithm), expected);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException(format("Unable to find digest implementation for: <%s>", algorithm), e);
+    }
+  }
+
+  public void assertHasDigest(AssertionInfo info, Path actual, String algorithm, String expected) {
+    checkNotNull(expected, "The string representation of digest to compare to should not be null");
+    assertHasDigest(info, actual, algorithm, Digests.fromHex(expected));
+  }
 }

--- a/src/main/java/org/assertj/core/util/Hexadecimals.java
+++ b/src/main/java/org/assertj/core/util/Hexadecimals.java
@@ -19,7 +19,7 @@ public class Hexadecimals {
 
   protected static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
-  public static String byteToHexString(Byte b) {
+  public static String byteToHexString(byte b) {
     int v = b & 0xFF;
     return new String(new char[]{HEX_ARRAY[v >>> 4], HEX_ARRAY[v & 0x0F]});
   }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_AlgorithmBytes_Test.java
@@ -10,30 +10,30 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.api.path;
+package org.assertj.core.api.file;
 
-import org.assertj.core.api.PathAssert;
-import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
 
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link PathAssert#hasDigest(String, String)}</code>
+ * Tests for <code>{@link FileAssert#hasDigest(String, byte[])}</code>
  *
  * @author Valeriy Vyrva
  */
-public class PathAssert_hasDigest_AlgorithmString_Test extends PathAssertBaseTest {
+public class FileAssert_hasDigest_AlgorithmBytes_Test extends FileAssertBaseTest {
 
   private final String algorithm = "MD5";
-  private final String expected = "";
+  private final byte[] expected = new byte[0];
 
   @Override
-  protected PathAssert invoke_api_method() {
+  protected FileAssert invoke_api_method() {
   return assertions.hasDigest(algorithm, expected);
   }
 
   @Override
   protected void verify_internal_effects() {
-  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  verify(files).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
   }
 }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_AlgorithmString_Test.java
@@ -10,30 +10,30 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.api.path;
+package org.assertj.core.api.file;
 
-import org.assertj.core.api.PathAssert;
-import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
 
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link PathAssert#hasDigest(String, String)}</code>
+ * Tests for <code>{@link FileAssert#hasDigest(String, String)}</code>
  *
  * @author Valeriy Vyrva
  */
-public class PathAssert_hasDigest_AlgorithmString_Test extends PathAssertBaseTest {
+public class FileAssert_hasDigest_AlgorithmString_Test extends FileAssertBaseTest {
 
   private final String algorithm = "MD5";
   private final String expected = "";
 
   @Override
-  protected PathAssert invoke_api_method() {
+  protected FileAssert invoke_api_method() {
   return assertions.hasDigest(algorithm, expected);
   }
 
   @Override
   protected void verify_internal_effects() {
-  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  verify(files).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
   }
 }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_DigestBytes_Test.java
@@ -10,30 +10,33 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.api.path;
+package org.assertj.core.api.file;
 
-import org.assertj.core.api.PathAssert;
-import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
 
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link PathAssert#hasDigest(String, String)}</code>
+ * Tests for <code>{@link FileAssert#hasDigest(MessageDigest, byte[])}</code>
  *
  * @author Valeriy Vyrva
  */
-public class PathAssert_hasDigest_AlgorithmString_Test extends PathAssertBaseTest {
+public class FileAssert_hasDigest_DigestBytes_Test extends FileAssertBaseTest {
 
-  private final String algorithm = "MD5";
-  private final String expected = "";
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final byte[] expected = new byte[0];
 
   @Override
-  protected PathAssert invoke_api_method() {
-  return assertions.hasDigest(algorithm, expected);
+  protected FileAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
   }
 
   @Override
   protected void verify_internal_effects() {
-  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  verify(files).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
   }
 }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasDigest_DigestString_Test.java
@@ -10,30 +10,33 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.api.path;
+package org.assertj.core.api.file;
 
-import org.assertj.core.api.PathAssert;
-import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
 
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link PathAssert#hasDigest(String, String)}</code>
+ * Tests for <code>{@link FileAssert#hasDigest(MessageDigest, String)}</code>
  *
  * @author Valeriy Vyrva
  */
-public class PathAssert_hasDigest_AlgorithmString_Test extends PathAssertBaseTest {
+public class FileAssert_hasDigest_DigestString_Test extends FileAssertBaseTest {
 
-  private final String algorithm = "MD5";
+  private final MessageDigest digest = mock(MessageDigest.class);
   private final String expected = "";
 
   @Override
-  protected PathAssert invoke_api_method() {
-  return assertions.hasDigest(algorithm, expected);
+  protected FileAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
   }
 
   @Override
   protected void verify_internal_effects() {
-  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  verify(files).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
   }
 }

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_AlgorithmBytes_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.assertj.core.api.InputStreamAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link InputStreamAssert#hasDigest(String, byte[])}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreamAssert_hasDigest_AlgorithmBytes_Test extends InputStreamAssertBaseTest {
+
+  private final String algorithm = "MD5";
+  private final byte[] expected = new byte[0];
+
+  @Override
+  protected InputStreamAssert invoke_api_method() {
+  return assertions.hasDigest(algorithm, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(inputStreams).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_AlgorithmString_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.assertj.core.api.InputStreamAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link InputStreamAssert#hasDigest(String, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreamAssert_hasDigest_AlgorithmString_Test extends InputStreamAssertBaseTest {
+
+  private final String algorithm = "MD5";
+  private final String expected = "";
+
+  @Override
+  protected InputStreamAssert invoke_api_method() {
+  return assertions.hasDigest(algorithm, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(inputStreams).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_DigestBytes_Test.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.assertj.core.api.InputStreamAssertBaseTest;
+
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link InputStreamAssert#hasDigest(MessageDigest, byte[])}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreamAssert_hasDigest_DigestBytes_Test extends InputStreamAssertBaseTest {
+
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final byte[] expected = new byte[0];
+
+  @Override
+  protected InputStreamAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(inputStreams).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasDigest_DigestString_Test.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.assertj.core.api.InputStreamAssertBaseTest;
+
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link InputStreamAssert#hasDigest(MessageDigest, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreamAssert_hasDigest_DigestString_Test extends InputStreamAssertBaseTest {
+
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final String expected = "";
+
+  @Override
+  protected InputStreamAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(inputStreams).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmBytes_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_hasDigest_AlgorithmBytes_Test extends PathAssertBaseTest {
+
+  private final String algorithm = "MD5";
+  private final byte[] expected = new byte[0];
+
+  @Override
+  protected PathAssert invoke_api_method() {
+  return assertions.hasDigest(algorithm, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmBytes_Test.java
@@ -18,6 +18,8 @@ import org.assertj.core.api.PathAssertBaseTest;
 import static org.mockito.Mockito.verify;
 
 /**
+ * Tests for <code>{@link PathAssert#hasDigest(String, byte[])}</code>
+ *
  * @author Valeriy Vyrva
  */
 public class PathAssert_hasDigest_AlgorithmBytes_Test extends PathAssertBaseTest {

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_AlgorithmString_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_hasDigest_AlgorithmString_Test extends PathAssertBaseTest {
+
+  private final String algorithm = "MD5";
+  private final String expected = "";
+
+  @Override
+  protected PathAssert invoke_api_method() {
+  return assertions.hasDigest(algorithm, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), algorithm, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestBytes_Test.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
+ * Tests for <code>{@link PathAssert#hasDigest(MessageDigest, byte[])}</code>
+ *
  * @author Valeriy Vyrva
  */
 public class PathAssert_hasDigest_DigestBytes_Test extends PathAssertBaseTest {

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestBytes_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_hasDigest_DigestBytes_Test extends PathAssertBaseTest {
+
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final byte[] expected = new byte[0];
+
+  @Override
+  protected PathAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestString_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.security.MessageDigest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_hasDigest_DigestString_Test extends PathAssertBaseTest {
+
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final String expected = "";
+
+  @Override
+  protected PathAssert invoke_api_method() {
+  return assertions.hasDigest(digest, expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  verify(paths).assertHasDigest(getInfo(assertions), getActual(assertions), digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasDigest_DigestString_Test.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
+ * Tests for <code>{@link PathAssert#hasDigest(MessageDigest, String)}</code>
+ *
  * @author Valeriy Vyrva
  */
 public class PathAssert_hasDigest_DigestString_Test extends PathAssertBaseTest {

--- a/src/test/java/org/assertj/core/internal/DigestsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/DigestsBaseTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.junit.Rule;
+
+import org.assertj.core.test.ExpectedException;
+
+import static org.assertj.core.test.ExpectedException.none;
+
+/**
+ * Base class for {@link Digests} unit tests.
+ *
+ * @author Valeriy Vyrva
+ */
+public abstract class DigestsBaseTest {
+  static final byte[] DIGEST_TEST_1_BYTES = {-38, 57, -93, -18, 94, 107, 75, 13, 50, 85, -65, -17, -107, 96, 24, -112, -81, -40, 7, 9};
+  static final String DIGEST_TEST_1_STR = "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709";
+  static final byte[] DIGEST_TEST_2_BYTES = {58, -63, -81, -94, -88, -101, 126, 79, 24, 102, 80, 40, 119, -65, 29, -59};
+  static final String DIGEST_TEST_2_STR = "3AC1AFA2A89B7E4F1866502877BF1DC5";
+
+  @Rule
+  public ExpectedException thrown = none();
+}

--- a/src/test/java/org/assertj/core/internal/Digests_digestDiff_Test.java
+++ b/src/test/java/org/assertj/core/internal/Digests_digestDiff_Test.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for <code>{@link Digests#digestDiff(InputStream, MessageDigest, byte[])}</code>.
+ *
+ * @author Valeriy Vyrva
+ */
+public class Digests_digestDiff_Test extends DigestsBaseTest {
+
+  private InputStream stream;
+  private MessageDigest digest;
+  private byte[] expected = new byte[]{0, 1};
+
+  @Before
+  public void init() {
+    stream = mock(InputStream.class);
+    digest = mock(MessageDigest.class);
+  }
+
+  @Test
+  public void should_fail_if_stream_is_null() throws IOException {
+  thrown.expectNullPointerException("The stream should not be null");
+  Digests.digestDiff(null, null, null);
+  }
+
+  @Test
+  public void should_fail_if_digest_is_null() throws IOException {
+  thrown.expectNullPointerException("The digest should not be null");
+  Digests.digestDiff(stream, null, null);
+  }
+
+  @Test
+  public void should_fail_if_expected_is_null() throws IOException {
+  thrown.expectNullPointerException("The expected should not be null");
+  Digests.digestDiff(stream, digest, null);
+  }
+
+  //todo should_error_if_IO
+
+  @Test
+  public void should_pass_if_stream_is_readable() throws IOException {
+  when(digest.digest()).thenReturn(expected);
+  Digests.digestDiff(stream, digest, expected);
+  }
+
+  @Test
+  public void should_pass_if_digest_is_MD5() throws IOException, NoSuchAlgorithmException {
+  DigestDiff diff = Digests.digestDiff(
+    getClass().getResourceAsStream("/red.png"),
+    MessageDigest.getInstance("MD5"),
+    DIGEST_TEST_2_BYTES
+  );
+  assertThat(diff.isEquals()).isTrue();
+  }
+
+  @Test
+  public void should_pass_if_digest_is_MD5_and_unclear() throws IOException, NoSuchAlgorithmException {
+  MessageDigest digest = MessageDigest.getInstance("MD5");
+  digest.update(expected);
+  DigestDiff diff = Digests.digestDiff(
+    getClass().getResourceAsStream("/red.png"),
+    digest,
+    DIGEST_TEST_2_BYTES
+  );
+  assertThat(diff.isEquals()).isTrue();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/Digests_fromHex_Test.java
+++ b/src/test/java/org/assertj/core/internal/Digests_fromHex_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
+
+/**
+ * Tests for <code>{@link Digests#fromHex(String)}</code>.
+ *
+ * @author Valeriy Vyrva
+ */
+public class Digests_fromHex_Test extends DigestsBaseTest {
+
+  @Test
+  public void should_fail_if_digest_is_null() {
+  thrown.expectNullPointerException("The digest should not be null");
+  Digests.fromHex(null);
+  }
+
+  @Test
+  public void should_pass_if_digest_is_empty() {
+  assertThat(Digests.fromHex("")).isEqualTo(new byte[0]);
+  }
+
+  @Test
+  public void should_pass_if_digest_converted_correctly() {
+  assertThat(Digests.fromHex(DIGEST_TEST_1_STR)).containsExactly(DIGEST_TEST_1_BYTES);
+  }
+
+  @Test
+  public void should_fail_if_digest_converted_incorrectly() {
+  Representation representation = StandardRepresentation.STANDARD_REPRESENTATION;
+  thrown.expectAssertionError(shouldBeEqual(DIGEST_TEST_2_BYTES, DIGEST_TEST_1_BYTES, StandardComparisonStrategy.instance(), representation));
+  assertThat(Digests.fromHex(DIGEST_TEST_2_STR)).containsExactly(DIGEST_TEST_1_BYTES);
+  }
+
+  @Test
+  public void should_pass_if_digest_length_is_not_even() {
+  assertThat(Digests.fromHex("A")).isEmpty();
+  assertThat(Digests.fromHex("AA")).containsExactly(170);
+  assertThat(Digests.fromHex("AAA")).containsExactly(170);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/Digests_toHex_Test.java
+++ b/src/test/java/org/assertj/core/internal/Digests_toHex_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
+
+/**
+ * Tests for <code>{@link Digests#toHex(byte[])}</code>.
+ *
+ * @author Valeriy Vyrva
+ */
+public class Digests_toHex_Test extends DigestsBaseTest {
+
+  @Test
+  @SuppressWarnings("ConstantConditions")
+  public void should_fail_if_digest_is_null() {
+  thrown.expectNullPointerException("The digest should not be null");
+  Digests.toHex(null);
+  }
+
+  @Test
+  public void should_pass_if_digest_is_empty() {
+  assertThat(Digests.toHex(new byte[0])).isEqualTo("");
+  }
+
+  @Test
+  public void should_pass_if_digest_converted_correctly() {
+  assertThat(Digests.toHex(DIGEST_TEST_1_BYTES)).isEqualTo(DIGEST_TEST_1_STR);
+  }
+
+  @Test
+  public void should_fail_if_digest_converted_incorrectly() {
+  thrown.expectAssertionError(shouldBeEqual(DIGEST_TEST_1_STR, DIGEST_TEST_2_STR, StandardComparisonStrategy.instance(), StandardRepresentation.STANDARD_REPRESENTATION));
+  assertThat(Digests.toHex(DIGEST_TEST_1_BYTES)).isEqualTo(DIGEST_TEST_2_STR);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/FilesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/FilesBaseTest.java
@@ -42,6 +42,7 @@ public class FilesBaseTest {
   protected Diff diff;
   protected Delta<String> delta;
   protected BinaryDiff binaryDiff;
+  protected NioFilesWrapper nioFilesWrapper;
 
   @SuppressWarnings("unchecked")
   @Before
@@ -57,6 +58,8 @@ public class FilesBaseTest {
     files.diff = diff;
     binaryDiff = mock(BinaryDiff.class);
     files.binaryDiff = binaryDiff;
+    nioFilesWrapper = mock(NioFilesWrapper.class);
+    files.nioFilesWrapper = nioFilesWrapper;
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmBytes_Test.java
@@ -10,49 +10,58 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.internal.paths;
+package org.assertj.core.internal.files;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
-import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.Digests;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
-import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, MessageDigest, byte[])}</code>
+ * Tests for <code>{@link Files#assertHasDigest(AssertionInfo, File, String, byte[])}</code>
  *
  * @author Valeriy Vyrva
  */
-public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
-  private final MessageDigest digest = mock(MessageDigest.class);
+public class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
+  private final String algorithm = "MD5";
   private final byte[] expected = new byte[0];
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
 
   @Test
   public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectAssertionError(actualIsNull());
-  paths.assertHasDigest(info, null, digest, expected);
+  files.assertHasDigest(info, null, algorithm, expected);
   }
 
   @Test
   public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
@@ -63,13 +72,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_file() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(false);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldBeRegularFile(actual));
+    verify(failures).failure(info, shouldBeFile(actual));
     return;
   }
   failBecauseExpectedAssertionErrorWasNotThrown();
@@ -77,11 +87,12 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
@@ -92,25 +103,35 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The message digest algorithm should not be null");
-  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  files.assertHasDigest(info, null, (MessageDigest) null, expected);
   }
 
   @Test
   public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
-  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  files.assertHasDigest(info, null, algorithm, (byte[]) null);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
   IOException cause = new IOException();
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
-  paths.assertHasDigest(info, actual, digest, expected);
+  files.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_NoSuchAlgorithmException() {
+  AssertionInfo info = someInfo();
+  thrown.expect(IllegalStateException.class, "Unable to find digest implementation for: <UnknownDigestAlgorithm>");
+  files.assertHasDigest(info, actual, "UnknownDigestAlgorithm", expected);
   }
 
   private void failIfStreamIsOpen(InputStream stream) {
@@ -122,18 +143,18 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
   }
 
   @Test
-  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException, NoSuchAlgorithmException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
-  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
     failIfStreamIsOpen(stream);
     return;
   }
@@ -142,13 +163,13 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_actual_has_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
-  when(digest.digest()).thenReturn(expected);
-  paths.assertHasDigest(info, actual, digest, expected);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
+  files.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
   failIfStreamIsOpen(stream);
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmString_Test.java
@@ -10,49 +10,58 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.internal.paths;
+package org.assertj.core.internal.files;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
-import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.Digests;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
-import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, MessageDigest, byte[])}</code>
+ * Tests for <code>{@link Files#assertHasDigest(AssertionInfo, File, MessageDigest, String)}</code>
  *
  * @author Valeriy Vyrva
  */
-public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
-  private final MessageDigest digest = mock(MessageDigest.class);
-  private final byte[] expected = new byte[0];
+public class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
+  private final String algorithm = "MD5";
+  private final String expected = "";
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
 
   @Test
   public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectAssertionError(actualIsNull());
-  paths.assertHasDigest(info, null, digest, expected);
+  files.assertHasDigest(info, null, algorithm, expected);
   }
 
   @Test
   public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
@@ -63,13 +72,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_file() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(false);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldBeRegularFile(actual));
+    verify(failures).failure(info, shouldBeFile(actual));
     return;
   }
   failBecauseExpectedAssertionErrorWasNotThrown();
@@ -77,11 +87,12 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
@@ -92,25 +103,35 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The message digest algorithm should not be null");
-  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  files.assertHasDigest(info, null, (MessageDigest) null, expected);
   }
 
   @Test
   public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
-  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  files.assertHasDigest(info, null, algorithm, (byte[]) null);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
   IOException cause = new IOException();
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
-  paths.assertHasDigest(info, actual, digest, expected);
+  files.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_NoSuchAlgorithmException() {
+  AssertionInfo info = someInfo();
+  thrown.expect(IllegalStateException.class, "Unable to find digest implementation for: <UnknownDigestAlgorithm>");
+  files.assertHasDigest(info, actual, "UnknownDigestAlgorithm", expected);
   }
 
   private void failIfStreamIsOpen(InputStream stream) {
@@ -122,18 +143,18 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
   }
 
   @Test
-  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException, NoSuchAlgorithmException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
-  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, algorithm, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
     failIfStreamIsOpen(stream);
     return;
   }
@@ -142,13 +163,13 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_actual_has_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
-  when(digest.digest()).thenReturn(expected);
-  paths.assertHasDigest(info, actual, digest, expected);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
+  files.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
   failIfStreamIsOpen(stream);
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestBytes_Test.java
@@ -10,49 +10,53 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.internal.paths;
+package org.assertj.core.internal.files;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
-import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.security.MessageDigest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
-import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, MessageDigest, byte[])}</code>
+ * Tests for <code>{@link Files#assertHasDigest(AssertionInfo, File, MessageDigest, byte[])}</code>
  *
  * @author Valeriy Vyrva
  */
-public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
+public class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
   private final MessageDigest digest = mock(MessageDigest.class);
   private final byte[] expected = new byte[0];
 
   @Test
   public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectAssertionError(actualIsNull());
-  paths.assertHasDigest(info, null, digest, expected);
+  files.assertHasDigest(info, null, digest, expected);
   }
 
   @Test
   public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
@@ -63,13 +67,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_file() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(false);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldBeRegularFile(actual));
+    verify(failures).failure(info, shouldBeFile(actual));
     return;
   }
   failBecauseExpectedAssertionErrorWasNotThrown();
@@ -77,11 +82,12 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
@@ -92,25 +98,28 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The message digest algorithm should not be null");
-  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  files.assertHasDigest(info, null, (MessageDigest) null, expected);
   }
 
   @Test
   public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
-  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  files.assertHasDigest(info, null, digest, (byte[]) null);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
   IOException cause = new IOException();
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
-  paths.assertHasDigest(info, actual, digest, expected);
+  files.assertHasDigest(info, actual, digest, expected);
   }
 
   private void failIfStreamIsOpen(InputStream stream) {
@@ -123,14 +132,15 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
   when(digest.digest()).thenReturn(new byte[]{0, 1});
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
     verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
@@ -142,13 +152,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_actual_has_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
   when(digest.digest()).thenReturn(expected);
-  paths.assertHasDigest(info, actual, digest, expected);
+  files.assertHasDigest(info, actual, digest, expected);
   failIfStreamIsOpen(stream);
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestString_Test.java
@@ -10,49 +10,53 @@
  *
  * Copyright 2012-2018 the original author or authors.
  */
-package org.assertj.core.internal.paths;
+package org.assertj.core.internal.files;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
-import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.security.MessageDigest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
-import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, MessageDigest, byte[])}</code>
+ * Tests for <code>{@link Files#assertHasDigest(AssertionInfo, File, MessageDigest, String)}</code>
  *
  * @author Valeriy Vyrva
  */
-public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
+public class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
   private final MessageDigest digest = mock(MessageDigest.class);
-  private final byte[] expected = new byte[0];
+  private final String expected = "";
 
   @Test
   public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectAssertionError(actualIsNull());
-  paths.assertHasDigest(info, null, digest, expected);
+  files.assertHasDigest(info, null, digest, expected);
   }
 
   @Test
   public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldExist(actual));
@@ -63,13 +67,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_file() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(false);
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
-    verify(failures).failure(info, shouldBeRegularFile(actual));
+    verify(failures).failure(info, shouldBeFile(actual));
     return;
   }
   failBecauseExpectedAssertionErrorWasNotThrown();
@@ -77,11 +82,12 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  AssertionInfo info = someInfo();
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(false);
   try {
-	  paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
 	  wasExpectingAssertionError();
 	} catch (AssertionError e) {
 	  verify(failures).failure(info, shouldBeReadable(actual));
@@ -92,25 +98,28 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The message digest algorithm should not be null");
-  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  files.assertHasDigest(info, null, (MessageDigest) null, expected);
   }
 
   @Test
   public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
   thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
-  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  files.assertHasDigest(info, null, digest, (byte[]) null);
   }
 
   @Test
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
   IOException cause = new IOException();
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
-  paths.assertHasDigest(info, actual, digest, expected);
+  files.assertHasDigest(info, actual, digest, expected);
   }
 
   private void failIfStreamIsOpen(InputStream stream) {
@@ -123,14 +132,15 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
   when(digest.digest()).thenReturn(new byte[]{0, 1});
   try {
-    paths.assertHasDigest(info, actual, digest, expected);
+    files.assertHasDigest(info, actual, digest, expected);
     wasExpectingAssertionError();
   } catch (AssertionError e) {
     verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
@@ -142,13 +152,14 @@ public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
 
   @Test
   public void should_pass_if_actual_has_expected_digest() throws IOException {
+  AssertionInfo info = someInfo();
   InputStream stream = getClass().getResourceAsStream("/red.png");
-  when(nioFilesWrapper.exists(actual)).thenReturn(true);
-  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
-  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
-  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
-  when(digest.digest()).thenReturn(expected);
-  paths.assertHasDigest(info, actual, digest, expected);
+  when(actual.exists()).thenReturn(true);
+  when(actual.isFile()).thenReturn(true);
+  when(actual.canRead()).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(any())).thenReturn(stream);
+  when(digest.digest()).thenReturn(new byte[0]);
+  files.assertHasDigest(info, actual, digest, expected);
   failIfStreamIsOpen(stream);
   }
 }

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_AlgorithmBytes_Test.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.inputstreams;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link InputStreams#assertHasDigest(AssertionInfo, InputStream, String, byte[])}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreams_assertHasDigest_AlgorithmBytes_Test extends InputStreamsBaseTest {
+  private final String algorithm = "MD5";
+  private final byte[] expected = new byte[0];
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectAssertionError(actualIsNull());
+  inputStreams.assertHasDigest(info, null, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  inputStreams.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  inputStreams.assertHasDigest(info, null, algorithm, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
+  IOException cause = new IOException();
+  actual = mock(InputStream.class);
+  when(actual.read(any())).thenThrow(cause);
+  thrown.expectWithCause(InputStreamsException.class, cause);
+  inputStreams.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws NoSuchAlgorithmException {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  try {
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  inputStreams.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_AlgorithmString_Test.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.inputstreams;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link InputStreams#assertHasDigest(AssertionInfo, InputStream, String, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreams_assertHasDigest_AlgorithmString_Test extends InputStreamsBaseTest {
+  private final String algorithm = "MD5";
+  private final String expected = "";
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectAssertionError(actualIsNull());
+  inputStreams.assertHasDigest(info, null, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  inputStreams.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  inputStreams.assertHasDigest(info, null, algorithm, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
+  IOException cause = new IOException();
+  actual = mock(InputStream.class);
+  when(actual.read(any())).thenThrow(cause);
+  thrown.expectWithCause(InputStreamsException.class, cause);
+  inputStreams.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws NoSuchAlgorithmException {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  try {
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  inputStreams.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_DigestBytes_Test.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.inputstreams;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.DigestDiff;
+import org.assertj.core.internal.InputStreams;
+import org.assertj.core.internal.InputStreamsBaseTest;
+import org.assertj.core.internal.InputStreamsException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link InputStreams#assertHasDigest(AssertionInfo, InputStream, MessageDigest, byte[])}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreams_assertHasDigest_DigestBytes_Test extends InputStreamsBaseTest {
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final byte[] expected = new byte[0];
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectAssertionError(actualIsNull());
+  inputStreams.assertHasDigest(info, null, digest, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  inputStreams.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  inputStreams.assertHasDigest(info, null, digest, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
+  IOException cause = new IOException();
+  actual = mock(InputStream.class);
+  when(actual.read(any())).thenThrow(cause);
+  thrown.expectWithCause(InputStreamsException.class, cause);
+  inputStreams.assertHasDigest(info, actual, digest, expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  try {
+    inputStreams.assertHasDigest(info, actual, digest, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  when(digest.digest()).thenReturn(expected);
+  inputStreams.assertHasDigest(info, actual, digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasDigest_DigestString_Test.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.inputstreams;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.DigestDiff;
+import org.assertj.core.internal.InputStreams;
+import org.assertj.core.internal.InputStreamsBaseTest;
+import org.assertj.core.internal.InputStreamsException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link InputStreams#assertHasDigest(AssertionInfo, InputStream, MessageDigest, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class InputStreams_assertHasDigest_DigestString_Test extends InputStreamsBaseTest {
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final String expected = "";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectAssertionError(actualIsNull());
+  inputStreams.assertHasDigest(info, null, digest, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  inputStreams.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  AssertionInfo info = someInfo();
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  inputStreams.assertHasDigest(info, null, digest, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  AssertionInfo info = someInfo();
+  IOException cause = new IOException();
+  actual = mock(InputStream.class);
+  when(actual.read(any())).thenThrow(cause);
+  thrown.expectWithCause(InputStreamsException.class, cause);
+  inputStreams.assertHasDigest(info, actual, digest, expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  try {
+    inputStreams.assertHasDigest(info, actual, digest, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() {
+  AssertionInfo info = someInfo();
+  actual = getClass().getResourceAsStream("/red.png");
+  when(digest.digest()).thenReturn(new byte[0]);
+  inputStreams.assertHasDigest(info, actual, digest, expected);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmBytes_Test.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.DigestDiff;
+import org.assertj.core.internal.Digests;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class Paths_assertHasDigest_AlgorithmBytes_Test extends MockPathsBaseTest {
+  private final String algorithm = "MD5";
+  private final byte[] expected = new byte[0];
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  thrown.expectAssertionError(actualIsNull());
+  paths.assertHasDigest(info, null, algorithm, expected);
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, algorithm, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldExist(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_readable() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, algorithm, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldBeReadable(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  paths.assertHasDigest(info, null, algorithm, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  IOException cause = new IOException();
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  thrown.expectWithCause(UncheckedIOException.class, cause);
+  paths.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_NoSuchAlgorithmException() {
+  thrown.expect(IllegalStateException.class, "Unable to find digest implementation for: <UnknownDigestAlgorithm>");
+  paths.assertHasDigest(info, actual, "UnknownDigestAlgorithm", expected);
+  }
+
+  private void failIfStreamIsOpen(InputStream stream) {
+  try {
+    assertThat(stream.read()).isNegative();
+  } catch (IOException e) {
+    assertThat(e).hasNoCause().hasMessage("Stream closed");
+  }
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException, NoSuchAlgorithmException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  try {
+    paths.assertHasDigest(info, actual, algorithm, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
+    failIfStreamIsOpen(stream);
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  paths.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
+  failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmString_Test.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.DigestDiff;
+import org.assertj.core.internal.Digests;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTest {
+  private final String algorithm = "MD5";
+  private final String expected = "";
+  private final String real = "3AC1AFA2A89B7E4F1866502877BF1DC5";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  thrown.expectAssertionError(actualIsNull());
+  paths.assertHasDigest(info, null, algorithm, expected);
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, algorithm, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldExist(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_readable() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, algorithm, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldBeReadable(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  paths.assertHasDigest(info, null, algorithm, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  IOException cause = new IOException();
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  thrown.expectWithCause(UncheckedIOException.class, cause);
+  paths.assertHasDigest(info, actual, algorithm, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_NoSuchAlgorithmException() {
+  thrown.expect(IllegalStateException.class, "Unable to find digest implementation for: <UnknownDigestAlgorithm>");
+  paths.assertHasDigest(info, actual, "UnknownDigestAlgorithm", expected);
+  }
+
+  private void failIfStreamIsOpen(InputStream stream) {
+  try {
+    assertThat(stream.read()).isNegative();
+  } catch (IOException e) {
+    assertThat(e).hasNoCause().hasMessage("Stream closed");
+  }
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException, NoSuchAlgorithmException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  try {
+    paths.assertHasDigest(info, actual, algorithm, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(MessageDigest.getInstance(algorithm), "", real)));
+    failIfStreamIsOpen(stream);
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  paths.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));
+  failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmString_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_AlgorithmString_Test.java
@@ -12,18 +12,22 @@
  */
 package org.assertj.core.internal.paths;
 
+import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
 import org.assertj.core.internal.Digests;
+import org.assertj.core.internal.Paths;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -33,6 +37,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
+ * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, String, String)}</code>
+ *
  * @author Valeriy Vyrva
  */
 public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTest {
@@ -60,8 +66,23 @@ public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTes
   }
 
   @Test
+  public void should_fail_if_actual_exists_but_is_not_file() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  try {
+    paths.assertHasDigest(info, actual, algorithm, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldBeRegularFile(actual));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
   try {
 	  paths.assertHasDigest(info, actual, algorithm, expected);
@@ -89,6 +110,7 @@ public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTes
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
   IOException cause = new IOException();
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
@@ -113,6 +135,7 @@ public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTes
   public void should_fail_if_actual_does_not_have_expected_digest() throws IOException, NoSuchAlgorithmException {
   InputStream stream = getClass().getResourceAsStream("/red.png");
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
   try {
@@ -130,6 +153,7 @@ public class Paths_assertHasDigest_AlgorithmString_Test extends MockPathsBaseTes
   public void should_pass_if_actual_has_expected_digest() throws IOException {
   InputStream stream = getClass().getResourceAsStream("/red.png");
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
   paths.assertHasDigest(info, actual, algorithm, Digests.fromHex(real));

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestBytes_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestBytes_Test.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.DigestDiff;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class Paths_assertHasDigest_DigestBytes_Test extends MockPathsBaseTest {
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final byte[] expected = new byte[0];
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  thrown.expectAssertionError(actualIsNull());
+  paths.assertHasDigest(info, null, digest, expected);
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, digest, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldExist(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_readable() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, digest, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldBeReadable(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  IOException cause = new IOException();
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  thrown.expectWithCause(UncheckedIOException.class, cause);
+  paths.assertHasDigest(info, actual, digest, expected);
+  }
+
+  private void failIfStreamIsOpen(InputStream stream) {
+  try {
+    assertThat(stream.read()).isNegative();
+  } catch (IOException e) {
+    assertThat(e).hasNoCause().hasMessage("Stream closed");
+  }
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  try {
+    paths.assertHasDigest(info, actual, digest, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    failIfStreamIsOpen(stream);
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(digest.digest()).thenReturn(expected);
+  paths.assertHasDigest(info, actual, digest, expected);
+  failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestString_Test.java
@@ -12,16 +12,20 @@
  */
 package org.assertj.core.internal.paths;
 
+import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.DigestDiff;
+import org.assertj.core.internal.Paths;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -30,6 +34,8 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.*;
 
 /**
+ * Tests for <code>{@link Paths#assertHasDigest(AssertionInfo, Path, MessageDigest, String)}</code>
+ *
  * @author Valeriy Vyrva
  */
 public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
@@ -56,8 +62,23 @@ public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
   }
 
   @Test
+  public void should_fail_if_actual_exists_but_is_not_file() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(false);
+  try {
+    paths.assertHasDigest(info, actual, digest, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldBeRegularFile(actual));
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
   public void should_fail_if_actual_exists_but_is_not_readable() {
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
   try {
 	  paths.assertHasDigest(info, actual, digest, expected);
@@ -85,6 +106,7 @@ public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
   public void should_throw_error_wrapping_catched_IOException() throws IOException {
   IOException cause = new IOException();
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
   thrown.expectWithCause(UncheckedIOException.class, cause);
@@ -103,6 +125,7 @@ public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
   public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
   InputStream stream = getClass().getResourceAsStream("/red.png");
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
   when(digest.digest()).thenReturn(new byte[]{0, 1});
@@ -121,6 +144,7 @@ public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
   public void should_pass_if_actual_has_expected_digest() throws IOException {
   InputStream stream = getClass().getResourceAsStream("/red.png");
   when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isRegularFile(actual)).thenReturn(true);
   when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
   when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
   when(digest.digest()).thenReturn(new byte[0]);

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestString_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_DigestString_Test.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.internal.DigestDiff;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Valeriy Vyrva
+ */
+public class Paths_assertHasDigest_DigestString_Test extends MockPathsBaseTest {
+  private final MessageDigest digest = mock(MessageDigest.class);
+  private final String expected = "";
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+  thrown.expectAssertionError(actualIsNull());
+  paths.assertHasDigest(info, null, digest, expected);
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, digest, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldExist(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_readable() {
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(false);
+  try {
+	  paths.assertHasDigest(info, actual, digest, expected);
+	  wasExpectingAssertionError();
+	} catch (AssertionError e) {
+	  verify(failures).failure(info, shouldBeReadable(actual));
+	  return;
+	}
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_throw_error_if_digest_is_null() {
+  thrown.expectNullPointerException("The message digest algorithm should not be null");
+  paths.assertHasDigest(info, null, (MessageDigest) null, expected);
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+  thrown.expectNullPointerException("The binary representation of digest to compare to should not be null");
+  paths.assertHasDigest(info, null, digest, (byte[]) null);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+  IOException cause = new IOException();
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenThrow(cause);
+  thrown.expectWithCause(UncheckedIOException.class, cause);
+  paths.assertHasDigest(info, actual, digest, expected);
+  }
+
+  private void failIfStreamIsOpen(InputStream stream) {
+  try {
+    assertThat(stream.read()).isNegative();
+  } catch (IOException e) {
+    assertThat(e).hasNoCause().hasMessage("Stream closed");
+  }
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_have_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(digest.digest()).thenReturn(new byte[]{0, 1});
+  try {
+    paths.assertHasDigest(info, actual, digest, expected);
+    wasExpectingAssertionError();
+  } catch (AssertionError e) {
+    verify(failures).failure(info, shouldHaveDigest(actual, new DigestDiff(digest, "", "0001")));
+    failIfStreamIsOpen(stream);
+    return;
+  }
+  failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_digest() throws IOException {
+  InputStream stream = getClass().getResourceAsStream("/red.png");
+  when(nioFilesWrapper.exists(actual)).thenReturn(true);
+  when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
+  when(nioFilesWrapper.newInputStream(actual)).thenReturn(stream);
+  when(digest.digest()).thenReturn(new byte[0]);
+  paths.assertHasDigest(info, actual, digest, expected);
+  failIfStreamIsOpen(stream);
+  }
+}


### PR DESCRIPTION
Implement `[Path|File|InputStream]Assert#hasDigest` with 4 variants:
* `hasDigest(MessageDigest digest, byte[] expected)`
* `hasDigest(MessageDigest digest, String expected)`
* `hasDigest(String algorithm, byte[] expected)`
* `hasDigest(String algorithm, String expected)`

Progress:
- [x] Core utils
- [x] PathAssert
- [x] FileAssert
- [x] InputStreamAssert
- [x] Javadoc with a code example (API only)

Fixes #1210 