### PR TITLE
Remove usages of the expected element of Test annotations.

### DIFF
--- a/src/test/java/org/assertj/core/api/ObjectAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/ObjectAssertBaseTest.java
@@ -12,11 +12,7 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.test.ExpectedException.none;
-
-import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Jedi;
-import org.junit.Rule;
 
 
 /**

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -140,17 +140,17 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void withAssertions_fail_Test() {
-    fail("Failed");
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> fail("Failed"));
   }
 
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void withAssertions_fail_with_throwable_Test() {
-    fail("Failed", new RuntimeException("expected"));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> fail("Failed", new RuntimeException("expected")));
   }
 
   /**
@@ -588,33 +588,33 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = UncheckedIOException.class)
+  @Test
   public void withAssertions_contentOf_Test() {
-    contentOf(new File("/non-existent file")).contains("a");
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> contentOf(new File("/non-existent file")).contains("a"));
   }
 
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = UncheckedIOException.class)
+  @Test
   public void withAssertions_contentOf_with_charset_Test() {
-    contentOf(new File("/non-existent file", "UTF-8")).contains("a");
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> contentOf(new File("/non-existent file", "UTF-8")).contains("a"));
   }
 
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = UncheckedIOException.class)
+  @Test
   public void withAssertions_linesOf_Test() {
-    linesOf(new File("/non-existent file")).contains("a");
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> linesOf(new File("/non-existent file")).contains("a"));
   }
 
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = UncheckedIOException.class)
+  @Test
   public void withAssertions_linesOf_with_charsetTest() {
-    linesOf(new File("/non-existent file", "UTF-8")).contains("a");
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> linesOf(new File("/non-existent file", "UTF-8")).contains("a"));
   }
 
   /**
@@ -645,9 +645,9 @@ public class WithAssertions_delegation_Test implements WithAssertions {
   /**
    * Test that the delegate method is called.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void withAssertions_failBecauseExceptionWasNotThrown_Test() {
-    failBecauseExceptionWasNotThrown(Throwable.class);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> failBecauseExceptionWasNotThrown(Throwable.class));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/optionaldouble/OptionalDoubleAssert_hasValueCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/api/optionaldouble/OptionalDoubleAssert_hasValueCloseTo_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.optionaldouble;
 
 import static java.lang.Math.abs;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.OptionalDoubleShouldHaveValueCloseTo.shouldHaveValueCloseTo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -55,10 +56,9 @@ public class OptionalDoubleAssert_hasValueCloseTo_Test extends BaseTest {
     assertThat(actual).hasValueCloseTo(expectedValue, offset);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    double expectedValue = 10.0;
-    assertThat(OptionalDouble.of(10.0)).hasValueCloseTo(expectedValue, null);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(OptionalDouble.of(10.0)).hasValueCloseTo(10.0, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessage_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessage_with_String_format_syntax_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.throwable;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.ThrowableAssert;
@@ -31,9 +32,9 @@ public class ThrowableAssert_hasMessage_with_String_format_syntax_Test extends T
     verify(throwables).assertHasMessage(getInfo(assertions), getActual(assertions), "throwable message foo");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_throw_if_String_format_syntax_is_not_met() {
-    assertions.hasMessage("throwable message %s %s %s", "foo");
+    assertThatIllegalArgumentException().isThrownBy(() -> assertions.hasMessage("throwable message %s %s %s", "foo"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/OptionalShouldBeEmpty_create_Test.java
+++ b/src/test/java/org/assertj/core/error/OptionalShouldBeEmpty_create_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 
 import java.util.NoSuchElementException;
@@ -32,9 +33,9 @@ public class OptionalShouldBeEmpty_create_Test {
     assertThat(errorMessage).isEqualTo(format("%nExpecting an empty Optional but was containing value: <\"not-empty\">."));
   }
 
-  @Test(expected = NoSuchElementException.class)
+  @Test
   public void should_fail_with_empty_optional() {
-    shouldBeEmpty(Optional.empty()).create();
+    assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> shouldBeEmpty(Optional.empty()).create());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsBetween_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
-
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -43,14 +43,14 @@ public class BigDecimals_assertIsBetween_Test extends BigDecimalsBaseTest {
     numbers.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    numbers.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    numbers.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class BigDecimals_assertIsCloseToPercentage_Test extends BigDecimalsBaseT
     numbers.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(1));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(1));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(1)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -82,9 +83,9 @@ public class BigDecimals_assertIsCloseTo_Test extends BigDecimalsBaseTest {
     numbers.assertIsCloseTo(someInfo(), new BigDecimal(6.0), null, offset(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_throw_error_if_offset_is_null() {
-    numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseToPercentage_Test.java
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith;
 import java.math.BigDecimal;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -39,19 +41,19 @@ public class BigDecimals_assertIsNotCloseToPercentage_Test extends BigDecimalsBa
     numbers.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(1));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(1));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(1)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -121,14 +122,14 @@ public class BigDecimals_assertIsNotCloseTo_Test extends BigDecimalsBaseTest {
     numbers.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    numbers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   // with comparison strategy

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsStrictlyBetween_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
-
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -43,14 +43,14 @@ public class BigDecimals_assertIsStrictlyBetween_Test extends BigDecimalsBaseTes
     numbers.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    numbers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    numbers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsBetween_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -39,14 +40,14 @@ public class BigIntegers_assertIsBetween_Test extends BigIntegersBaseTest {
     numbers.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    numbers.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    numbers.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class BigIntegers_assertIsCloseToPercentage_Test extends BigIntegersBaseT
     numbers.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(1));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(1));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(1)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -100,14 +101,14 @@ public class BigIntegers_assertIsCloseTo_Test extends BigIntegersBaseTest {
     numbers.assertIsCloseTo(someInfo(), null, ONE, offset(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if__expected_value_is_null() {
-    numbers.assertIsCloseTo(someInfo(), ONE, null, within(ONE));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseTo(someInfo(), ONE, null, within(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   // @format:off
@@ -125,9 +126,9 @@ public class BigIntegers_assertIsCloseTo_Test extends BigIntegersBaseTest {
     numbers.assertIsCloseTo(someInfo(), SIX, null, offset(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_throw_error_if_offset_is_null() {
-    numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseToPercentage_Test.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class BigIntegers_assertIsNotCloseToPercentage_Test extends BigIntegersBa
     numbers.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(1));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(1));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(1)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -116,14 +117,14 @@ public class BigIntegers_assertIsNotCloseTo_Test extends BigIntegersBaseTest {
     numbers.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    numbers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    numbers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   // with comparison strategy

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsStrictlyBetween_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -39,14 +40,14 @@ public class BigIntegers_assertIsStrictlyBetween_Test extends BigIntegersBaseTes
     numbers.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    numbers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    numbers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> numbers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -44,14 +45,14 @@ public class Bytes_assertIsBetween_Test extends BytesBaseTest {
     bytes.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    bytes.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    bytes.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -41,19 +43,19 @@ public class Bytes_assertIsCloseToPercentage_Test extends BytesBaseTest {
     bytes.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    bytes.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> bytes.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.bytes;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -118,14 +119,14 @@ public class Bytes_assertIsCloseTo_Test extends BytesBaseTest {
     bytes.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    bytes.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    bytes.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseToPercentage_Test.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class Bytes_assertIsNotCloseToPercentage_Test extends BytesBaseTest {
     bytes.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    bytes.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    bytes.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    bytes.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> bytes.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.bytes;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -118,14 +119,14 @@ public class Bytes_assertIsNotCloseTo_Test extends BytesBaseTest {
     bytes.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    bytes.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    bytes.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsStrictlyBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -44,14 +45,14 @@ public class Bytes_assertIsStrictlyBetween_Test extends BytesBaseTest {
     bytes.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    bytes.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    bytes.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> bytes.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -42,14 +43,14 @@ public class Doubles_assertIsBetween_Test extends DoublesBaseTest {
     doubles.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    doubles.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    doubles.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -44,19 +46,19 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
     doubles.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    doubles.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0));
+    assertThatIllegalArgumentException().isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -84,9 +85,9 @@ public class Doubles_assertIsCloseTo_Test extends DoublesBaseTest {
     doubles.assertIsCloseTo(someInfo(), 6d, null, offset(1d));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_throw_error_if_offset_is_null() {
-    doubles.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
@@ -16,6 +16,8 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -46,19 +48,19 @@ public class Doubles_assertIsNotCloseToPercentage_Test extends DoublesBaseTest {
     doubles.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    doubles.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    doubles.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    doubles.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0));
+    assertThatIllegalArgumentException().isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -85,14 +86,14 @@ public class Doubles_assertIsNotCloseTo_Test extends DoublesBaseTest {
     doubles.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    doubles.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    doubles.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -42,14 +43,14 @@ public class Doubles_assertIsStrictlyBetween_Test extends DoublesBaseTest {
     doubles.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    doubles.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    doubles.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> doubles.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -41,14 +42,14 @@ public class Floats_assertIsBetween_Test extends FloatsBaseTest {
     floats.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    floats.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    floats.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,8 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -44,19 +46,19 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
     floats.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    floats.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0f));
+    assertThatIllegalArgumentException().isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0f)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
@@ -84,9 +85,9 @@ public class Floats_assertIsCloseTo_Test extends FloatsBaseTest {
     floats.assertIsCloseTo(someInfo(), 6f, null, offset(1f));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_throw_error_if_offset_is_null() {
-    floats.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
@@ -16,6 +16,8 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -46,19 +48,19 @@ public class Floats_assertIsNotCloseToPercentage_Test extends FloatsBaseTest {
     floats.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    floats.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    floats.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    floats.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0f));
+    assertThatIllegalArgumentException().isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1.0f)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -85,14 +86,14 @@ public class Floats_assertIsNotCloseTo_Test extends FloatsBaseTest {
     floats.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    floats.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    floats.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsStrictlyBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -42,14 +43,14 @@ public class Floats_assertIsStrictlyBetween_Test extends FloatsBaseTest {
     floats.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    floats.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    floats.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> floats.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -42,14 +43,14 @@ public class Integers_assertIsBetween_Test extends IntegersBaseTest {
     integers.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    integers.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    integers.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -41,19 +43,19 @@ public class Integers_assertIsCloseToPercentage_Test extends IntegersBaseTest {
     integers.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    integers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> integers.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.integers;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
@@ -104,14 +105,14 @@ public class Integers_assertIsCloseTo_Test extends IntegersBaseTest {
     integers.assertIsCloseTo(someInfo(), null, ONE, within(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    integers.assertIsCloseTo(someInfo(), ONE, null, within(ONE));
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsCloseTo(someInfo(), ONE, null, within(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    integers.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseToPercentage_Test.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class Integers_assertIsNotCloseToPercentage_Test extends IntegersBaseTest
     integers.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    integers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    integers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    integers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> integers.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.integers;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -118,14 +119,14 @@ public class Integers_assertIsNotCloseTo_Test extends IntegersBaseTest {
     integers.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    integers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    integers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsStrictlyBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -44,14 +45,14 @@ public class Integers_assertIsStrictlyBetween_Test extends IntegersBaseTest {
     integers.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    integers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    integers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> integers.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
@@ -20,6 +20,8 @@ import org.junit.runner.RunWith;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -41,19 +43,19 @@ public class Longs_assertIsCloseToPercentage_Test extends LongsBaseTest {
         longs.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void should_fail_if_expected_value_is_null() {
-        longs.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+      assertThatNullPointerException().isThrownBy(() -> longs.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void should_fail_if_percentage_is_null() {
-        longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+      assertThatNullPointerException().isThrownBy(() ->  longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void should_fail_if_percentage_is_negative() {
-        longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1L));
+      assertThatIllegalArgumentException().isThrownBy(() ->     longs.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1L)));
     }
 
     // @format:off

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.longs;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
@@ -103,14 +104,14 @@ public class Longs_assertIsCloseTo_Test extends LongsBaseTest {
     longs.assertIsCloseTo(someInfo(), null, ONE, within(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    longs.assertIsCloseTo(someInfo(), ONE, null, within(ONE));
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsCloseTo(someInfo(), ONE, null, within(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    longs.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseToPercentage_Test.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class Longs_assertIsNotCloseToPercentage_Test extends LongsBaseTest {
     longs.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    longs.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    longs.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    longs.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1L));
+    assertThatIllegalArgumentException().isThrownBy(() -> longs.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage(-1L)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.longs;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -118,14 +119,14 @@ public class Longs_assertIsNotCloseTo_Test extends LongsBaseTest {
     longs.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    longs.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    longs.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> longs.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -42,14 +43,14 @@ public class Shorts_assertIsBetween_Test extends ShortsBaseTest {
     shorts.assertIsBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    shorts.assertIsBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    shorts.assertIsBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
@@ -41,19 +43,19 @@ public class Shorts_assertIsCloseToPercentage_Test extends ShortsBaseTest {
     shorts.assertIsCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    shorts.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) -1));
+    assertThatIllegalArgumentException().isThrownBy(() -> shorts.assertIsCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) -1)));
   }
 
   // @format:off

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.shorts;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
@@ -108,13 +109,13 @@ public class Shorts_assertIsCloseTo_Test extends ShortsBaseTest {
     shorts.assertIsCloseTo(someInfo(), null, ONE, within(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    shorts.assertIsCloseTo(someInfo(), ONE, null, within(ONE));
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsCloseTo(someInfo(), ONE, null, within(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    shorts.assertIsCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsCloseTo(someInfo(), ONE, ZERO, null));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseToPercentage_Test.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
@@ -42,19 +44,19 @@ public class Shorts_assertIsNotCloseToPercentage_Test extends ShortsBaseTest {
     shorts.assertIsNotCloseToPercentage(someInfo(), null, ONE, withPercentage(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    shorts.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE));
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsNotCloseToPercentage(someInfo(), ONE, null, withPercentage(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_percentage_is_null() {
-    shorts.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void should_fail_if_percentage_is_negative() {
-    shorts.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) -1));
+    assertThatIllegalArgumentException().isThrownBy(() -> shorts.assertIsNotCloseToPercentage(someInfo(), ONE, ZERO, withPercentage((short) -1)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.shorts;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
@@ -118,14 +119,14 @@ public class Shorts_assertIsNotCloseTo_Test extends ShortsBaseTest {
     shorts.assertIsNotCloseTo(someInfo(), null, ONE, byLessThan(ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_expected_value_is_null() {
-    shorts.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE));
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsNotCloseTo(someInfo(), ONE, null, byLessThan(ONE)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_offset_is_null() {
-    shorts.assertIsNotCloseTo(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsNotCloseTo(someInfo(), ONE, ZERO, null));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -44,14 +45,14 @@ public class Shorts_assertIsStrictlyBetween_Test extends ShortsBaseTest {
     shorts.assertIsStrictlyBetween(someInfo(), null, ZERO, ONE);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_start_is_null() {
-    shorts.assertIsStrictlyBetween(someInfo(), ONE, null, ONE);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsStrictlyBetween(someInfo(), ONE, null, ONE));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_fail_if_end_is_null() {
-    shorts.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null);
+    assertThatNullPointerException().isThrownBy(() -> shorts.assertIsStrictlyBetween(someInfo(), ONE, ZERO, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/IterableUtil_sizeOf_Test.java
+++ b/src/test/java/org/assertj/core/util/IterableUtil_sizeOf_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.Lists.newArrayList;
 
 import java.sql.SQLException;
@@ -34,9 +34,9 @@ public class IterableUtil_sizeOf_Test {
     assertThat(IterableUtil.sizeOf(new ArrayList<>())).isEqualTo(0);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void should_throws_exception_if_iterable_is_null() {
-    IterableUtil.sizeOf(null);
+    assertThatNullPointerException().isThrownBy(() -> IterableUtil.sizeOf(null));
   }
 
   @Test


### PR DESCRIPTION
First step of the JUnit 5 migration (expected element was removed from `@Test`).

Migration was done mostly by regex search and replace.


