### PR TITLE
Remove various ExpectedException methods

### DIFF
--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 import static org.assertj.core.test.ExpectedException.none;
 
@@ -55,10 +56,9 @@ public class Assertions_assertThatCode_Test {
     ThrowingCallable boom = raisingException("boom");
 
     // Expect
-    thrown.expectWithMessageStartingWith(AssertionError.class, "[Test]");
-
-    // When
-    assertThatCode(boom).as("Test").doesNotThrowAnyException();
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatCode(boom).as("Test")
+                                                                                         .doesNotThrowAnyException())
+                                                   .withMessageStartingWith("[Test]");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -188,9 +189,10 @@ public class Assertions_assertThat_with_Iterator_Test {
 
   @Test
   public void should_fail_if_sequence_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    assertThat(names).startsWith(new String[0]);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      assertThat(names).startsWith(new String[0]);
+    });
   }
 
   // startsWith tests
@@ -204,26 +206,29 @@ public class Assertions_assertThat_with_Iterator_Test {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
-    thrown.expectAssertionError();
-    String[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
-    thrown.expectAssertionError();
-    String[] sequence = { "Han", "C-3PO" };
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Han", "C-3PO" };
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
-    thrown.expectAssertionError();
-    String[] sequence = { "Luke", "Yoda" };
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Luke", "Yoda" };
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
@@ -244,18 +249,20 @@ public class Assertions_assertThat_with_Iterator_Test {
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
-    thrown.expectAssertionError();
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    String[] sequence = { "Han", "C-3PO" };
-    assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      String[] sequence = { "Han", "C-3PO" };
+      assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
-    thrown.expectAssertionError();
-    Iterator<String> names = asList("Luke", "Leia").iterator();
-    String[] sequence = { "Luke", "Obi-Wan", "Han" };
-    assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Iterator<String> names = asList("Luke", "Leia").iterator();
+      String[] sequence = { "Luke", "Obi-Wan", "Han" };
+      assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Stream_startsWith_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Stream_startsWith_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -67,9 +68,10 @@ public class Assertions_assertThat_with_Stream_startsWith_Test {
 
   @Test
   public void should_fail_if_sequence_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expect(AssertionError.class);
-    Stream<String> names = asList("Luke", "Leia").stream();
-    assertThat(names).startsWith(new String[0]);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Stream<String> names = asList("Luke", "Leia").stream();
+      assertThat(names).startsWith(new String[0]);
+    });
   }
 
   @Test
@@ -81,26 +83,29 @@ public class Assertions_assertThat_with_Stream_startsWith_Test {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
-    thrown.expect(AssertionError.class);
-    String[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    Stream<String> names = asList("Luke", "Leia").stream();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
+      Stream<String> names = asList("Luke", "Leia").stream();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
-    thrown.expect(AssertionError.class);
-    String[] sequence = { "Han", "C-3PO" };
-    Stream<String> names = asList("Luke", "Leia").stream();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Han", "C-3PO" };
+      Stream<String> names = asList("Luke", "Leia").stream();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
-    thrown.expect(AssertionError.class);
-    String[] sequence = { "Luke", "Yoda" };
-    Stream<String> names = asList("Luke", "Leia").stream();
-    assertThat(names).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      String[] sequence = { "Luke", "Yoda" };
+      Stream<String> names = asList("Luke", "Leia").stream();
+      assertThat(names).startsWith(sequence);
+    });
   }
 
   @Test
@@ -121,18 +126,20 @@ public class Assertions_assertThat_with_Stream_startsWith_Test {
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
-    thrown.expect(AssertionError.class);
-    Stream<String> names = asList("Luke", "Leia").stream();
-    String[] sequence = { "Han", "C-3PO" };
-    assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Stream<String> names = asList("Luke", "Leia").stream();
+      String[] sequence = { "Han", "C-3PO" };
+      assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    });
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
-    thrown.expect(AssertionError.class);
-    Stream<String> names = asList("Luke", "Leia").stream();
-    String[] sequence = { "Luke", "Obi-Wan", "Han" };
-    assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Stream<String> names = asList("Luke", "Leia").stream();
+      String[] sequence = { "Luke", "Obi-Wan", "Han" };
+      assertThat(names).usingElementComparator(CaseInsensitiveStringComparator.instance).startsWith(sequence);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_fail_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_fail_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
@@ -39,7 +40,7 @@ public class Assertions_fail_Test {
   public void should_include_message_with_cause_when_failing() {
     String message = "Some Throwable";
     Throwable cause = new Throwable();
-    thrown.expectWithCause(AssertionError.class, message, cause);
-    Assertions.fail(message, cause);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions.fail(message, cause))
+                                                   .withMessage(message).withCause(cause);
   }
 }

--- a/src/test/java/org/assertj/core/api/Condition_constructor_with_predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/Condition_constructor_with_predicate_Test.java
@@ -13,18 +13,13 @@
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.util.function.Predicate;
 
-import org.assertj.core.test.ExpectedException;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class Condition_constructor_with_predicate_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_create_condition_with_predicate() {
@@ -33,11 +28,9 @@ public class Condition_constructor_with_predicate_Test {
 	assertThat(littleRedCap).is(fairyTale);
   }
 
-  @SuppressWarnings("unused")
   @Test
   public void should_throw_error_if_predicate_is_null() {
-	thrown.expect(NullPointerException.class);
-	new Condition<Object>((Predicate<Object>) null, "");
+    assertThatNullPointerException().isThrownBy(() ->  new Condition<Object>((Predicate<Object>) null, ""));
   }
 }
 

--- a/src/test/java/org/assertj/core/api/Java6Assertions_fail_Test.java
+++ b/src/test/java/org/assertj/core/api/Java6Assertions_fail_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
@@ -39,7 +40,7 @@ public class Java6Assertions_fail_Test {
   public void should_include_message_with_cause_when_failing() {
     String message = "Some Throwable";
     Throwable cause = new Throwable();
-    thrown.expectWithCause(AssertionError.class, message, cause);
-    Java6Assertions.fail(message, cause);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Java6Assertions.fail(message, cause))
+                                                   .withMessage(message).withCause(cause);
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
@@ -12,14 +12,11 @@
  */
 package org.assertj.core.api.abstract_;
 
-import static org.assertj.core.test.ExpectedException.none;
-import static org.assertj.core.api.Assertions.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ConcreteAssert;
-import org.assertj.core.test.ExpectedException;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -29,16 +26,13 @@ import org.junit.Test;
  */
 public class AbstractAssert_equal_hashCode_Test {
 
-  @Rule
-  public ExpectedException thrown = none();
-
   private ConcreteAssert assertions = new ConcreteAssert("myString");
 
   @Test
   @SuppressWarnings("deprecation")
   public void should_fail_because_not_supported_operation() {
-    thrown.expectUnsupportedOperationException("'equals' is not supported...maybe you intended to call 'isEqualTo'");
-    assertions.equals("anotherString");
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> assertions.equals("anotherString"))
+                                                                  .withMessageContaining("'equals' is not supported...maybe you intended to call 'isEqualTo'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extractingResultOf_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extractingResultOf_Test.java
@@ -60,8 +60,7 @@ public class AtomicReferenceArrayAssert_extractingResultOf_Test {
 
   @Test
   public void should_throw_error_if_no_method_with_given_name_can_be_extracted() {
-    thrown.expectIllegalArgumentException();
-    thrown.expectMessage("Can't find method 'unknown' in class FluentJedi.class. Make sure public method exists and accepts no arguments!");
+    thrown.expectIllegalArgumentException("Can't find method 'unknown' in class FluentJedi.class. Make sure public method exists and accepts no arguments!");
     assertThat(jedis).extractingResultOf("unknown");
   }
 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.Arrays.array;
@@ -24,6 +25,7 @@ import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,8 +68,7 @@ public class AtomicReferenceArrayAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_no_property_nor_field_with_given_name_can_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(employees).extracting("unknown");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).extracting("unknown"));
   }
 
   @Test
@@ -78,9 +79,10 @@ public class AtomicReferenceArrayAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_one_property_or_field_can_not_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(employees).extracting("unknown", "age", "id").containsOnly(tuple("Yoda", 800, 1L),
-                                                                          tuple("Luke", 26, 2L));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      assertThat(employees).extracting("unknown", "age", "id").containsOnly(tuple("Yoda", 800, 1L),
+                                                                            tuple("Luke", 26, 2L));
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
@@ -134,32 +134,29 @@ public class AtomicReferenceArrayAssert_extracting_Test {
 
   @Test
   public void should_let_anonymous_class_extractor_runtime_exception_bubble_up() {
-    thrown.expect(RuntimeException.class, "age > 100");
-    assertThat(employees).extracting(new Extractor<Employee, String>() {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(employees).extracting(new Extractor<Employee, String>() {
       @Override
       public String extract(Employee employee) {
         if (employee.getAge() > 100) throw new RuntimeException("age > 100");
         return employee.getName().getFirst();
       }
-    });
+    })).withMessage("age > 100");
   }
 
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
-    thrown.expect(RuntimeException.class, "java.lang.Exception: age > 100");
-    assertThat(employees).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(employees).extracting(employee -> {
       if (employee.getAge() > 100) throw new Exception("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("java.lang.Exception: age > 100");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
-    thrown.expect(RuntimeException.class, "age > 100");
-    assertThat(employees).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(employees).extracting(employee -> {
       if (employee.getAge() > 100) throw new RuntimeException("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("age > 100");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
@@ -90,8 +90,9 @@ public class AtomicReferenceArrayAssert_filteredOn_Test extends AtomicReferenceA
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", "???");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          "???"))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
@@ -14,10 +14,12 @@ package org.assertj.core.api.atomic.referencearray;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class AtomicReferenceArrayAssert_filteredOn_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
@@ -46,10 +48,11 @@ public class AtomicReferenceArrayAssert_filteredOn_Test extends AtomicReferenceA
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", "New York").isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", "New York").isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
@@ -97,7 +97,10 @@ public class AtomicReferenceArrayAssert_filteredOn_Test extends AtomicReferenceA
 
   @Test
   public void should_fail_if_filter_operators_are_combined() {
-    thrown.expectWithMessageStartingWith(UnsupportedOperationException.class, "Combining operator is not supported");
-    assertThat(employees).filteredOn("age", not(in(800))).containsOnly(luke, noname);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> assertThat(employees).filteredOn("age",
+                                                                                                                     not(in(800)))
+                                                                                                         .containsOnly(luke,
+                                                                                                                       noname))
+                                                                  .withMessageStartingWith("Combining operator is not supported");
   }
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class AtomicReferenceArrayAssert_filteredOn_in_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
@@ -46,9 +48,10 @@ public class AtomicReferenceArrayAssert_filteredOn_in_Test extends AtomicReferen
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
     setAllowExtractingPrivateFields(false);
-    thrown.expectIntrospectionError();
     try {
-      assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
@@ -82,8 +82,9 @@ public class AtomicReferenceArrayAssert_filteredOn_in_Test extends AtomicReferen
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", in("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          in("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.notIn;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class AtomicReferenceArrayAssert_filteredOn_notIn_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
@@ -47,10 +49,11 @@ public class AtomicReferenceArrayAssert_filteredOn_notIn_Test extends AtomicRefe
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
@@ -85,8 +85,9 @@ public class AtomicReferenceArrayAssert_filteredOn_notIn_Test extends AtomicRefe
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", notIn("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          notIn("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
@@ -14,9 +14,11 @@ package org.assertj.core.api.atomic.referencearray;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class AtomicReferenceArrayAssert_filteredOn_not_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
@@ -45,10 +47,11 @@ public class AtomicReferenceArrayAssert_filteredOn_not_Test extends AtomicRefere
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", not("New York"));
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", not("New York"));
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
@@ -89,7 +89,8 @@ public class AtomicReferenceArrayAssert_filteredOn_not_Test extends AtomicRefere
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", not("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          not("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.Arrays.array;
 
@@ -79,21 +80,19 @@ public class AtomicReferenceArrayAssert_flatExtracting_Test {
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
     AtomicReferenceArray<CartoonCharacter> childCharacters = new AtomicReferenceArray<>(array(bart, lisa, maggie));
-    thrown.expect(RuntimeException.class, "java.lang.Exception: no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new Exception("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("java.lang.Exception: no children");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
     AtomicReferenceArray<CartoonCharacter> childCharacters = new AtomicReferenceArray<>(array(bart, lisa, maggie));
-    thrown.expect(RuntimeException.class, "no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new RuntimeException("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("no children");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.Arrays.array;
 
 import java.util.List;
@@ -72,8 +73,7 @@ public class AtomicReferenceArrayAssert_flatExtracting_Test {
 
   @Test
   public void should_throw_null_pointer_exception_when_extracting_from_null() {
-    thrown.expectNullPointerException();
-    assertThat(new AtomicReferenceArray<>(array(homer, null))).flatExtracting(children);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(new AtomicReferenceArray<>(array(homer, null))).flatExtracting(children));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_with_String_parameter_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.atomic.referencearray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.util.Arrays.array;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -71,8 +72,7 @@ public class AtomicReferenceArrayAssert_flatExtracting_with_String_parameter_Tes
 
   @Test
   public void should_throw_illegal_argument_exception_when_extracting_from_null() {
-    thrown.expectIllegalArgumentException();
-    assertThat(new AtomicReferenceArray<>(array(homer, null))).flatExtracting("children");
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(new AtomicReferenceArray<>(array(homer, null))).flatExtracting("children"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/boolean_/BooleanAssert_usingComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/boolean_/BooleanAssert_usingComparator_Test.java
@@ -12,17 +12,14 @@
  */
 package org.assertj.core.api.boolean_;
 
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
-
 import org.assertj.core.api.BooleanAssert;
 import org.assertj.core.api.BooleanAssertBaseTest;
-import org.assertj.core.test.ExpectedException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 
@@ -32,9 +29,6 @@ import org.mockito.Mock;
  * @author Joel Costigliola
  */
 public class BooleanAssert_usingComparator_Test extends BooleanAssertBaseTest {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Mock
   private Comparator<Boolean> comparator;
@@ -48,9 +42,9 @@ public class BooleanAssert_usingComparator_Test extends BooleanAssertBaseTest {
   @Test
   @SuppressWarnings("deprecation")
   public void should_have_internal_effects() {
-    thrown.expect(UnsupportedOperationException.class);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
-    assertions.usingComparator(comparator);
+    assertions.usingComparator(comparator));
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_usingDefaultElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_usingDefaultElementComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.booleanarray;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.util.Comparator;
@@ -38,8 +39,7 @@ public class BooleanArrayAssert_usingDefaultElementComparator_Test extends Boole
   @Test
   @SuppressWarnings("deprecation")
   public void should_have_internal_effects() {
-    thrown.expect(UnsupportedOperationException.class);
-    assertions.usingDefaultElementComparator();
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> assertions.usingDefaultElementComparator());
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_usingElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_usingElementComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api.booleanarray;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.util.Comparator;
@@ -42,9 +43,9 @@ public class BooleanArrayAssert_usingElementComparator_Test extends BooleanArray
   @Test
   @SuppressWarnings("deprecation")
   public void should_have_internal_effects() {
-    thrown.expect(UnsupportedOperationException.class);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
-    assertions.usingElementComparator(comparator);
+    assertions.usingElementComparator(comparator));
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/date/DateAssert_hasSameTimeAsDateInString_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_hasSameTimeAsDateInString_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.DateUtil.parseDatetime;
@@ -52,8 +53,7 @@ public class DateAssert_hasSameTimeAsDateInString_Test extends DateAssertBaseTes
   @Test
   public void should_fail_when_checking_if_date_has_same_time_as_other_date() {
     Date date = parseDatetime("2003-04-26T12:00:00");
-    thrown.expectAssertionError();
-    assertThat(date).hasSameTimeAs("2003-04-27T12:00:00");
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(date).hasSameTimeAs("2003-04-27T12:00:00"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.setLenientDateParsing;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.DateUtil.parseDatetime;
@@ -73,8 +74,7 @@ public class DateAssert_setLenientDateParsing_Test extends DateAssertBaseTest {
   @Test
   public void should_fail_if_given_date_string_representation_cant_be_parsed() {
     final String dateAsString = "2001/02/03";
-    thrown.expectAssertionError();
-    assertThat(new Date()).isEqualTo(dateAsString);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(new Date()).isEqualTo(dateAsString));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/fail/Fail_fail_withMessageAndCause_Test.java
+++ b/src/test/java/org/assertj/core/api/fail/Fail_fail_withMessageAndCause_Test.java
@@ -12,11 +12,9 @@
  */
 package org.assertj.core.api.fail;
 
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.assertj.core.api.Fail;
-import org.assertj.core.test.ExpectedException;
-import org.junit.Rule;
 import org.junit.Test;
 
 
@@ -28,14 +26,11 @@ import org.junit.Test;
  */
 public class Fail_fail_withMessageAndCause_Test {
 
-  @Rule
-  public ExpectedException thrown = none();
-
   @Test
   public void shouldThrowErrorWithGivenMessageAndCause() {
     String message = "Some Throwable";
     Throwable cause = new Throwable();
-    thrown.expectWithCause(AssertionError.class, message, cause);
-    Fail.fail(message, cause);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Fail.fail(message, cause))
+                                                   .withMessage(message).withCause(cause);
   }
 }

--- a/src/test/java/org/assertj/core/api/filter/AbstractTest_equals_filter.java
+++ b/src/test/java/org/assertj/core/api/filter/AbstractTest_equals_filter.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 import static org.assertj.core.api.filter.Filters.filter;
 import static org.assertj.core.test.ExpectedException.none;
@@ -20,6 +21,7 @@ import static org.assertj.core.test.ExpectedException.none;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
 import org.assertj.core.test.WithPlayerData;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +63,8 @@ public abstract class AbstractTest_equals_filter extends WithPlayerData {
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
-    filterIterable(players, "country", "France");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> filterIterable(players, "country", "France"))
+                                                       .withMessageContaining("Can't find any field or property with name 'country'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_on_different_properties_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_on_different_properties_Test.java
@@ -13,10 +13,12 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.filter.Filters.filter;
 
 import org.assertj.core.test.Player;
 import org.assertj.core.test.WithPlayerData;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class Filter_on_different_properties_Test extends WithPlayerData {
@@ -31,8 +33,11 @@ public class Filter_on_different_properties_Test extends WithPlayerData {
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_one_of_the_property_or_field_used_by_filter() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'numberOfTitle'");
-    filter(players).with("reboundsPerGame").equalsTo(5).and("numberOfTitle").notEqualsTo(0);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> filter(players).with("reboundsPerGame")
+                                                                                        .equalsTo(5)
+                                                                                        .and("numberOfTitle")
+                                                                                        .notEqualsTo(0))
+                                                       .withMessageContaining("Can't find any field or property with name 'numberOfTitle'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_in_given_values_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_in_given_values_Test.java
@@ -13,12 +13,14 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.filter.Filters.filter;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
 import org.assertj.core.test.WithPlayerData;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,8 +51,9 @@ public class Filter_with_property_in_given_values_Test extends WithPlayerData {
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_or_field_used_by_filter() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
-    filter(players).with("country").in("France", "Italy");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> filter(players).with("country").in("France",
+                                                                                                            "Italy"))
+                                                       .withMessageContaining("Can't find any field or property with name 'country'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_equals_to_given_value_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_equals_to_given_value_Test.java
@@ -13,12 +13,14 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.filter.Filters.filter;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
 import org.assertj.core.test.WithPlayerData;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,8 +51,9 @@ public class Filter_with_property_not_equals_to_given_value_Test extends WithPla
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
-    filter(players).with("country").notEqualsTo("France");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> filter(players).with("country")
+                                                                                        .notEqualsTo("France"))
+                                                       .withMessageContaining("Can't find any field or property with name 'country'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_in_given_values_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_with_property_not_in_given_values_Test.java
@@ -13,12 +13,14 @@
 package org.assertj.core.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.filter.Filters.filter;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Player;
 import org.assertj.core.test.WithPlayerData;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,8 +51,9 @@ public class Filter_with_property_not_in_given_values_Test extends WithPlayerDat
 
   @Test
   public void should_fail_if_elements_to_filter_do_not_have_property_used_by_filter() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'country'");
-    filter(players).with("country").in("France", "Italy");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> filter(players).with("country").in("France",
+                                                                                                            "Italy"))
+                                                       .withMessageContaining("Can't find any field or property with name 'country'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
@@ -46,6 +47,7 @@ import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -172,8 +174,7 @@ public class IterableAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_no_property_nor_field_with_given_name_can_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(jedis).extracting("unknown"));
   }
 
   @Test
@@ -184,9 +185,10 @@ public class IterableAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_one_property_or_field_can_not_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown", "age", "id")
-                     .containsOnly(tuple("Yoda", 800, 1L), tuple("Luke", 26, 2L));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      assertThat(jedis).extracting("unknown", "age", "id")
+                       .containsOnly(tuple("Yoda", 800, 1L), tuple("Luke", 26, 2L));
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -199,8 +199,7 @@ public class IterableAssert_extracting_Test {
 
   @Test
   public void should_allow_assertions_on_extractor_assertions_extracted_from_given_array_compatibility_runtimeexception() {
-    thrown.expect(RuntimeException.class);
-    assertThat(jedis).extracting(new Extractor<Employee, String>() {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(new Extractor<Employee, String>() {
       @Override
       public String extract(Employee input) {
         if (input.getAge() > 100) {
@@ -208,7 +207,7 @@ public class IterableAssert_extracting_Test {
         }
         return input.getName().getFirst();
       }
-    });
+    }));
   }
 
   @Test
@@ -218,20 +217,18 @@ public class IterableAssert_extracting_Test {
 
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
-    thrown.expect(RuntimeException.class, "java.lang.Exception: age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new Exception("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("java.lang.Exception: age > 100");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
-    thrown.expect(RuntimeException.class, "age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new RuntimeException("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("age > 100");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
@@ -199,8 +199,7 @@ public class IterableAssert_extracting_with_SortedSet_Test {
 
   @Test
   public void should_allow_assertions_on_extractor_assertions_extracted_from_given_array_compatibility_runtimeexception() {
-    thrown.expect(RuntimeException.class);
-    assertThat(jedis).extracting(new Extractor<Employee, String>() {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(new Extractor<Employee, String>() {
       @Override
       public String extract(Employee input) {
         if (input.getAge() > 100) {
@@ -208,7 +207,7 @@ public class IterableAssert_extracting_with_SortedSet_Test {
         }
         return input.getName().getFirst();
       }
-    });
+    }));
   }
 
   @Test
@@ -218,20 +217,18 @@ public class IterableAssert_extracting_with_SortedSet_Test {
 
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
-    thrown.expect(RuntimeException.class, "java.lang.Exception: age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new Exception("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("java.lang.Exception: age > 100");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
-    thrown.expect(RuntimeException.class, "age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new RuntimeException("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("age > 100");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.setRemoveAssertJRelatedElementsFromStackTrace;
@@ -48,6 +49,7 @@ import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -172,8 +174,7 @@ public class IterableAssert_extracting_with_SortedSet_Test {
 
   @Test
   public void should_throw_error_if_no_property_nor_field_with_given_name_can_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(jedis).extracting("unknown"));
   }
 
   @Test
@@ -184,9 +185,10 @@ public class IterableAssert_extracting_with_SortedSet_Test {
 
   @Test
   public void should_throw_error_if_one_property_or_field_can_not_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown", "age", "id")
-                     .containsOnly(tuple("Yoda", 800, 1L), tuple("Luke", 26, 2L));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      assertThat(jedis).extracting("unknown", "age", "id")
+                       .containsOnly(tuple("Yoda", 800, 1L), tuple("Luke", 26, 2L));
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOnNull_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOnNull_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.TolkienCharacter.Race.HOBBIT;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.assertj.core.test.AlwaysEqualComparator.alwaysEqual;
@@ -24,6 +25,7 @@ import org.assertj.core.data.TolkienCharacter;
 import org.assertj.core.data.TolkienCharacterAssert;
 import org.assertj.core.data.TolkienCharacterAssertFactory;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOnNull_Test extends IterableAssert_filtered_baseTest {
@@ -40,8 +42,8 @@ public class IterableAssert_filteredOnNull_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOnNull("secret");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOnNull("secret"))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
@@ -30,6 +31,7 @@ import org.assertj.core.data.TolkienCharacterAssert;
 import org.assertj.core.data.TolkienCharacterAssertFactory;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_baseTest {
@@ -65,10 +67,11 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", "New York").isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", "New York").isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -121,8 +121,9 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", "???");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          "???"))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -113,8 +113,7 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_given_expected_value_is_null() {
-    thrown.expectWithMessageContaining(IllegalArgumentException.class,
-                                       "The expected value should not be null.%n"
+    thrown.expectIllegalArgumentException("The expected value should not be null.%n"
                                                                        + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead");
     assertThat(employees).filteredOn("name", null);
   }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -128,8 +128,11 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_filter_operators_are_combined() {
-    thrown.expectWithMessageStartingWith(UnsupportedOperationException.class, "Combining operator is not supported");
-    assertThat(employees).filteredOn("age", not(in(800))).containsOnly(luke, noname);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> assertThat(employees).filteredOn("age",
+                                                                                                                     not(in(800)))
+                                                                                                         .containsOnly(luke,
+                                                                                                                       noname))
+                                                                  .withMessageStartingWith("Combining operator is not supported");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
@@ -13,12 +13,14 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
 import org.assertj.core.data.TolkienCharacter;
 import org.assertj.core.data.TolkienCharacterAssert;
 import org.assertj.core.data.TolkienCharacterAssertFactory;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_baseTest {
@@ -48,10 +50,11 @@ public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_b
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
@@ -96,8 +96,9 @@ public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_b
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", in("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          in("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   // these tests validate any FilterOperator with strongly typed navigation assertions

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.notIn;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtered_baseTest {
@@ -47,10 +49,11 @@ public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtere
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
@@ -96,8 +96,9 @@ public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtere
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", notIn("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          notIn("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
@@ -105,8 +105,9 @@ public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_on_of_the_iterable_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", not("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          not("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
@@ -22,6 +23,7 @@ import static org.assertj.core.test.Name.name;
 
 import org.assertj.core.api.IterableAssert;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_baseTest {
@@ -50,10 +52,11 @@ public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", not("New York"));
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", not("New York"));
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
@@ -103,21 +104,19 @@ public class IterableAssert_flatExtracting_Test {
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
     List<CartoonCharacter> childCharacters = newArrayList(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "java.lang.Exception: no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new Exception("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("java.lang.Exception: no children");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
     List<CartoonCharacter> childCharacters = newArrayList(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new RuntimeException("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("no children");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -96,8 +97,7 @@ public class IterableAssert_flatExtracting_Test {
 
   @Test
   public void should_throw_null_pointer_exception_when_extracting_from_null() {
-    thrown.expectNullPointerException();
-    assertThat(newArrayList(homer, null)).flatExtracting(children);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(newArrayList(homer, null)).flatExtracting(children));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
@@ -105,21 +106,19 @@ public class IterableAssert_flatExtracting_with_SortedSet_Test {
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
     SortedSet<CartoonCharacter> childCharacters = newSortedSet(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "java.lang.Exception: no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new Exception("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("java.lang.Exception: no children");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
     SortedSet<CartoonCharacter> childCharacters = newSortedSet(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new RuntimeException("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("no children");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -98,8 +99,7 @@ public class IterableAssert_flatExtracting_with_SortedSet_Test {
 
   @Test
   public void should_throw_null_pointer_exception_when_extracting_from_null() {
-    thrown.expectNullPointerException();
-    assertThat(newSortedSet(homer, null)).flatExtracting(children);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(newSortedSet(homer, null)).flatExtracting(children));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -81,8 +82,7 @@ public class IterableAssert_flatExtracting_with_String_parameter_Test {
 
   @Test
   public void should_throw_exception_when_extracting_from_null() {
-    thrown.expectIllegalArgumentException();
-    assertThat(newArrayList(homer, null)).flatExtracting("children");
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(newArrayList(homer, null)).flatExtracting("children"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.iterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -31,16 +33,11 @@ import java.util.List;
 
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.data.TolkienCharacter;
-import org.assertj.core.test.ExpectedException;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class IterableAssert_flatExtracting_with_multiple_extractors_Test {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private final List<TolkienCharacter> fellowshipOfTheRing = new ArrayList<>();
 
@@ -74,29 +71,25 @@ public class IterableAssert_flatExtracting_with_multiple_extractors_Test {
 
   @Test
   public void should_throw_IllegalArgumentException_when_no_fields_or_properties_are_specified() {
-    thrown.expectIllegalArgumentException();
-    assertThat(fellowshipOfTheRing).flatExtracting(new String[0]);
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(fellowshipOfTheRing).flatExtracting(new String[0]));
   }
 
   @Test
   public void should_throw_IllegalArgumentException_when_null_fields_or_properties_vararg() {
-    thrown.expectIllegalArgumentException();
     String[] fields = null;
-    assertThat(fellowshipOfTheRing).flatExtracting(fields);
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(fellowshipOfTheRing).flatExtracting(fields));
   }
 
   @Test
   public void should_throw_IllegalArgumentException_when_extracting_from_null() {
-    thrown.expectIllegalArgumentException();
     fellowshipOfTheRing.add(null);
-    assertThat(fellowshipOfTheRing).flatExtracting("age", "name");
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(fellowshipOfTheRing).flatExtracting("age", "name"));
   }
 
   @Test
   public void should_throw_IllegalArgumentException_when_extracting_from_null_extractors() {
-    thrown.expect(NullPointerException.class);
     fellowshipOfTheRing.add(null);
-    assertThat(fellowshipOfTheRing).flatExtracting(age, name);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(fellowshipOfTheRing).flatExtracting(age, name));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
@@ -134,11 +134,10 @@ public class ObjectArrayAssert_extracting_Test {
 
   @Test
   public void should_allow_assertions_on_extractor_assertions_extracted_from_given_array_compatibility_RuntimeException() {
-    thrown.expect(RuntimeException.class);
-    assertThat(jedis).extracting(input -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(input -> {
       if (input.getAge() > 100) throw new RuntimeException("age > 100");
       return input.getName().getFirst();
-    });
+    }));
   }
 
   @Test
@@ -148,20 +147,18 @@ public class ObjectArrayAssert_extracting_Test {
 
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
-    thrown.expect(RuntimeException.class, "java.lang.Exception: age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new Exception("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("java.lang.Exception: age > 100");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
-    thrown.expect(RuntimeException.class, "age > 100");
-    assertThat(jedis).extracting(employee -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(jedis).extracting(employee -> {
       if (employee.getAge() > 100) throw new RuntimeException("age > 100");
       return employee.getName().getFirst();
-    });
+    })).withMessage("age > 100");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.objectarray;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
@@ -45,6 +46,7 @@ import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,8 +110,7 @@ public class ObjectArrayAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_no_property_nor_field_with_given_name_can_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(jedis).extracting("unknown"));
   }
 
   @Test
@@ -120,9 +121,10 @@ public class ObjectArrayAssert_extracting_Test {
 
   @Test
   public void should_throw_error_if_one_property_or_field_can_not_be_extracted() {
-    thrown.expectIntrospectionError();
-    assertThat(jedis).extracting("unknown", "age", "id").containsOnly(tuple("Yoda", 800, 1L),
-                                                                      tuple("Luke", 26, 2L));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      assertThat(jedis).extracting("unknown", "age", "id").containsOnly(tuple("Yoda", 800, 1L),
+                                                                        tuple("Luke", 26, 2L));
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
@@ -96,7 +96,10 @@ public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtere
 
   @Test
   public void should_fail_if_filter_operators_are_combined() {
-    thrown.expectWithMessageStartingWith(UnsupportedOperationException.class, "Combining operator is not supported");
-    assertThat(employees).filteredOn("age", not(in(800))).containsOnly(luke, noname);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> assertThat(employees).filteredOn("age",
+                                                                                                                     not(in(800)))
+                                                                                                         .containsOnly(luke,
+                                                                                                                       noname))
+                                                                  .withMessageStartingWith("Combining operator is not supported");
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
@@ -89,8 +89,9 @@ public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtere
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", "???");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          "???"))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
@@ -13,10 +13,12 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtered_baseTest {
@@ -45,10 +47,11 @@ public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtere
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", "New York").isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", "New York").isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class ObjectArrayAssert_filteredOn_in_Test extends ObjectArrayAssert_filtered_baseTest {
@@ -46,9 +48,10 @@ public class ObjectArrayAssert_filteredOn_in_Test extends ObjectArrayAssert_filt
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
     setAllowExtractingPrivateFields(false);
-    thrown.expectIntrospectionError();
     try {
-      assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", in("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
@@ -82,8 +82,9 @@ public class ObjectArrayAssert_filteredOn_in_Test extends ObjectArrayAssert_filt
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", in("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          in("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
@@ -85,8 +85,9 @@ public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_f
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", notIn("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          notIn("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.notIn;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_filtered_baseTest {
@@ -47,10 +49,11 @@ public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_f
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", notIn("New York")).isEmpty();
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
@@ -88,7 +88,8 @@ public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_fil
 
   @Test
   public void should_fail_if_on_of_the_object_array_element_does_not_have_given_property_or_field() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'secret'");
-    assertThat(employees).filteredOn("secret", not("???"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> assertThat(employees).filteredOn("secret",
+                                                                                                          not("???")))
+                                                       .withMessageContaining("Can't find any field or property with name 'secret'");
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.setAllowExtractingPrivateFields;
 
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_filtered_baseTest {
@@ -44,10 +46,11 @@ public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_fil
 
   @Test
   public void should_fail_if_filter_is_on_private_field_and_reading_private_field_is_disabled() {
-    thrown.expectIntrospectionError();
     setAllowExtractingPrivateFields(false);
     try {
-      assertThat(employees).filteredOn("city", not("New York"));
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+        assertThat(employees).filteredOn("city", not("New York"));
+      });
     } finally {
       setAllowExtractingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -80,8 +81,7 @@ public class ObjectArrayAssert_flatExtracting_Test {
 
   @Test
   public void should_throw_null_pointer_exception_when_extracting_from_null() {
-    thrown.expectNullPointerException();
-    assertThat(array(homer, null)).flatExtracting(children);
+    assertThatNullPointerException().isThrownBy(() -> assertThat(array(homer, null)).flatExtracting(children));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
@@ -101,21 +102,19 @@ public class ObjectArrayAssert_flatExtracting_Test {
   @Test
   public void should_rethrow_throwing_extractor_checked_exception_as_a_runtime_exception() {
     CartoonCharacter[] childCharacters = array(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "java.lang.Exception: no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new Exception("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("java.lang.Exception: no children");
   }
 
   @Test
   public void should_let_throwing_extractor_runtime_exception_bubble_up() {
     CartoonCharacter[] childCharacters = array(bart, lisa, maggie);
-    thrown.expect(RuntimeException.class, "no children");
-    assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(childCharacters).flatExtracting(cartoonCharacter -> {
       if (cartoonCharacter.getChildren().isEmpty()) throw new RuntimeException("no children");
       return cartoonCharacter.getChildren();
-    });
+    })).withMessage("no children");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_with_String_parameter_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.objectarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithNamesOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorForElementFieldsWithTypeOf;
 import static org.assertj.core.api.GroupAssertTestHelper.comparatorsByTypeOf;
@@ -77,8 +78,7 @@ public class ObjectArrayAssert_flatExtracting_with_String_parameter_Test {
 
   @Test
   public void should_throw_illegal_argument_exception_when_extracting_from_null() {
-    thrown.expectIllegalArgumentException();
-    assertThat(array(homer, null)).flatExtracting("children");
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(array(homer, null)).flatExtracting("children"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_BigDecimal_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_BigDecimal_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -32,9 +33,10 @@ public class Offset_built_with_BigDecimal_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    BigDecimal value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      BigDecimal value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_BigInteger_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_BigInteger_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -32,9 +33,10 @@ public class Offset_built_with_BigInteger_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    BigInteger value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      BigInteger value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_Double_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_Double_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -35,9 +36,10 @@ public class Offset_built_with_Double_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Double value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Double value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_Float_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_Float_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -35,9 +36,10 @@ public class Offset_built_with_Float_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Float value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Float value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_Integer_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_Integer_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -35,9 +36,10 @@ public class Offset_built_with_Integer_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Integer value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Integer value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Offset_built_with_Long_Test.java
+++ b/src/test/java/org/assertj/core/data/Offset_built_with_Long_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.data.Offset.strictOffset;
 import static org.assertj.core.internal.ErrorMessages.offsetValueIsNotPositive;
@@ -30,9 +31,10 @@ public class Offset_built_with_Long_Test {
 
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Long value = null;
-    offset(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Long value = null;
+      offset(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Double_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Double_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.internal.ErrorMessages.percentageValueIsInRange;
 import static org.assertj.core.test.ExpectedException.none;
@@ -33,9 +34,10 @@ public class Percentage_withPercentage_with_Double_Test {
   @SuppressWarnings("null")
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Double value = null;
-    withPercentage(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Double value = null;
+      withPercentage(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Integer_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Integer_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.internal.ErrorMessages.percentageValueIsInRange;
 import static org.assertj.core.test.ExpectedException.none;
@@ -33,9 +34,10 @@ public class Percentage_withPercentage_with_Integer_Test {
   @SuppressWarnings("null")
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Integer value = null;
-    withPercentage(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Integer value = null;
+      withPercentage(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Long_Test.java
+++ b/src/test/java/org/assertj/core/data/Percentage_withPercentage_with_Long_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.internal.ErrorMessages.percentageValueIsInRange;
 import static org.assertj.core.test.ExpectedException.none;
@@ -33,9 +34,10 @@ public class Percentage_withPercentage_with_Long_Test {
   @SuppressWarnings("null")
   @Test
   public void should_throw_error_if_value_is_null() {
-    thrown.expectNullPointerException();
-    Long value = null;
-    withPercentage(value);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Long value = null;
+      withPercentage(value);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/error/MessageFormatter_format_Test.java
+++ b/src/test/java/org/assertj/core/error/MessageFormatter_format_Test.java
@@ -16,6 +16,7 @@ import static com.tngtech.junit.dataprovider.DataProviders.$;
 import static com.tngtech.junit.dataprovider.DataProviders.$$;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.mockito.Mockito.spy;
@@ -56,15 +57,15 @@ public class MessageFormatter_format_Test {
 
   @Test
   public void should_throw_error_if_format_string_is_null() {
-    thrown.expectNullPointerException();
-    messageFormatter.format(null, null, null);
+    assertThatNullPointerException().isThrownBy(() -> messageFormatter.format(null, null, null));
   }
 
   @Test
   public void should_throw_error_if_args_array_is_null() {
-    thrown.expectNullPointerException();
-    Object[] args = null;
-    messageFormatter.format(null, null, "", args);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Object[] args = null;
+      messageFormatter.format(null, null, "", args);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/error/ShouldBeSorted_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeSorted_create_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSorted;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.test.ExpectedException.none;
@@ -50,7 +51,6 @@ public class ShouldBeSorted_create_Test {
 
   @Test
   public void should_fail_if_object_parameter_is_not_an_array() {
-    thrown.expectIllegalArgumentException();
-    shouldBeSorted(1, "not an array");
+    assertThatIllegalArgumentException().isThrownBy(() -> shouldBeSorted(1, "not an array"));
   }
 }

--- a/src/test/java/org/assertj/core/extractor/ByNameMultipleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameMultipleExtractorTest.java
@@ -25,6 +25,7 @@ import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -53,9 +54,7 @@ public class ByNameMultipleExtractorTest {
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_one_of_given_names() {
-	thrown.expectIntrospectionError();
-
-	new ByNameMultipleExtractor<Employee>("id", "name.first", "unknown").extract(yoda);
+	assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameMultipleExtractor<Employee>("id", "name.first", "unknown").extract(yoda));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -14,6 +14,8 @@ package org.assertj.core.extractor;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.extractor.Extractors.byName;
 
 import java.util.HashMap;
@@ -23,6 +25,7 @@ import java.util.Map;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,9 +58,7 @@ public class ByNameSingleExtractorTest {
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_given_name() {
-	thrown.expectIntrospectionError();
-
-	new ByNameSingleExtractor<Employee>("unknown").extract(yoda);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameSingleExtractor<Employee>("unknown").extract(yoda));
   }
 
   @Test
@@ -90,17 +91,15 @@ public class ByNameSingleExtractorTest {
 
   @Test
   public void should_throw_exception_if_property_cannot_be_extracted_due_to_runtime_exception_during_property_access() {
-	thrown.expectIntrospectionError();
-
-	Employee employee = new BrokenEmployee();
-	adultExtractor().extract(employee);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      Employee employee = new BrokenEmployee();
+      adultExtractor().extract(employee);
+    });
   }
 
   @Test
   public void should_throw_exception_if_no_object_is_given() {
-	thrown.expectIllegalArgumentException();
-
-	idExtractor().extract(null);
+	assertThatIllegalArgumentException().isThrownBy(() -> idExtractor().extract(null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_Test.java
+++ b/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.extractor.Extractors.byName;
 import static org.assertj.core.groups.FieldsOrPropertiesExtractor.extract;
 import static org.assertj.core.test.ExpectedException.none;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,8 +93,7 @@ public class FieldsOrPropertiesExtractor_extract_Test {
   
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_given_name() {
-    thrown.expectIntrospectionError();
-    extract(employees, byName("unknown"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> extract(employees, byName("unknown")));
   }
   
   @Test
@@ -125,11 +126,10 @@ public class FieldsOrPropertiesExtractor_extract_Test {
 
   @Test
   public void should_throw_exception_if_property_cannot_be_extracted_due_to_runtime_exception_during_property_access() {
-    
-    thrown.expectIntrospectionError();
-    
-    List<Employee> employees = Arrays.<Employee>asList(new BrokenEmployee());
-    extract(employees, byName("adult"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      List<Employee> employees = Arrays.<Employee> asList(new BrokenEmployee());
+      extract(employees, byName("adult"));
+    });
   }
 
   public static class EmployeeWithBrokenName extends Employee {

--- a/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_tuples_Test.java
+++ b/src/test/java/org/assertj/core/groups/FieldsOrPropertiesExtractor_extract_tuples_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.extractor.Extractors.byName;
 import static org.assertj.core.groups.FieldsOrPropertiesExtractor.extract;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -26,6 +27,7 @@ import java.util.Set;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,8 +72,7 @@ public class FieldsOrPropertiesExtractor_extract_tuples_Test {
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_one_of_given_names() {
-    thrown.expectIntrospectionError();
-    extract(employees, byName("id", "age", "unknown"));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> extract(employees, byName("id", "age", "unknown")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/Arrays_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/Arrays_assertContains_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.emptyArray;
@@ -61,8 +62,7 @@ public class Arrays_assertContains_Test extends BaseArraysTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContains(someInfo(), failures, actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContains(someInfo(), failures, actual, emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class Arrays_assertContains_Test extends BaseArraysTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), failures, actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(), failures, actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/Arrays_containsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/Arrays_containsAnyOf_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -65,8 +66,7 @@ public class Arrays_containsAnyOf_Test extends BaseArraysTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsAnyOf(someInfo(), failures, actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsAnyOf(someInfo(), failures, actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_areEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_areEqual_Test.java
@@ -53,8 +53,8 @@ public class ComparatorBasedComparisonStrategy_areEqual_Test extends AbstractTes
 
   @Test
   public void should_fail_if_objects_are_not_mutually_comparable() {
-    thrown.expect(ClassCastException.class);
-    assertThat(caseInsensitiveComparisonStrategy.areEqual("Yoda", 5)).isFalse();
+    assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> assertThat(caseInsensitiveComparisonStrategy.areEqual("Yoda",
+                                                                                                                               5)).isFalse());
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_arrayContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_arrayContains_Test.java
@@ -49,8 +49,7 @@ public class ComparatorBasedComparisonStrategy_arrayContains_Test extends Abstra
 
   @Test
   public void should_fail_if_first_parameter_is_not_an_array() {
-    thrown.expectIllegalArgumentException();
-    caseInsensitiveComparisonStrategy.arrayContains("not an array", "Pippin");
+    assertThatIllegalArgumentException().isThrownBy(() -> caseInsensitiveComparisonStrategy.arrayContains("not an array", "Pippin"));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isGreaterThanOrEqualTo_Test.java
@@ -41,8 +41,8 @@ public class ComparatorBasedComparisonStrategy_isGreaterThanOrEqualTo_Test exten
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(ClassCastException.class);
-    caseInsensitiveComparisonStrategy.isGreaterThanOrEqualTo(new Rectangle(), new Rectangle());
+    assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> caseInsensitiveComparisonStrategy.isGreaterThanOrEqualTo(new Rectangle(),
+                                                                                                                                  new Rectangle()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isGreaterThan_Test.java
@@ -52,8 +52,8 @@ public class ComparatorBasedComparisonStrategy_isGreaterThan_Test extends Abstra
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(ClassCastException.class);
-    caseInsensitiveComparisonStrategy.isGreaterThan(new Rectangle(), new Rectangle());
+    assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> caseInsensitiveComparisonStrategy.isGreaterThan(new Rectangle(),
+                                                                                                                         new Rectangle()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isLessThanOrEqualTo_Test.java
@@ -41,8 +41,8 @@ public class ComparatorBasedComparisonStrategy_isLessThanOrEqualTo_Test extends 
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(ClassCastException.class);
-    caseInsensitiveComparisonStrategy.isLessThanOrEqualTo(new Rectangle(), new Rectangle());
+    assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> caseInsensitiveComparisonStrategy.isLessThanOrEqualTo(new Rectangle(),
+                                                                                                                               new Rectangle()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy_isLessThan_Test.java
@@ -41,8 +41,8 @@ public class ComparatorBasedComparisonStrategy_isLessThan_Test extends AbstractT
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(ClassCastException.class);
-    caseInsensitiveComparisonStrategy.isLessThan(new Rectangle(), new Rectangle());
+    assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> caseInsensitiveComparisonStrategy.isLessThan(new Rectangle(),
+                                                                                                                      new Rectangle()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_arrayContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_arrayContains_Test.java
@@ -49,8 +49,7 @@ public class StandardComparisonStrategy_arrayContains_Test extends AbstractTest_
 
   @Test
   public void should_fail_if_first_parameter_is_not_an_array() {
-    thrown.expectIllegalArgumentException();
-    standardComparisonStrategy.arrayContains("not an array", "Pippin");
+    assertThatIllegalArgumentException().isThrownBy(() -> standardComparisonStrategy.arrayContains("not an array", "Pippin"));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThanOrEqualTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.awt.Rectangle;
 
@@ -37,10 +38,11 @@ public class StandardComparisonStrategy_isGreaterThanOrEqualTo_Test extends Abst
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expectIllegalArgumentException();
-    Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isGreaterThanOrEqualTo(r1, r2);
+    assertThatIllegalArgumentException().isThrownBy(() -> {
+      Rectangle r1 = new Rectangle(10, 20);
+      Rectangle r2 = new Rectangle(20, 10);
+      standardComparisonStrategy.isGreaterThanOrEqualTo(r1, r2);
+    });
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThan_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -47,7 +48,6 @@ public class StandardComparisonStrategy_isGreaterThan_Test extends AbstractTest_
 
   @Test
   public void should_fail_if_first_parameter_is_not_comparable() {
-    thrown.expectIllegalArgumentException();
-    standardComparisonStrategy.isGreaterThan(new Rectangle(), "foo");
+    assertThatIllegalArgumentException().isThrownBy(() -> standardComparisonStrategy.isGreaterThan(new Rectangle(), "foo"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThanOrEqualTo_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.awt.Rectangle;
 
@@ -37,10 +38,11 @@ public class StandardComparisonStrategy_isLessThanOrEqualTo_Test extends Abstrac
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expectIllegalArgumentException();
-    Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isLessThanOrEqualTo(r1, r2);
+    assertThatIllegalArgumentException().isThrownBy(() -> {
+      Rectangle r1 = new Rectangle(10, 20);
+      Rectangle r2 = new Rectangle(20, 10);
+      standardComparisonStrategy.isLessThanOrEqualTo(r1, r2);
+    });
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThan_Test.java
@@ -38,10 +38,11 @@ public class StandardComparisonStrategy_isLessThan_Test extends AbstractTest_Sta
 
   @Test
   public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expectIllegalArgumentException();
-    Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isLessThan(r1, r2);
+    assertThatIllegalArgumentException().isThrownBy(() -> {
+      Rectangle r1 = new Rectangle(10, 20);
+      Rectangle r2 = new Rectangle(20, 10);
+      standardComparisonStrategy.isLessThan(r1, r2);
+    });
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.BooleanArrays.*;
@@ -48,14 +49,12 @@ public class BooleanArrays_assertContainsExactlyInAnyOrder_Test extends BooleanA
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(true));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(true)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseT
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(true));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(true)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
@@ -72,8 +73,7 @@ public class BooleanArrays_assertContainsOnlyOnce_Test extends BooleanArraysBase
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
@@ -65,8 +66,7 @@ public class BooleanArrays_assertContainsOnly_Test extends BooleanArraysBaseTest
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.BooleanArrays.*;
@@ -64,8 +65,7 @@ public class BooleanArrays_assertContainsSequence_Test extends BooleanArraysBase
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
@@ -59,8 +61,10 @@ public class BooleanArrays_assertContains_at_Index_Test extends BooleanArraysBas
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <1> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, true, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, true,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <1> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class BooleanArrays_assertIsSortedAccordingToComparator_Test extends Bool
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
@@ -48,8 +49,7 @@ public class BooleanArrays_assertStartsWith_Test extends BooleanArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -48,14 +49,12 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -147,8 +146,7 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test.java
@@ -17,6 +17,7 @@ import org.assertj.core.internal.*;
 import org.assertj.core.test.IntArrays;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -49,14 +50,12 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_T
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -143,8 +142,7 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_T
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -59,14 +60,12 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, IntArrays.arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, IntArrays.arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
@@ -72,8 +73,7 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -136,8 +136,7 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
@@ -70,8 +71,7 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -132,8 +132,7 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
@@ -65,8 +66,7 @@ public class ByteArrays_assertContainsOnly_Test extends ByteArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -118,8 +118,7 @@ public class ByteArrays_assertContainsOnly_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
@@ -63,8 +64,7 @@ public class ByteArrays_assertContainsOnly_with_Integer_Arguments_Test extends B
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -115,8 +115,7 @@ public class ByteArrays_assertContainsOnly_with_Integer_Arguments_Test extends B
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -61,8 +62,7 @@ public class ByteArrays_assertContainsSequence_Test extends ByteArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -128,8 +128,7 @@ public class ByteArrays_assertContainsSequence_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -59,8 +60,7 @@ public class ByteArrays_assertContainsSequence_with_Integer_Arguments_Test exten
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -123,8 +123,7 @@ public class ByteArrays_assertContainsSequence_with_Integer_Arguments_Test exten
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
@@ -57,8 +59,10 @@ public class ByteArrays_assertContains_at_Index_Test extends ByteArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, (byte) 8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, (byte) 8,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -101,8 +105,11 @@ public class ByteArrays_assertContains_at_Index_Test extends ByteArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, (byte) -8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  (byte) -8,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_with_Integer_Argument_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_with_Integer_Argument_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
@@ -54,8 +56,10 @@ public class ByteArrays_assertContains_at_Index_with_Integer_Argument_Test exten
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 8,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -97,8 +101,11 @@ public class ByteArrays_assertContains_at_Index_with_Integer_Argument_Test exten
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, -8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  -8,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
@@ -65,8 +66,7 @@ public class ByteArrays_assertContains_with_Integer_Arguments_Test extends ByteA
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContains(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContains(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class ByteArrays_assertContains_with_Integer_Arguments_Test extends ByteA
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class ByteArrays_assertIsSortedAccordingToComparator_Test extends ByteArr
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -55,8 +56,7 @@ public class ByteArrays_assertStartsWith_Test extends ByteArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class ByteArrays_assertStartsWith_Test extends ByteArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_with_Integer_Arguments_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
@@ -53,8 +54,7 @@ public class ByteArrays_assertStartsWith_with_Integer_Arguments_Test extends Byt
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test
@@ -117,8 +117,7 @@ public class ByteArrays_assertStartsWith_with_Integer_Arguments_Test extends Byt
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, IntArrays.emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, IntArrays.emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.CharArrays.*;
@@ -48,14 +49,12 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf('a', 'b'));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf('a', 'b')));
   }
 
   @Test
   public void should_fail_if_expected_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -147,8 +146,7 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
 
   @Test
   public void should_fail_if_expected_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf('a', 'b'));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf('a', 'b')));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
@@ -72,8 +73,7 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -137,8 +137,7 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
@@ -65,8 +66,7 @@ public class CharArrays_assertContainsOnly_Test extends CharArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -117,8 +117,7 @@ public class CharArrays_assertContainsOnly_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.CharArrays.*;
@@ -61,8 +62,7 @@ public class CharArrays_assertContainsSequence_Test extends CharArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -128,8 +128,7 @@ public class CharArrays_assertContainsSequence_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.CharArrays.emptyArray;
@@ -57,8 +59,10 @@ public class CharArrays_assertContains_at_Index_Test extends CharArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 'a', atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 'a',
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -99,8 +103,11 @@ public class CharArrays_assertContains_at_Index_Test extends CharArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, 'A', atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  'A',
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class CharArrays_assertIsSortedAccordingToComparator_Test extends CharArr
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.CharArrays.*;
@@ -55,8 +56,7 @@ public class CharArrays_assertStartsWith_Test extends CharArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class CharArrays_assertStartsWith_Test extends CharArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.DoubleArrays.*;
@@ -46,14 +47,12 @@ public class DoubleArrays_assertContainsExactlyInAnyOrder_Test extends DoubleArr
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6d, 8d));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6d, 8d)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -118,8 +117,7 @@ public class DoubleArrays_assertContainsExactlyInAnyOrder_Test extends DoubleArr
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -56,14 +57,12 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6d, 8d));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6d, 8d)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -111,8 +110,7 @@ public class DoubleArrays_assertContainsExactly_Test extends DoubleArraysBaseTes
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
@@ -64,8 +65,7 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -113,8 +113,7 @@ public class DoubleArrays_assertContainsOnlyOnce_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
@@ -63,8 +64,7 @@ public class DoubleArrays_assertContainsOnly_Test extends DoubleArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -109,8 +109,7 @@ public class DoubleArrays_assertContainsOnly_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
@@ -58,8 +59,7 @@ public class DoubleArrays_assertContainsSequence_Test extends DoubleArraysBaseTe
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -107,8 +107,7 @@ public class DoubleArrays_assertContainsSequence_Test extends DoubleArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
@@ -55,8 +57,10 @@ public class DoubleArrays_assertContains_at_Index_Test extends DoubleArraysBaseT
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 8d, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 8d,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -92,8 +96,11 @@ public class DoubleArrays_assertContains_at_Index_Test extends DoubleArraysBaseT
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, -8d, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  -8d,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.DoubleArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -65,8 +66,7 @@ public class DoubleArrays_assertIsSortedAccordingToComparator_Test extends Doubl
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.doublearrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.DoubleArrays.arrayOf;
@@ -52,8 +53,7 @@ public class DoubleArrays_assertStartsWith_Test extends DoubleArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -101,8 +101,7 @@ public class DoubleArrays_assertStartsWith_Test extends DoubleArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
@@ -105,8 +106,7 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NaN_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseToPercentage(someInfo(), NaN, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), NaN, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -116,8 +116,7 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -127,8 +126,7 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -138,13 +136,11 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
@@ -128,32 +129,27 @@ public class Doubles_assertIsCloseTo_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NaN_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseTo(someInfo(), NaN, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), NaN, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, within(ONE)));
   }
 
   // with comparison stratgey

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
@@ -113,20 +114,17 @@ public class Doubles_assertIsNotCloseToPercentage_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_and_expected_are_NaN() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseToPercentage(someInfo(), NaN, NaN, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), NaN, NaN, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseToPercentage(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseToPercentage(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseToPercentage(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
@@ -139,20 +140,17 @@ public class Doubles_assertIsNotCloseTo_Test extends DoublesBaseTest {
 
   @Test
   public void should_fail_if_actual_and_expected_are_NaN() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseTo(someInfo(), NaN, NaN, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseTo(someInfo(), NaN, NaN, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseTo(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseTo(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    doubles.assertIsNotCloseTo(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsNotCloseTo(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, within(ONE)));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.test.TestData.someInfo;
@@ -86,9 +87,10 @@ public class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(binaryDiff.diff(actual, expected)).thenThrow(cause);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    files.assertHasBinaryContent(someInfo(), actual, expected);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertHasBinaryContent(someInfo(),
+                                                                                                        actual,
+                                                                                                        expected))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.assertj.core.test.TestData.someInfo;
@@ -92,9 +93,9 @@ public class Files_assertHasContent_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(diff.diff(actual, expected, charset)).thenThrow(cause);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    files.assertHasContent(someInfo(), actual, expected, charset);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertHasContent(someInfo(), actual,
+                                                                                                  expected, charset))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -95,24 +96,22 @@ public class Files_assertHasParent_Test extends FilesBaseTest {
 
   @Test
   public void should_throw_exception_when_canonical_form_representation_fail() throws Exception {
-    thrown.expect(UncheckedIOException.class);
-
     File actual = mock(File.class);
     File expectedParent = mock(File.class);
 
     when(actual.getParentFile()).thenReturn(expectedParent);
     when(expectedParent.getCanonicalFile()).thenThrow(new IOException());
 
-    files.assertHasParent(someInfo(), actual, expectedParent);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertHasParent(someInfo(), actual,
+                                                                                                 expectedParent));
   }
 
   @Test
   public void should_throw_exception_when_canonical_form_representation_fail_for_expected_parent() throws Exception {
-    thrown.expect(UncheckedIOException.class);
-
     File expectedParent = mock(File.class);
     when(expectedParent.getCanonicalFile()).thenThrow(new IOException());
 
-    files.assertHasParent(someInfo(), actual, expectedParent);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertHasParent(someInfo(), actual,
+                                                                                                 expectedParent));
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -12,8 +12,10 @@
  */
 package org.assertj.core.internal.files;
 
+import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.Files.readAllBytes;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
@@ -133,14 +135,16 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   public void should_fail_if_files_are_not_binary_identical() throws IOException {
-    thrown.expectWithMessageEndingWith(AssertionError.class,
-                                       "does not have expected binary content at offset <0>, expecting:%n" +
-                                       " <\"EOF\">%n" +
-                                       "but was:%n" +
-                                       " <\"0x0\">");
-    unMockedFiles.assertSameContentAs(someInfo(),
-                                      createFileWithNonUTF8Character(), StandardCharsets.UTF_8,
-                                      expected, StandardCharsets.UTF_8);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> unMockedFiles.assertSameContentAs(someInfo(),
+                                                                                                       createFileWithNonUTF8Character(),
+                                                                                                       StandardCharsets.UTF_8,
+                                                                                                       expected,
+                                                                                                       StandardCharsets.UTF_8))
+                                                   .withMessageEndingWith(format("does not have expected binary content at offset <0>, expecting:%n"
+                                                                                 +
+                                                                                 " <\"EOF\">%n" +
+                                                                                 "but was:%n" +
+                                                                                 " <\"0x0\">"));
   }
 
   private File createFileWithNonUTF8Character() throws IOException {

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -127,10 +127,12 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   public void should_throw_an_error_if_files_cant_be_compared_with_the_given_charsets_even_if_binary_identical() throws IOException {
-    thrown.expectWithMessageStartingWith(UncheckedIOException.class, "Unable to compare contents of files");
-    unMockedFiles.assertSameContentAs(someInfo(),
-                                      createFileWithNonUTF8Character(), StandardCharsets.UTF_8,
-                                      createFileWithNonUTF8Character(), StandardCharsets.UTF_8);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> unMockedFiles.assertSameContentAs(someInfo(),
+                                                                                                             createFileWithNonUTF8Character(),
+                                                                                                             StandardCharsets.UTF_8,
+                                                                                                             createFileWithNonUTF8Character(),
+                                                                                                             StandardCharsets.UTF_8))
+                                                         .withMessageStartingWith("Unable to compare contents of files");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -105,9 +105,11 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenThrow(cause);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    files.assertSameContentAs(someInfo(), actual, defaultCharset(), expected, defaultCharset());
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertSameContentAs(someInfo(), actual,
+                                                                                                     defaultCharset(),
+                                                                                                     expected,
+                                                                                                     defaultCharset()))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.FloatArrays.*;
@@ -48,14 +49,12 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6f, 8f));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6f, 8f)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -147,8 +146,7 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6f, 8f));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6f, 8f)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
@@ -72,8 +73,7 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -138,8 +138,7 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
@@ -64,8 +65,7 @@ public class FloatArrays_assertContainsOnly_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -116,8 +116,7 @@ public class FloatArrays_assertContainsOnly_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.FloatArrays.*;
@@ -59,8 +60,7 @@ public class FloatArrays_assertContainsSequence_Test extends FloatArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -126,8 +126,7 @@ public class FloatArrays_assertContainsSequence_Test extends FloatArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.FloatArrays.emptyArray;
@@ -55,8 +57,10 @@ public class FloatArrays_assertContains_at_Index_Test extends FloatArraysBaseTes
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 8f, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 8f,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -98,8 +102,11 @@ public class FloatArrays_assertContains_at_Index_Test extends FloatArraysBaseTes
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, -8f, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  -8f,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -66,8 +67,7 @@ public class FloatArrays_assertIsSortedAccordingToComparator_Test extends FloatA
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.FloatArrays.*;
@@ -53,8 +54,7 @@ public class FloatArrays_assertStartsWith_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -120,8 +120,7 @@ public class FloatArrays_assertStartsWith_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
@@ -104,8 +105,7 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NaN_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseToPercentage(someInfo(), NaN, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), NaN, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -115,8 +115,7 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -126,8 +125,7 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, ONE, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, ONE, withPercentage(ONE)));
   }
 
   @Test
@@ -137,13 +135,11 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseToPercentage(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
@@ -128,32 +129,27 @@ public class Floats_assertIsCloseTo_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_NaN_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseTo(someInfo(), NaN, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseTo(someInfo(), NaN, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_not() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, ONE, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, ONE, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_POSITIVE_INFINITY_and_expected_is_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseTo(someInfo(), POSITIVE_INFINITY, NEGATIVE_INFINITY, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_is_NEGATIVE_INFINITY_and_expected_is_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsCloseTo(someInfo(), NEGATIVE_INFINITY, POSITIVE_INFINITY, within(ONE)));
   }
 
   // with comparison stratgey

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.withinPercentage;
@@ -111,20 +112,17 @@ public class Floats_assertIsNotCloseToPercentage_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_and_expected_are_NaN() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseToPercentage(someInfo(), NaN, NaN, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), NaN, NaN, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseToPercentage(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseToPercentage(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseToPercentage(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, withPercentage(ONE)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
@@ -16,6 +16,7 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.Assertions.within;
@@ -139,19 +140,16 @@ public class Floats_assertIsNotCloseTo_Test extends FloatsBaseTest {
 
   @Test
   public void should_fail_if_actual_and_expected_are_NaN() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseTo(someInfo(), NaN, NaN, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseTo(someInfo(), NaN, NaN, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_POSITIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseTo(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseTo(someInfo(), POSITIVE_INFINITY, POSITIVE_INFINITY, within(ONE)));
   }
 
   @Test
   public void should_fail_if_actual_and_expected_are_NEGATIVE_INFINITY() {
-    thrown.expectAssertionError();
-    floats.assertIsNotCloseTo(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, within(ONE));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsNotCloseTo(someInfo(), NEGATIVE_INFINITY, NEGATIVE_INFINITY, within(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.inputstreams;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -64,9 +65,10 @@ public class InputStreams_assertSameContentAs_Test extends InputStreamsBaseTest 
     IOException cause = new IOException();
     when(diff.diff(actual, expected)).thenThrow(cause);
 
-    thrown.expectWithCause(InputStreamsException.class, cause);
-
-    inputStreams.assertSameContentAs(someInfo(), actual, expected);
+    assertThatExceptionOfType(InputStreamsException.class).isThrownBy(() -> inputStreams.assertSameContentAs(someInfo(),
+                                                                                                             actual,
+                                                                                                             expected))
+                                                          .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.IntArrays.*;
@@ -54,14 +55,12 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -153,8 +152,7 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -64,14 +65,12 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -138,8 +137,7 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
@@ -72,8 +73,7 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -136,8 +136,7 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
@@ -65,8 +66,7 @@ public class IntArrays_assertContainsOnly_Test extends IntArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -117,8 +117,7 @@ public class IntArrays_assertContainsOnly_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.IntArrays.*;
@@ -61,8 +62,7 @@ public class IntArrays_assertContainsSequence_Test extends IntArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -128,8 +128,7 @@ public class IntArrays_assertContainsSequence_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.IntArrays.emptyArray;
@@ -57,8 +59,10 @@ public class IntArrays_assertContains_at_Index_Test extends IntArraysBaseTest {
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 8,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -99,8 +103,11 @@ public class IntArrays_assertContains_at_Index_Test extends IntArraysBaseTest {
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, -8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  -8,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class IntArrays_assertIsSortedAccordingToComparator_Test extends IntArray
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.IntArrays.*;
@@ -55,8 +56,7 @@ public class IntArrays_assertStartsWith_Test extends IntArraysBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -126,8 +126,7 @@ public class IntArrays_assertStartsWith_Test extends IntArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.Name.name;
@@ -84,8 +85,7 @@ public class Iterables_assertContainsAnyOf_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsAnyOf(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsAnyOf(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactlyInAnyOrder_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -56,8 +57,7 @@ public class Iterables_assertContainsExactlyInAnyOrder_Test extends IterablesBas
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -59,8 +60,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -106,8 +107,7 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -74,8 +75,7 @@ public class Iterables_assertContainsOnly_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -61,8 +62,7 @@ public class Iterables_assertContainsSequence_Test extends IterablesBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -59,8 +60,7 @@ public class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest 
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContainsSubsequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsSubsequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -72,8 +73,7 @@ public class Iterables_assertContains_Test extends IterablesBaseTest {
   
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertContains(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContains(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWithFirstAndRest_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWithFirstAndRest_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -40,8 +41,7 @@ public class Iterables_assertEndsWithFirstAndRest_Test extends IterablesBaseTest
 
   @Test
   public void should_throw_error_if_sequence_is_null() {
-    thrown.expectNullPointerException();
-    iterables.assertEndsWith(someInfo(), actual, "Luke", null);
+    assertThatNullPointerException().isThrownBy(() -> iterables.assertEndsWith(someInfo(), actual, "Luke", null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -60,8 +61,7 @@ public class Iterables_assertStartsWith_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_sequence_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    iterables.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/List_assertIs_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/List_assertIs_Test.java
@@ -12,8 +12,9 @@
  */
 package org.assertj.core.internal.lists;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
-
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldBeAtIndex.shouldBeAtIndex;
 import static org.assertj.core.test.TestData.someIndex;
@@ -72,8 +73,9 @@ public class List_assertIs_Test extends ListsBaseTest {
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    lists.assertIs(someInfo(), actual, condition, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> lists.assertIs(someInfo(), actual,
+                                                                                               condition, atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertContains_Test.java
@@ -12,8 +12,9 @@
  */
 package org.assertj.core.internal.lists;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
-
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.TestData.*;
@@ -63,8 +64,10 @@ public class Lists_assertContains_Test extends ListsBaseTest {
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    lists.assertContains(someInfo(), actual, "Yoda", atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> lists.assertContains(someInfo(), actual,
+                                                                                                     "Yoda",
+                                                                                                     atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertHas_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertHas_Test.java
@@ -12,8 +12,9 @@
  */
 package org.assertj.core.internal.lists;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
-
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldHaveAtIndex.shouldHaveAtIndex;
 import static org.assertj.core.test.TestData.someIndex;
@@ -74,8 +75,9 @@ public class Lists_assertHas_Test extends ListsBaseTest {
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    lists.assertHas(someInfo(), actual, condition, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> lists.assertHas(someInfo(), actual,
+                                                                                                condition, atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.lists;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -71,8 +72,7 @@ public class Lists_assertIsSortedAccordingToComparator_Test extends ListsBaseTes
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    lists.assertIsSortedAccordingToComparator(someInfo(), newArrayList(), null);
+    assertThatNullPointerException().isThrownBy(() -> lists.assertIsSortedAccordingToComparator(someInfo(), newArrayList(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_satisfies_at_index_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_satisfies_at_index_Test.java
@@ -12,7 +12,9 @@
  */
 package org.assertj.core.internal.lists;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.TestData.someInfo;
@@ -52,8 +54,10 @@ public class Lists_satisfies_at_index_Test extends ListsBaseTest {
 
   @Test
   public void should_fail_if_index_is_out_of_bound() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <3>");
-    lists.satisfies(info, jedis, shouldBeLuke, atIndex(3));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> lists.satisfies(info, jedis,
+                                                                                                shouldBeLuke,
+                                                                                                atIndex(3)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <3>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.LongArrays.*;
@@ -48,14 +49,12 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6L, 8L));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6L, 8L)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -146,8 +145,7 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6L, 8L));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6L, 8L)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
@@ -72,8 +73,7 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -136,8 +136,7 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
@@ -65,8 +66,7 @@ public class LongArrays_assertContainsOnly_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -117,8 +117,7 @@ public class LongArrays_assertContainsOnly_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.LongArrays.*;
@@ -61,8 +62,7 @@ public class LongArrays_assertContainsSequence_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +132,7 @@ public class LongArrays_assertContainsSequence_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.LongArrays.emptyArray;
@@ -59,8 +61,10 @@ public class LongArrays_assertContains_at_Index_Test extends LongArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, 8L, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, 8L,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -102,8 +106,11 @@ public class LongArrays_assertContains_at_Index_Test extends LongArraysBaseTest 
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, -8L, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  -8L,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class LongArrays_assertIsSortedAccordingToComparator_Test extends LongArr
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.LongArrays.*;
@@ -55,8 +56,7 @@ public class LongArrays_assertStartsWith_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class LongArrays_assertStartsWith_Test extends LongArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsAnyOf_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
@@ -56,8 +57,7 @@ public class Maps_assertContainsAnyOf_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   @Test
   public void should_throw_error_if_array_of_entries_to_look_for_is_empty_and_the_map_under_test_is_not() {
-    thrown.expectAssertionError();
-    maps.assertContainsAnyOf(someInfo(), actual, new MapEntry[0]);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> maps.assertContainsAnyOf(someInfo(), actual, new MapEntry[0]));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
@@ -66,8 +67,7 @@ public class Maps_assertContains_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   @Test
   public void should_throw_error_if_array_of_entries_to_look_for_is_empty() {
-    thrown.expectAssertionError();
-    maps.assertContains(someInfo(), actual, new MapEntry[0]);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> maps.assertContains(someInfo(), actual, new MapEntry[0]));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.TestData.*;
@@ -50,14 +51,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, array());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, array()));
   }
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, array("Luke", "Yoda"));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, array("Luke", "Yoda")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -60,14 +61,12 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, array());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, array()));
   }
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, array("Luke", "Yoda"));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, array("Luke", "Yoda")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -82,8 +83,7 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -147,8 +147,7 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -65,8 +66,7 @@ public class ObjectArrays_assertContainsOnly_Test extends ObjectArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -119,8 +119,7 @@ public class ObjectArrays_assertContainsOnly_Test extends ObjectArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -79,8 +80,7 @@ public class ObjectArrays_assertContainsSequence_Test extends ObjectArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -140,8 +140,7 @@ public class ObjectArrays_assertContainsSequence_Test extends ObjectArraysBaseTe
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -75,8 +76,7 @@ public class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBas
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSubsequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSubsequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -136,8 +136,7 @@ public class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBas
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSubsequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -63,8 +65,10 @@ public class ObjectArrays_assertContains_at_Index_Test extends ObjectArraysBaseT
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, "Yoda", atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, "Yoda",
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -93,8 +97,11 @@ public class ObjectArrays_assertContains_at_Index_Test extends ObjectArraysBaseT
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, "YodA", atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  "YodA",
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
@@ -17,6 +17,7 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldNotContainSequence.shouldNotContainSequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -99,8 +100,7 @@ public class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArrays
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertDoesNotContainSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertDoesNotContainSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -133,8 +133,7 @@ public class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArrays
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
@@ -17,6 +17,7 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldNotContainSubsequence.shouldNotContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -89,8 +90,7 @@ public class ObjectArrays_assertDoesNotContainSubsequence_Test extends ObjectArr
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertDoesNotContainSubsequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertDoesNotContainSubsequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -125,8 +125,7 @@ public class ObjectArrays_assertDoesNotContainSubsequence_Test extends ObjectArr
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertDoesNotContainSubsequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainSubsequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWithFirstAndRest_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWithFirstAndRest_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -37,8 +38,7 @@ public class ObjectArrays_assertEndsWithFirstAndRest_Test extends ObjectArraysBa
 
   @Test
   public void should_throw_error_if_sequence_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertEndsWith(someInfo(), actual, "Luke", null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertEndsWith(someInfo(), actual, "Luke", null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasAtLeastOneElementOfType_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasAtLeastOneElementOfType_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldHaveAtLeastOneElementOfType.shouldHaveAtLeastOneElementOfType;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -38,8 +39,7 @@ public class ObjectArrays_assertHasAtLeastOneElementOfType_Test extends ObjectAr
 
   @Test
   public void should_throw_exception_if_expected_type_is_null() {
-	thrown.expectNullPointerException();
-	arrays.assertHasAtLeastOneElementOfType(someInfo(), array, null);
+	assertThatNullPointerException().isThrownBy(() -> arrays.assertHasAtLeastOneElementOfType(someInfo(), array, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfType_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfType_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldHaveOnlyElementsOfType.shouldHaveOnlyElementsOfType;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -40,8 +41,7 @@ public class ObjectArrays_assertHasOnlyElementsOfType_Test extends ObjectArraysB
 
   @Test
   public void should_throw_exception_if_expected_type_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertHasOnlyElementsOfType(someInfo(), array, null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertHasOnlyElementsOfType(someInfo(), array, null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfTypes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldOnlyHaveElementsOfTypes.shouldOnlyHaveElementsOfTypes;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -44,9 +45,10 @@ public class ObjectArrays_assertHasOnlyElementsOfTypes_Test extends ObjectArrays
 
   @Test
   public void should_throw_exception_if_no_expected_types_are_given() {
-    thrown.expectNullPointerException();
-    Class<?>[] types = null;
-    arrays.assertHasOnlyElementsOfTypes(someInfo(), ARRAY, types);
+    assertThatNullPointerException().isThrownBy(() -> {
+      Class<?>[] types = null;
+      arrays.assertHasOnlyElementsOfTypes(someInfo(), ARRAY, types);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasOnlyElementsOfTypes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldOnlyHaveElementsOfTypes.shouldOnlyHaveElementsOfTypes;
 import static org.assertj.core.test.TestData.someInfo;
@@ -59,9 +60,10 @@ public class ObjectArrays_assertHasOnlyElementsOfTypes_Test extends ObjectArrays
 
   @Test
   public void should_fail_if_expected_types_are_empty_but_actual_is_not() {
-    thrown.expectAssertionError();
-    Class<?>[] types = new Class<?>[0];
-    arrays.assertHasOnlyElementsOfTypes(someInfo(), ARRAY, types);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      Class<?>[] types = new Class<?>[0];
+      arrays.assertHasOnlyElementsOfTypes(someInfo(), ARRAY, types);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -69,8 +70,7 @@ public class ObjectArrays_assertIsSortedAccordingToComparator_Test extends Objec
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), array(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), array(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
@@ -56,8 +57,7 @@ public class ObjectArrays_assertStartsWith_Test extends ObjectArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -123,8 +123,7 @@ public class ObjectArrays_assertStartsWith_Test extends ObjectArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objects;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeEqualByComparingOnlyGivenFields.shouldBeEqualComparingOnlyGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
@@ -162,15 +163,16 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
 
   @Test
   public void should_fail_when_selected_field_does_not_exist() {
-    thrown.expect(IntrospectionError.class, "%nCan't find any field or property with name 'age'.%n" +
-                                            "Error when introspecting properties was :%n" +
-                                            "- No getter for property 'age' in org.assertj.core.test.Jedi %n" +
-                                            "Error when introspecting fields was :%n" +
-                                            "- Unable to obtain the value of the field <'age'> from <Yoda the Jedi>");
-    Jedi actual = new Jedi("Yoda", "Green");
-    Jedi other = new Jedi("Yoda", "Blue");
-    objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
-                                                    defaultTypeComparators(), "age");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      Jedi actual = new Jedi("Yoda", "Green");
+      Jedi other = new Jedi("Yoda", "Blue");
+      objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
+                                                      defaultTypeComparators(), "age");
+    }).withMessage(format("%nCan't find any field or property with name 'age'.%n" +
+                          "Error when introspecting properties was :%n" +
+                          "- No getter for property 'age' in org.assertj.core.test.Jedi %n" +
+                          "Error when introspecting fields was :%n" +
+                          "- Unable to obtain the value of the field <'age'> from <Yoda the Jedi>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeEqualByComparingOnlyGivenFields.shouldBeEqualComparingOnlyGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
@@ -151,11 +152,12 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
 
   @Test
   public void should_fail_when_one_of_actual_field_to_compare_can_not_be_found_in_the_other_object() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'lightSaberColor'");
-    Jedi actual = new Jedi("Yoda", "Green");
-    Employee other = new Employee();
-    objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
-                                                    defaultTypeComparators(), "lightSaberColor");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      Jedi actual = new Jedi("Yoda", "Green");
+      Employee other = new Employee();
+      objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
+                                                      defaultTypeComparators(), "lightSaberColor");
+    }).withMessageContaining("Can't find any field or property with name 'lightSaberColor'");
   }
 
   @Test
@@ -175,12 +177,12 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
   public void should_fail_when_selected_field_is_not_accessible_and_private_field_use_is_forbidden() {
     boolean allowedToUsePrivateFields = FieldSupport.comparison().isAllowedToUsePrivateFields();
     Assertions.setAllowComparingPrivateFields(false);
-    thrown.expectIntrospectionErrorWithMessageContaining(
-                                                         "Can't find any field or property with name 'strangeNotReadablePrivateField'.");
-    Jedi actual = new Jedi("Yoda", "Green");
-    Jedi other = new Jedi("Yoda", "Blue");
-    objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
-                                                    defaultTypeComparators(), "strangeNotReadablePrivateField");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      Jedi actual = new Jedi("Yoda", "Green");
+      Jedi other = new Jedi("Yoda", "Blue");
+      objects.assertIsEqualToComparingOnlyGivenFields(someInfo(), actual, other, noFieldComparators(),
+                                                      defaultTypeComparators(), "strangeNotReadablePrivateField");
+    }).withMessageContaining("Can't find any field or property with name 'strangeNotReadablePrivateField'.");
     Assertions.setAllowComparingPrivateFields(allowedToUsePrivateFields);
   }
 

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringGivenFields_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeEqualToIgnoringFields.shouldBeEqualToIgnoringGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
@@ -38,6 +39,7 @@ import org.assertj.core.test.Jedi;
 import org.assertj.core.test.Person;
 import org.assertj.core.test.TestClassWithRandomId;
 import org.assertj.core.util.introspection.FieldSupport;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 /**
@@ -167,10 +169,10 @@ public class Objects_assertIsEqualToIgnoringGivenFields_Test extends ObjectsBase
     Jedi actual = new Jedi("Yoda", "Green");
     Employee other = new Employee();
 
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'lightSaberColor'");
-
-    objects.assertIsEqualToIgnoringGivenFields(someInfo(), actual, other, noFieldComparators(),
-                                               defaultTypeComparators(), "name");
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      objects.assertIsEqualToIgnoringGivenFields(someInfo(), actual, other, noFieldComparators(),
+                                                 defaultTypeComparators(), "name");
+    }).withMessageContaining("Can't find any field or property with name 'lightSaberColor'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeEqualToIgnoringFields.shouldBeEqualToIgnoringGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
@@ -35,6 +36,7 @@ import org.assertj.core.test.Jedi;
 import org.assertj.core.test.Person;
 import org.assertj.core.test.TestClassWithRandomId;
 import org.assertj.core.util.introspection.FieldSupport;
+import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.Test;
 
 /**
@@ -127,11 +129,12 @@ public class Objects_assertIsEqualToIgnoringNullFields_Test extends ObjectsBaseT
 
   @Test
   public void should_fail_when_one_of_actual_field_to_compare_can_not_be_found_in_the_other_object() {
-    thrown.expectIntrospectionErrorWithMessageContaining("Can't find any field or property with name 'lightSaberColor'");
-    Jedi actual = new Jedi("Yoda", "Green");
-    Employee other = new Employee();
-    objects.assertIsEqualToIgnoringNullFields(someInfo(), actual, other, noFieldComparators(),
-                                              defaultTypeComparators());
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      Jedi actual = new Jedi("Yoda", "Green");
+      Employee other = new Employee();
+      objects.assertIsEqualToIgnoringNullFields(someInfo(), actual, other, noFieldComparators(),
+                                                defaultTypeComparators());
+    }).withMessageContaining("Can't find any field or property with name 'lightSaberColor'");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldEndWithPath.shouldEndWith;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -41,12 +42,12 @@ public class Paths_assertEndsWith_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_with_PathsException_if_actual_cannot_be_resolved() throws IOException {
-	final IOException causeException = new IOException();
-	when(actual.toRealPath()).thenThrow(causeException);
+    final IOException causeException = new IOException();
+    when(actual.toRealPath()).thenThrow(causeException);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve actual real path", causeException);
-
-    paths.assertEndsWith(info, actual, other);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertEndsWith(info, actual, other))
+                                                   .withMessage("failed to resolve actual real path")
+                                                   .withCause(causeException);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
@@ -111,9 +112,9 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    paths.assertHasBinaryContent(someInfo(), path, expected);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> paths.assertHasBinaryContent(someInfo(),
+                                                                                                        path, expected))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
@@ -119,9 +120,9 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
 	when(nioFilesWrapper.exists(path)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(path)).thenReturn(true);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    paths.assertHasContent(someInfo(), path, expected, charset);
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> paths.assertHasContent(someInfo(), path,
+                                                                                                  expected, charset))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -35,12 +36,12 @@ public class Paths_assertHasNoParent_Test extends MockPathsBaseTest {
 
   @Test
   public void should_throw_PathsException_if_actual_cannot_be_canonicalized() throws IOException {
-	final IOException exception = new IOException();
-	when(actual.toRealPath()).thenThrow(exception);
+    final IOException exception = new IOException();
+    when(actual.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve actual real path", exception);
-
-    paths.assertHasNoParent(info, actual);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertHasNoParent(info, actual))
+                                                   .withMessage("failed to resolve actual real path")
+                                                   .withCause(exception);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -54,12 +55,12 @@ public class Paths_assertHasParent_Test extends MockPathsBaseTest {
 
   @Test
   public void should_fail_if_actual_cannot_be_canonicalized() throws IOException {
-	final IOException exception = new IOException();
-	when(actual.toRealPath()).thenThrow(exception);
+    final IOException exception = new IOException();
+    when(actual.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve actual real path", exception);
-
-    paths.assertHasParent(info, actual, expected);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertHasParent(info, actual, expected))
+                                                   .withMessage("failed to resolve actual real path")
+                                                   .withCause(exception);
   }
 
   @Test
@@ -69,9 +70,9 @@ public class Paths_assertHasParent_Test extends MockPathsBaseTest {
 	when(actual.toRealPath()).thenReturn(canonicalActual);
 	when(expected.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve argument real path", exception);
-
-    paths.assertHasParent(info, actual, expected);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertHasParent(info, actual, expected))
+                                                   .withMessage("failed to resolve argument real path")
+                                                   .withCause(exception);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal.paths;
 
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
@@ -110,9 +111,12 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
 	when(nioFilesWrapper.isReadable(actual)).thenReturn(true);
 	when(nioFilesWrapper.isReadable(other)).thenReturn(true);
 
-    thrown.expectWithCause(UncheckedIOException.class, cause);
-
-    paths.assertHasSameContentAs(someInfo(), actual, defaultCharset(), other, defaultCharset());
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> paths.assertHasSameContentAs(someInfo(),
+                                                                                                        actual,
+                                                                                                        defaultCharset(),
+                                                                                                        other,
+                                                                                                        defaultCharset()))
+                                                         .withCause(cause);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldBeCanonicalPath.shouldBeCanonicalPath;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -38,9 +39,9 @@ public class Paths_assertIsCanonical_Test extends MockPathsBaseTest {
 	final IOException exception = new IOException();
 	when(actual.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve actual real path", exception);
-
-    paths.assertIsCanonical(info, actual);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertIsCanonical(info, actual))
+                                                   .withMessage("failed to resolve actual real path")
+                                                   .withCause(exception);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
 import static org.assertj.core.test.TestFailures.wasExpectingAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -56,9 +57,9 @@ public class Paths_assertStartsWith_Test extends MockPathsBaseTest {
 	final IOException exception = new IOException();
 	when(actual.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve actual real path", exception);
-
-    paths.assertStartsWith(info, actual, other);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertStartsWith(info, actual, other))
+                                                   .withMessage("failed to resolve actual real path")
+                                                   .withCause(exception);
   }
 
   @Test
@@ -67,9 +68,9 @@ public class Paths_assertStartsWith_Test extends MockPathsBaseTest {
 	when(actual.toRealPath()).thenReturn(canonicalActual);
 	when(other.toRealPath()).thenThrow(exception);
 
-    thrown.expectWithCause(PathsException.class, "failed to resolve argument real path", exception);
-
-    paths.assertStartsWith(info, actual, other);
+    assertThatExceptionOfType(PathsException.class).isThrownBy(() -> paths.assertStartsWith(info, actual, other))
+                                                   .withMessage("failed to resolve argument real path")
+                                                   .withCause(exception);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.*;
 import org.assertj.core.internal.*;
 import org.junit.*;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ShortArrays.*;
@@ -48,14 +49,12 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -147,8 +146,7 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
 
   @Test
   public void should_fail_if_expected_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -58,14 +59,12 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
 
   @Test
   public void should_fail_if_arrays_have_different_sizes() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8));
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, arrayOf(6, 8)));
   }
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +131,7 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
@@ -74,8 +75,7 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -138,8 +138,7 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
@@ -65,8 +66,7 @@ public class ShortArrays_assertContainsOnly_Test extends ShortArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -118,8 +118,7 @@ public class ShortArrays_assertContainsOnly_Test extends ShortArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ShortArrays.*;
@@ -61,8 +62,7 @@ public class ShortArrays_assertContainsSequence_Test extends ShortArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -132,8 +132,7 @@ public class ShortArrays_assertContainsSequence_Test extends ShortArraysBaseTest
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ShortArrays.emptyArray;
@@ -57,8 +59,10 @@ public class ShortArrays_assertContains_at_Index_Test extends ShortArraysBaseTes
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arrays.assertContains(someInfo(), actual, (short) 8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arrays.assertContains(someInfo(),
+                                                                                                      actual, (short) 8,
+                                                                                                      atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test
@@ -101,8 +105,11 @@ public class ShortArrays_assertContains_at_Index_Test extends ShortArraysBaseTes
 
   @Test
   public void should_throw_error_if_Index_is_out_of_bounds_whatever_custom_comparison_strategy_is() {
-    thrown.expectIndexOutOfBoundsException("Index should be between <0> and <2> (inclusive) but was:%n <6>");
-    arraysWithCustomComparisonStrategy.assertContains(someInfo(), actual, (short) 8, atIndex(6));
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertContains(someInfo(),
+                                                                                                                                  actual,
+                                                                                                                                  (short) 8,
+                                                                                                                                  atIndex(6)))
+                                                              .withMessageContaining(format("Index should be between <0> and <2> (inclusive) but was:%n <6>"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
@@ -68,8 +69,7 @@ public class ShortArrays_assertIsSortedAccordingToComparator_Test extends ShortA
 
   @Test
   public void should_fail_if_comparator_is_null() {
-    thrown.expectNullPointerException();
-    arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null);
+    assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSortedAccordingToComparator(someInfo(), emptyArray(), null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ShortArrays.*;
@@ -55,8 +56,7 @@ public class ShortArrays_assertStartsWith_Test extends ShortArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    thrown.expectAssertionError();
-    arrays.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arrays.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test
@@ -122,8 +122,7 @@ public class ShortArrays_assertStartsWith_Test extends ShortArraysBaseTest {
 
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not_whatever_custom_comparison_strategy_is() {
-    thrown.expectAssertionError();
-    arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray());
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> arraysWithCustomComparisonStrategy.assertStartsWith(someInfo(), actual, emptyArray()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldContainPattern.shouldContainPattern;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.matchAnything;
@@ -44,8 +45,9 @@ public class Strings_assertContainsPattern_CharSequence_Test extends StringsBase
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid() {
-    thrown.expect(PatternSyntaxException.class);
-    strings.assertContainsPattern(someInfo(), actual, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> strings.assertContainsPattern(someInfo(),
+                                                                                                           actual,
+                                                                                                           "*..."));
   }
 
   @Test
@@ -74,8 +76,9 @@ public class Strings_assertContainsPattern_CharSequence_Test extends StringsBase
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid_whatever_custom_comparison_strategy_is() {
-    thrown.expect(PatternSyntaxException.class);
-    stringsWithCaseInsensitiveComparisonStrategy.assertContainsPattern(someInfo(), actual, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsPattern(someInfo(),
+                                                                                                                                                actual,
+                                                                                                                                                "*..."));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.matchAnything;
@@ -43,8 +44,9 @@ public class Strings_assertDoesNotContainPattern_CharSequence_Test extends Strin
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid() {
-    thrown.expect(PatternSyntaxException.class);
-    strings.assertDoesNotContainPattern(someInfo(), ACTUAL, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> strings.assertDoesNotContainPattern(someInfo(),
+                                                                                                                 ACTUAL,
+                                                                                                                 "*..."));
   }
 
   @Test
@@ -73,8 +75,9 @@ public class Strings_assertDoesNotContainPattern_CharSequence_Test extends Strin
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid_whatever_custom_comparison_strategy_is() {
-    thrown.expect(PatternSyntaxException.class);
-    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(), ACTUAL, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainPattern(someInfo(),
+                                                                                                                                                      ACTUAL,
+                                                                                                                                                      "*..."));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotMatch_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotMatch_CharSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldNotMatchPattern.shouldNotMatch;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.*;
@@ -43,8 +44,8 @@ public class Strings_assertDoesNotMatch_CharSequence_Test extends StringsBaseTes
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid() {
-    thrown.expect(PatternSyntaxException.class);
-    strings.assertDoesNotMatch(someInfo(), actual, "*...");
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> strings.assertDoesNotMatch(someInfo(), actual,
+                                                                                                  "*..."));
   }
 
   @Test
@@ -74,8 +75,9 @@ public class Strings_assertDoesNotMatch_CharSequence_Test extends StringsBaseTes
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid_whatever_custom_comparison_strategy_is() {
-    thrown.expect(PatternSyntaxException.class);
-    stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotMatch(someInfo(), actual, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotMatch(someInfo(),
+                                                                                                                                             actual,
+                                                                                                                                             "*..."));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldMatchPattern.shouldMatch;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.*;
@@ -48,8 +49,8 @@ public class Strings_assertMatches_CharSequence_Test extends StringsBaseTest {
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid() {
-    thrown.expect(PatternSyntaxException.class);
-    strings.assertMatches(someInfo(), actual, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> strings.assertMatches(someInfo(), actual,
+                                                                                                   "*..."));
   }
 
   @Test
@@ -78,8 +79,9 @@ public class Strings_assertMatches_CharSequence_Test extends StringsBaseTest {
 
   @Test
   public void should_throw_error_if_syntax_of_regular_expression_is_invalid_whatever_custom_comparison_strategy_is() {
-    thrown.expect(PatternSyntaxException.class);
-    stringsWithCaseInsensitiveComparisonStrategy.assertMatches(someInfo(), actual, "*...");
+    assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(() -> stringsWithCaseInsensitiveComparisonStrategy.assertMatches(someInfo(),
+                                                                                                                                        actual,
+                                                                                                                                        "*..."));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/navigation/ClassBasedNavigableIterable_Test.java
+++ b/src/test/java/org/assertj/core/navigation/ClassBasedNavigableIterable_Test.java
@@ -20,6 +20,7 @@ import org.assertj.core.test.VehicleFactory;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ClassBasedNavigableIterable_Test extends BaseNavigableIterableAssert_Test {
 
@@ -30,9 +31,11 @@ public class ClassBasedNavigableIterable_Test extends BaseNavigableIterableAsser
 
   @Test
   public void do_not_swallow_reflection_problem() {
-    thrown.expectWithMessageContaining(RuntimeException.class, "not access a member of class org.assertj.core.test.IllegalVehicleAssert");
-    assertThat(expectedVehicles, IllegalVehicleAssert.class)
-      .toAssert(new VehicleFactory.Car("car"), "unused");
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(expectedVehicles,
+                                                                                  IllegalVehicleAssert.class)
+                                                                                                             .toAssert(new VehicleFactory.Car("car"),
+                                                                                                                       "unused"))
+                                                     .withMessageContaining("not access a member of class org.assertj.core.test.IllegalVehicleAssert");
   }
 
 }

--- a/src/test/java/org/assertj/core/navigation/ClassBasedNavigableList_Test.java
+++ b/src/test/java/org/assertj/core/navigation/ClassBasedNavigableList_Test.java
@@ -22,6 +22,7 @@ import org.assertj.core.test.VehicleFactory;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ClassBasedNavigableList_Test extends BaseNavigableListAssert_Test {
 
@@ -32,9 +33,11 @@ public class ClassBasedNavigableList_Test extends BaseNavigableListAssert_Test {
 
   @Test
   public void do_not_swallow_reflection_problem() {
-    thrown.expectWithMessageContaining(RuntimeException.class, "not access a member of class org.assertj.core.test.IllegalVehicleAssert");
-    assertThat(expectedVehicles, IllegalVehicleAssert.class)
-      .toAssert(new VehicleFactory.Car("car"), "unused");
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(expectedVehicles,
+                                                                                  IllegalVehicleAssert.class)
+                                                                                                             .toAssert(new VehicleFactory.Car("car"),
+                                                                                                                       "unused"))
+                                                     .withMessageContaining("not access a member of class org.assertj.core.test.IllegalVehicleAssert");
   }
 
 }

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -54,10 +54,6 @@ public class ExpectedException implements TestRule {
     return delegate.apply(base, description);
   }
 
-  public void expectAssertionError() {
-    expect(AssertionError.class);
-  }
-
   public void expectAssertionError(String message) {
     expect(AssertionError.class, message);
   }

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -78,10 +78,6 @@ public class ExpectedException implements TestRule {
     expect(IllegalArgumentException.class, message);
   }
 
-  public void expectIndexOutOfBoundsException(String message) {
-    expect(IndexOutOfBoundsException.class, message);
-  }
-
   public void expect(Class<? extends Throwable> type, String message) {
     expect(type);
     expectMessage(message);

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -25,7 +25,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsSame;
 import org.hamcrest.core.StringContains;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -89,11 +88,6 @@ public class ExpectedException implements TestRule {
     delegate.expect(type);
   }
 
-  public void expectWithCause(Class<? extends Throwable> type, Throwable cause) {
-    expect(type);
-    expectCause(cause);
-  }
-
   public void expectMessage(String message) {
     delegate.expectMessage(IsEqual.equalTo(format(message)));
   }
@@ -103,10 +97,6 @@ public class ExpectedException implements TestRule {
                                                    .map(part -> StringContains.containsString(format(part)))
                                                    .collect(toList());
     delegate.expectMessage(AllOf.allOf(matchers));
-  }
-
-  private void expectCause(Throwable cause) {
-    delegate.expectCause(IsSame.sameInstance(cause));
   }
 
   private static class ThrowableMatcher<T extends Throwable> extends TypeSafeMatcher<T> {

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -94,12 +94,6 @@ public class ExpectedException implements TestRule {
     expectCause(cause);
   }
 
-  public void expectWithCause(Class<? extends Throwable> type, String message, Throwable cause) {
-    expect(type);
-    expectMessage(message);
-    expectCause(cause);
-  }
-
   public void expectMessage(String message) {
     delegate.expectMessage(IsEqual.equalTo(format(message)));
   }

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -12,10 +12,9 @@
  */
 package org.assertj.core.test;
 
-import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
-
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +27,6 @@ import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsSame;
 import org.hamcrest.core.StringContains;
-import org.hamcrest.core.StringEndsWith;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -93,11 +91,6 @@ public class ExpectedException implements TestRule {
     expectMessageStartingWith(start);
   }
 
-  public void expectWithMessageEndingWith(Class<? extends Throwable> type, String end) {
-    expect(type);
-    expectMessageEndingWith(end);
-  }
-
   public void expect(Class<? extends Throwable> type) {
     delegate.expect(type);
   }
@@ -126,10 +119,6 @@ public class ExpectedException implements TestRule {
 
   private void expectMessageStartingWith(String start) {
     delegate.expectMessage(StringStartsWith.startsWith(format(start)));
-  }
-
-  private void expectMessageEndingWith(String end) {
-    delegate.expectMessage(StringEndsWith.endsWith(format(end)));
   }
 
   private void expectCause(Throwable cause) {

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -75,12 +75,12 @@ public class ExpectedException implements TestRule {
     expect(IllegalArgumentException.class, message);
   }
 
-  public void expect(Class<? extends Throwable> type, String message) {
+  private void expect(Class<? extends Throwable> type, String message) {
     expect(type);
     expectMessage(message);
   }
 
-  public void expectWithMessageContaining(Class<? extends Throwable> type, String... parts) {
+  private void expectWithMessageContaining(Class<? extends Throwable> type, String... parts) {
     expect(type);
     expectMessageContaining(parts);
   }

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -82,10 +82,6 @@ public class ExpectedException implements TestRule {
     expect(IndexOutOfBoundsException.class, message);
   }
 
-  public void expectUnsupportedOperationException(String message) {
-    expect(UnsupportedOperationException.class, message);
-  }
-
   public void expect(Class<? extends Throwable> type, String message) {
     expect(type);
     expectMessage(message);

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.assertj.core.error.AssertionErrorFactory;
 import org.assertj.core.error.ErrorMessageFactory;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.AllOf;
@@ -85,10 +84,6 @@ public class ExpectedException implements TestRule {
 
   public void expectUnsupportedOperationException(String message) {
     expect(UnsupportedOperationException.class, message);
-  }
-
-  public void expectIntrospectionErrorWithMessageContaining(String... parts) {
-    expectWithMessageContaining(IntrospectionError.class, parts);
   }
 
   public void expect(Class<? extends Throwable> type, String message) {

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -75,16 +75,8 @@ public class ExpectedException implements TestRule {
     expectWithMessageContaining(AssertionError.class, parts);
   }
 
-  public void expectNullPointerException() {
-    expect(NullPointerException.class);
-  }
-
   public void expectNullPointerException(String message) {
     expect(NullPointerException.class, message);
-  }
-
-  public void expectIllegalArgumentException() {
-    expect(IllegalArgumentException.class);
   }
 
   public void expectIllegalArgumentException(String message) {
@@ -97,10 +89,6 @@ public class ExpectedException implements TestRule {
 
   public void expectUnsupportedOperationException(String message) {
     expect(UnsupportedOperationException.class, message);
-  }
-
-  public void expectIntrospectionError() {
-    expect(IntrospectionError.class);
   }
 
   public void expectIntrospectionErrorWithMessageContaining(String... parts) {

--- a/src/test/java/org/assertj/core/test/ExpectedException.java
+++ b/src/test/java/org/assertj/core/test/ExpectedException.java
@@ -27,7 +27,6 @@ import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsSame;
 import org.hamcrest.core.StringContains;
-import org.hamcrest.core.StringStartsWith;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -86,11 +85,6 @@ public class ExpectedException implements TestRule {
     expectMessageContaining(parts);
   }
 
-  public void expectWithMessageStartingWith(Class<? extends Throwable> type, String start) {
-    expect(type);
-    expectMessageStartingWith(start);
-  }
-
   public void expect(Class<? extends Throwable> type) {
     delegate.expect(type);
   }
@@ -115,10 +109,6 @@ public class ExpectedException implements TestRule {
                                                    .map(part -> StringContains.containsString(format(part)))
                                                    .collect(toList());
     delegate.expectMessage(AllOf.allOf(matchers));
-  }
-
-  private void expectMessageStartingWith(String start) {
-    delegate.expectMessage(StringStartsWith.startsWith(format(start)));
   }
 
   private void expectCause(Throwable cause) {

--- a/src/test/java/org/assertj/core/util/ArrayWrapperList_get_Test.java
+++ b/src/test/java/org/assertj/core/util/ArrayWrapperList_get_Test.java
@@ -13,8 +13,9 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.test.ExpectedException.none;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.assertj.core.test.ExpectedException;
 import org.assertj.core.util.ArrayWrapperList;
@@ -45,19 +46,19 @@ public class ArrayWrapperList_get_Test {
 
   @Test
   public void should_throw_error_if_index_is_negative() {
-    thrown.expectIndexOutOfBoundsException("Index should be between 0 and 1 (inclusive) but was -1");
-    list.get(-1);
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> list.get(-1))
+                                                              .withMessageContaining("Index should be between 0 and 1 (inclusive) but was -1");
   }
 
   @Test
   public void should_throw_error_if_index_is_equal_to_size() {
-    thrown.expectIndexOutOfBoundsException("Index should be between 0 and 1 (inclusive) but was 2");
-    list.get(2);
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> list.get(2))
+                                                              .withMessageContaining("Index should be between 0 and 1 (inclusive) but was 2");
   }
 
   @Test
   public void should_throw_error_if_index_is_greater_than_size() {
-    thrown.expectIndexOutOfBoundsException("Index should be between 0 and 1 (inclusive) but was 6");
-    list.get(6);
+    assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> list.get(6))
+                                                              .withMessageContaining("Index should be between 0 and 1 (inclusive) but was 6");
   }
 }

--- a/src/test/java/org/assertj/core/util/Arrays_hasOnlyNullElements_Test.java
+++ b/src/test/java/org/assertj/core/util/Arrays_hasOnlyNullElements_Test.java
@@ -31,8 +31,7 @@ public class Arrays_hasOnlyNullElements_Test {
 
   @Test
   public void should_throw_error_if_array_is_null() {
-    thrown.expectNullPointerException();
-    Arrays.hasOnlyNullElements(null);
+    assertThatNullPointerException().isThrownBy(() -> Arrays.hasOnlyNullElements(null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/DateUtil_dayOfMonthOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_dayOfMonthOf_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import static org.assertj.core.util.DateUtil.dayOfMonthOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.text.*;
@@ -42,8 +43,7 @@ public class DateUtil_dayOfMonthOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    dayOfMonthOf(null);
+    assertThatNullPointerException().isThrownBy(() -> dayOfMonthOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_dayOfWeekOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_dayOfWeekOf_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import static org.assertj.core.util.DateUtil.dayOfWeekOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.text.*;
@@ -42,8 +43,7 @@ public class DateUtil_dayOfWeekOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    dayOfWeekOf(null);
+    assertThatNullPointerException().isThrownBy(() -> dayOfWeekOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_hourOfDayOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_hourOfDayOf_Test.java
@@ -12,16 +12,15 @@
  */
 package org.assertj.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.DateUtil.hourOfDayOf;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
-
-import java.text.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.junit.*;
-import org.assertj.core.test.ExpectedException;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link DateUtil#hourOfDayOf(Date)}</code>.
@@ -29,9 +28,6 @@ import org.assertj.core.test.ExpectedException;
  * @author Joel Costigliola
  */
 public class DateUtil_hourOfDayOf_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_return_hour_of_day_of_date() throws ParseException {
@@ -42,8 +38,7 @@ public class DateUtil_hourOfDayOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    hourOfDayOf(null);
+    assertThatNullPointerException().isThrownBy(() -> hourOfDayOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_millisecondOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_millisecondOf_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import static org.assertj.core.util.DateUtil.millisecondOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.text.*;
@@ -42,8 +43,7 @@ public class DateUtil_millisecondOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    millisecondOf(null);
+    assertThatNullPointerException().isThrownBy(() -> millisecondOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_minuteOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_minuteOf_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.util;
 import static org.assertj.core.util.DateUtil.minuteOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.text.*;
@@ -42,8 +43,7 @@ public class DateUtil_minuteOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    minuteOf(null);
+    assertThatNullPointerException().isThrownBy(() -> minuteOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_monthOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_monthOf_Test.java
@@ -12,16 +12,15 @@
  */
 package org.assertj.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.DateUtil.monthOf;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
-
-import java.text.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.junit.*;
-import org.assertj.core.test.ExpectedException;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link DateUtil#monthOf(Date)}</code>.
@@ -29,9 +28,6 @@ import org.assertj.core.test.ExpectedException;
  * @author Joel Costigliola
  */
 public class DateUtil_monthOf_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_return_month_of_date() throws ParseException {
@@ -42,8 +38,7 @@ public class DateUtil_monthOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    monthOf(null);
+    assertThatNullPointerException().isThrownBy(() -> monthOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_secondOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_secondOf_Test.java
@@ -12,16 +12,15 @@
  */
 package org.assertj.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.util.DateUtil.secondOf;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
-
-import java.text.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.junit.*;
-import org.assertj.core.test.ExpectedException;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link DateUtil#secondOf(Date)}</code>.
@@ -29,9 +28,6 @@ import org.assertj.core.test.ExpectedException;
  * @author Joel Costigliola
  */
 public class DateUtil_secondOf_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_return_second_of_date() throws ParseException {
@@ -42,8 +38,7 @@ public class DateUtil_secondOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    secondOf(null);
+    assertThatNullPointerException().isThrownBy(() -> secondOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/DateUtil_yearOf_Test.java
+++ b/src/test/java/org/assertj/core/util/DateUtil_yearOf_Test.java
@@ -15,13 +15,12 @@ package org.assertj.core.util;
 import static org.assertj.core.util.DateUtil.yearOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.text.*;
 import java.util.Date;
 
 import org.junit.*;
-import org.assertj.core.test.ExpectedException;
 
 /**
  * Tests for <code>{@link DateUtil#yearOf(Date)}</code>.
@@ -29,9 +28,6 @@ import org.assertj.core.test.ExpectedException;
  * @author Joel Costigliola
  */
 public class DateUtil_yearOf_Test {
-
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_return_year_of_date() throws ParseException {
@@ -42,8 +38,7 @@ public class DateUtil_yearOf_Test {
 
   @Test
   public void should_throws_NullPointerException_if_date_parameter_is_null() {
-    thrown.expectNullPointerException();
-    yearOf(null);
+    assertThatNullPointerException().isThrownBy(() -> yearOf(null));
   }
 
 }

--- a/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import java.io.File;
@@ -39,14 +41,12 @@ public class Files_contentOf_Test {
   @Test
   public void should_throw_exception_if_charset_is_null() {
     Charset charset = null;
-    thrown.expectNullPointerException();
-    Files.contentOf(new File("test"), charset);
+    assertThatNullPointerException().isThrownBy(() -> Files.contentOf(new File("test"), charset));
   }
 
   @Test
   public void should_throw_exception_if_charset_name_does_not_exist() {
-    thrown.expectIllegalArgumentException();
-    Files.contentOf(new File("test"), "Klingon");
+    assertThatIllegalArgumentException().isThrownBy(() -> Files.contentOf(new File("test"), "Klingon"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
@@ -54,8 +55,8 @@ public class Files_contentOf_Test {
     File missingFile = new File("missing.txt");
     assertThat(missingFile.exists()).isFalse();
 
-    thrown.expect(UncheckedIOException.class);
-    Files.contentOf(missingFile, Charset.defaultCharset());
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> Files.contentOf(missingFile,
+                                                                                           Charset.defaultCharset()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Files_fileNamesIn_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_fileNamesIn_Test.java
@@ -39,8 +39,7 @@ public class Files_fileNamesIn_Test extends Files_TestCase {
   @Test
   public void should_throw_error_if_directory_does_not_exist() {
     String path = concat("root", separator, "not_existing_dir");
-    thrown.expectIllegalArgumentException();
-    Files.fileNamesIn(path, false);
+    assertThatIllegalArgumentException().isThrownBy(() -> Files.fileNamesIn(path, false));
   }
 
   @Test
@@ -48,8 +47,7 @@ public class Files_fileNamesIn_Test extends Files_TestCase {
     String fileName = "file_1";
     root.addFiles(fileName);
     String path = concat("root", separator, fileName);
-    thrown.expectIllegalArgumentException();
-    Files.fileNamesIn(path, false);
+    assertThatIllegalArgumentException().isThrownBy(() -> Files.fileNamesIn(path, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.Files.linesOf;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -47,14 +49,12 @@ public class Files_linesOf_Test {
   @Test
   public void should_throw_exception_when_charset_is_null() {
     Charset charset = null;
-    thrown.expectNullPointerException();
-    linesOf(SAMPLE_UNIX_FILE, charset);
+    assertThatNullPointerException().isThrownBy(() -> linesOf(SAMPLE_UNIX_FILE, charset));
   }
 
   @Test
   public void should_throw_exception_if_charset_name_does_not_exist() {
-    thrown.expectIllegalArgumentException();
-    linesOf(new File("test"), "Klingon");
+    assertThatIllegalArgumentException().isThrownBy(() -> linesOf(new File("test"), "Klingon"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
@@ -62,8 +63,8 @@ public class Files_linesOf_Test {
     File missingFile = new File("missing.txt");
     assertThat(missingFile).doesNotExist();
 
-    thrown.expect(UncheckedIOException.class);
-    linesOf(missingFile, Charset.defaultCharset());
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> linesOf(missingFile,
+                                                                                   Charset.defaultCharset()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Introspection_getProperty_Test.java
+++ b/src/test/java/org/assertj/core/util/Introspection_getProperty_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.introspection.Introspection.getPropertyGetter;
 
@@ -44,29 +45,27 @@ public class Introspection_getProperty_Test {
 
   @Test
   public void should_raise_an_error_because_of_missing_getter() {
-    thrown.expect(IntrospectionError.class, "No getter for property 'salary' in org.assertj.core.util.Employee");
-    getPropertyGetter("salary", judy);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> getPropertyGetter("salary", judy))
+                                                       .withMessage("No getter for property 'salary' in org.assertj.core.util.Employee");
   }
 
   @Test
   public void should_raise_an_error_because_of_non_public_getter_when_getter_does_not_exists() {
-    thrown.expect(IntrospectionError.class,
-                  "No public getter for property 'company' in org.assertj.core.util.Employee");
-    getPropertyGetter("company", judy);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> getPropertyGetter("company", judy))
+                                                       .withMessage("No public getter for property 'company' in org.assertj.core.util.Employee");
   }
 
   @Test
   public void should_raise_an_error_because_of_non_public_getter_when_getter_is_package_private() {
-    thrown.expect(IntrospectionError.class,
-                  "No public getter for property 'firstJob' in org.assertj.core.util.Employee");
-    getPropertyGetter("firstJob", judy);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> getPropertyGetter("firstJob", judy))
+                                                       .withMessage("No public getter for property 'firstJob' in org.assertj.core.util.Employee");
   }
 
   @Test
   public void should_raise_an_error_because_of_non_public_getter_when_getter_is_in_superclass() {
-    thrown.expect(IntrospectionError.class,
-                  "No public getter for property 'name' in org.assertj.core.util.Introspection_getProperty_Test$Example");
-    getPropertyGetter("name", new Example());
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> getPropertyGetter("name",
+                                                                                           new Example()))
+                                                       .withMessage("No public getter for property 'name' in org.assertj.core.util.Introspection_getProperty_Test$Example");
   }
 
   public static class Example extends Super {

--- a/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_GenericArray_Test.java
+++ b/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_GenericArray_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
@@ -37,9 +38,10 @@ public class Preconditions_checkNotNullOrEmpty_GenericArray_Test {
 
   @Test
   public void should_throw_NullPointerException_if_array_is_null() {
-    thrown.expectNullPointerException();
-    String[] array = null;
-    Preconditions.checkNotNullOrEmpty(array);
+    assertThatNullPointerException().isThrownBy(() -> {
+      String[] array = null;
+      Preconditions.checkNotNullOrEmpty(array);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_String_String_Test.java
+++ b/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_String_String_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
@@ -39,9 +40,10 @@ public class Preconditions_checkNotNullOrEmpty_String_String_Test {
 
   @Test
   public void should_throw_nullpointerexception_if_string_is_null() {
-    thrown.expectNullPointerException();
-    String string = null;
-    Preconditions.checkNotNullOrEmpty(string, CUSTOM_MESSAGE);
+    assertThatNullPointerException().isThrownBy(() -> {
+      String string = null;
+      Preconditions.checkNotNullOrEmpty(string, CUSTOM_MESSAGE);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_String_Test.java
+++ b/src/test/java/org/assertj/core/util/Preconditions_checkNotNullOrEmpty_String_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.test.ExpectedException.none;
 
 import org.assertj.core.test.ExpectedException;
@@ -37,9 +38,10 @@ public class Preconditions_checkNotNullOrEmpty_String_Test {
 
   @Test
   public void should_throw_NullPointerException_if_string_is_null() {
-    thrown.expectNullPointerException();
-    String string = null;
-    Preconditions.checkNotNullOrEmpty(string);
+    assertThatNullPointerException().isThrownBy(() -> {
+      String string = null;
+      Preconditions.checkNotNullOrEmpty(string);
+    });
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Preconditions_checkNotNull_GenericObject_Test.java
+++ b/src/test/java/org/assertj/core/util/Preconditions_checkNotNull_GenericObject_Test.java
@@ -13,10 +13,8 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import org.assertj.core.test.ExpectedException;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -25,14 +23,11 @@ import org.junit.Test;
  * @author Christian Rösch
  */
 public class Preconditions_checkNotNull_GenericObject_Test {
-  @Rule
-  public ExpectedException thrown = none();
 
   @Test
   public void should_throw_nullpointerexception_if_object_is_null() {
-    thrown.expectNullPointerException();
-    Object object = null;
-    Preconditions.checkNotNull(object);
+    assertThatNullPointerException().isThrownBy(() -> {Object object = null;
+    Preconditions.checkNotNull(object);});
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Strings_join_Test.java
+++ b/src/test/java/org/assertj/core/util/Strings_join_Test.java
@@ -13,12 +13,10 @@
 package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.ExpectedException.none;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.assertj.core.test.ExpectedException;
 
 /**
  * Tests for <code>{@link Strings#join(String...)}</code>.
@@ -27,18 +25,14 @@ import org.assertj.core.test.ExpectedException;
  */
 public class Strings_join_Test {
 
-  @Rule
-  public ExpectedException thrown = none();
-
   @Test
   public void should_throw_error_if_delimiter_is_null() {
-    thrown.expectIllegalArgumentException();
-    Strings.join(null, "Uno", "Dos").with(null);
+    assertThatIllegalArgumentException().isThrownBy(() -> Strings.join(null, "Uno", "Dos").with(null));
   }
 
   @Test
   public void should_return_empty_String_if_array_to_join_is_null() {
-    assertThat( Strings.join((String[]) null).with("|")).isEmpty();
+    assertThat(Strings.join((String[]) null).with("|")).isEmpty();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/introspection/FieldSupport_fieldValues_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/FieldSupport_fieldValues_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.util.introspection;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -89,9 +90,9 @@ public class FieldSupport_fieldValues_Test {
 
   @Test
   public void should_throw_error_if_field_not_found() {
-    thrown.expect(IntrospectionError.class,
-                  "Unable to obtain the value of the field <'id.'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>");
-    fieldSupport.fieldValues("id.", Long.class, employees);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> fieldSupport.fieldValues("id.", Long.class,
+                                                                                                  employees))
+                                                       .withMessage("Unable to obtain the value of the field <'id.'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>");
   }
 
   @Test
@@ -104,9 +105,10 @@ public class FieldSupport_fieldValues_Test {
   public void should_throw_error_if_field_is_not_public_and_allowExtractingPrivateFields_set_to_false() {
     FieldSupport.EXTRACTION.setAllowUsingPrivateFields(false);
     try {
-      thrown.expect(IntrospectionError.class,
-                    "Unable to obtain the value of the field <'age'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>, check that field is public.");
-      fieldSupport.fieldValues("age", Integer.class, employees);
+      assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> fieldSupport.fieldValues("age",
+                                                                                                    Integer.class,
+                                                                                                    employees))
+                                                         .withMessage("Unable to obtain the value of the field <'age'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>, check that field is public.");
     } finally { // back to default value
       FieldSupport.EXTRACTION.setAllowUsingPrivateFields(true);
     }

--- a/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
@@ -14,6 +14,8 @@ package org.assertj.core.util.introspection;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -100,19 +102,17 @@ public class PropertyOrFieldSupport_getValueOf_Test {
 
   @Test
   public void should_throw_error_when_no_property_nor_field_match_given_name() {
-    thrown.expectIntrospectionError();
-
-    propertyOrFieldSupport.getValueOf("unknown", yoda);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> propertyOrFieldSupport.getValueOf("unknown", yoda));
   }
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_given_name_if_extraction_is_limited_to_public_fields() {
-    thrown.expectIntrospectionError();
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
+      propertyOrFieldSupport = new PropertyOrFieldSupport(new PropertySupport(),
+                                                          FieldSupport.EXTRACTION_OF_PUBLIC_FIELD_ONLY);
 
-    propertyOrFieldSupport = new PropertyOrFieldSupport(new PropertySupport(),
-                                                        FieldSupport.EXTRACTION_OF_PUBLIC_FIELD_ONLY);
-
-    propertyOrFieldSupport.getValueOf("city", yoda);
+      propertyOrFieldSupport.getValueOf("city", yoda);
+    });
   }
 
   @Test
@@ -129,15 +129,12 @@ public class PropertyOrFieldSupport_getValueOf_Test {
 
   @Test
   public void should_throw_exception_if_property_cannot_be_extracted_due_to_runtime_exception_during_property_access() {
-    thrown.expectIntrospectionError();
-
-    propertyOrFieldSupport.getValueOf("adult", brokenEmployee());
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> propertyOrFieldSupport.getValueOf("adult", brokenEmployee()));
   }
 
   @Test
   public void should_throw_exception_if_no_object_is_given() {
-    thrown.expectIllegalArgumentException();
-    propertyOrFieldSupport.getValueOf("name", null);
+    assertThatIllegalArgumentException().isThrownBy(() -> propertyOrFieldSupport.getValueOf("name", null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/introspection/PropertySupport_propertyValues_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/PropertySupport_propertyValues_Test.java
@@ -14,6 +14,8 @@ package org.assertj.core.util.introspection;
 
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -99,14 +101,12 @@ public class PropertySupport_propertyValues_Test {
 
   @Test
   public void should_throw_error_if_property_not_found() {
-    thrown.expectIntrospectionError();
-    PropertySupport.instance().propertyValues("foo", Integer.class, employees);
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> PropertySupport.instance().propertyValues("foo", Integer.class, employees));
   }
 
   @Test
   public void should_throw_error_if_property_name_is_null() {
-    thrown.expectIllegalArgumentException();
-    PropertySupport.instance().propertyValueOf(null, Integer.class, employees);
+    assertThatIllegalArgumentException().isThrownBy(() -> PropertySupport.instance().propertyValueOf(null, Integer.class, employees));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
+++ b/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.util.xml;
 
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.xml.XmlStringPrettyFormatter.xmlPrettyFormat;
 
@@ -85,8 +86,8 @@ public class XmlStringPrettyFormatter_prettyFormat_Test {
 
   @Test
   public void should_throw_error_when_xml_string_is_null() {
-    thrown.expectWithMessageStartingWith(IllegalArgumentException.class, "Expecting XML String not to be null");
-    xmlPrettyFormat(null);
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> xmlPrettyFormat(null))
+                                                             .withMessageStartingWith("Expecting XML String not to be null");
   }
 
   @Test


### PR DESCRIPTION
Another small step of the JUnit 5 migration (Rules were removed).

