### PR TITLE
containsAnyElementsOf should use bounded wildcard

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -745,7 +745,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @since 2.9.0 / 3.9.0
    */
   @Override
-  public SELF containsAnyElementsOf(Iterable<ELEMENT> iterable) {
+  public SELF containsAnyElementsOf(Iterable<? extends ELEMENT> iterable) {
     return containsAnyOf(toArray(iterable));
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -2841,7 +2841,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @since 2.9.0 / 3.9.0
    */
   @Override
-  public SELF containsAnyElementsOf(Iterable<ELEMENT> iterable) {
+  public SELF containsAnyElementsOf(Iterable<? extends ELEMENT> iterable) {
     return containsAnyOf(toArray(iterable));
   }
 

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -2872,7 +2872,7 @@ public class AtomicReferenceArrayAssert<T>
    * @since 2.9.0 / 3.9.0
    */
   @Override
-  public AtomicReferenceArrayAssert<T> containsAnyElementsOf(Iterable<T> iterable) {
+  public AtomicReferenceArrayAssert<T> containsAnyElementsOf(Iterable<? extends T> iterable) {
     return containsAnyOf(toArray(iterable));
   }
 

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1312,7 +1312,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the {@code Iterable} under test does not contain any of elements from the given {@code Iterable}.
    * @since 2.9.0 / 3.9.0
    */
-  SELF containsAnyElementsOf(Iterable<ELEMENT> iterable);
+  SELF containsAnyElementsOf(Iterable<? extends ELEMENT> iterable);
 
   /**
    * Verifies that no elements match the given {@link Predicate}.

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_containsAnyElementsOf_Test.java
@@ -12,13 +12,16 @@
  */
 package org.assertj.core.api.atomic.referencearray;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.assertj.core.api.AtomicReferenceArrayAssert;
 import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
 public class AtomicReferenceArrayAssert_containsAnyElementsOf_Test extends AtomicReferenceArrayAssertBaseTest {
 
@@ -32,6 +35,12 @@ public class AtomicReferenceArrayAssert_containsAnyElementsOf_Test extends Atomi
   @Override
   protected void verify_internal_effects() {
     verify(arrays).assertContainsAnyOf(info(), internalArray(), iterable.toArray());
+  }
+
+  @Test
+  public void should_allow_assertion_on_atomic_reference_array() {
+    assertThat(new AtomicReferenceArray<>(iterable.toArray()))
+      .containsAnyElementsOf(iterable);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
@@ -12,17 +12,21 @@
  */
 package org.assertj.core.api.iterable;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.ConcreteIterableAssert;
 import org.assertj.core.api.IterableAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link AbstractIterableAssert#containsAnyOf(Object[])} }</code>.
+ * Tests for <code>{@link AbstractIterableAssert#containsAnyElementsOf(Iterable)}}</code>.
  *
  * @author Marko Bekhta
  */
@@ -38,6 +42,15 @@ public class IterableAssert_containsAnyElementsOf_Test extends IterableAssertBas
   @Override
   protected void verify_internal_effects() {
     verify(iterables).assertContainsAnyOf(getInfo(assertions), getActual(assertions), iterable.toArray());
+  }
+
+  @Test
+  public void should_allow_assertion_on_values_extracted_from_given_map_keys() {
+    Map<Object, Object> map = new HashMap<>();
+    map.put("foo", "bar");
+
+    assertThat(map).extracting("foo")
+      .containsAnyElementsOf(iterable);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_containsAnyElementsOf_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api.objectarray;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.ObjectArrays.arrayOf;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
@@ -19,6 +21,7 @@ import java.util.List;
 
 import org.assertj.core.api.ObjectArrayAssert;
 import org.assertj.core.api.ObjectArrayAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
 public class ObjectArrayAssert_containsAnyElementsOf_Test extends ObjectArrayAssertBaseTest {
 
@@ -32,6 +35,12 @@ public class ObjectArrayAssert_containsAnyElementsOf_Test extends ObjectArrayAss
   @Override
   protected void verify_internal_effects() {
     verify(arrays).assertContainsAnyOf(info(), getActual(assertions), iterable.toArray());
+  }
+
+  @Test
+  public void should_allow_assertion_on_object_array() {
+    assertThat(arrayOf("foo", "bar"))
+      .containsAnyElementsOf(iterable);
   }
 
 }


### PR DESCRIPTION
`containsAnyElementsOf` takes an `Iterable<ELEMENT>` but should be a `Iterable<? extends ELEMENT>`

If I have this simple example:

```
Map<String, String> map = Map.of("some_key", "some_value");

List<String> values = List.of("some_value", "some_other_value");

assertThat(map).extracting("some_key").containsAnyElementsOf(values);
```

The `assertThat` statement will not compile with:

```
java: no suitable method found for containsAnyElementsOf(java.util.List<java.lang.String>)
method org.assertj.core.api.ObjectEnumerableAssert.containsAnyElementsOf(java.lang.Iterable<java.lang.Object>) is not applicable
  (argument mismatch; java.util.List<java.lang.String> cannot be converted to java.lang.Iterable<java.lang.Object>)
method org.assertj.core.api.AbstractIterableAssert.containsAnyElementsOf(java.lang.Iterable<java.lang.Object>) is not applicable
  (argument mismatch; java.util.List<java.lang.String> cannot be converted to java.lang.Iterable<java.lang.Object>)
```

`containsAnyElementsOf` will expect a `java.lang.Iterable<java.lang.Object>` instead of `java.lang.Iterable<?>` which will compile.

#### Check List:
* Unit tests : NA
* Javadoc with a code example (API only) : NA


