### PR TITLE
Skip JavaDoc on Java 12, because it currently fails with "javadoc: er…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,5 +346,15 @@
         <sonar.skip>true</sonar.skip>
       </properties>
     </profile>
+    <profile>
+      <id>java12+</id>
+      <activation>
+        <jdk>[12,)</jdk>
+      </activation>
+      <properties>
+        <!-- currently fails with "javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module." -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
…ror - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module."

