### PR TITLE
Fix class loading strategy to no longer rely on sun.misc.Unsafe and several performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.8.3</version>
+      <version>1.8.8</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/assertj/core/api/AssertJProxySetup.java
+++ b/src/main/java/org/assertj/core/api/AssertJProxySetup.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api;
+
+public interface AssertJProxySetup {
+
+  void assertj$setup(ProxifyMethodChangingTheObjectUnderTest proxifyMethodChangingTheObjectUnderTest, ErrorCollector errorCollector);
+}

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -17,8 +17,10 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.io.File;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -64,6 +66,9 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.auxiliary.AuxiliaryType;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.util.CheckReturnValue;
 
@@ -84,14 +89,29 @@ import net.bytebuddy.matcher.ElementMatchers;
  */
 public class Assumptions {
 
-  private static final TypeCache<SimpleKey> CACHE = new TypeCache.WithInlineExpunction<>(Sort.SOFT);
-  private static ByteBuddy byteBuddy = new ByteBuddy().with(TypeValidation.DISABLED);
+  private static ByteBuddy BYTE_BUDDY = new ByteBuddy()
+    .with(TypeValidation.DISABLED)
+    .with(new AuxiliaryType.NamingStrategy.SuffixingRandom("Assertj$Assumptions"));
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final Method PRIVATE_LOOKUP_IN;
+
+  private static final TypeCache<TypeCache.SimpleKey> CACHE = new TypeCache.WithInlineExpunction<>(Sort.SOFT);
+
+  static {
+    Method privateLookupIn;
+    try {
+      privateLookupIn = MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+    } catch (Exception e) {
+      privateLookupIn = null;
+    }
+    PRIVATE_LOOKUP_IN = privateLookupIn;
+  }
 
   private static final class AssumptionMethodInterceptor {
 
     @RuntimeType
-    public Object intercept(@This AbstractAssert<?, ?> assertion,
-                            @SuperCall Callable<Object> proxy) throws Exception {
+    public static Object intercept(@This AbstractAssert<?, ?> assertion, @SuperCall Callable<Object> proxy) throws Exception {
       try {
         Object result = proxy.call();
         if (result != assertion && result instanceof AbstractAssert) {
@@ -1135,15 +1155,11 @@ public class Assumptions {
     return asAssumption(assertionType, array(actualType), array(actual));
   }
 
-  @SuppressWarnings({ "unchecked" })
-  private static <ASSERTION> ASSERTION asAssumption(final Class<ASSERTION> assertionType,
+  private static <ASSERTION> ASSERTION asAssumption(Class<ASSERTION> assertionType,
                                                     Class<?>[] constructorTypes,
                                                     Object... constructorParams) {
     try {
-      Class<? extends ASSERTION> type = (Class<? extends ASSERTION>) CACHE.findOrInsert(Assumptions.class.getClassLoader(),
-                                                                                        new SimpleKey(assertionType),
-                                                                                        () -> createAssumption(assertionType));
-
+      Class<? extends ASSERTION> type = createAssumption(assertionType);
       Constructor<? extends ASSERTION> constructor = type.getConstructor(constructorTypes);
       return constructor.newInstance(constructorParams);
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException e) {
@@ -1151,14 +1167,30 @@ public class Assumptions {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static <ASSERTION> Class<? extends ASSERTION> createAssumption(Class<ASSERTION> assertionType) {
-
-    return byteBuddy.subclass(assertionType)
+    return (Class<? extends ASSERTION>) CACHE.findOrInsert(Assumptions.class.getClassLoader(),
+      new SimpleKey(assertionType),
+      () -> BYTE_BUDDY.subclass(assertionType)
                     .method(ElementMatchers.any())
-                    .intercept(MethodDelegation.to(new AssumptionMethodInterceptor()))
+                    .intercept(MethodDelegation.to(AssumptionMethodInterceptor.class))
                     .make()
-                    .load(Assumptions.class.getClassLoader())
-                    .getLoaded();
+                    .load(Assumptions.class.getClassLoader(), classLoadingStrategy(assertionType))
+                    .getLoaded());
+  }
+
+  private static ClassLoadingStrategy<ClassLoader> classLoadingStrategy(Class<?> assertClass) {
+    if (ClassInjector.UsingReflection.isAvailable()) {
+      return ClassLoadingStrategy.Default.INJECTION;
+    } else if (ClassInjector.UsingLookup.isAvailable()) {
+      try {
+        return ClassLoadingStrategy.UsingLookup.of(PRIVATE_LOOKUP_IN.invoke(null, assertClass, LOOKUP));
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not access package of " + assertClass, e);
+      }
+    } else {
+      throw new IllegalStateException("No code generation strategy available");
+    }
   }
 
   private static RuntimeException assumptionNotMet(AssertionError assertionError) throws ReflectiveOperationException {

--- a/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
+++ b/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
@@ -22,11 +22,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
+import net.bytebuddy.implementation.bind.annotation.FieldValue;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.implementation.bind.annotation.This;
 
 public class ProxifyMethodChangingTheObjectUnderTest {
+
+  public static final String FIELD_NAME = "dispatcher";
 
   private final SoftProxies proxies;
 
@@ -35,10 +38,12 @@ public class ProxifyMethodChangingTheObjectUnderTest {
   }
 
   @RuntimeType
-  public AbstractAssert<?, ?> intercept(@SuperCall Callable<AbstractAssert<?, ?>> assertionMethod,
-                                        @This AbstractAssert<?, ?> currentAssertInstance) throws Exception {
+  public static AbstractAssert<?, ?> intercept(
+    @FieldValue(FIELD_NAME) ProxifyMethodChangingTheObjectUnderTest dispatcher,
+    @SuperCall Callable<AbstractAssert<?, ?>> assertionMethod,
+    @This AbstractAssert<?, ?> currentAssertInstance) throws Exception {
     Object result = assertionMethod.call();
-    return createAssertProxy(result).withAssertionState(currentAssertInstance);
+    return dispatcher.createAssertProxy(result).withAssertionState(currentAssertInstance);
   }
 
   // can't return AbstractAssert<?, ?> otherwise withAssertionState(currentAssertInstance) does not compile.

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -16,8 +16,10 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import net.bytebuddy.ByteBuddy;
@@ -25,8 +27,13 @@ import net.bytebuddy.TypeCache;
 import net.bytebuddy.TypeCache.SimpleKey;
 import net.bytebuddy.TypeCache.Sort;
 import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
+import net.bytebuddy.implementation.FieldAccessor;
 import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.auxiliary.AuxiliaryType;
 import net.bytebuddy.matcher.ElementMatcher.Junction;
 import net.bytebuddy.matcher.ElementMatchers;
 
@@ -65,10 +72,26 @@ class SoftProxies {
                                                                                             .or(named("withTypeComparators"))
                                                                                             .or(named("withThreadDumpOnError"));
 
-  private static ByteBuddy byteBuddy = new ByteBuddy().with(TypeValidation.DISABLED);
+  private static final ByteBuddy BYTE_BUDDY = new ByteBuddy()
+    .with(new AuxiliaryType.NamingStrategy.SuffixingRandom("AssertJ$SoftProxies"))
+    .with(TypeValidation.DISABLED);
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final Method PRIVATE_LOOKUP_IN;
+
+  private static final TypeCache<TypeCache.SimpleKey> CACHE = new TypeCache.WithInlineExpunction<>(Sort.SOFT);
+
+  static {
+    Method privateLookupIn;
+    try {
+      privateLookupIn = MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+    } catch (Exception e) {
+      privateLookupIn = null;
+    }
+    PRIVATE_LOOKUP_IN = privateLookupIn;
+  }
 
   private final ErrorCollector collector = new ErrorCollector();
-  private final TypeCache<TypeCache.SimpleKey> cache = new TypeCache.WithInlineExpunction<>(Sort.SOFT);
 
   public boolean wasSuccess() {
     return collector.wasSuccess();
@@ -83,58 +106,78 @@ class SoftProxies {
   }
 
   // TODO V extends AbstractAssert ?
-  @SuppressWarnings("unchecked")
-  <V, T> V create(final Class<V> assertClass, Class<T> actualClass, T actual) {
-
+  <V, T> V create(Class<V> assertClass, Class<T> actualClass, T actual) {
     try {
-      ClassLoader classLoader = getClass().getClassLoader();
-      SimpleKey key = new SimpleKey(assertClass);
-      Class<V> proxyClass = (Class<V>) cache.findOrInsert(classLoader, key, () -> createProxy(assertClass, collector));
-
+      Class<? extends V> proxyClass = createProxy(assertClass);
       Constructor<? extends V> constructor = proxyClass.getConstructor(actualClass);
-      return constructor.newInstance(actual);
+      V instance = constructor.newInstance(actual);
+      ((AssertJProxySetup) instance).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
+      return instance;
     } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
   }
 
-  private <V> Class<?> createProxy(Class<V> assertClass, ErrorCollector collector) {
-
-    return byteBuddy.subclass(assertClass)
+  @SuppressWarnings("unchecked")
+  private static <V> Class<? extends V> createProxy(Class<V> assertClass) {
+    return (Class<V>) CACHE.findOrInsert(SoftProxies.class.getClassLoader(), new SimpleKey(assertClass), () -> BYTE_BUDDY.subclass(assertClass)
+                    .defineField(ProxifyMethodChangingTheObjectUnderTest.FIELD_NAME, ProxifyMethodChangingTheObjectUnderTest.class, Visibility.PRIVATE)
                     .method(METHODS_CHANGING_THE_OBJECT_UNDER_TEST)
-                    .intercept(MethodDelegation.to(new ProxifyMethodChangingTheObjectUnderTest(this)))
+                    .intercept(MethodDelegation.to(ProxifyMethodChangingTheObjectUnderTest.class))
+                    .defineField(ErrorCollector.FIELD_NAME, ErrorCollector.class, Visibility.PRIVATE)
                     .method(any().and(not(METHODS_CHANGING_THE_OBJECT_UNDER_TEST))
                                  .and(not(METHODS_NOT_TO_PROXY)))
-                    .intercept(MethodDelegation.to(collector))
+                    .intercept(MethodDelegation.to(ErrorCollector.class))
+                    .implement(AssertJProxySetup.class)
+                    .intercept(FieldAccessor.ofField(ProxifyMethodChangingTheObjectUnderTest.FIELD_NAME)
+                      .setsArgumentAt(0)
+                      .andThen(FieldAccessor.ofField(ErrorCollector.FIELD_NAME).setsArgumentAt(1)))
                     .make()
                     // Use ClassLoader of soft assertion class to allow ByteBuddy to always find it.
                     // This is needed in OSGI runtime when custom soft assertion is defined outside of assertj bundle.
-                    .load(assertClass.getClassLoader())
-                    .getLoaded();
+                    .load(assertClass.getClassLoader(), classLoadingStrategy(assertClass))
+                    .getLoaded());
+  }
+
+  private static ClassLoadingStrategy<ClassLoader> classLoadingStrategy(Class<?> assertClass) {
+    if (ClassInjector.UsingReflection.isAvailable()) {
+      return ClassLoadingStrategy.Default.INJECTION;
+    } else if (ClassInjector.UsingLookup.isAvailable()) {
+      try {
+        return ClassLoadingStrategy.UsingLookup.of(PRIVATE_LOOKUP_IN.invoke(null, assertClass, LOOKUP));
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not access package of " + assertClass, e);
+      }
+    } else {
+      throw new IllegalStateException("No code generation strategy available");
+    }
   }
 
   private static Junction<MethodDescription> methodsNamed(String name) {
-    return ElementMatchers.<MethodDescription> named(name);
+    return ElementMatchers.<MethodDescription>named(name);
   }
 
   IterableSizeAssert<?> createIterableSizeAssertProxy(IterableSizeAssert<?> iterableSizeAssert) {
-    Class<?> proxyClass = createProxy(IterableSizeAssert.class, collector);
+    Class<?> proxyClass = createProxy(IterableSizeAssert.class);
     try {
       Constructor<?> constructor = proxyClass.getConstructor(AbstractIterableAssert.class, Integer.class);
-      return (IterableSizeAssert<?>) constructor.newInstance(iterableSizeAssert.returnToIterable(), iterableSizeAssert.actual);
+      IterableSizeAssert<?> instance = (IterableSizeAssert<?>) constructor.newInstance(iterableSizeAssert.returnToIterable(), iterableSizeAssert.actual);
+      ((AssertJProxySetup) instance).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
+      return instance;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
   MapSizeAssert<?, ?> createMapSizeAssertProxy(MapSizeAssert<?, ?> mapSizeAssert) {
-    Class<?> proxyClass = createProxy(MapSizeAssert.class, collector);
+    Class<?> proxyClass = createProxy(MapSizeAssert.class);
     try {
       Constructor<?> constructor = proxyClass.getConstructor(AbstractMapAssert.class, Integer.class);
-      return (MapSizeAssert<?, ?>) constructor.newInstance(mapSizeAssert.returnToMap(), mapSizeAssert.actual);
+      MapSizeAssert<?, ?> instance = (MapSizeAssert<?, ?>) constructor.newInstance(mapSizeAssert.returnToMap(), mapSizeAssert.actual);
+      ((AssertJProxySetup) instance).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
+      return instance;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
-
 }


### PR DESCRIPTION
- Updates to Byte Buddy 1.8.4.
- Adds support for class loading under Java 11 after changing the default class loading strategy in Byte Buddy 1.8.4.
- Make interception stateless to allow for better reuse of classes.

There are still a few test failures which seem related to filtering stack traces what might have changed after my recent alterations.