### PR TITLE
java11 compatibility

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2566,7 +2566,7 @@ public class Assertions {
   }
 
   /**
-   * Creates a new instance of <code>{@link CharSequenceAssert}from a {@link StringBuilder}</code>.
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
    *
    * @param actual the actual value.
    * @return the created assertion object.
@@ -2574,10 +2574,10 @@ public class Assertions {
    */
   @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
-    return new CharSequenceAssert(actual);
+    return AssertionsForClassTypes.assertThat(actual);
   }
   /**
-   * Creates a new instance of <code>{@link CharSequenceAssert}from a {@link StringBuffer}</code>.
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
    *
    * @param actual the actual value.
    * @return the created assertion object.
@@ -2585,7 +2585,7 @@ public class Assertions {
    */
   @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
-    return new CharSequenceAssert(actual);
+    return AssertionsForClassTypes.assertThat(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2566,6 +2566,29 @@ public class Assertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}from a {@link StringBuilder}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+    return new CharSequenceAssert(actual);
+  }
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}from a {@link StringBuffer}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+    return new CharSequenceAssert(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link CharSequenceAssert}from a {@link String}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -488,6 +488,30 @@ public class AssertionsForClassTypes {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}..
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+    return new CharSequenceAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+    return new CharSequenceAssert(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -488,7 +488,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}..
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
    *
    * @param actual the actual value.
    * @return the created assertion object.

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -309,6 +309,31 @@ public class Assumptions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> assumption from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuilder actual) {
+    return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> assumption from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuffer actual) {
+    return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+
+  /**
    * Creates a new instance of <code>{@link ShortAssert}</code> assumption.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -801,6 +801,30 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
+    return assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link org.assertj.core.api.StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -488,6 +488,30 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public CharSequenceAssert then(StringBuilder actual) {
+    return proxy(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public CharSequenceAssert then(StringBuffer actual) {
+    return proxy(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -490,6 +490,30 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public CharSequenceAssert assertThat(StringBuilder actual) {
+    return proxy(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public CharSequenceAssert assertThat(StringBuffer actual) {
+    return proxy(CharSequenceAssert.class, CharSequence.class, actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -925,6 +925,30 @@ public class Java6Assertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+    return new CharSequenceAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+    return new CharSequenceAssert(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -796,6 +796,30 @@ public class Java6BDDAssertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
+    return assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link org.assertj.core.api.StringAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -565,6 +565,30 @@ public interface WithAssertions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuilder actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuffer actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link ShortArrayAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -372,6 +372,29 @@ public interface WithAssumptions {
   }
 
   /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> assumption from a {@link StringBuilder}.
+   *
+   * @param actual the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuilder actual) {
+    return Assumptions.assumeThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link CharSequenceAssert}</code> assumption from a {@link StringBuffer}.
+   *
+   * @param actual the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.11.0
+   */
+  @CheckReturnValue
+  default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuffer actual) {
+    return Assumptions.assumeThat(actual);
+  }
+  /**
    * Creates a new instance of <code>{@link ShortArrayAssert}</code> assumption.
    *
    * @param actual the actual value.

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StringBuffer_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StringBuffer_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(StringBuffer)}</code>.
+ */
+public class Assertions_assertThat_with_StringBuffer_Test {
+
+  @Test
+  public void should_create_Assert() {
+    AbstractCharSequenceAssert<?, ?> assertions = Assertions.assertThat(new StringBuffer("Yoda"));
+    assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  public void should_pass_actual() {
+    StringBuffer actual = new StringBuffer("Yoda");
+    AbstractCharSequenceAssert<?, ?> assertions = Assertions.assertThat(actual);
+    assertThat(assertions.actual).isSameAs(actual);
+  }
+}

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StringBuilder_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StringBuilder_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(StringBuilder)}</code>.
+ */
+public class Assertions_assertThat_with_StringBuilder_Test {
+
+  @Test
+  public void should_create_Assert() {
+    AbstractCharSequenceAssert<?, ?> assertions = Assertions.assertThat(new StringBuilder("Yoda"));
+    assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  public void should_pass_actual() {
+    StringBuilder actual = new StringBuilder("Yoda");
+    AbstractCharSequenceAssert<?, ?> assertions = Assertions.assertThat(actual);
+    assertThat(assertions.actual).isSameAs(actual);
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes  #1232
* Unit tests : YES / NO / NA
* Javadoc with a code example (API only) : YES / NO / NA

Should we add some additional test too or are we fine with the ones we are having in place?
Additionally, should we merge  #1234 first and I do a rebase afterwards and make a change to no longer allow failing java11 builds?
