### PR TITLE
Enabled fluent String assertions for non-String objects with asString

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -456,8 +456,8 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   @Override
   @CheckReturnValue
   public AbstractStringAssert<?> asString() {
-    objects.assertIsInstanceOf(info, actual, String.class);
-    return Assertions.assertThat((String) actual);
+    objects.assertNotNull(info, actual);
+    return Assertions.assertThat(actual.toString());
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -559,9 +559,8 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
   AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> asList();
 
   /**
-   * Verifies that the actual value is an instance of String,
-   * and returns a String assertion, to allow chaining of String-specific
-   * assertions from this call.
+   * Returns a String assertion for the <code>toString()</code> of the actual
+   * value, to allow chaining of String-specific assertions from this call.
    * <p>
    * Example :
    * <pre><code class='java'> Object stringAsObject = "hello world";

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_asString_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_asString_Test.java
@@ -12,11 +12,10 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Assert.asString() methods
@@ -25,16 +24,28 @@ public class Assertions_assertThat_asString_Test {
 
   @Test
   public void should_pass_string_asserts_on_string_objects_with_asString() {
-	Object stringAsObject = "hello world";
-	assertThat(stringAsObject).asString().contains("hello");
+    Object stringAsObject = "hello world";
+    assertThat(stringAsObject).asString().contains("hello");
   }
 
   @Test
-  public void should_fail_string_asserts_on_non_string_objects_even_with_asString() {
+  public void should_pass_string_asserts_on_non_string_objects_with_asString() {
     Object nonString = new Object();
+    assertThat(nonString).asString().isEqualTo(nonString.toString());
+  }
 
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(nonString).asString().contains("hello"))
-                                                   .withMessageContaining(format("an instance of:%n  <java.lang.String>%nbut was instance of:%n  <java.lang.Object>"));
+  @Test
+  public void should_fail_string_asserts_on_non_string_objects_with_asString() {
+    Object nonString = new Object();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(nonString).asString().contains("probably not this"));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null_with_asString() {
+    Object nullObject = null;
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(nullObject).asString().isEqualTo("never gonna happen"));
   }
 
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1307
* Unit tests : YES
* Javadoc with a code example (API only) : YES

This is a breaking change for those that depended on `asString()` to
assert that `actual` is an instance of `String`.  It now only asserts that
`actual` is not null.  Those needing that functionality can use
`assertThat(actual).isInstanceOf(String.class).asString()`.



