### PR TITLE
Fix if-else logic in PredicateAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractPredicateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPredicateAssert.java
@@ -60,7 +60,9 @@ public abstract class AbstractPredicateAssert<SELF extends AbstractPredicateAsse
    */
   public SELF accepts(@SuppressWarnings("unchecked") T... values) {
     isNotNull();
-    if (values.length == 1 && !actual.test(values[0])) throwAssertionError(shouldAccept(actual, values[0], GIVEN));
+    if (values.length == 1) {
+      if (!actual.test(values[0])) throwAssertionError(shouldAccept(actual, values[0], GIVEN));
+    }
     else iterables.assertAllMatch(info, newArrayList(values), actual, PredicateDescription.GIVEN);
     return myself;
   }
@@ -85,7 +87,9 @@ public abstract class AbstractPredicateAssert<SELF extends AbstractPredicateAsse
    */
   public SELF rejects(@SuppressWarnings("unchecked") T... values) {
     isNotNull();
-    if (values.length == 1 && actual.test(values[0])) throwAssertionError(shouldNotAccept(actual, values[0], GIVEN));
+    if (values.length == 1) {
+      if (actual.test(values[0])) throwAssertionError(shouldNotAccept(actual, values[0], GIVEN));
+    }
     else iterables.assertNoneMatch(info, newArrayList(values), actual, PredicateDescription.GIVEN);
     return myself;
   }

--- a/src/test/java/org/assertj/core/api/predicate/PredicateAssert_accepts_Test.java
+++ b/src/test/java/org/assertj/core/api/predicate/PredicateAssert_accepts_Test.java
@@ -17,7 +17,11 @@ import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldAccept.shouldAccept;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.function.Predicate;
 
@@ -77,6 +81,16 @@ public class PredicateAssert_accepts_Test extends PredicateAssertBaseTest {
     Predicate<String> predicate = val -> val.equals("something");
 
     assertThat(predicate).accepts("something");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_pass_and_only_invoke_predicate_once_for_single_value() {
+    Predicate<Object> predicate = mock(Predicate.class);
+    when(predicate.test(any())).thenReturn(true);
+
+    assertThat(predicate).accepts("something");
+    verify(predicate, times(1)).test("something");
   }
 
 

--- a/src/test/java/org/assertj/core/api/predicate/PredicateAssert_rejects_Test.java
+++ b/src/test/java/org/assertj/core/api/predicate/PredicateAssert_rejects_Test.java
@@ -17,7 +17,11 @@ import static org.assertj.core.error.NoElementsShouldMatch.noElementsShouldMatch
 import static org.assertj.core.error.ShouldNotAccept.shouldNotAccept;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.function.Predicate;
 
@@ -74,6 +78,16 @@ public class PredicateAssert_rejects_Test extends PredicateAssertBaseTest {
     Predicate<String> ballSportPredicate = sport -> sport.contains("ball");
 
     assertThat(ballSportPredicate).rejects("curling", "judo", "marathon");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_pass_and_only_invoke_predicate_once_for_single_value() {
+    Predicate<Object> predicate = mock(Predicate.class);
+    when(predicate.test(any())).thenReturn(false);
+
+    assertThat(predicate).rejects("something");
+    verify(predicate, times(1)).test("something");
   }
 
   @Override


### PR DESCRIPTION
Both accepts() & rejects() invoked the predicate
twice if given a single value because of broken
if-else logic.

Not a super big deal, but kind of annoying as it breaks chained `Mockito.when(..).thenReturn(..).thenReturn(..)` stuff in tests

#### Check List:
* Unit tests : YES


