### PR TITLE
Improve error message for Iterables.allSatisfy

### DIFF
--- a/src/main/java/org/assertj/core/error/ElementsShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ElementsShouldSatisfy.java
@@ -12,25 +12,18 @@
  */
 package org.assertj.core.error;
 
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
 public class ElementsShouldSatisfy extends BasicErrorMessageFactory {
-
-  public static <T> ErrorMessageFactory elementsShouldSatisfy(Object actual, T elementNotSatisfyingRestrictions,
-                                                              String assertionErrorDetails) {
-    return new ElementsShouldSatisfy(actual, elementNotSatisfyingRestrictions, assertionErrorDetails);
-  }
-
-  public static <T> ErrorMessageFactory elementsShouldSatisfyAny(Object actual) {
+  public static ErrorMessageFactory elementsShouldSatisfyAny(Object actual) {
     return new ElementsShouldSatisfy(actual);
   }
 
-  private ElementsShouldSatisfy(Object actual, Object notSatisfies, String assertionErrorDetails) {
-    super("%n" +
-          "Expecting all elements of:%n" +
-          "  <%s>%n" +
-          "to satisfy given requirements, but this element did not:%n" +
-          "  <%s> %n" +
-          "Details: %s",
-          actual, notSatisfies, assertionErrorDetails);
+  public static ErrorMessageFactory elementsShouldSatisfy(Object actual,
+                                                          List<UnsatisfiedRequirementError> elementsNotSatisfyingRestrictions) {
+    return new ElementsShouldSatisfy(actual, elementsNotSatisfyingRestrictions);
   }
 
   private ElementsShouldSatisfy(Object actual) {
@@ -39,6 +32,35 @@ public class ElementsShouldSatisfy extends BasicErrorMessageFactory {
           "  <%s>%n" +
           "to satisfy the given assertions requirements but none did.",
           actual);
+  }
+
+  private ElementsShouldSatisfy(Object actual, List<UnsatisfiedRequirementError> elementsNotSatisfyingRequirements) {
+    super("%n" +
+          "Expecting all elements of:%n" +
+          "  <%s>%n" +
+          "to satisfy given requirements, but these elements did not:%n%n" +
+          describeErrors(elementsNotSatisfyingRequirements),
+          actual);
+  }
+
+  private static String describeErrors(List<UnsatisfiedRequirementError> elementsNotSatisfyingRequirements) {
+    return elementsNotSatisfyingRequirements.stream().map(UnsatisfiedRequirementError::toString)
+                                            .collect(joining("%n%n"));
+  }
+
+  public static class UnsatisfiedRequirementError {
+    private final Object elementNotSatisfyRequirement;
+    private final String errorMessage;
+
+    public UnsatisfiedRequirementError(Object elementNotSatisfyRequirement, String errorMessage) {
+      this.elementNotSatisfyRequirement = elementNotSatisfyRequirement;
+      this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("  <%s> %s", elementNotSatisfyRequirement, errorMessage);
+    }
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ElementsShouldSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ElementsShouldSatisfy_create_Test.java
@@ -12,29 +12,37 @@
  */
 package org.assertj.core.error;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
-import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfyAny;
-import static org.assertj.core.util.Lists.newArrayList;
-
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Test;
 
-public class ElementsShouldSatisfy_create_Test {
+import java.util.List;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirementError;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfyAny;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class ElementsShouldSatisfy_create_Test {
   @Test
-  public void should_create_error_message() {
-    ErrorMessageFactory factory = elementsShouldSatisfy(newArrayList("Luke", "Yoda"), "Yoda",
-                                                        "Yoda violates some restrictions");
+  public void should_create_error_message_all() {
+    List<UnsatisfiedRequirementError> elementsNotSatisfyingRestrictions = newArrayList(new UnsatisfiedRequirementError("Leia",
+                                                                                                                       "Leia violates some requirement."),
+                                                                                       new UnsatisfiedRequirementError("Luke",
+                                                                                                                       "Luke violates some requirement."));
+
+    ErrorMessageFactory factory = elementsShouldSatisfy(newArrayList("Leia", "Luke", "Yoda"),
+                                                        elementsNotSatisfyingRestrictions);
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting all elements of:%n" +
-                                         "  <[\"Luke\", \"Yoda\"]>%n" +
-                                         "to satisfy given requirements, but this element did not:%n" +
-                                         "  <\"Yoda\"> %n" +
-                                         "Details: \"Yoda violates some restrictions\""));
+                                         "  <[\"Leia\", \"Luke\", \"Yoda\"]>%n" +
+                                         "to satisfy given requirements, but these elements did not:%n%n" +
+                                         "  <Leia> Leia violates some requirement.%n%n" +
+                                         "  <Luke> Luke violates some requirement."));
   }
 
   @Test
@@ -46,5 +54,4 @@ public class ElementsShouldSatisfy_create_Test {
                                          "  <[\"Luke\", \"Yoda\"]>%n" +
                                          "to satisfy the given assertions requirements but none did."));
   }
-
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllSatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllSatisfy_Test.java
@@ -12,20 +12,21 @@
  */
 package org.assertj.core.internal.iterables;
 
+import org.assertj.core.internal.IterablesBaseTest;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Consumer;
+
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirementError;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
-
-import java.util.List;
-import java.util.function.Consumer;
-
-import org.assertj.core.internal.IterablesBaseTest;
-import org.junit.Test;
 
 public class Iterables_assertAllSatisfy_Test extends IterablesBaseTest {
 
@@ -53,11 +54,17 @@ public class Iterables_assertAllSatisfy_Test extends IterablesBaseTest {
     try {
       iterables.assertAllSatisfy(someInfo(), actual, restrictions);
     } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldSatisfy(actual, "Yoda", format("%n" +
-                                                                                  "Expecting:%n" +
-                                                                                  " <\"Yoda\">%n" +
-                                                                                  "to start with:%n" +
-                                                                                  " <\"L\">%n")));
+      List<UnsatisfiedRequirementError> errors = newArrayList(new UnsatisfiedRequirementError("Yoda", format("%n" +
+                                                                                                             "Expecting:%n"
+                                                                                                             +
+                                                                                                             " <\"Yoda\">%n"
+                                                                                                             +
+                                                                                                             "to start with:%n"
+                                                                                                             +
+                                                                                                             " <\"L\">%n")));
+
+      verify(failures).failure(info, elementsShouldSatisfy(actual, errors));
+
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION
* Earlier only the failure of the first item was reported in the error message
* This could lead to multiple iterations of rerunning/fixing when a failure was found
* Now the first failure for each item is reported in the error message