### PR TITLE
Fixes problems caused by @CheckReturnValue 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>25.0-jre</version>

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -94,12 +94,11 @@ import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.presentation.UnicodeRepresentation;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
-
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * Entry point for assertion methods for different types. Each method in this class is a static factory for a

--- a/src/main/java/org/assertj/core/util/CanIgnoreReturnValue.java
+++ b/src/main/java/org/assertj/core/util/CanIgnoreReturnValue.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to skip "CheckReturnValue" check.
+ */
+@Target({
+  ElementType.CONSTRUCTOR,
+  ElementType.METHOD,
+  ElementType.PACKAGE,
+  ElementType.TYPE,
+})
+@Retention(RetentionPolicy.CLASS)
+public @interface CanIgnoreReturnValue {
+}


### PR DESCRIPTION
... by using `CanIgnoreReturnValue` for `Assertions.fail*`

#### Check List:
* Fixes #1298
* Unit tests : NA
* Javadoc with a code example (API only) :  NA

This pr is based on #1299

