### PR TITLE
Fix #1217: Close stream after materialisation in ListAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -226,7 +226,10 @@ public class ListAssert<ELEMENT> extends
     }
 
     private List<ELEMENT> initList() {
-      if (list == null) list = Lists.newArrayList(stream.iterator());
+      if (list == null) {
+        list = Lists.newArrayList(stream.iterator());
+        stream.close();
+      }
       return list;
     }
 


### PR DESCRIPTION
Streams may carry resources which require closing such as
java.nio.file.Files#lines(java.nio.file.Path).

#### Check List:
* Fixes #1217 
* Unit tests : NO
* Javadoc with a code example (API only) : NO


