### PR TITLE
Add test packages as optional imports to OSGi manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,19 @@
             <configuration>
               <instructions>
                 <Export-Package>org.assertj.core.*</Export-Package>
-                <!-- Don't import what assertj-core exports but import everything else -->
-                <Import-Package>!org.assertj.core.*, *</Import-Package>
+                <!--
+                  Don't import what assertj-core exports but import everything else.
+                  Also need to explicitly import packages that are dynamically loaded using
+                  Class.forName() (org.junit, org.opentest4j and org.testng are needed
+                  by the assumptions engine).
+                -->
+                <Import-Package>
+                  !org.assertj.core.*,
+                  org.junit;resolution:="optional",
+                  org.opentest4j;resolution:="optional",
+                  org.testng;resolution:="optional",
+                  *
+                </Import-Package>
                 <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                 <_removeheaders>Bnd-LastModified</_removeheaders>
               </instructions>


### PR DESCRIPTION
#### Check List:
* Fixes #1290
* Unit tests : NO

Added org.junit, org.opentest4j and org.testng as optional imports to the OSGi Import-Package manifest entry. This allows `org.assertj.core.api.Assumptions.getAssumptionClass()` to resolve these classes if their bundles are installed in the current environment - without these import statements, they won't load and the assumption will throw an `IllegalStateException`.

Proper regression testing would be nice, but requires a full-blown OSGi integration test which does not exist yet.