### PR TITLE
Throw AssertionFailedError instead in non-strict string assertions

### DIFF
--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -550,7 +550,7 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are not equal.
    */
   public void assertEqualsIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (!areEqualIgnoringCase(actual, expected)) throw failures.failure(info, shouldBeEqual(actual, expected));
+    if (!areEqualIgnoringCase(actual, expected)) throw failures.failure(info, shouldBeEqual(actual, expected), actual, expected);
   }
 
   /**
@@ -584,7 +584,7 @@ public class Strings {
     String actualNormalized = normalizeNewlines(actual);
     String expectedNormalized = normalizeNewlines(expected);
     if (!actualNormalized.equals(expectedNormalized))
-      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, expected));
+      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
   }
 
   private static String normalizeNewlines(CharSequence actual) {
@@ -601,7 +601,7 @@ public class Strings {
    */
   public void assertEqualsIgnoringWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
     if (!areEqualIgnoringWhitespace(actual, expected))
-      throw failures.failure(info, shouldBeEqualIgnoringWhitespace(actual, expected));
+      throw failures.failure(info, shouldBeEqualIgnoringWhitespace(actual, expected), actual, expected);
   }
 
   /**
@@ -647,7 +647,7 @@ public class Strings {
    */
   public void assertEqualsNormalizingWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
     if (!areEqualNormalizingWhitespace(actual, expected))
-      throw failures.failure(info, shouldBeEqualNormalizingWhitespace(actual, expected));
+      throw failures.failure(info, shouldBeEqualNormalizingWhitespace(actual, expected), actual, expected);
   }
 
   /**
@@ -1084,7 +1084,7 @@ public class Strings {
     String actualWithoutNewLines = removeNewLines(actual);
     String expectedWithoutNewLines = removeNewLines(expected);
     if (!actualWithoutNewLines.equals(expectedWithoutNewLines))
-      throw failures.failure(info, shouldBeEqualIgnoringNewLines(actual, expected));
+      throw failures.failure(info, shouldBeEqualIgnoringNewLines(actual, expected), actual, expected);
   }
 
   public void assertLowerCase(AssertionInfo info, CharSequence actual) {

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
@@ -94,6 +94,6 @@ public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest
 
   private void verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(AssertionInfo info, String actual,
                                                                            String expected) {
-    verify(failures).failure(info, shouldBeEqualIgnoringWhitespace(actual, expected));
+    verify(failures).failure(info, shouldBeEqualIgnoringWhitespace(actual, expected), actual, expected);
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -51,7 +51,7 @@ public class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBase
     try {
       strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected);
     } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected));
+      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualsToIgnoringNewLines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualsToIgnoringNewLines_Test.java
@@ -54,7 +54,7 @@ public class Strings_assertIsEqualsToIgnoringNewLines_Test extends StringsBaseTe
     try {
       strings.assertIsEqualToIgnoringNewLines(someInfo(), actual, expected);
     } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLines(actual, expected));
+      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLines(actual, expected), actual, expected);
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION

#### Check List:
* Fixes #1331
* Unit tests : YES
* Javadoc with a code example (API only) : NA

