### PR TITLE
Remove usages of JUnit theories.

### DIFF
--- a/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
@@ -12,25 +12,13 @@
  */
 package org.assertj.core.api.instant;
 
-import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
-
 import java.time.Instant;
 
-import static org.junit.Assume.assumeTrue;
+import org.assertj.core.api.BaseTest;
 
 
 public class InstantAssertBaseTest extends BaseTest {
-  @DataPoint
-  public static Instant instant1 = Instant.now().minusSeconds(10);
-  @DataPoint
-  public static Instant instant2 = Instant.now();
-  @DataPoint
-  public static Instant instant3 = Instant.now().plusSeconds(10);
-
-  protected static void testAssumptions(Instant reference, Instant dateBefore, Instant dateAfter) {
-    assumeTrue(dateBefore.isBefore(reference));
-    assumeTrue(dateAfter.isAfter(reference));
-  }
-
+  public static final Instant BEFORE = Instant.now().minusSeconds(1);
+  public static final Instant REFERENCE = Instant.now();
+  public static final Instant AFTER = Instant.now().plusSeconds(1);
 }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
@@ -12,29 +12,23 @@
  */
 package org.assertj.core.api.instant;
 
-import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
-
-import java.time.Instant;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
-@RunWith(Theories.class)
+import java.time.Instant;
+
+import org.junit.Test;
+
 public class InstantAssert_IsBeforeOrEqualTo_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(Instant referenceDate, Instant dateBefore, Instant dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
     // WHEN
-    assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
-    assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
     // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
@@ -20,22 +20,16 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isAfterOrEqual_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(Instant referenceDate, Instant dateBefore, Instant dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
-    assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
     // THEN
-    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
@@ -20,23 +20,17 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isAfter_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(Instant referenceDate, Instant dateBefore, Instant dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfter_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfter(referenceDate);
-    assertThat(dateAfter).isAfter(referenceDate.toString());
+    assertThat(AFTER).isAfter(REFERENCE);
+    assertThat(AFTER).isAfter(REFERENCE.toString());
     // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
@@ -20,22 +20,16 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isBefore_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(Instant referenceDate, Instant dateBefore, Instant dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(dateBefore).isBefore(referenceDate);
+    assertThat(BEFORE).isBefore(REFERENCE);
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
@@ -12,25 +12,21 @@
  */
 package org.assertj.core.api.instant;
 
-import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
-
-import java.time.Instant;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@RunWith(Theories.class)
+import java.time.Instant;
+
+import org.junit.Test;
+
 public class InstantAssert_isEqualTo_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(Instant referenceDate) {
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isEqualTo(referenceDate.plusSeconds(1)
+    assertThatThrownBy(() -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusSeconds(1)
                                                                               .toString())).isInstanceOf(AssertionError.class);
   }
 

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isIn_Test.java
@@ -19,20 +19,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isIn_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(Instant referenceDate) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusSeconds(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusSeconds(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isIn(referenceDate.plusSeconds(1).toString(),
-                                                            referenceDate.plusSeconds(2).toString()))
+    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusSeconds(1).toString(),
+                                                        REFERENCE.plusSeconds(2).toString()))
                                                                                                      .isInstanceOf(AssertionError.class);
   }
 

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
@@ -18,19 +18,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isNotEqualTo_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(Instant referenceDate) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotEqualTo(referenceDate.plusSeconds(1).toString());
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusSeconds(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isNotEqualTo(referenceDate.toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotIn_Test.java
@@ -19,19 +19,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class InstantAssert_isNotIn_Test extends InstantAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(Instant referenceDate) {
+  @Test
+  public void test_isNotIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotIn(referenceDate.plusSeconds(1).toString(), referenceDate.plusSeconds(2).toString());
+    assertThat(REFERENCE).isNotIn(REFERENCE.plusSeconds(1).toString(), REFERENCE.plusSeconds(2).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isNotIn(referenceDate.toString(), referenceDate.plusSeconds(1).toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), REFERENCE.plusSeconds(1).toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssertBaseTest.java
@@ -12,13 +12,10 @@
  */
 package org.assertj.core.api.localdate;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.LocalDate;
 
 import org.assertj.core.api.AbstractLocalDateAssert;
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 
 /**
@@ -28,16 +25,8 @@ import org.junit.experimental.theories.DataPoint;
  */
 public class LocalDateAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static LocalDate localDate1 = LocalDate.now().minusDays(10);
-  @DataPoint
-  public static LocalDate localDate2 = LocalDate.now();
-  @DataPoint
-  public static LocalDate localDate3 = LocalDate.now().plusDays(10);
-
-  protected static void testAssumptions(LocalDate reference, LocalDate dateBefore, LocalDate dateAfter) {
-    assumeTrue(dateBefore.isBefore(reference));
-    assumeTrue(dateAfter.isAfter(reference));
-  }
+  public static final LocalDate BEFORE = LocalDate.now().minusDays(1);
+  public static final LocalDate REFERENCE = LocalDate.now();
+  public static final LocalDate AFTER = LocalDate.now().plusDays(1);
 
 }

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfterOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isAfterOrEqualTo_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(LocalDate referenceDate, LocalDate dateBefore,
-	                                        LocalDate dateAfter) {
-	// GIVEN
-	testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
 	// WHEN
-	assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
-	assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
+	assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+	assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
 	// THEN
-	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isAfter_Test.java
@@ -20,23 +20,17 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class LocalDateAssert_isAfter_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(LocalDate referenceDate, LocalDate dateBefore, LocalDate dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfter_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfter(referenceDate);
-    assertThat(dateAfter).isAfter(referenceDate.toString());
+    assertThat(AFTER).isAfter(REFERENCE);
+    assertThat(AFTER).isAfter(REFERENCE.toString());
     // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBeforeOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isBeforeOrEqualTo_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(LocalDate referenceDate, LocalDate dateBefore,
-      LocalDate dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
     // WHEN
-    assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
-    assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
     // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isBefore_Test.java
@@ -19,27 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isBefore_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(LocalDate referenceDate, LocalDate dateBefore, LocalDate dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(dateBefore).isBefore(referenceDate);
+    assertThat(BEFORE).isBefore(REFERENCE);
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isEqualTo_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.LocalDate} are already defined in assertj-core)
@@ -28,16 +25,15 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isEqualTo_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(LocalDate referenceDate) {
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isEqualTo(referenceDate.plusDays(1)
-                                                                 .toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusDays(1)
+                                                                      .toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isIn_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDate} are already defined in assertj-core)
@@ -28,17 +25,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isIn_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(LocalDate referenceDate) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusDays(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isIn(referenceDate.plusDays(1).toString(),
-                                                            referenceDate.plusDays(2).toString()))
-                                                                                                  .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusDays(1).toString(),
+                                                        REFERENCE.plusDays(2).toString()))
+                                                                                          .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotEqualTo_Test.java
@@ -18,22 +18,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDate} are already defined in assertj-core)
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isNotEqualTo_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(LocalDate referenceDate) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
 	// WHEN
-	assertThat(referenceDate).isNotEqualTo(referenceDate.plusDays(1).toString());
+	assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusDays(1).toString());
 	// THEN
-	assertThatThrownBy(() -> assertThat(referenceDate).isNotEqualTo(referenceDate.toString())).isInstanceOf(AssertionError.class);
+	assertThatThrownBy(() -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isNotIn_Test.java
@@ -18,22 +18,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDate} are already defined in assertj-core)
  */
-@RunWith(Theories.class)
 public class LocalDateAssert_isNotIn_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(LocalDate referenceDate) {
+  @Test
+  public void test_isNotIn_assertion() {
 	// WHEN
-	assertThat(referenceDate).isNotIn(referenceDate.plusDays(1).toString(), referenceDate.plusDays(2).toString());
+	assertThat(REFERENCE).isNotIn(REFERENCE.plusDays(1).toString(), REFERENCE.plusDays(2).toString());
 	// THEN
-	assertThatThrownBy(() -> assertThat(referenceDate).isNotIn(referenceDate.toString(), referenceDate.plusDays(1).toString())).isInstanceOf(AssertionError.class);
+	assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isToday_Test.java
+++ b/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isToday_Test.java
@@ -20,22 +20,16 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDate;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class LocalDateAssert_isToday_Test extends LocalDateAssertBaseTest {
 
-  @Theory
-  public void test_isToday_assertion(LocalDate referenceDate, LocalDate dateBefore, LocalDate dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isToday_assertion() {
     // WHEN
-    assertThat(referenceDate).isToday();
+    assertThat(REFERENCE).isToday();
     // THEN
-    verify_that_isToday_assertion_fails_and_throws_AssertionError(dateBefore);
-    verify_that_isToday_assertion_fails_and_throws_AssertionError(dateAfter);
+    verify_that_isToday_assertion_fails_and_throws_AssertionError(BEFORE);
+    verify_that_isToday_assertion_fails_and_throws_AssertionError(AFTER);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
@@ -12,13 +12,10 @@
  */
 package org.assertj.core.api.localdatetime;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.LocalDateTime;
 
 import org.assertj.core.api.AbstractLocalDateTimeAssert;
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 
 /**
@@ -30,22 +27,8 @@ import org.junit.experimental.theories.DataPoint;
  */
 public class LocalDateTimeAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static LocalDateTime localDateTime1 = LocalDateTime.of(2000, 12, 14, 0, 0);
-  @DataPoint
-  public static LocalDateTime localDateTime2 = LocalDateTime.of(2000, 12, 13, 23, 59, 59, 999);
-  @DataPoint
-  public static LocalDateTime localDateTime3 = LocalDateTime.of(2000, 12, 14, 0, 0, 0, 1);
-  @DataPoint
-  public static LocalDateTime localDateTime4 = LocalDateTime.of(2000, 12, 14, 22, 15, 15, 875);
-  @DataPoint
-  public static LocalDateTime localDateTime5 = LocalDateTime.of(2000, 12, 14, 22, 15, 15, 874);
-  @DataPoint
-  public static LocalDateTime localDateTime6 = LocalDateTime.of(2000, 12, 14, 22, 15, 15, 876);
-
-  protected static void testAssumptions(LocalDateTime reference, LocalDateTime dateBefore, LocalDateTime dateAfter) {
-    assumeTrue(dateBefore.isBefore(reference));
-    assumeTrue(dateAfter.isAfter(reference));
-  }
+  public static final LocalDateTime REFERENCE = LocalDateTime.of(2000, 12, 14, 0, 0);
+  public static final LocalDateTime BEFORE = LocalDateTime.of(2000, 12, 13, 23, 59, 59, 999);
+  public static final LocalDateTime AFTER = LocalDateTime.of(2000, 12, 14, 0, 0, 0, 1);
 
 }

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isAfterOrEqualTo_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(LocalDateTime referenceDate, LocalDateTime dateBefore,
-	                                        LocalDateTime dateAfter) {
-	// GIVEN
-	testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
 	// WHEN
-	assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
-	assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
+	assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+	assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
 	// THEN
-	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
@@ -20,28 +20,22 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isAfter_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(LocalDateTime referenceDate, LocalDateTime dateBefore, LocalDateTime dateAfter) {
-	// GIVEN
-	testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfter_assertion() {
 	// WHEN
-	assertThat(dateAfter).isAfter(referenceDate);
-	assertThat(dateAfter).isAfter(referenceDate.toString());
+	assertThat(AFTER).isAfter(REFERENCE);
+	assertThat(AFTER).isAfter(REFERENCE.toString());
 	// THEN
-	verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-	verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isBeforeOrEqualTo_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(LocalDateTime referenceDate, LocalDateTime dateBefore,
-      LocalDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
     // WHEN
-    assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
-    assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
     // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
@@ -19,27 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isBefore_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(LocalDateTime referenceDate, LocalDateTime dateBefore, LocalDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(dateBefore).isBefore(referenceDate);
+    assertThat(BEFORE).isBefore(REFERENCE);
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isEqualTo_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.LocalDateTime} are already defined in assertj-core)
@@ -28,16 +25,15 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isEqualTo_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(LocalDateTime referenceDate) {
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isEqualTo(referenceDate.plusSeconds(1)
-                                                                 .toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusSeconds(1)
+                                                                      .toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDateTime} are already defined in assertj-core)
@@ -28,17 +25,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isIn_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(LocalDateTime referenceDate) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusDays(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isIn(referenceDate.plusDays(1).toString(),
-                                                            referenceDate.plusDays(2).toString()))
-                                                                                                  .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusDays(1).toString(),
+                                                        REFERENCE.plusDays(2).toString()))
+                                                                                          .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDateTime} are already defined in assertj-core)
@@ -28,15 +25,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isNotEqualTo_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(LocalDateTime referenceDate) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotEqualTo(referenceDate.plusDays(1).toString());
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusDays(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isNotEqualTo(referenceDate.toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalDateTime} are already defined in assertj-core)
@@ -28,15 +25,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalDateTimeAssert_isNotIn_Test extends LocalDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(LocalDateTime referenceDate) {
+  @Test
+  public void test_isNotIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotIn(referenceDate.plusDays(1).toString(), referenceDate.plusDays(2).toString());
+    assertThat(REFERENCE).isNotIn(REFERENCE.plusDays(1).toString(), REFERENCE.plusDays(2).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isNotIn(referenceDate.toString(), referenceDate.plusDays(1).toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssertBaseTest.java
@@ -12,35 +12,17 @@
  */
 package org.assertj.core.api.localtime;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.LocalTime;
 
 import org.assertj.core.api.AbstractLocalTimeAssert;
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 /**
  * Base test class for {@link AbstractLocalTimeAssert} tests.
  */
 public class LocalTimeAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static LocalTime localTime1 = LocalTime.of(0, 0);
-  @DataPoint
-  public static LocalTime localTime2 = LocalTime.of(23, 59, 59, 999);
-  @DataPoint
-  public static LocalTime localTime3 = LocalTime.of(0, 0, 0, 1);
-  @DataPoint
-  public static LocalTime localTime4 = LocalTime.of(22, 15, 15, 875);
-  @DataPoint
-  public static LocalTime localTime5 = LocalTime.of(22, 15, 15, 874);
-  @DataPoint
-  public static LocalTime localTime6 = LocalTime.of(22, 15, 15, 876);
-
-  protected static void testAssumptions(LocalTime reference, LocalTime timeBefore, LocalTime timeAfter) {
-    assumeTrue(timeBefore.isBefore(reference));
-    assumeTrue(timeAfter.isAfter(reference));
-  }
-
+  public static final LocalTime REFERENCE = LocalTime.of(0, 0, 0, 1);
+  public static final LocalTime BEFORE = LocalTime.of(0, 0, 0, 0);
+  public static final LocalTime AFTER = LocalTime.of(0, 0, 0, 2);
 }

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfterOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isAfterOrEqualTo_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(LocalTime referenceTime, LocalTime timeBefore,
-	                                        LocalTime timeAfter) {
-	// GIVEN
-	testAssumptions(referenceTime, timeBefore, timeAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
 	// WHEN
-	assertThat(timeAfter).isAfterOrEqualTo(referenceTime);
-	assertThat(referenceTime).isAfterOrEqualTo(referenceTime);
+	assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+	assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
 	// THEN
-	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+	verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isAfter_Test.java
@@ -20,23 +20,17 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class LocalTimeAssert_isAfter_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(LocalTime referenceTime, LocalTime timeBefore, LocalTime timeAfter) {
-	// GIVEN
-	testAssumptions(referenceTime, timeBefore, timeAfter);
+  @Test
+  public void test_isAfter_assertion() {
 	// WHEN
-	assertThat(timeAfter).isAfter(referenceTime);
-	assertThat(timeAfter).isAfter(referenceTime.toString());
+	assertThat(AFTER).isAfter(REFERENCE);
+	assertThat(AFTER).isAfter(REFERENCE.toString());
 	// THEN
-	verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
-	verify_that_isAfter_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+	verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBeforeOrEqualTo_Test.java
@@ -19,28 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isBeforeOrEqualTo_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(LocalTime referenceTime, LocalTime timeBefore,
-	                                         LocalTime timeAfter) {
-	// GIVEN
-	testAssumptions(referenceTime, timeBefore, timeAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
 	// WHEN
-	assertThat(timeBefore).isBeforeOrEqualTo(referenceTime);
-	assertThat(referenceTime).isBeforeOrEqualTo(referenceTime);
+	assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+	assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
 	// THEN
-	verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+	verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isBefore_Test.java
@@ -19,27 +19,21 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isBefore_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(LocalTime referenceTime, LocalTime timeBefore, LocalTime timeAfter) {
-	// GIVEN
-	testAssumptions(referenceTime, timeBefore, timeAfter);
+  @Test
+  public void test_isBefore_assertion() {
 	// WHEN
-	assertThat(timeBefore).isBefore(referenceTime);
+	assertThat(BEFORE).isBefore(REFERENCE);
 	// THEN
-	verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
-	verify_that_isBefore_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+	verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+	verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isEqualTo_Test.java
@@ -18,19 +18,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class LocalTimeAssert_isEqualTo_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(LocalTime referenceTime) {
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(referenceTime).isEqualTo(referenceTime.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceTime).isEqualTo(referenceTime.plusHours(1).toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusHours(1).toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isIn_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalTime} are already defined in assertj-core)
@@ -28,17 +25,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isIn_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(LocalTime referenceTime) {
+  @Test
+  public void test_isIn_assertion() {
 	// WHEN
-	assertThat(referenceTime).isIn(referenceTime.toString(), referenceTime.plusHours(1).toString());
+	assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusHours(1).toString());
 	// THEN
-    assertThatThrownBy(() -> assertThat(referenceTime).isIn(referenceTime.plusHours(1).toString(),
-                                                            referenceTime.plusHours(2).toString()))
-                                                                                                   .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusHours(1).toString(),
+                                                        REFERENCE.plusHours(2).toString()))
+                                                                                           .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotEqualTo_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.fail;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalTime} are already defined in assertj-core)
@@ -28,15 +25,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isNotEqualTo_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(LocalTime referenceTime) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
 	// WHEN
-	assertThat(referenceTime).isNotEqualTo(referenceTime.plusHours(1).toString());
+	assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusHours(1).toString());
 	// THEN
-	verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceTime);
+	verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_isNotIn_Test.java
@@ -18,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link LocalTime} are already defined in assertj-core)
@@ -28,17 +25,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class LocalTimeAssert_isNotIn_Test extends LocalTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(LocalTime referenceTime) {
+  @Test
+  public void test_isNotIn_assertion() {
 	// WHEN
-	assertThat(referenceTime).isNotIn(referenceTime.plusHours(1).toString(), referenceTime.plusHours(2).toString());
+	assertThat(REFERENCE).isNotIn(REFERENCE.plusHours(1).toString(), REFERENCE.plusHours(2).toString());
 	// THEN
-    assertThatThrownBy(() -> assertThat(referenceTime).isNotIn(referenceTime.toString(),
-                                                               referenceTime.plusHours(1).toString()))
-                                                                                                      .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(),
+                                                           REFERENCE.plusHours(1).toString()))
+                                                                                              .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssertBaseTest.java
@@ -12,13 +12,10 @@
  */
 package org.assertj.core.api.offsetdatetime;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 /**
  * Base test class for {@link org.assertj.core.api.AbstractOffsetDateTimeAssert} tests.
@@ -28,24 +25,8 @@ import org.junit.experimental.theories.DataPoint;
  */
 public class OffsetDateTimeAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static OffsetDateTime offsetDateTime1 = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetDateTime offsetDateTime2 = OffsetDateTime.of(2000, 12, 13, 23, 59, 59, 999, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetDateTime offsetDateTime3 = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetDateTime offsetDateTime4 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 875, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetDateTime offsetDateTime5 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 874, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetDateTime offsetDateTime6 = OffsetDateTime.of(2000, 12, 14, 22, 15, 15, 876, ZoneOffset.UTC);
-
-  protected static void testAssumptions(OffsetDateTime reference, OffsetDateTime before, OffsetDateTime equal,
-                                        OffsetDateTime after) {
-    assumeTrue(before.isBefore(reference));
-    assumeTrue(equal.isEqual(reference));
-    assumeTrue(after.isAfter(reference));
-  }
+  public static final OffsetDateTime REFERENCE = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
+  public static final OffsetDateTime BEFORE = OffsetDateTime.of(2000, 12, 13, 23, 59, 59, 999, ZoneOffset.UTC);
+  public static final OffsetDateTime AFTER = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
 
 }

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -21,30 +21,23 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isAfterOrEqualTo_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(OffsetDateTime reference, OffsetDateTime dateBefore, OffsetDateTime dateEqual,
-                                            OffsetDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(reference, dateBefore, dateEqual, dateAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfterOrEqualTo(reference);
-    assertThat(dateAfter).isAfterOrEqualTo(reference.toString());
-    assertThat(dateEqual).isAfterOrEqualTo(reference);
-    assertThat(dateEqual).isAfterOrEqualTo(reference.toString());
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE.toString());
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, reference);
+    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isAfter_Test.java
@@ -20,29 +20,22 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isAfter_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(OffsetDateTime referenceDate, OffsetDateTime dateBefore, OffsetDateTime dateEqual,
-                                     OffsetDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateEqual, dateAfter);
+  @Test
+  public void test_isAfter_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfter(referenceDate);
-    assertThat(dateAfter).isAfter(referenceDate.toString());
+    assertThat(AFTER).isAfter(REFERENCE);
+    assertThat(AFTER).isAfter(REFERENCE.toString());
     // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -21,30 +21,23 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isBeforeOrEqualTo_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(OffsetDateTime reference, OffsetDateTime dateBefore,
-                                             OffsetDateTime dateEqual, OffsetDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(reference, dateBefore, dateEqual, dateAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
     // WHEN
-    assertThat(dateBefore).isBeforeOrEqualTo(reference);
-    assertThat(dateBefore).isBeforeOrEqualTo(reference.toString());
-    assertThat(dateEqual).isBeforeOrEqualTo(reference);
-    assertThat(dateEqual).isBeforeOrEqualTo(reference.toString());
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE.toString());
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, reference);
+    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isBefore_Test.java
@@ -21,29 +21,22 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isBefore_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(OffsetDateTime reference, OffsetDateTime dateBefore, OffsetDateTime dateEqual,
-                                      OffsetDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(reference, dateBefore, dateEqual, dateAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(dateBefore).isBefore(reference);
-    assertThat(dateBefore).isBefore(reference.toString());
+    assertThat(BEFORE).isBefore(REFERENCE);
+    assertThat(BEFORE).isBefore(REFERENCE.toString());
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(reference, reference);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, reference);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isEqualTo_Test.java
@@ -30,20 +30,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isEqualTo_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(OffsetDateTime reference, OffsetDateTime dateBefore, OffsetDateTime dateEqual,
-                                       OffsetDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(reference, dateBefore, dateEqual, dateAfter);
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(dateEqual).isEqualTo(reference);
-    assertThat(dateEqual).isEqualTo(reference.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE);
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(reference).isEqualTo(reference.plusSeconds(1)
-                                                                 .toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusSeconds(1)
+                                                                      .toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isIn_Test.java
@@ -20,9 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
@@ -30,17 +27,16 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isIn_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(OffsetDateTime referenceDate) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusDays(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isIn(referenceDate.plusDays(1).toString(),
-                                                            referenceDate.plusDays(2).toString()))
-                                                                                                  .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusDays(1).toString(),
+                                                        REFERENCE.plusDays(2).toString()))
+                                                                                          .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotEqualTo_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
@@ -29,19 +26,15 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isNotEqualTo_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(OffsetDateTime reference, OffsetDateTime before, OffsetDateTime equal,
-                                          OffsetDateTime after) {
-    // GIVEN
-    testAssumptions(reference, before, equal, after);
+  @Test
+  public void test_isNotEqualTo_assertion() {
     // WHEN
-    assertThat(equal).isNotEqualTo(reference.plusDays(1));
-    assertThat(equal).isNotEqualTo(reference.plusDays(1).toString());
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusDays(1));
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusDays(1).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(reference).isNotEqualTo(reference.toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isNotIn_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.OffsetDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetDateTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetDateTimeAssert_isNotIn_Test extends OffsetDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(OffsetDateTime referenceDate) {
+  @Test
+  public void test_isNotIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotIn(referenceDate.plusDays(1).toString(), referenceDate.plusDays(2).toString());
+    assertThat(REFERENCE).isNotIn(REFERENCE.plusDays(1).toString(), REFERENCE.plusDays(2).toString());
     // THEN
-    assertThatThrownBy(() -> assertThat(referenceDate).isNotIn(referenceDate.toString(), referenceDate.plusDays(1).toString())).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), REFERENCE.plusDays(1).toString())).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssertBaseTest.java
@@ -12,37 +12,18 @@
  */
 package org.assertj.core.api.offsettime;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 /**
  * Base test class for {@link org.assertj.core.api.AbstractOffsetTimeAssert} tests.
  */
 public class OffsetTimeAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static OffsetTime OffsetTime1 = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetTime OffsetTime2 = OffsetTime.of(23, 59, 59, 999, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetTime OffsetTime3 = OffsetTime.of(0, 0, 0, 1, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetTime OffsetTime4 = OffsetTime.of(22, 15, 15, 875, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetTime OffsetTime5 = OffsetTime.of(22, 15, 15, 874, ZoneOffset.UTC);
-  @DataPoint
-  public static OffsetTime OffsetTime6 = OffsetTime.of(22, 15, 15, 876, ZoneOffset.UTC);
-
-  protected static void testAssumptions(OffsetTime reference, OffsetTime timeBefore, OffsetTime timeEqual,
-                                        OffsetTime timeAfter) {
-    assumeTrue(timeBefore.isBefore(reference));
-    assumeTrue(timeEqual.isEqual(reference));
-    assumeTrue(timeAfter.isAfter(reference));
-  }
+  public static final OffsetTime REFERENCE = OffsetTime.of(0, 0, 0, 1, ZoneOffset.UTC);
+  public static final OffsetTime BEFORE = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC);
+  public static final OffsetTime AFTER = OffsetTime.of(0, 0, 0, 2, ZoneOffset.UTC);
 
 }

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfterOrEqualTo_Test.java
@@ -20,30 +20,23 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isAfterOrEqualTo_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeEqual,
-                                            OffsetTime timeAfter) {
-    // GIVEN
-    testAssumptions(referenceTime, timeBefore, timeEqual, timeAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
     // WHEN
-    assertThat(timeAfter).isAfterOrEqualTo(referenceTime);
-    assertThat(timeAfter).isAfterOrEqualTo(referenceTime.toString());
-    assertThat(timeEqual).isAfterOrEqualTo(referenceTime);
-    assertThat(timeEqual).isAfterOrEqualTo(referenceTime.toString());
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE.toString());
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isAfter_Test.java
@@ -20,24 +20,17 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.time.OffsetTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isAfter_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeEqual,
-                                     OffsetTime timeAfter) {
-    // GIVEN
-    testAssumptions(referenceTime, timeBefore, timeEqual, timeAfter);
+  @Test
+  public void test_isAfter_assertion() {
     // WHEN
-    assertThat(timeAfter).isAfter(referenceTime);
-    assertThat(timeAfter).isAfter(referenceTime.toString());
+    assertThat(AFTER).isAfter(REFERENCE);
+    assertThat(AFTER).isAfter(REFERENCE.toString());
     // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(timeBefore, referenceTime);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBeforeOrEqualTo_Test.java
@@ -20,30 +20,23 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isBeforeOrEqualTo_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeEqual,
-                                             OffsetTime timeAfter) {
-    // GIVEN
-    testAssumptions(referenceTime, timeBefore, timeEqual, timeAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
     // WHEN
-    assertThat(timeBefore).isBeforeOrEqualTo(referenceTime);
-    assertThat(timeBefore).isBeforeOrEqualTo(referenceTime.toString());
-    assertThat(timeEqual).isBeforeOrEqualTo(referenceTime);
-    assertThat(timeEqual).isBeforeOrEqualTo(referenceTime.toString());
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE.toString());
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isBefore_Test.java
@@ -20,29 +20,22 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isBefore_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeEqual,
-                                      OffsetTime timeAfter) {
-    // GIVEN
-    testAssumptions(referenceTime, timeBefore, timeEqual, timeAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(timeBefore).isBefore(referenceTime);
-    assertThat(timeBefore).isBefore(referenceTime.toString());
+    assertThat(BEFORE).isBefore(REFERENCE);
+    assertThat(BEFORE).isBefore(REFERENCE.toString());
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceTime, referenceTime);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(timeAfter, referenceTime);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isEqualTo_Test.java
@@ -19,22 +19,16 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isEqualTo_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(OffsetTime referenceTime, OffsetTime timeBefore, OffsetTime timeEqual,
-                                       OffsetTime timeAfter) {
-    testAssumptions(referenceTime, timeBefore, timeEqual, timeAfter);
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(timeEqual).isEqualTo(referenceTime);
-    assertThat(timeEqual).isEqualTo(referenceTime.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE);
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(referenceTime);
+    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isIn_Test.java
@@ -19,9 +19,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
@@ -29,16 +26,15 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isIn_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(OffsetTime referenceTime) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceTime).isIn(referenceTime, referenceTime.plusHours(1));
-    assertThat(referenceTime).isIn(referenceTime.toString(), referenceTime.plusHours(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE, REFERENCE.plusHours(1));
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusHours(1).toString());
     // THEN
-    verify_that_isIn_assertion_fails_and_throws_AssertionError(referenceTime);
+    verify_that_isIn_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotEqualTo_Test.java
@@ -19,9 +19,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isNotEqualTo_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(OffsetTime referenceTime) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
     // WHEN
-    assertThat(referenceTime).isNotEqualTo(referenceTime.plusHours(1).toString());
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusHours(1).toString());
     // THEN
-    verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceTime);
+    verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/offsettime/OffsetTimeAssert_isNotIn_Test.java
@@ -19,9 +19,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link java.time.OffsetTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class OffsetTimeAssert_isNotIn_Test extends OffsetTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(OffsetTime referenceTime) {
+  @Test
+  public void test_isNotIn_assertion() {
     // WHEN
-    assertThat(referenceTime).isNotIn(referenceTime.plusHours(1).toString(), referenceTime.plusHours(2).toString());
+    assertThat(REFERENCE).isNotIn(REFERENCE.plusHours(1).toString(), REFERENCE.plusHours(2).toString());
     // THEN
-    verify_that_isNotIn_assertion_fails_and_throws_AssertionError(referenceTime);
+    verify_that_isNotIn_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssertBaseTest.java
@@ -12,13 +12,10 @@
  */
 package org.assertj.core.api.zoneddatetime;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import org.assertj.core.api.BaseTest;
-import org.junit.experimental.theories.DataPoint;
 
 
 /**
@@ -30,22 +27,8 @@ import org.junit.experimental.theories.DataPoint;
  */
 public class ZonedDateTimeAssertBaseTest extends BaseTest {
 
-  @DataPoint
-  public static ZonedDateTime dateTime1 = ZonedDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
-  @DataPoint
-  public static ZonedDateTime dateTime2 = ZonedDateTime.of(2000, 12, 13, 23, 59, 59, 999, ZoneOffset.UTC);
-  @DataPoint
-  public static ZonedDateTime dateTime3 = ZonedDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
-  @DataPoint
-  public static ZonedDateTime dateTime4 = ZonedDateTime.of(2000, 12, 14, 22, 15, 15, 875, ZoneOffset.UTC);
-  @DataPoint
-  public static ZonedDateTime dateTime5 = ZonedDateTime.of(2000, 12, 14, 22, 15, 15, 874, ZoneOffset.UTC);
-  @DataPoint
-  public static ZonedDateTime dateTime6 = ZonedDateTime.of(2000, 12, 14, 22, 15, 15, 876, ZoneOffset.UTC);
-
-  protected static void testAssumptions(ZonedDateTime reference, ZonedDateTime dateBefore, ZonedDateTime dateAfter) {
-    assumeTrue(dateBefore.isBefore(reference));
-    assumeTrue(dateAfter.isAfter(reference));
-  }
+  public static final ZonedDateTime REFERENCE = ZonedDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
+  public static final ZonedDateTime BEFORE = ZonedDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
+  public static final ZonedDateTime AFTER = ZonedDateTime.of(2000, 12, 14, 0, 0, 0, 2, ZoneOffset.UTC);
 
 }

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -21,29 +21,23 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isAfterOrEqualTo_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfterOrEqual_assertion(ZonedDateTime referenceDate, ZonedDateTime dateBefore, ZonedDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfterOrEqual_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfterOrEqualTo(referenceDate);
-    assertThat(dateAfter).isAfterOrEqualTo(referenceDate.toString());
-    assertThat(referenceDate).isAfterOrEqualTo(referenceDate);
-    assertThat(referenceDate).isAfterOrEqualTo(referenceDate.toString());
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE.toString());
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isAfter_Test.java
@@ -22,28 +22,22 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isAfter_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isAfter_assertion(ZonedDateTime referenceDate, ZonedDateTime dateBefore, ZonedDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isAfter_assertion() {
     // WHEN
-    assertThat(dateAfter).isAfter(referenceDate);
-    assertThat(dateAfter).isAfter(referenceDate.format(DateTimeFormatter.ISO_DATE_TIME));
+    assertThat(AFTER).isAfter(REFERENCE);
+    assertThat(AFTER).isAfter(REFERENCE.format(DateTimeFormatter.ISO_DATE_TIME));
     // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(dateBefore, referenceDate);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isAfter_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -22,30 +22,23 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isBeforeOrEqualTo_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBeforeOrEqual_assertion(ZonedDateTime referenceDate, ZonedDateTime dateBefore,
-	                                         ZonedDateTime dateAfter) {
-	// GIVEN
-	testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBeforeOrEqual_assertion() {
 	// WHEN
-	assertThat(dateBefore).isBeforeOrEqualTo(referenceDate);
-	assertThat(dateBefore).isBeforeOrEqualTo(referenceDate.toString());
-	assertThat(referenceDate).isBeforeOrEqualTo(referenceDate);
-	assertThat(referenceDate).isBeforeOrEqualTo(referenceDate.toString());
+	assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+	assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE.toString());
+	assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
+	assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE.toString());
 	// THEN
-	verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+	verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isBefore_Test.java
@@ -21,28 +21,22 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * @author Paweł Stawicki
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isBefore_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isBefore_assertion(ZonedDateTime referenceDate, ZonedDateTime dateBefore, ZonedDateTime dateAfter) {
-    // GIVEN
-    testAssumptions(referenceDate, dateBefore, dateAfter);
+  @Test
+  public void test_isBefore_assertion() {
     // WHEN
-    assertThat(dateBefore).isBefore(referenceDate);
-    assertThat(dateBefore).isBefore(referenceDate.toString());
+    assertThat(BEFORE).isBefore(REFERENCE);
+    assertThat(BEFORE).isBefore(REFERENCE.toString());
     // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(referenceDate, referenceDate);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(dateAfter, referenceDate);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
+    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualTo_errors_Test.java
@@ -29,15 +29,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isEqualTo_errors_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isEqualTo_assertion(ZonedDateTime referenceDate) {
+  @Test
+  public void test_isEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isEqualTo(referenceDate.toString());
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
     // THEN
-    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
+    verify_that_isEqualTo_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isIn_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isIn_errors_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.fail;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link ZonedDateTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isIn_errors_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isIn_assertion(ZonedDateTime referenceDate) {
+  @Test
+  public void test_isIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isIn(referenceDate.toString(), referenceDate.plusNanos(1).toString());
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusNanos(1).toString());
     // THEN
-    verify_that_isIn_assertion_fails_and_throws_AssertionError(referenceDate);
+    verify_that_isIn_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotEqualTo_errors_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.fail;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link ZonedDateTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isNotEqualTo_errors_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotEqualTo_assertion(ZonedDateTime referenceDate) {
+  @Test
+  public void test_isNotEqualTo_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotEqualTo(referenceDate.plusNanos(1).toString());
+    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusNanos(1).toString());
     // THEN
-    verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(referenceDate);
+    verify_that_isNotEqualTo_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotIn_errors_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isNotIn_errors_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.fail;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
 
 /**
  * Only test String based assertion (tests with {@link ZonedDateTime} are already defined in assertj-core)
@@ -29,15 +26,14 @@ import org.junit.runner.RunWith;
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
  */
-@RunWith(Theories.class)
 public class ZonedDateTimeAssert_isNotIn_errors_Test extends ZonedDateTimeAssertBaseTest {
 
-  @Theory
-  public void test_isNotIn_assertion(ZonedDateTime referenceDate) {
+  @Test
+  public void test_isNotIn_assertion() {
     // WHEN
-    assertThat(referenceDate).isNotIn(referenceDate.plusNanos(1).toString(), referenceDate.plusNanos(2).toString());
+    assertThat(REFERENCE).isNotIn(REFERENCE.plusNanos(1).toString(), REFERENCE.plusNanos(2).toString());
     // THEN
-    verify_that_isNotIn_assertion_fails_and_throws_AssertionError(referenceDate);
+    verify_that_isNotIn_assertion_fails_and_throws_AssertionError(REFERENCE);
   }
 
   @Test


### PR DESCRIPTION
Another step for the JUnit 5 migration.

