### PR TITLE
fail(): return a value

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1329,8 +1329,8 @@ public class Assertions {
    * @param failureMessage error message.
    * @throws AssertionError with the given message.
    */
-  public static void fail(String failureMessage) {
-    Fail.fail(failureMessage);
+  public static <T> T fail(String failureMessage) {
+    return Fail.fail(failureMessage);
   }
 
   /**
@@ -1340,8 +1340,8 @@ public class Assertions {
    * @param args Arguments referenced by the format specifiers in the format string.
    * @throws AssertionError with the given built message.
    */
-  public static void fail(String failureMessage, Object... args) {
-    Fail.fail(failureMessage, args);
+  public static <T> T fail(String failureMessage, Object... args) {
+    return Fail.fail(failureMessage, args);
   }
 
   /**
@@ -1350,8 +1350,8 @@ public class Assertions {
    * @param realCause cause of the error.
    * @throws AssertionError with the given message and with the {@link Throwable} that caused the failure.
    */
-  public static void fail(String failureMessage, Throwable realCause) {
-    Fail.fail(failureMessage, realCause);
+  public static <T> T fail(String failureMessage, Throwable realCause) {
+    return Fail.fail(failureMessage, realCause);
   }
 
   /**
@@ -1365,8 +1365,8 @@ public class Assertions {
    *           not been.
    *
    */
-  public static void failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
-    Fail.shouldHaveThrown(throwableClass);
+  public static <T> T failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
+    return Fail.shouldHaveThrown(throwableClass);
   }
 
   /**
@@ -1376,8 +1376,8 @@ public class Assertions {
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
    */
-  public static void shouldHaveThrown(Class<? extends Throwable> throwableClass) {
-    Fail.shouldHaveThrown(throwableClass);
+  public static <T> T shouldHaveThrown(Class<? extends Throwable> throwableClass) {
+    return Fail.shouldHaveThrown(throwableClass);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Fail.java
+++ b/src/main/java/org/assertj/core/api/Fail.java
@@ -39,7 +39,7 @@ public final class Fail {
    * @param failureMessage error message.
    * @throws AssertionError with the given message.
    */
-  public static void fail(String failureMessage) {
+  public static <T> T fail(String failureMessage) {
     throw Failures.instance().failure(failureMessage);
   }
 
@@ -50,8 +50,8 @@ public final class Fail {
    * @param args Arguments referenced by the format specifiers in the format string.
    * @throws AssertionError with the given built message.
    */
-  public static void fail(String failureMessage, Object... args) {
-    fail(String.format(failureMessage, args));
+  public static <T> T fail(String failureMessage, Object... args) {
+    return fail(String.format(failureMessage, args));
   }
 
   /**
@@ -61,7 +61,7 @@ public final class Fail {
    * @param realCause cause of the error.
    * @throws AssertionError with the given message and with the {@link Throwable} that caused the failure.
    */
-  public static void fail(String failureMessage, Throwable realCause) {
+  public static <T> T fail(String failureMessage, Throwable realCause) {
     AssertionError error = Failures.instance().failure(failureMessage);
     error.initCause(realCause);
     throw error;
@@ -77,8 +77,8 @@ public final class Fail {
    *
    * {@link Fail#shouldHaveThrown(Class)} can be used as a replacement.
    */
-  public static void failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
-    shouldHaveThrown(throwableClass);
+  public static <T> T failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
+    return shouldHaveThrown(throwableClass);
   }
 
   /**
@@ -89,7 +89,7 @@ public final class Fail {
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
    */
-  public static void shouldHaveThrown(Class<? extends Throwable> throwableClass) {
+  public static <T> T shouldHaveThrown(Class<? extends Throwable> throwableClass) {
     throw Failures.instance().expectedThrowableNotThrown(throwableClass);
   }
 

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -154,8 +154,8 @@ public interface WithAssertions {
    * @param failureMessage error message.
    * @throws AssertionError with the given message.
    */
-  default void fail(final String failureMessage) {
-    Assertions.fail(failureMessage);
+  default <T> T fail(final String failureMessage) {
+    return Assertions.fail(failureMessage);
   }
 
   /**
@@ -166,8 +166,8 @@ public interface WithAssertions {
    * @throws AssertionError with the given built message.
    * @since 3.9.0
    */
-  default void fail(String failureMessage, Object... args) {
-    Assertions.fail(failureMessage, args);
+  default <T> T fail(String failureMessage, Object... args) {
+    return Assertions.fail(failureMessage, args);
   }
 
   /**
@@ -176,8 +176,8 @@ public interface WithAssertions {
    * @param realCause cause of the error.
    * @throws AssertionError with the given message and with the {@link Throwable} that caused the failure.
    */
-  default void fail(final String failureMessage, final Throwable realCause) {
-    Assertions.fail(failureMessage, realCause);
+  default <T> T fail(final String failureMessage, final Throwable realCause) {
+    return Assertions.fail(failureMessage, realCause);
   }
 
   /**
@@ -1826,8 +1826,8 @@ public interface WithAssertions {
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
    */
-  default void failBecauseExceptionWasNotThrown(final Class<? extends Throwable> throwableClass) {
-    Assertions.failBecauseExceptionWasNotThrown(throwableClass);
+  default <T> T failBecauseExceptionWasNotThrown(final Class<? extends Throwable> throwableClass) {
+    return Assertions.failBecauseExceptionWasNotThrown(throwableClass);
   }
 
   /**
@@ -1838,8 +1838,8 @@ public interface WithAssertions {
    *           not been.
    * @since 3.9.0
    */
-  default void shouldHaveThrown(Class<? extends Throwable> throwableClass) {
-    Assertions.shouldHaveThrown(throwableClass);
+  default <T> T shouldHaveThrown(Class<? extends Throwable> throwableClass) {
+    return Assertions.shouldHaveThrown(throwableClass);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/Assertions_fail_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_fail_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class Assertions_fail_Test {
@@ -36,5 +37,12 @@ public class Assertions_fail_Test {
     Throwable cause = new Throwable();
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions.fail(message, cause))
                                                    .withMessage(message).withCause(cause);
+  }
+
+  @Test
+  public void should_return_a_value() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      int i = Optional.<Integer>empty().orElseGet(() -> Assertions.fail("Failed :("));
+    }).withMessage("Failed :(");
   }
 }


### PR DESCRIPTION
This allows `fail()` to be used where the java compiler expects a value like
`Optional.orElseGet()`.

If requested I can provide more tests (and javadoc).

#### Check List:
* Unit tests : YES
* Javadoc with a code example (API only) : NA


