### PR TITLE
Annotate Assertions and Assumptions classes with @CheckReturnValue an…

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import org.assertj.core.util.CheckReturnValue;
 
+@CheckReturnValue
 public abstract class AbstractStandardSoftAssertions extends Java6AbstractStandardSoftAssertions {
 
   /**
@@ -46,7 +47,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the path
    * @return the created assertion object
    */
-  @CheckReturnValue
   public PathAssert assertThat(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
@@ -59,7 +59,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <VALUE> OptionalAssert<VALUE> assertThat(Optional<VALUE> actual) {
     return proxy(OptionalAssert.class, Optional.class, actual);
   }
@@ -71,7 +70,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return proxy(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
@@ -83,7 +81,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public OptionalLongAssert assertThat(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
   }
@@ -95,7 +92,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public OptionalIntAssert assertThat(OptionalInt actual) {
     return proxy(OptionalIntAssert.class, OptionalInt.class, actual);
   }
@@ -106,7 +102,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LocalDateAssert assertThat(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
   }
@@ -117,7 +112,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LocalDateTimeAssert assertThat(LocalDateTime actual) {
     return proxy(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
@@ -128,7 +122,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
     return proxy(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
@@ -139,7 +132,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LocalTimeAssert assertThat(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
@@ -150,7 +142,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public OffsetTimeAssert assertThat(OffsetTime actual) {
     return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
@@ -161,7 +152,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
     return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
@@ -173,7 +163,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public InstantAssert assertThat(Instant actual) {
     return proxy(InstantAssert.class, Instant.class, actual);
   }
@@ -186,7 +175,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletableFuture<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
@@ -201,7 +189,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletionStage<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletionStage.class, actual);
   }
@@ -216,7 +203,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public <T> ProxyablePredicateAssert<T> assertThat(Predicate<T> actual) {
     return proxy(ProxyablePredicateAssert.class, Predicate.class, actual);
   }
@@ -228,7 +214,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public IntPredicateAssert assertThat(IntPredicate actual) {
     return proxy(IntPredicateAssert.class, IntPredicate.class, actual);
   }
@@ -240,7 +225,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public DoublePredicateAssert assertThat(DoublePredicate actual) {
     return proxy(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
@@ -252,7 +236,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public LongPredicateAssert assertThat(LongPredicate actual) {
     return proxy(LongPredicateAssert.class, LongPredicate.class, actual);
   }
@@ -268,7 +251,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
     return proxy(ProxyableListAssert.class, Stream.class, actual);
   }
@@ -283,7 +265,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assertThat(DoubleStream actual) {
     return proxy(ProxyableListAssert.class, DoubleStream.class, actual);
   }
@@ -298,7 +279,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assertThat(LongStream actual) {
     return proxy(ProxyableListAssert.class, LongStream.class, actual);
   }
@@ -313,7 +293,6 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assertThat(IntStream actual) {
     return proxy(ProxyableListAssert.class, IntStream.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -146,7 +146,6 @@ public class Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -159,7 +158,6 @@ public class Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static IntPredicateAssert assertThat(IntPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -172,7 +170,6 @@ public class Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -185,7 +182,6 @@ public class Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -198,7 +194,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletableFuture<RESULT> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -213,7 +208,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletionStage<RESULT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -226,7 +220,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <VALUE> OptionalAssert<VALUE> assertThat(Optional<VALUE> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -238,7 +231,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -250,7 +242,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -262,7 +253,6 @@ public class Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalLongAssert assertThat(OptionalLong actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -273,7 +263,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -285,7 +274,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
@@ -296,7 +284,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -307,7 +294,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -318,7 +304,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -329,7 +314,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -340,7 +324,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -351,7 +334,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -362,7 +344,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -373,7 +354,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -384,7 +364,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -395,7 +374,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -406,7 +384,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -417,7 +394,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ClassAssert assertThat(Class<?> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -428,7 +404,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -439,7 +414,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -450,7 +424,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -461,7 +434,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -475,7 +447,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
     return new FutureAssert<>(actual);
   }
@@ -486,7 +457,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -497,7 +467,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -508,7 +477,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -519,7 +487,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -530,7 +497,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -541,7 +507,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -552,7 +517,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -595,7 +559,6 @@ public class Assertions {
    * @since 2.5.0 / 3.5.0
    */
   //@format:off
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          FactoryBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(Iterable<? extends ELEMENT> actual,
                                                                                  AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -631,7 +594,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.5.0 / 3.5.0
    */
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          ClassBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(ACTUAL actual,
                                                                                           Class<ELEMENT_ASSERT> assertClass) {
@@ -675,7 +637,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.5.0 / 3.5.0
    */
-  @CheckReturnValue
   public static <ACTUAL extends List<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          FactoryBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
                                                                                         AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -711,7 +672,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.5.0 / 3.5.0
    */
-  @CheckReturnValue
   public static <ELEMENT, ACTUAL extends List<? extends ELEMENT>, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          ClassBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
                                                                                       Class<ELEMENT_ASSERT> assertClass) {
@@ -726,7 +686,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -737,7 +696,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -748,7 +706,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -760,7 +717,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectAssert<T> assertThat(T actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -772,7 +728,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectArrayAssert<T> assertThat(T[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -783,7 +738,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -794,7 +748,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -805,7 +758,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -816,7 +768,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -827,7 +778,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -838,7 +788,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -849,7 +798,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -860,7 +808,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -871,7 +818,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -882,7 +828,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -894,7 +839,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractInstantAssert<?> assertThat(Instant actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -906,7 +850,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return new AtomicBooleanAssert(actual);
   }
@@ -918,7 +861,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
   }
@@ -930,7 +872,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return new AtomicIntegerArrayAssert(actual);
   }
@@ -943,7 +884,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assertThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return new AtomicIntegerFieldUpdaterAssert<>(actual);
   }
@@ -955,7 +895,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongAssert assertThat(AtomicLong actual) {
     return new AtomicLongAssert(actual);
   }
@@ -967,7 +906,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return new AtomicLongArrayAssert(actual);
   }
@@ -980,7 +918,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assertThat(AtomicLongFieldUpdater<OBJECT> actual) {
     return new AtomicLongFieldUpdaterAssert<>(actual);
   }
@@ -993,7 +930,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicReferenceAssert<VALUE> assertThat(AtomicReference<VALUE> actual) {
     return new AtomicReferenceAssert<>(actual);
   }
@@ -1006,7 +942,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assertThat(AtomicReferenceArray<ELEMENT> actual) {
     return new AtomicReferenceArrayAssert<>(actual);
   }
@@ -1020,7 +955,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assertThat(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return new AtomicReferenceFieldUpdaterAssert<>(actual);
   }
@@ -1033,7 +967,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicMarkableReferenceAssert<VALUE> assertThat(AtomicMarkableReference<VALUE> actual) {
     return new AtomicMarkableReferenceAssert<>(actual);
   }
@@ -1046,7 +979,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicStampedReferenceAssert<VALUE> assertThat(AtomicStampedReference<VALUE> actual) {
     return new AtomicStampedReferenceAssert<>(actual);
   }
@@ -1057,7 +989,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -1090,6 +1021,7 @@ public class Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return the created {@link ThrowableAssert}.
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -1126,6 +1058,7 @@ public class Assertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -1166,7 +1099,6 @@ public class Assertions {
    * @return the created {@link ThrowableAssert}.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return AssertionsForClassTypes.assertThatCode(shouldRaiseOrNotThrowable);
   }
@@ -1258,7 +1190,6 @@ public class Assertions {
    * @param exceptionType the exception type class.
    * @return the created {@link ThrowableTypeAssert}.
    */
-  @CheckReturnValue
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return AssertionsForClassTypes.assertThatExceptionOfType(exceptionType);
   }
@@ -1270,7 +1201,6 @@ public class Assertions {
    *
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static ThrowableTypeAssert<NullPointerException> assertThatNullPointerException() {
     return assertThatExceptionOfType(NullPointerException.class);
   }
@@ -1282,7 +1212,6 @@ public class Assertions {
    *
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static ThrowableTypeAssert<IllegalArgumentException> assertThatIllegalArgumentException() {
     return assertThatExceptionOfType(IllegalArgumentException.class);
   }
@@ -1294,7 +1223,6 @@ public class Assertions {
    *
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static ThrowableTypeAssert<IOException> assertThatIOException() {
     return assertThatExceptionOfType(IOException.class);
   }
@@ -1306,7 +1234,6 @@ public class Assertions {
    *
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static ThrowableTypeAssert<IllegalStateException> assertThatIllegalStateException() {
     return assertThatExceptionOfType(IllegalStateException.class);
   }
@@ -2575,7 +2502,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2587,7 +2513,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -2598,7 +2523,6 @@ public class Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -2609,7 +2533,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> assertThat(String actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
@@ -2621,7 +2544,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> IterableAssert<ELEMENT> assertThat(Iterable<? extends ELEMENT> actual) {
     if (actual instanceof SortedSet) {
       @SuppressWarnings("unchecked")
@@ -2653,7 +2575,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> IteratorAssert<ELEMENT> assertThat(Iterator<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2665,7 +2586,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(List<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2697,7 +2617,6 @@ public class Assertions {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2728,7 +2647,6 @@ public class Assertions {
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Double> assertThat(DoubleStream actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2759,7 +2677,6 @@ public class Assertions {
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Long> assertThat(LongStream actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2790,7 +2707,6 @@ public class Assertions {
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Integer> assertThat(IntStream actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2801,7 +2717,6 @@ public class Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
-  @CheckReturnValue
   public static AbstractPathAssert<?> assertThat(Path actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2817,7 +2732,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2830,7 +2744,6 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
@@ -2886,7 +2799,6 @@ public class Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -55,6 +55,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
@@ -69,6 +70,7 @@ import org.assertj.core.util.introspection.FieldSupport;
  * This why {@link Assertions} have been split in {@link AssertionsForClassTypes} and {@link AssertionsForInterfaceTypes}
  * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
  */
+@CheckReturnValue
 public class AssertionsForClassTypes {
 
   /**
@@ -79,7 +81,6 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletableFuture<RESULT> actual) {
     return new CompletableFutureAssert<>(actual);
   }
@@ -92,7 +93,6 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <VALUE> OptionalAssert<VALUE> assertThat(Optional<VALUE> actual) {
     return new OptionalAssert<>(actual);
   }
@@ -104,7 +104,6 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return new OptionalDoubleAssert(actual);
   }
@@ -116,7 +115,6 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return new OptionalIntAssert(actual);
   }
@@ -128,7 +126,6 @@ public class AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalLongAssert assertThat(OptionalLong actual) {
     return new OptionalLongAssert(actual);
   }
@@ -139,7 +136,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
@@ -150,7 +146,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return new UriAssert(actual);
   }
@@ -161,7 +156,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return new UrlAssert(actual);
   }
@@ -172,7 +166,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -183,7 +176,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -194,7 +186,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
@@ -205,7 +196,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return new ByteAssert(actual);
   }
@@ -216,7 +206,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
@@ -227,7 +216,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
@@ -238,7 +226,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return new CharacterAssert(actual);
   }
@@ -249,7 +236,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
@@ -260,7 +246,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
@@ -271,7 +256,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ClassAssert assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
@@ -282,7 +266,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return new DoubleAssert(actual);
   }
@@ -293,7 +276,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
@@ -304,7 +286,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
@@ -315,7 +296,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return new FileAssert(actual);
   }
@@ -326,7 +306,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
@@ -337,7 +316,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return new FloatAssert(actual);
   }
@@ -348,7 +326,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return new FloatAssert(actual);
   }
@@ -359,7 +336,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
@@ -370,7 +346,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return new IntegerAssert(actual);
   }
@@ -381,7 +356,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
@@ -392,7 +366,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
@@ -403,7 +376,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return new LongAssert(actual);
   }
@@ -414,7 +386,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return new LongAssert(actual);
   }
@@ -425,7 +396,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
@@ -437,7 +407,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectAssert<T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
@@ -449,7 +418,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectArrayAssert<T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
@@ -460,7 +428,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return new ShortAssert(actual);
   }
@@ -471,7 +438,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return new ShortAssert(actual);
   }
@@ -482,7 +448,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
@@ -494,7 +459,6 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
     return new CharSequenceAssert(actual);
   }
@@ -506,7 +470,6 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
     return new CharSequenceAssert(actual);
   }
@@ -517,7 +480,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> assertThat(String actual) {
     return new StringAssert(actual);
   }
@@ -528,7 +490,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return new DateAssert(actual);
   }
@@ -539,7 +500,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
     return new ZonedDateTimeAssert(actual);
   }
@@ -550,7 +510,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
     return new LocalDateTimeAssert(actual);
   }
@@ -561,7 +520,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return new OffsetDateTimeAssert(actual);
   }
@@ -572,7 +530,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
     return new OffsetTimeAssert(actual);
   }
@@ -583,7 +540,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return new LocalTimeAssert(actual);
   }
@@ -594,7 +550,6 @@ public class AssertionsForClassTypes {
    * @param localDate the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateAssert<?> assertThat(LocalDate localDate) {
     return new LocalDateAssert(localDate);
   }
@@ -606,7 +561,6 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractInstantAssert<?> assertThat(Instant instant) {
     return new InstantAssert(instant);
   }
@@ -617,7 +571,6 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
@@ -650,6 +603,7 @@ public class AssertionsForClassTypes {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return the created {@link ThrowableAssert}.
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -686,6 +640,7 @@ public class AssertionsForClassTypes {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -706,7 +661,6 @@ public class AssertionsForClassTypes {
    * @param exceptionType the class of exception type.
    * @return the created {@link ThrowableTypeAssert}.
    */
-  @CheckReturnValue
   public static <T extends Throwable> ThrowableTypeAssert<T> assertThatExceptionOfType(final Class<? extends T> exceptionType) {
     return new ThrowableTypeAssert<>(exceptionType);
   }
@@ -752,7 +706,6 @@ public class AssertionsForClassTypes {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }

--- a/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -61,6 +61,7 @@ import org.assertj.core.util.CheckReturnValue;
  * @author Turbo87
  * @author dorzey
  */
+@CheckReturnValue
 public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
 
   /**
@@ -89,7 +90,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
@@ -101,7 +101,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> IterableAssert<ELEMENT> assertThat(Iterable<? extends ELEMENT> actual) {
     return new IterableAssert<>(actual);
   }
@@ -113,7 +112,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> IteratorAssert<ELEMENT> assertThat(Iterator<? extends ELEMENT> actual) {
     return new IteratorAssert<>(actual);
   }
@@ -125,7 +123,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(List<? extends ELEMENT> actual) {
     return new ListAssert<>(actual);
   }
@@ -157,7 +154,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
     return new ListAssert<>(actual);
   }
@@ -188,7 +184,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Double> assertThat(DoubleStream actual) {
     return new ListAssert<>(actual);
   }
@@ -219,7 +214,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Long> assertThat(LongStream actual) {
     return new ListAssert<>(actual);
   }
@@ -250,7 +244,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Integer> assertThat(IntStream actual) {
     return new ListAssert<>(actual);
   }
@@ -301,7 +294,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the path to test
    * @return the created assertion object
    */
-  @CheckReturnValue
   public static AbstractPathAssert<?> assertThat(Path actual) {
     return new PathAssert(actual);
   }
@@ -317,7 +309,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return new MapAssert<>(actual);
   }
@@ -330,7 +321,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
@@ -386,7 +376,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
@@ -399,7 +388,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static <T> PredicateAssert<T> assertThat(Predicate<T> actual) {
     return new PredicateAssert<>(actual);
   }
@@ -411,7 +399,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static IntPredicateAssert assertThat(IntPredicate actual) {
     return new IntPredicateAssert(actual);
   }
@@ -423,7 +410,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return new LongPredicateAssert(actual);
   }
@@ -435,7 +421,6 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return new DoublePredicateAssert(actual);
   }
@@ -450,10 +435,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletionStage<RESULT> actual) {
     return new CompletableFutureAssert<>(actual);
   }
-
 
 }

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -85,6 +85,7 @@ import net.bytebuddy.implementation.bind.annotation.This;
  * Entry point for assumption methods for different types, which allow to skip test execution on failed assumptions.
  * @since 2.9.0 / 3.9.0
  */
+@CheckReturnValue
 public class Assumptions {
 
   /**
@@ -122,7 +123,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <T> ProxyableObjectAssert<T> assumeThat(T actual) {
     return asAssumption(ProxyableObjectAssert.class, Object.class, actual);
@@ -135,7 +135,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> assumeThat(String actual) {
     return asAssumption(StringAssert.class, String.class, actual);
   }
@@ -147,7 +146,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assumeThat(BigDecimal actual) {
     return asAssumption(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -159,7 +157,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractBigIntegerAssert<?> assumeThat(BigInteger actual) {
     return asAssumption(BigIntegerAssert.class, BigInteger.class, actual);
   }
@@ -171,7 +168,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> assumeThat(URI actual) {
     return asAssumption(UriAssert.class, URI.class, actual);
   }
@@ -183,7 +179,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> assumeThat(URL actual) {
     return asAssumption(UrlAssert.class, URL.class, actual);
   }
@@ -195,7 +190,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assumeThat(boolean actual) {
     return asAssumption(BooleanAssert.class, Boolean.class, actual);
   }
@@ -207,7 +201,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assumeThat(Boolean actual) {
     return asAssumption(BooleanAssert.class, Boolean.class, actual);
   }
@@ -219,7 +212,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assumeThat(boolean[] actual) {
     return asAssumption(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -231,7 +223,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assumeThat(byte actual) {
     return asAssumption(ByteAssert.class, Byte.class, actual);
   }
@@ -243,7 +234,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assumeThat(Byte actual) {
     return asAssumption(ByteAssert.class, Byte.class, actual);
   }
@@ -255,7 +245,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assumeThat(byte[] actual) {
     return asAssumption(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -267,7 +256,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assumeThat(char actual) {
     return asAssumption(CharacterAssert.class, Character.class, actual);
   }
@@ -279,7 +267,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assumeThat(Character actual) {
     return asAssumption(CharacterAssert.class, Character.class, actual);
   }
@@ -291,7 +278,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assumeThat(char[] actual) {
     return asAssumption(CharArrayAssert.class, char[].class, actual);
   }
@@ -303,7 +289,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(CharSequence actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -315,7 +300,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuilder actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -327,7 +311,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuffer actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -340,7 +323,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assumeThat(short actual) {
     return asAssumption(ShortAssert.class, Short.class, actual);
   }
@@ -352,7 +334,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assumeThat(Short actual) {
     return asAssumption(ShortAssert.class, Short.class, actual);
   }
@@ -364,7 +345,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assumeThat(short[] actual) {
     return asAssumption(ShortArrayAssert.class, short[].class, actual);
   }
@@ -376,7 +356,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assumeThat(int actual) {
     return asAssumption(IntegerAssert.class, Integer.class, actual);
   }
@@ -388,7 +367,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assumeThat(Integer actual) {
     return asAssumption(IntegerAssert.class, Integer.class, actual);
   }
@@ -400,7 +378,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assumeThat(int[] actual) {
     return asAssumption(IntArrayAssert.class, int[].class, actual);
   }
@@ -412,7 +389,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assumeThat(long actual) {
     return asAssumption(LongAssert.class, Long.class, actual);
   }
@@ -424,7 +400,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assumeThat(Long actual) {
     return asAssumption(LongAssert.class, Long.class, actual);
   }
@@ -436,7 +411,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assumeThat(long[] actual) {
     return asAssumption(LongArrayAssert.class, long[].class, actual);
   }
@@ -448,7 +422,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assumeThat(float actual) {
     return asAssumption(FloatAssert.class, Float.class, actual);
   }
@@ -460,7 +433,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assumeThat(Float actual) {
     return asAssumption(FloatAssert.class, Float.class, actual);
   }
@@ -472,7 +444,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assumeThat(float[] actual) {
     return asAssumption(FloatArrayAssert.class, float[].class, actual);
   }
@@ -484,7 +455,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assumeThat(double actual) {
     return asAssumption(DoubleAssert.class, Double.class, actual);
   }
@@ -496,7 +466,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assumeThat(Double actual) {
     return asAssumption(DoubleAssert.class, Double.class, actual);
   }
@@ -508,7 +477,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assumeThat(double[] actual) {
     return asAssumption(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -520,7 +488,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AtomicBooleanAssert assumeThat(AtomicBoolean actual) {
     return asAssumption(AtomicBooleanAssert.class, AtomicBoolean.class, actual);
   }
@@ -532,7 +499,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AtomicIntegerAssert assumeThat(AtomicInteger actual) {
     return asAssumption(AtomicIntegerAssert.class, AtomicInteger.class, actual);
   }
@@ -544,7 +510,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AtomicIntegerArrayAssert assumeThat(AtomicIntegerArray actual) {
     return asAssumption(AtomicIntegerArrayAssert.class, AtomicIntegerArray.class, actual);
   }
@@ -557,7 +522,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assumeThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return asAssumption(AtomicIntegerFieldUpdaterAssert.class, AtomicIntegerFieldUpdater.class, actual);
@@ -570,7 +534,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AtomicLongAssert assumeThat(AtomicLong actual) {
     return asAssumption(AtomicLongAssert.class, AtomicLong.class, actual);
   }
@@ -582,7 +545,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AtomicLongArrayAssert assumeThat(AtomicLongArray actual) {
     return asAssumption(AtomicLongArrayAssert.class, AtomicLongArray.class, actual);
   }
@@ -595,7 +557,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assumeThat(AtomicLongFieldUpdater<OBJECT> actual) {
     return asAssumption(AtomicLongFieldUpdaterAssert.class, AtomicLongFieldUpdater.class, actual);
@@ -609,7 +570,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <VALUE> AtomicReferenceAssert<VALUE> assumeThat(AtomicReference<VALUE> actual) {
     return asAssumption(AtomicReferenceAssert.class, AtomicReference.class, actual);
@@ -623,7 +583,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assumeThat(AtomicReferenceArray<ELEMENT> actual) {
     return asAssumption(AtomicReferenceArrayAssert.class, AtomicReferenceArray.class, actual);
@@ -638,7 +597,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assumeThat(
                                                                                             AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
@@ -653,7 +611,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <VALUE> AtomicMarkableReferenceAssert<VALUE> assumeThat(AtomicMarkableReference<VALUE> actual) {
     return asAssumption(AtomicMarkableReferenceAssert.class, AtomicMarkableReference.class, actual);
@@ -667,7 +624,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <VALUE> AtomicStampedReferenceAssert<VALUE> assumeThat(AtomicStampedReference<VALUE> actual) {
     return asAssumption(AtomicStampedReferenceAssert.class, AtomicStampedReference.class, actual);
@@ -680,7 +636,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractClassAssert<?> assumeThat(Class<?> actual) {
     return asAssumption(ProxyableClassAssert.class, Class.class, actual);
   }
@@ -692,7 +647,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> assumeThat(Date actual) {
     return asAssumption(DateAssert.class, Date.class, actual);
   }
@@ -704,7 +658,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> assumeThat(File actual) {
     return asAssumption(FileAssert.class, File.class, actual);
   }
@@ -716,7 +669,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractPathAssert<?> assumeThat(Path actual) {
     return asAssumption(PathAssert.class, Path.class, actual);
   }
@@ -728,7 +680,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assumeThat(InputStream actual) {
     return asAssumption(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -742,7 +693,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assumeThat(Future<RESULT> future) {
     return asAssumption(FutureAssert.class, Future.class, future);
@@ -756,7 +706,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <ELEMENT> ProxyableIterableAssert<ELEMENT> assumeThat(Iterable<? extends ELEMENT> actual) {
     return asAssumption(ProxyableIterableAssert.class, Iterable.class, actual);
@@ -772,7 +721,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <ELEMENT> IteratorAssert<ELEMENT> assumeThat(Iterator<? extends ELEMENT> actual) {
     return asAssumption(IteratorAssert.class, Iterator.class, actual);
@@ -786,7 +734,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <ELEMENT> FactoryBasedNavigableListAssert<ProxyableListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(List<? extends ELEMENT> actual) {
     return asAssumption(ProxyableListAssert.class, List.class, actual);
@@ -800,7 +747,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <T> ProxyableObjectArrayAssert<T> assumeThat(T[] actual) {
     return asAssumption(ProxyableObjectArrayAssert.class, Object[].class, actual);
@@ -815,7 +761,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <K, V> AbstractMapAssert<?, ?, K, V> assumeThat(Map<K, V> actual) {
     return asAssumption(ProxyableMapAssert.class, Map.class, actual);
@@ -829,7 +774,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   @SuppressWarnings("unchecked")
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assumeThat(T actual) {
     return asAssumption(GenericComparableAssert.class, Comparable.class, actual);
@@ -842,7 +786,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assumeThat(Throwable actual) {
     return asAssumption(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -861,7 +804,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assumeThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return asAssumption(ThrowableAssert.class, Throwable.class, catchThrowable(shouldRaiseThrowable));
   }
@@ -889,7 +831,6 @@ public class Assumptions {
    * @return the created {@link ThrowableAssert}.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assumeThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -905,7 +846,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static <T> ProxyablePredicateAssert<T> assumeThat(Predicate<T> actual) {
     return asAssumption(ProxyablePredicateAssert.class, Predicate.class, actual);
   }
@@ -917,7 +857,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static IntPredicateAssert assumeThat(IntPredicate actual) {
     return asAssumption(IntPredicateAssert.class, IntPredicate.class, actual);
   }
@@ -929,7 +868,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static LongPredicateAssert assumeThat(LongPredicate actual) {
     return asAssumption(LongPredicateAssert.class, LongPredicate.class, actual);
   }
@@ -941,7 +879,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static DoublePredicateAssert assumeThat(DoublePredicate actual) {
     return asAssumption(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
@@ -955,7 +892,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assumeThat(CompletableFuture<RESULT> actual) {
     return asAssumption(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
@@ -972,7 +908,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> assumeThat(CompletionStage<RESULT> actual) {
     return asAssumption(CompletableFutureAssert.class, CompletionStage.class, actual);
   }
@@ -986,7 +921,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static <VALUE> OptionalAssert<VALUE> assumeThat(Optional<VALUE> actual) {
     return asAssumption(OptionalAssert.class, Optional.class, actual);
   }
@@ -998,7 +932,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static OptionalDoubleAssert assumeThat(OptionalDouble actual) {
     return asAssumption(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
@@ -1010,7 +943,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static OptionalIntAssert assumeThat(OptionalInt actual) {
     return asAssumption(OptionalIntAssert.class, OptionalInt.class, actual);
   }
@@ -1022,7 +954,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static OptionalLongAssert assumeThat(OptionalLong actual) {
     return asAssumption(OptionalLongAssert.class, OptionalLong.class, actual);
   }
@@ -1034,7 +965,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> assumeThat(ZonedDateTime actual) {
     return asAssumption(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
@@ -1046,7 +976,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> assumeThat(LocalDateTime actual) {
     return asAssumption(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
@@ -1058,7 +987,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> assumeThat(OffsetDateTime actual) {
     return asAssumption(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
@@ -1070,7 +998,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> assumeThat(OffsetTime actual) {
     return asAssumption(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
@@ -1082,7 +1009,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> assumeThat(LocalTime actual) {
     return asAssumption(LocalTimeAssert.class, LocalTime.class, actual);
   }
@@ -1094,7 +1020,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractLocalDateAssert<?> assumeThat(LocalDate actual) {
     return asAssumption(LocalDateAssert.class, LocalDate.class, actual);
   }
@@ -1106,7 +1031,6 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   public static AbstractInstantAssert<?> assumeThat(Instant actual) {
     return asAssumption(InstantAssert.class, Instant.class, actual);
   }
@@ -1120,7 +1044,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(Stream<? extends ELEMENT> actual) {
     return asAssumption(ProxyableListAssert.class, Stream.class, actual);
   }
@@ -1133,7 +1056,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assumeThat(DoubleStream actual) {
     return asAssumption(ProxyableListAssert.class, DoubleStream.class, actual);
   }
@@ -1146,7 +1068,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assumeThat(LongStream actual) {
     return asAssumption(ProxyableListAssert.class, LongStream.class, actual);
   }
@@ -1159,7 +1080,6 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  @CheckReturnValue
   public static AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assumeThat(IntStream actual) {
     return asAssumption(ProxyableListAssert.class, IntStream.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -59,6 +59,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
@@ -93,6 +94,7 @@ import org.assertj.core.util.CheckReturnValue;
  * @author William Delanoue
  * @author Mariusz Smykula
  */
+@CheckReturnValue
 public class BDDAssertions extends Assertions {
 
   /**
@@ -104,7 +106,6 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static <T> PredicateAssert<T> then(Predicate<T> actual) {
     return assertThat(actual);
   }
@@ -117,7 +118,6 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static IntPredicateAssert then(IntPredicate actual) {
     return assertThat(actual);
   }
@@ -130,7 +130,6 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static LongPredicateAssert then(LongPredicate actual) {
     return assertThat(actual);
   }
@@ -143,7 +142,6 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.5.0
    */
-  @CheckReturnValue
   public static DoublePredicateAssert then(DoublePredicate actual) {
     return assertThat(actual);
   }
@@ -156,7 +154,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <VALUE> OptionalAssert<VALUE> then(Optional<VALUE> optional) {
     return assertThat(optional);
   }
@@ -168,7 +165,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalIntAssert then(OptionalInt optional) {
     return assertThat(optional);
   }
@@ -180,7 +176,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalLongAssert then(OptionalLong optional) {
     return assertThat(optional);
   }
@@ -192,7 +187,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static OptionalDoubleAssert then(OptionalDouble optional) {
     return assertThat(optional);
   }
@@ -203,7 +197,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
     return assertThat(actual);
   }
@@ -215,7 +208,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AbstractBigIntegerAssert<?> then(BigInteger actual) {
     return assertThat(actual);
   }
@@ -226,7 +218,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(boolean actual) {
     return assertThat(actual);
   }
@@ -237,7 +228,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(Boolean actual) {
     return assertThat(actual);
   }
@@ -248,7 +238,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
     return assertThat(actual);
   }
@@ -259,7 +248,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> then(byte actual) {
     return assertThat(actual);
   }
@@ -270,7 +258,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> then(Byte actual) {
     return assertThat(actual);
   }
@@ -281,7 +268,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> then(byte[] actual) {
     return assertThat(actual);
   }
@@ -292,7 +278,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(char actual) {
     return assertThat(actual);
   }
@@ -303,7 +288,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> then(char[] actual) {
     return assertThat(actual);
   }
@@ -314,7 +298,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(Character actual) {
     return assertThat(actual);
   }
@@ -325,7 +308,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ClassAssert then(Class<?> actual) {
     return assertThat(actual);
   }
@@ -338,7 +320,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -350,7 +331,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> IterableAssert<T> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
@@ -375,7 +355,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> IteratorAssert<T> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
@@ -417,7 +396,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
 //@format:off
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          FactoryBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(Iterable<? extends ELEMENT> actual,
                                                                                  AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -452,7 +430,6 @@ public class BDDAssertions extends Assertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          ClassBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(ACTUAL actual,
                                                                                           Class<ELEMENT_ASSERT> assertClass) {
@@ -495,7 +472,6 @@ public class BDDAssertions extends Assertions {
    * @param assertFactory the factory used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ACTUAL extends List<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          FactoryBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(List<? extends ELEMENT> actual,
                                                                                         AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -530,7 +506,6 @@ public class BDDAssertions extends Assertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT, ACTUAL extends List<? extends ELEMENT>, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
          ClassBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(List<? extends ELEMENT> actual,
                                                                                       Class<ELEMENT_ASSERT> assertClass) {
@@ -545,7 +520,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(double actual) {
     return assertThat(actual);
   }
@@ -556,7 +530,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(Double actual) {
     return assertThat(actual);
   }
@@ -567,7 +540,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> then(double[] actual) {
     return assertThat(actual);
   }
@@ -578,7 +550,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> then(File actual) {
     return assertThat(actual);
   }
@@ -589,7 +560,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
-  @CheckReturnValue
   public static AbstractPathAssert<?> then(Path actual) {
     return assertThat(actual);
   }
@@ -602,7 +572,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <RESULT> FutureAssert<RESULT> then(Future<RESULT> actual) {
     return assertThat(actual);
   }
@@ -613,7 +582,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
     return assertThat(actual);
   }
@@ -624,7 +592,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> then(float actual) {
     return assertThat(actual);
   }
@@ -635,7 +602,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> then(Float actual) {
     return assertThat(actual);
   }
@@ -646,7 +612,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> then(float[] actual) {
     return assertThat(actual);
   }
@@ -657,7 +622,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(int actual) {
     return assertThat(actual);
   }
@@ -668,7 +632,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> then(int[] actual) {
     return assertThat(actual);
   }
@@ -679,7 +642,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(Integer actual) {
     return assertThat(actual);
   }
@@ -691,7 +653,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ListAssert<T> then(List<? extends T> actual) {
     return assertThat(actual);
   }
@@ -702,7 +663,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> then(long actual) {
     return assertThat(actual);
   }
@@ -713,7 +673,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> then(Long actual) {
     return assertThat(actual);
   }
@@ -724,7 +683,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> then(long[] actual) {
     return assertThat(actual);
   }
@@ -736,7 +694,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectAssert<T> then(T actual) {
     return assertThat(actual);
   }
@@ -748,7 +705,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> ObjectArrayAssert<T> then(T[] actual) {
     return assertThat(actual);
   }
@@ -761,7 +717,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <K, V> MapAssert<K, V> then(Map<K, V> actual) {
     return assertThat(actual);
   }
@@ -772,7 +727,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> then(short actual) {
     return assertThat(actual);
   }
@@ -783,7 +737,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> then(Short actual) {
     return assertThat(actual);
   }
@@ -794,7 +747,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> then(short[] actual) {
     return assertThat(actual);
   }
@@ -805,7 +757,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
     return assertThat(actual);
   }
@@ -817,7 +768,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
     return assertThat(actual);
   }
@@ -829,7 +779,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
     return assertThat(actual);
   }
@@ -840,7 +789,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> then(String actual) {
     return assertThat(actual);
   }
@@ -851,7 +799,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> then(Date actual) {
     return assertThat(actual);
   }
@@ -863,7 +810,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicBooleanAssert then(AtomicBoolean actual) {
     return assertThat(actual);
   }
@@ -875,7 +821,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerAssert then(AtomicInteger actual) {
     return assertThat(actual);
   }
@@ -887,7 +832,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerArrayAssert then(AtomicIntegerArray actual) {
     return assertThat(actual);
   }
@@ -900,7 +844,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> then(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return assertThat(actual);
   }
@@ -912,7 +855,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongAssert then(AtomicLong actual) {
     return assertThat(actual);
   }
@@ -924,7 +866,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongArrayAssert then(AtomicLongArray actual) {
     return assertThat(actual);
   }
@@ -937,7 +878,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> then(AtomicLongFieldUpdater<OBJECT> actual) {
     return assertThat(actual);
   }
@@ -950,7 +890,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicReferenceAssert<VALUE> then(AtomicReference<VALUE> actual) {
     return assertThat(actual);
   }
@@ -963,7 +902,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> then(AtomicReferenceArray<ELEMENT> actual) {
     return assertThat(actual);
   }
@@ -977,7 +915,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> then(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return assertThat(actual);
   }
@@ -990,7 +927,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicMarkableReferenceAssert<VALUE> then(AtomicMarkableReference<VALUE> actual) {
     return assertThat(actual);
   }
@@ -1003,7 +939,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicStampedReferenceAssert<VALUE> then(AtomicStampedReference<VALUE> actual) {
     return assertThat(actual);
   }
@@ -1014,7 +949,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
     return assertThat(actual);
   }
@@ -1047,6 +981,7 @@ public class BDDAssertions extends Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return the created {@link ThrowableAssert}.
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -1082,6 +1017,7 @@ public class BDDAssertions extends Assertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -1128,7 +1064,6 @@ public class BDDAssertions extends Assertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -1139,7 +1074,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateAssert<?> then(LocalDate actual) {
     return assertThat(actual);
   }
@@ -1150,7 +1084,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalDateTimeAssert<?> then(LocalDateTime actual) {
     return assertThat(actual);
   }
@@ -1161,7 +1094,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractZonedDateTimeAssert<?> then(ZonedDateTime actual) {
     return assertThat(actual);
   }
@@ -1172,7 +1104,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLocalTimeAssert<?> then(LocalTime actual) {
     return assertThat(actual);
   }
@@ -1183,7 +1114,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetTimeAssert<?> then(OffsetTime actual) {
     return assertThat(actual);
   }
@@ -1195,7 +1125,6 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractInstantAssert<?> then(Instant actual) {
     return assertThat(actual);
   }
@@ -1206,7 +1135,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> then(URI actual) {
     return assertThat(actual);
   }
@@ -1217,7 +1145,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> then(URL actual) {
     return assertThat(actual);
   }
@@ -1228,7 +1155,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractOffsetDateTimeAssert<?> then(OffsetDateTime actual) {
     return assertThat(actual);
   }
@@ -1241,7 +1167,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> then(CompletableFuture<RESULT> future) {
     return assertThat(future);
   }
@@ -1256,7 +1181,6 @@ public class BDDAssertions extends Assertions {
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <RESULT> CompletableFutureAssert<RESULT> then(CompletionStage<RESULT> actual) {
     return assertThat(actual);
   }
@@ -1311,7 +1235,6 @@ public class BDDAssertions extends Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T then(T assertion) {
     return assertion;
   }
@@ -1328,7 +1251,6 @@ public class BDDAssertions extends Assertions {
    *          the component that creates its own assert
    * @return the associated {@link Assert} of the given component
    */
-  @CheckReturnValue
   public static <T> T then(final AssertProvider<T> component) {
     return component.assertThat();
   }
@@ -1360,7 +1282,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT> ListAssert<ELEMENT> then(Stream<? extends ELEMENT> actual) {
     return assertThat(actual);
   }
@@ -1391,7 +1312,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Double> then(DoubleStream actual) {
     return assertThat(actual);
   }
@@ -1422,7 +1342,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Long> then(LongStream actual) {
     return assertThat(actual);
   }
@@ -1453,7 +1372,6 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static ListAssert<Integer> then(IntStream actual) {
     return assertThat(actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
@@ -48,6 +49,7 @@ import org.assertj.core.util.CheckReturnValue;
  *
  * @since 2.5.0 / 3.5.0
  */
+@CheckReturnValue
 public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
   // then* methods duplicated from BDDAssertions
 
@@ -57,7 +59,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BigDecimalAssert then(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -69,7 +70,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public BigIntegerAssert then(BigInteger actual) {
     return proxy(BigIntegerAssert.class, BigInteger.class, actual);
   }
@@ -80,7 +80,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanAssert then(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -91,7 +90,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanAssert then(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -102,7 +100,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanArrayAssert then(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -113,7 +110,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteAssert then(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -124,7 +120,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteAssert then(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -135,7 +130,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteArrayAssert then(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -146,7 +140,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharacterAssert then(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -157,7 +150,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharArrayAssert then(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
@@ -168,7 +160,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharacterAssert then(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -181,7 +172,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ProxyableClassAssert then(Class<?> actual) {
     return proxy(ProxyableClassAssert.class, Class.class, actual);
   }
@@ -194,7 +184,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
@@ -206,7 +195,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableIterableAssert<T> then(Iterable<? extends T> actual) {
     return proxy(ProxyableIterableAssert.class, Iterable.class, actual);
   }
@@ -220,7 +208,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> IteratorAssert<T> then(Iterator<? extends T> actual) {
     return proxy(IteratorAssert.class, Iterator.class, actual);
   }
@@ -231,7 +218,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleAssert then(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -242,7 +228,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleAssert then(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -253,7 +238,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleArrayAssert then(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -264,7 +248,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FileAssert then(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
@@ -277,7 +260,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <RESULT> FutureAssert<RESULT> then(Future<RESULT> actual) {
     return proxy(FutureAssert.class, Future.class, actual);
   }
@@ -288,7 +270,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public InputStreamAssert then(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -299,7 +280,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatAssert then(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -310,7 +290,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatAssert then(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -321,7 +300,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatArrayAssert then(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
@@ -332,7 +310,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntegerAssert then(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -343,7 +320,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntArrayAssert then(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
@@ -354,7 +330,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntegerAssert then(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -366,7 +341,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableListAssert<T> then(List<? extends T> actual) {
     return proxy(ProxyableListAssert.class, List.class, actual);
   }
@@ -377,7 +351,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongAssert then(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -388,7 +361,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongAssert then(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -399,7 +371,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongArrayAssert then(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
@@ -411,7 +382,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param <T> the type of the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableObjectAssert<T> then(T actual) {
     return proxy(ProxyableObjectAssert.class, Object.class, actual);
   }
@@ -423,7 +393,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableObjectArrayAssert<T> then(T[] actual) {
     return proxy(ProxyableObjectArrayAssert.class, Object[].class, actual);
   }
@@ -438,7 +407,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <K, V> ProxyableMapAssert<K, V> then(Map<K, V> actual) {
     return proxy(ProxyableMapAssert.class, Map.class, actual);
   }
@@ -449,7 +417,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortAssert then(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -460,7 +427,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortAssert then(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -471,7 +437,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortArrayAssert then(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
@@ -482,7 +447,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharSequenceAssert then(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -494,7 +458,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public CharSequenceAssert then(StringBuilder actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -506,7 +469,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public CharSequenceAssert then(StringBuffer actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -517,7 +479,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public StringAssert then(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
@@ -528,7 +489,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DateAssert then(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
@@ -540,7 +500,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public AtomicBooleanAssert then(AtomicBoolean actual) {
     return proxy(AtomicBooleanAssert.class, AtomicBoolean.class, actual);
   }
@@ -552,7 +511,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public AtomicIntegerAssert then(AtomicInteger actual) {
     return proxy(AtomicIntegerAssert.class, AtomicInteger.class, actual);
   }
@@ -564,7 +522,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public AtomicIntegerArrayAssert then(AtomicIntegerArray actual) {
     return proxy(AtomicIntegerArrayAssert.class, AtomicIntegerArray.class, actual);
   }
@@ -577,7 +534,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> then(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return proxy(AtomicIntegerFieldUpdaterAssert.class, AtomicIntegerFieldUpdater.class, actual);
   }
@@ -589,7 +545,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public AtomicLongAssert then(AtomicLong actual) {
     return proxy(AtomicLongAssert.class, AtomicLong.class, actual);
   }
@@ -601,7 +556,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public AtomicLongArrayAssert then(AtomicLongArray actual) {
     return proxy(AtomicLongArrayAssert.class, AtomicLongArray.class, actual);
   }
@@ -614,7 +568,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> then(AtomicLongFieldUpdater<OBJECT> actual) {
     return proxy(AtomicLongFieldUpdaterAssert.class, AtomicLongFieldUpdater.class, actual);
   }
@@ -627,7 +580,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <VALUE> AtomicReferenceAssert<VALUE> then(AtomicReference<VALUE> actual) {
     return proxy(AtomicReferenceAssert.class, AtomicReference.class, actual);
   }
@@ -640,7 +592,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> then(AtomicReferenceArray<ELEMENT> actual) {
     return proxy(AtomicReferenceArrayAssert.class, AtomicReferenceArray.class, actual);
   }
@@ -654,7 +605,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> then(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return proxy(AtomicReferenceFieldUpdaterAssert.class, AtomicReferenceFieldUpdater.class, actual);
   }
@@ -667,7 +617,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <VALUE> AtomicMarkableReferenceAssert<VALUE> then(AtomicMarkableReference<VALUE> actual) {
     return proxy(AtomicMarkableReferenceAssert.class, AtomicMarkableReference.class, actual);
   }
@@ -680,7 +629,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public <VALUE> AtomicStampedReferenceAssert<VALUE> then(AtomicStampedReference<VALUE> actual) {
     return proxy(AtomicStampedReferenceAssert.class, AtomicStampedReference.class, actual);
   }
@@ -691,7 +639,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  @CheckReturnValue
   public ThrowableAssert then(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -738,6 +685,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CanIgnoreReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return then(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -775,6 +723,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                       String description, Object... args) {
     return then(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -815,7 +764,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -826,7 +774,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public UriAssert then(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
@@ -837,7 +784,6 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AbstractUrlAssert<?> then(URL actual) {
     return proxy(AbstractUrlAssert.class, URL.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
@@ -48,6 +49,7 @@ import org.assertj.core.util.CheckReturnValue;
  * 
  * @since 2.5.0 / 3.5.0
  */
+@CheckReturnValue
 public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions {
   /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
@@ -55,7 +57,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BigDecimalAssert assertThat(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
@@ -67,7 +68,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public BigIntegerAssert assertThat(BigInteger actual) {
     return proxy(BigIntegerAssert.class, BigInteger.class, actual);
   }
@@ -78,7 +78,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanAssert assertThat(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -89,7 +88,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanAssert assertThat(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
@@ -100,7 +98,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public BooleanArrayAssert assertThat(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
@@ -111,7 +108,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteAssert assertThat(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -122,7 +118,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteAssert assertThat(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
@@ -133,7 +128,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ByteArrayAssert assertThat(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
@@ -144,7 +138,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharacterAssert assertThat(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -155,7 +148,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharArrayAssert assertThat(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
@@ -166,7 +158,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharacterAssert assertThat(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
@@ -179,7 +170,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ProxyableClassAssert assertThat(Class<?> actual) {
     return proxy(ProxyableClassAssert.class, Class.class, actual);
   }
@@ -192,7 +182,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
@@ -206,7 +195,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableIterableAssert<T> assertThat(Iterable<? extends T> actual) {
     return proxy(ProxyableIterableAssert.class, Iterable.class, actual);
   }
@@ -220,7 +208,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> IteratorAssert<T> assertThat(Iterator<? extends T> actual) {
     return proxy(IteratorAssert.class, Iterator.class, actual);
   }
@@ -231,7 +218,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleAssert assertThat(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -242,7 +228,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleAssert assertThat(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
@@ -253,7 +238,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DoubleArrayAssert assertThat(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
@@ -264,7 +248,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FileAssert assertThat(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
@@ -276,7 +259,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value
    * @return the created assertion object
    */
-  @CheckReturnValue
   public <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
     return proxy(FutureAssert.class, Future.class, actual);
   }
@@ -287,7 +269,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public InputStreamAssert assertThat(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
@@ -298,7 +279,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatAssert assertThat(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -309,7 +289,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatAssert assertThat(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
@@ -320,7 +299,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public FloatArrayAssert assertThat(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
@@ -331,7 +309,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntegerAssert assertThat(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -342,7 +319,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntArrayAssert assertThat(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
@@ -353,7 +329,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public IntegerAssert assertThat(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
@@ -367,7 +342,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableListAssert<T> assertThat(List<? extends T> actual) {
     return proxy(ProxyableListAssert.class, List.class, actual);
   }
@@ -378,7 +352,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongAssert assertThat(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -389,7 +362,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongAssert assertThat(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
@@ -400,7 +372,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public LongArrayAssert assertThat(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
@@ -412,7 +383,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <T> the type of the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableObjectAssert<T> assertThat(T actual) {
     return proxy(ProxyableObjectAssert.class, Object.class, actual);
   }
@@ -424,7 +394,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <T> the type values of the actual array.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <T> ProxyableObjectArrayAssert<T> assertThat(T[] actual) {
     return proxy(ProxyableObjectArrayAssert.class, Object[].class, actual);
   }
@@ -439,7 +408,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <K, V> ProxyableMapAssert<K, V> assertThat(Map<K, V> actual) {
     return proxy(ProxyableMapAssert.class, Map.class, actual);
   }
@@ -450,7 +418,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortAssert assertThat(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -461,7 +428,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortAssert assertThat(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
@@ -472,7 +438,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public ShortArrayAssert assertThat(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
@@ -483,7 +448,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public CharSequenceAssert assertThat(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -495,7 +459,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public CharSequenceAssert assertThat(StringBuilder actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -507,7 +470,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public CharSequenceAssert assertThat(StringBuffer actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
@@ -518,7 +480,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public StringAssert assertThat(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
@@ -529,7 +490,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public DateAssert assertThat(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
@@ -541,7 +501,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return proxy(AtomicBooleanAssert.class, AtomicBoolean.class, actual);
   }
@@ -553,7 +512,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return proxy(AtomicIntegerAssert.class, AtomicInteger.class, actual);
   }
@@ -565,7 +523,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return proxy(AtomicIntegerArrayAssert.class, AtomicIntegerArray.class, actual);
   }
@@ -578,7 +535,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assertThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return proxy(AtomicIntegerFieldUpdaterAssert.class, AtomicIntegerFieldUpdater.class, actual);
   }
@@ -590,7 +546,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AtomicLongAssert assertThat(AtomicLong actual) {
     return proxy(AtomicLongAssert.class, AtomicLong.class, actual);
   }
@@ -602,7 +557,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    *
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return proxy(AtomicLongArrayAssert.class, AtomicLongArray.class, actual);
   }
@@ -615,7 +569,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assertThat(AtomicLongFieldUpdater<OBJECT> actual) {
     return proxy(AtomicLongFieldUpdaterAssert.class, AtomicLongFieldUpdater.class, actual);
   }
@@ -628,7 +581,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <VALUE> the type of object referred to by the {@link AtomicReference}.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <VALUE> AtomicReferenceAssert<VALUE> assertThat(AtomicReference<VALUE> actual) {
     return proxy(AtomicReferenceAssert.class, AtomicReference.class, actual);
   }
@@ -640,7 +592,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assertThat(AtomicReferenceArray<ELEMENT> actual) {
     return proxy(AtomicReferenceArrayAssert.class, AtomicReferenceArray.class, actual);
   }
@@ -654,7 +605,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assertThat(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return proxy(AtomicReferenceFieldUpdaterAssert.class, AtomicReferenceFieldUpdater.class, actual);
   }
@@ -666,7 +616,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <VALUE> AtomicMarkableReferenceAssert<VALUE> assertThat(AtomicMarkableReference<VALUE> actual) {
     return proxy(AtomicMarkableReferenceAssert.class, AtomicMarkableReference.class, actual);
   }
@@ -678,7 +627,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public <VALUE> AtomicStampedReferenceAssert<VALUE> assertThat(AtomicStampedReference<VALUE> actual) {
     return proxy(AtomicStampedReferenceAssert.class, AtomicStampedReference.class, actual);
   }
@@ -689,7 +637,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  @CheckReturnValue
   public ThrowableAssert assertThat(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
@@ -720,6 +667,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CanIgnoreReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -757,6 +705,7 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * 
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                             String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -803,7 +752,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -814,7 +762,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public UriAssert assertThat(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
@@ -825,7 +772,6 @@ public class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions 
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public AbstractUrlAssert<?> assertThat(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -59,6 +59,7 @@ import org.assertj.core.data.Percentage;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
@@ -69,6 +70,7 @@ import org.assertj.core.util.introspection.FieldSupport;
  *
  * @see Assertions
  */
+@CheckReturnValue
 public class Java6Assertions {
 
   /**
@@ -79,7 +81,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return new AtomicBooleanAssert(actual);
   }
@@ -92,7 +93,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
   }
@@ -105,7 +105,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return new AtomicIntegerArrayAssert(actual);
   }
@@ -119,7 +118,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assertThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return new AtomicIntegerFieldUpdaterAssert<>(actual);
   }
@@ -132,7 +130,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongAssert assertThat(AtomicLong actual) {
     return new AtomicLongAssert(actual);
   }
@@ -145,7 +142,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return new AtomicLongArrayAssert(actual);
   }
@@ -159,7 +155,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assertThat(AtomicLongFieldUpdater<OBJECT> actual) {
     return new AtomicLongFieldUpdaterAssert<>(actual);
   }
@@ -173,7 +168,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicReferenceAssert<VALUE> assertThat(AtomicReference<VALUE> actual) {
     return new AtomicReferenceAssert<>(actual);
   }
@@ -187,7 +181,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assertThat(AtomicReferenceArray<ELEMENT> actual) {
     return new AtomicReferenceArrayAssert<>(actual);
   }
@@ -202,7 +195,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assertThat(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return new AtomicReferenceFieldUpdaterAssert<>(actual);
   }
@@ -216,7 +208,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicMarkableReferenceAssert<VALUE> assertThat(AtomicMarkableReference<VALUE> actual) {
     return new AtomicMarkableReferenceAssert<>(actual);
   }
@@ -230,7 +221,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicStampedReferenceAssert<VALUE> assertThat(AtomicStampedReference<VALUE> actual) {
     return new AtomicStampedReferenceAssert<>(actual);
   }
@@ -241,7 +231,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
@@ -253,7 +242,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
@@ -264,7 +252,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return new UriAssert(actual);
   }
@@ -275,7 +262,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return new UrlAssert(actual);
   }
@@ -286,7 +272,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -297,7 +282,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
@@ -308,7 +292,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
@@ -319,7 +302,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return new ByteAssert(actual);
   }
@@ -330,7 +312,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
@@ -341,7 +322,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
@@ -352,7 +332,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return new CharacterAssert(actual);
   }
@@ -363,7 +342,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
@@ -374,7 +352,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
@@ -385,7 +362,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractClassAssert<?> assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
@@ -398,7 +374,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
@@ -410,7 +385,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> assertThat(Iterable<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
@@ -434,7 +408,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractIteratorAssert<?, T> assertThat(Iterator<? extends T> actual) {
     return new IteratorAssert<>(actual);
   }
@@ -445,7 +418,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return new DoubleAssert(actual);
   }
@@ -456,7 +428,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
@@ -467,7 +438,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
@@ -478,7 +448,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> assertThat(File actual) {
     return new FileAssert(actual);
   }
@@ -492,7 +461,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assertThat(Future<RESULT> actual) {
     return new FutureAssert<>(actual);
   }
@@ -503,7 +471,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
@@ -514,7 +481,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return new FloatAssert(actual);
   }
@@ -525,7 +491,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> assertThat(Float actual) {
     return new FloatAssert(actual);
   }
@@ -536,7 +501,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
@@ -547,7 +511,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return new IntegerAssert(actual);
   }
@@ -558,7 +521,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
@@ -569,7 +531,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
@@ -581,7 +542,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> assertThat(List<? extends T> actual) {
     return new ListAssert<>(actual);
   }
@@ -749,7 +709,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(long actual) {
     return new LongAssert(actual);
   }
@@ -760,7 +719,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> assertThat(Long actual) {
     return new LongAssert(actual);
   }
@@ -771,7 +729,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
@@ -783,7 +740,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
@@ -839,7 +795,6 @@ public class Java6Assertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T assertThat(T assertion) {
     return assertion;
   }
@@ -867,7 +822,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
@@ -883,7 +837,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return new MapAssert<>(actual);
   }
@@ -894,7 +847,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(short actual) {
     return new ShortAssert(actual);
   }
@@ -905,7 +857,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> assertThat(Short actual) {
     return new ShortAssert(actual);
   }
@@ -916,7 +867,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
@@ -927,7 +877,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
@@ -939,7 +888,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
     return new CharSequenceAssert(actual);
   }
@@ -951,7 +899,6 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
     return new CharSequenceAssert(actual);
   }
@@ -962,7 +909,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> assertThat(String actual) {
     return new StringAssert(actual);
   }
@@ -973,7 +919,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return new DateAssert(actual);
   }
@@ -984,7 +929,6 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
@@ -1027,6 +971,7 @@ public class Java6Assertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
@@ -1063,6 +1008,7 @@ public class Java6Assertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -1115,7 +1061,6 @@ public class Java6Assertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }

--- a/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.AtomicStampedReference;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
@@ -49,6 +50,7 @@ import org.assertj.core.util.CheckReturnValue;
  *
  * @since 2.5.0 / 3.5.0
  */
+@CheckReturnValue
 public class Java6BDDAssertions {
 
   /**
@@ -58,7 +60,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicBooleanAssert then(AtomicBoolean actual) {
     return new AtomicBooleanAssert(actual);
   }
@@ -70,7 +71,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerAssert then(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
   }
@@ -82,7 +82,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicIntegerArrayAssert then(AtomicIntegerArray actual) {
     return new AtomicIntegerArrayAssert(actual);
   }
@@ -95,7 +94,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> then(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return new AtomicIntegerFieldUpdaterAssert<>(actual);
   }
@@ -107,7 +105,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongAssert then(AtomicLong actual) {
     return new AtomicLongAssert(actual);
   }
@@ -119,7 +116,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AtomicLongArrayAssert then(AtomicLongArray actual) {
     return new AtomicLongArrayAssert(actual);
   }
@@ -132,7 +128,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> then(AtomicLongFieldUpdater<OBJECT> actual) {
     return new AtomicLongFieldUpdaterAssert<>(actual);
   }
@@ -145,7 +140,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicReferenceAssert<VALUE> then(AtomicReference<VALUE> actual) {
     return new AtomicReferenceAssert<>(actual);
   }
@@ -158,7 +152,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> then(AtomicReferenceArray<ELEMENT> actual) {
     return new AtomicReferenceArrayAssert<>(actual);
   }
@@ -172,7 +165,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> then(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return new AtomicReferenceFieldUpdaterAssert<>(actual);
   }
@@ -185,7 +177,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicMarkableReferenceAssert<VALUE> then(AtomicMarkableReference<VALUE> actual) {
     return new AtomicMarkableReferenceAssert<>(actual);
   }
@@ -198,7 +189,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <VALUE> AtomicStampedReferenceAssert<VALUE> then(AtomicStampedReference<VALUE> actual) {
     return new AtomicStampedReferenceAssert<>(actual);
   }
@@ -209,7 +199,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
     return assertThat(actual);
   }
@@ -221,7 +210,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static AbstractBigIntegerAssert<?> then(BigInteger actual) {
     return assertThat(actual);
   }
@@ -232,7 +220,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(boolean actual) {
     return assertThat(actual);
   }
@@ -243,7 +230,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanAssert<?> then(Boolean actual) {
     return assertThat(actual);
   }
@@ -254,7 +240,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
     return assertThat(actual);
   }
@@ -265,7 +250,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> then(byte actual) {
     return assertThat(actual);
   }
@@ -276,7 +260,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteAssert<?> then(Byte actual) {
     return assertThat(actual);
   }
@@ -287,7 +270,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractByteArrayAssert<?> then(byte[] actual) {
     return assertThat(actual);
   }
@@ -298,7 +280,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(char actual) {
     return assertThat(actual);
   }
@@ -309,7 +290,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharArrayAssert<?> then(char[] actual) {
     return assertThat(actual);
   }
@@ -320,7 +300,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharacterAssert<?> then(Character actual) {
     return assertThat(actual);
   }
@@ -331,7 +310,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractClassAssert<?> then(Class<?> actual) {
     return assertThat(actual);
   }
@@ -344,7 +322,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -356,7 +333,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
@@ -380,7 +356,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractIteratorAssert<?, T> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
@@ -422,7 +397,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    */
   //@format:off
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
       FactoryBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(Iterable<? extends ELEMENT> actual,
                                                                                AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -457,7 +431,6 @@ public class Java6BDDAssertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
       ClassBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(ACTUAL actual,
                                                                              Class<ELEMENT_ASSERT> assertClass) {
@@ -500,7 +473,6 @@ public class Java6BDDAssertions {
    * @param assertFactory the factory used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ACTUAL extends List<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
       FactoryBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(List<? extends ELEMENT> actual,
                                                                            AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
@@ -535,7 +507,6 @@ public class Java6BDDAssertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <ELEMENT, ACTUAL extends List<? extends ELEMENT>, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>>
       ClassBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> then(List<? extends ELEMENT> actual,
                                                                          Class<ELEMENT_ASSERT> assertClass) {
@@ -550,7 +521,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(double actual) {
     return assertThat(actual);
   }
@@ -561,7 +531,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleAssert<?> then(Double actual) {
     return assertThat(actual);
   }
@@ -572,7 +541,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDoubleArrayAssert<?> then(double[] actual) {
     return assertThat(actual);
   }
@@ -583,7 +551,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFileAssert<?> then(File actual) {
     return assertThat(actual);
   }
@@ -596,7 +563,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> then(Future<RESULT> actual) {
     return assertThat(actual);
   }
@@ -607,7 +573,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
     return assertThat(actual);
   }
@@ -618,7 +583,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> then(float actual) {
     return assertThat(actual);
   }
@@ -629,7 +593,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatAssert<?> then(Float actual) {
     return assertThat(actual);
   }
@@ -640,7 +603,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractFloatArrayAssert<?> then(float[] actual) {
     return assertThat(actual);
   }
@@ -651,7 +613,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(int actual) {
     return assertThat(actual);
   }
@@ -662,7 +623,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntArrayAssert<?> then(int[] actual) {
     return assertThat(actual);
   }
@@ -673,7 +633,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractIntegerAssert<?> then(Integer actual) {
     return assertThat(actual);
   }
@@ -685,7 +644,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> then(List<? extends T> actual) {
     return assertThat(actual);
   }
@@ -696,7 +654,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> then(long actual) {
     return assertThat(actual);
   }
@@ -707,7 +664,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongAssert<?> then(Long actual) {
     return assertThat(actual);
   }
@@ -718,7 +674,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractLongArrayAssert<?> then(long[] actual) {
     return assertThat(actual);
   }
@@ -730,7 +685,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractObjectAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
@@ -742,7 +696,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <T> AbstractObjectArrayAssert<?, T> then(T[] actual) {
     return assertThat(actual);
   }
@@ -755,7 +708,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static <K, V> MapAssert<K, V> then(Map<K, V> actual) {
     return assertThat(actual);
   }
@@ -766,7 +718,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> then(short actual) {
     return assertThat(actual);
   }
@@ -777,7 +728,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortAssert<?> then(Short actual) {
     return assertThat(actual);
   }
@@ -788,7 +738,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractShortArrayAssert<?> then(short[] actual) {
     return assertThat(actual);
   }
@@ -799,7 +748,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
     return assertThat(actual);
   }
@@ -811,7 +759,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
     return assertThat(actual);
   }
@@ -823,7 +770,6 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
     return assertThat(actual);
   }
@@ -834,7 +780,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractStringAssert<?> then(String actual) {
     return assertThat(actual);
   }
@@ -845,7 +790,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractDateAssert<?> then(Date actual) {
     return assertThat(actual);
   }
@@ -856,7 +800,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  @CheckReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
     return assertThat(actual);
   }
@@ -901,6 +844,7 @@ public class Java6BDDAssertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return Assertions.assertThatThrownBy(shouldRaiseThrowable);
   }
@@ -937,6 +881,7 @@ public class Java6BDDAssertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -977,7 +922,6 @@ public class Java6BDDAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   public AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -988,7 +932,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUriAssert<?> then(URI actual) {
     return assertThat(actual);
   }
@@ -999,7 +942,6 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   public static AbstractUrlAssert<?> then(URL actual) {
     return assertThat(actual);
   }
@@ -1055,7 +997,6 @@ public class Java6BDDAssertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   public static <T extends AssertDelegateTarget> T then(T assertion) {
     return assertion;
   }
@@ -1072,7 +1013,6 @@ public class Java6BDDAssertions {
    *          the component that creates its own assert
    * @return the associated {@link Assert} of the given component
    */
-  @CheckReturnValue
   public static <T> T then(final AssertProvider<T> component) {
     return component.assertThat();
   }

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -87,6 +87,7 @@ import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.presentation.UnicodeRepresentation;
+import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
@@ -102,6 +103,7 @@ import org.assertj.core.util.CheckReturnValue;
  * @author Alan Rothkopf
  *
  */
+@CheckReturnValue
 public interface WithAssertions {
 
   /**
@@ -231,7 +233,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T> ObjectArrayAssert<T> assertThat(final T[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -287,7 +288,6 @@ public interface WithAssertions {
    * @param assertion the assertion to return.
    * @return the given assertion.
    */
-  @CheckReturnValue
   default <T extends AssertDelegateTarget> T assertThat(final T assertion) {
     return Assertions.assertThat(assertion);
   }
@@ -303,7 +303,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <K, V> MapAssert<K, V> assertThat(final Map<K, V> actual) {
     return Assertions.assertThat(actual);
   }
@@ -314,7 +313,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractShortAssert<?> assertThat(final short actual) {
     return Assertions.assertThat(actual);
   }
@@ -325,7 +323,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractLongAssert<?> assertThat(final long actual) {
     return Assertions.assertThat(actual);
   }
@@ -336,7 +333,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractLongAssert<?> assertThat(final Long actual) {
     return Assertions.assertThat(actual);
   }
@@ -347,7 +343,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractLongArrayAssert<?> assertThat(final long[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -359,7 +354,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T> ObjectAssert<T> assertThat(final T actual) {
     return Assertions.assertThat(actual);
   }
@@ -370,7 +364,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractStringAssert<?> assertThat(final String actual) {
     return Assertions.assertThat(actual);
   }
@@ -381,7 +374,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractDateAssert<?> assertThat(final Date actual) {
     return Assertions.assertThat(actual);
   }
@@ -392,7 +384,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  @CheckReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assertThat(final Throwable actual) {
     return Assertions.assertThat(actual);
   }
@@ -403,7 +394,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractBigDecimalAssert<?> assertThat(final BigDecimal actual) {
     return Assertions.assertThat(actual);
   }
@@ -415,7 +405,6 @@ public interface WithAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  @CheckReturnValue
   default AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
     return Assertions.assertThat(actual);
   }
@@ -566,7 +555,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final CharSequence actual) {
     return Assertions.assertThat(actual);
   }
@@ -578,7 +566,6 @@ public interface WithAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuilder actual) {
     return Assertions.assertThat(actual);
   }
@@ -590,7 +577,6 @@ public interface WithAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuffer actual) {
     return Assertions.assertThat(actual);
   }
@@ -601,7 +587,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractShortArrayAssert<?> assertThat(final short[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -612,7 +597,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractShortAssert<?> assertThat(final Short actual) {
     return Assertions.assertThat(actual);
   }
@@ -623,7 +607,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default ClassAssert assertThat(final Class<?> actual) {
     return Assertions.assertThat(actual);
   }
@@ -634,7 +617,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractCharacterAssert<?> assertThat(final Character actual) {
     return Assertions.assertThat(actual);
   }
@@ -645,7 +627,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractCharArrayAssert<?> assertThat(final char[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -656,7 +637,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractCharacterAssert<?> assertThat(final char actual) {
     return Assertions.assertThat(actual);
   }
@@ -669,7 +649,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(final T actual) {
     return Assertions.assertThat(actual);
   }
@@ -681,7 +660,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T> IterableAssert<T> assertThat(final Iterable<? extends T> actual) {
     return Assertions.assertThat(actual);
   }
@@ -722,7 +700,6 @@ public interface WithAssertions {
    * @param assertFactory the factory used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>> FactoryBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(Iterable<? extends ELEMENT> actual,
                                                                                                                                                                                                                    AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
     return Assertions.assertThat(actual, assertFactory);
@@ -747,7 +724,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T> IteratorAssert<T> assertThat(final Iterator<? extends T> actual) {
     return Assertions.assertThat(actual);
   }
@@ -780,7 +756,6 @@ public interface WithAssertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <ACTUAL extends Iterable<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>> ClassBasedNavigableIterableAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(ACTUAL actual,
                                                                                                                                                                                                                  Class<ELEMENT_ASSERT> assertClass) {
     return Assertions.assertThat(actual, assertClass);
@@ -792,7 +767,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractBooleanAssert<?> assertThat(final Boolean actual) {
     return Assertions.assertThat(actual);
   }
@@ -803,7 +777,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractBooleanArrayAssert<?> assertThat(final boolean[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -814,7 +787,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractByteAssert<?> assertThat(final byte actual) {
     return Assertions.assertThat(actual);
   }
@@ -825,7 +797,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractByteAssert<?> assertThat(final Byte actual) {
     return Assertions.assertThat(actual);
   }
@@ -836,7 +807,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractByteArrayAssert<?> assertThat(final byte[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -847,7 +817,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractBooleanAssert<?> assertThat(final boolean actual) {
     return Assertions.assertThat(actual);
   }
@@ -858,7 +827,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractFloatAssert<?> assertThat(final float actual) {
     return Assertions.assertThat(actual);
   }
@@ -869,7 +837,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractInputStreamAssert<?, ? extends InputStream> assertThat(final InputStream actual) {
     return Assertions.assertThat(actual);
   }
@@ -880,7 +847,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractFileAssert<?> assertThat(final File actual) {
     return Assertions.assertThat(actual);
   }
@@ -894,7 +860,6 @@ public interface WithAssertions {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  @CheckReturnValue
   default <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
     return Assertions.assertThat(actual);
   }
@@ -905,7 +870,6 @@ public interface WithAssertions {
    * @param actual the path to test
    * @return the created assertion object
    */
-  @CheckReturnValue
   default AbstractPathAssert<?> assertThat(final Path actual) {
     return Assertions.assertThat(actual);
   }
@@ -916,7 +880,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractIntArrayAssert<?> assertThat(final int[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -927,7 +890,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractFloatAssert<?> assertThat(final Float actual) {
     return Assertions.assertThat(actual);
   }
@@ -938,7 +900,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractIntegerAssert<?> assertThat(final int actual) {
     return Assertions.assertThat(actual);
   }
@@ -949,7 +910,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractFloatArrayAssert<?> assertThat(final float[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -960,7 +920,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractIntegerAssert<?> assertThat(final Integer actual) {
     return Assertions.assertThat(actual);
   }
@@ -971,7 +930,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractDoubleAssert<?> assertThat(final double actual) {
     return Assertions.assertThat(actual);
   }
@@ -982,7 +940,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractDoubleAssert<?> assertThat(final Double actual) {
     return Assertions.assertThat(actual);
   }
@@ -994,7 +951,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <T> ListAssert<T> assertThat(final List<? extends T> actual) {
     return Assertions.assertThat(actual);
   }
@@ -1027,7 +983,6 @@ public interface WithAssertions {
    * @param assertClass the class used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <ELEMENT, ACTUAL extends List<? extends ELEMENT>, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>> ClassBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
                                                                                                                                                                                                          Class<ELEMENT_ASSERT> assertClass) {
     return Assertions.assertThat(actual, assertClass);
@@ -1069,7 +1024,6 @@ public interface WithAssertions {
    * @param assertFactory the factory used to create the elements assert instance.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <ACTUAL extends List<? extends ELEMENT>, ELEMENT, ELEMENT_ASSERT extends AbstractAssert<ELEMENT_ASSERT, ELEMENT>> FactoryBasedNavigableListAssert<?, ACTUAL, ELEMENT, ELEMENT_ASSERT> assertThat(List<? extends ELEMENT> actual,
                                                                                                                                                                                                            AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
     return Assertions.assertThat(actual, assertFactory);
@@ -1102,7 +1056,6 @@ public interface WithAssertions {
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
     return Assertions.assertThat(actual);
   }
@@ -1133,7 +1086,6 @@ public interface WithAssertions {
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default ListAssert<Double> assertThat(DoubleStream actual) {
     return Assertions.assertThat(actual);
   }
@@ -1164,7 +1116,6 @@ public interface WithAssertions {
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default ListAssert<Long> assertThat(LongStream actual) {
     return Assertions.assertThat(actual);
   }
@@ -1195,7 +1146,6 @@ public interface WithAssertions {
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default ListAssert<Integer> assertThat(IntStream actual) {
     return Assertions.assertThat(actual);
   }
@@ -1206,7 +1156,6 @@ public interface WithAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  @CheckReturnValue
   default AbstractDoubleArrayAssert<?> assertThat(final double[] actual) {
     return Assertions.assertThat(actual);
   }
@@ -2268,6 +2217,7 @@ public interface WithAssertions {
    * @param shouldRaiseThrowable The {@link ThrowingCallable} or lambda with the code that should raise the throwable.
    * @return the created {@link ThrowableAssert}.
    */
+  @CanIgnoreReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
     return Assertions.assertThatThrownBy(shouldRaiseThrowable);
   }
@@ -2304,6 +2254,7 @@ public interface WithAssertions {
    *
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
@@ -2350,7 +2301,6 @@ public interface WithAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  @CheckReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
@@ -2450,7 +2400,6 @@ public interface WithAssertions {
    * @return the created {@link ThrowableTypeAssert}.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default ThrowableTypeAssert<NullPointerException> assertThatNullPointerException() {
     return assertThatExceptionOfType(NullPointerException.class);
   }
@@ -2461,7 +2410,6 @@ public interface WithAssertions {
    * @return the created {@link ThrowableTypeAssert}.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default ThrowableTypeAssert<IllegalArgumentException> assertThatIllegalArgumentException() {
     return assertThatExceptionOfType(IllegalArgumentException.class);
   }
@@ -2472,7 +2420,6 @@ public interface WithAssertions {
    * @return the created {@link ThrowableTypeAssert}.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default ThrowableTypeAssert<IOException> assertThatIOException() {
     return assertThatExceptionOfType(IOException.class);
   }
@@ -2483,7 +2430,6 @@ public interface WithAssertions {
    * @return the created {@link ThrowableTypeAssert}.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default ThrowableTypeAssert<IllegalStateException> assertThatIllegalStateException() {
     return assertThatExceptionOfType(IllegalStateException.class);
   }

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -69,6 +69,7 @@ import org.assertj.core.util.CheckReturnValue;
  * As a convenience, the methods are defined in an interface so that no static imports are necessary if the test class
  * implements this interface.
  */
+@CheckReturnValue
 public interface WithAssumptions {
 
   /**
@@ -79,7 +80,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <T> ProxyableObjectArrayAssert<T> assumeThat(final T[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -93,7 +93,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <K, V> AbstractMapAssert<?, ?, K, V> assumeThat(final Map<K, V> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -105,7 +104,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractShortAssert<?> assumeThat(final short actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -117,7 +115,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractLongAssert<?> assumeThat(final long actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -129,7 +126,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractLongAssert<?> assumeThat(final Long actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -141,7 +137,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractLongArrayAssert<?> assumeThat(final long[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -154,7 +149,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <T> ProxyableObjectAssert<T> assumeThat(final T actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -166,7 +160,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractStringAssert<?> assumeThat(final String actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -178,7 +171,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractDateAssert<?> assumeThat(final Date actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -190,7 +182,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assumeThat(final Throwable actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -202,7 +193,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractBigDecimalAssert<?> assumeThat(final BigDecimal actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -214,7 +204,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractBigIntegerAssert<?> assumeThat(BigInteger actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -366,7 +355,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final CharSequence actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -378,7 +366,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuilder actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -390,7 +377,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  @CheckReturnValue
   default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuffer actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -401,7 +387,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractShortArrayAssert<?> assumeThat(final short[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -413,7 +398,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractShortAssert<?> assumeThat(final Short actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -425,7 +409,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractClassAssert<?> assumeThat(final Class<?> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -437,7 +420,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractCharacterAssert<?> assumeThat(final Character actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -449,7 +431,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractCharArrayAssert<?> assumeThat(final char[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -461,7 +442,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractCharacterAssert<?> assumeThat(final char actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -474,7 +454,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assumeThat(final T actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -487,7 +466,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <ELEMENT> ProxyableIterableAssert<ELEMENT> assumeThat(final Iterable<? extends ELEMENT> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -502,7 +480,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <ELEMENT> IteratorAssert<ELEMENT> assumeThat(final Iterator<? extends ELEMENT> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -514,7 +491,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractBooleanAssert<?> assumeThat(final Boolean actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -526,7 +502,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractBooleanArrayAssert<?> assumeThat(final boolean[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -538,7 +513,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractByteAssert<?> assumeThat(final byte actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -550,7 +524,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractByteAssert<?> assumeThat(final Byte actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -562,7 +535,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractByteArrayAssert<?> assumeThat(final byte[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -574,7 +546,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractBooleanAssert<?> assumeThat(final boolean actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -586,7 +557,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractFloatAssert<?> assumeThat(final float actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -598,7 +568,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractInputStreamAssert<?, ? extends InputStream> assumeThat(final InputStream actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -610,7 +579,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractFileAssert<?> assumeThat(final File actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -624,7 +592,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assumeThat(Future<RESULT> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -636,7 +603,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractPathAssert<?> assumeThat(final Path actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -648,7 +614,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractIntArrayAssert<?> assumeThat(final int[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -660,7 +625,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractFloatAssert<?> assumeThat(final Float actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -672,7 +636,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractIntegerAssert<?> assumeThat(final int actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -684,7 +647,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractFloatArrayAssert<?> assumeThat(final float[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -696,7 +658,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractIntegerAssert<?> assumeThat(final Integer actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -708,7 +669,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractDoubleAssert<?> assumeThat(final double actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -720,7 +680,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractDoubleAssert<?> assumeThat(final Double actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -733,7 +692,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default <ELEMENT> FactoryBasedNavigableListAssert<ProxyableListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(List<? extends ELEMENT> list) {
     return Assumptions.assumeThat(list);
   }
@@ -746,7 +704,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(Stream<? extends ELEMENT> stream) {
     return Assumptions.assumeThat(stream);
   }
@@ -758,7 +715,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assumeThat(DoubleStream doubleStream) {
     return Assumptions.assumeThat(doubleStream);
   }
@@ -770,7 +726,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assumeThat(LongStream longStream) {
     return Assumptions.assumeThat(longStream);
   }
@@ -782,7 +737,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assumeThat(IntStream intStream) {
     return Assumptions.assumeThat(intStream);
   }
@@ -794,7 +748,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractDoubleArrayAssert<?> assumeThat(final double[] actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -833,7 +786,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  @CheckReturnValue
   default <RESULT> CompletableFutureAssert<RESULT> assumeThat(CompletionStage<RESULT> actual) {
     return Assumptions.assumeThat(actual);
   }
@@ -989,7 +941,6 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  @CheckReturnValue
   default AbstractThrowableAssert<?, ? extends Throwable> assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assumeThat(catchThrowable(shouldRaiseOrNotThrowable));
   }


### PR DESCRIPTION
…d explicitly annotate methods to exclude form checking with @CanIgnoreReturnValue.

This means static analysis tools can now catch more errors.

Also fixes #1345 "Assertions#assertThatThrownBy without chained assertions should not cause static code analysis error".


