### PR TITLE
Deprecate extractor

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -1600,7 +1600,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object whose object under test is the list of Tuples containing the extracted values.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(@SuppressWarnings("unchecked") Function<ELEMENT, ?>... extractors) {
+  public AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(@SuppressWarnings("unchecked") Function<? super ELEMENT, ?>... extractors) {
     // combine all extractors into one function
     Function<ELEMENT, Tuple> tupleExtractor = objectToExtractValueFrom -> new Tuple(Stream.of(extractors)
                                                                                           .map(extractor -> extractor.apply(objectToExtractValueFrom))

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -50,7 +50,6 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.condition.Not;
 import org.assertj.core.description.Description;
@@ -1246,9 +1245,9 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * fellowshipOfTheRing.add(new TolkienCharacter(&quot;Boromir&quot;, 37, MAN));
    *
    * // this extracts the race
-   * Extractor&lt;TolkienCharacter, Race&gt; race = new Extractor&lt;TolkienCharacter, Race&gt;() {
+   * Function&lt;TolkienCharacter, Race&gt; race = new Function&lt;TolkienCharacter, Race&gt;() {
    *    {@literal @}Override
-   *    public Race extract(TolkienCharacter input) {
+   *    public Race apply(TolkienCharacter input) {
    *        return input.getRace();
    *    }
    * }
@@ -1265,7 +1264,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object whose object under test is the list of values extracted
    */
   @CheckReturnValue
-  public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> extracting(Extractor<? super ELEMENT, V> extractor) {
+  public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> extracting(Function<? super ELEMENT, V> extractor) {
     List<V> values = FieldsOrPropertiesExtractor.extract(actual, extractor);
     return newListAssertInstanceForMethodsChangingElementType(values);
   }
@@ -1317,7 +1316,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   }
 
   /**
-   * Should be used after any methods changing the elements type like {@link #extracting(Extractor)} as it will propagate the correct
+   * Should be used after any methods changing the elements type like {@link #extracting(Function)} as it will propagate the correct
    * assertions state, that is everyting but the element comparator (since the element type has changed).
    */
   private <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> newListAssertInstanceForMethodsChangingElementType(List<V> values) {
@@ -1347,7 +1346,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * CartoonCharacter fred = new CartoonCharacter("Fred Flintstone");
    * fred.getChildren().add(pebbles);
    *
-   * Extractor&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt; childrenOf = new Extractor&lt;CartoonChildren, List&lt;CartoonChildren&gt;&gt;() {
+   * Function&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt; childrenOf = new Function&lt;CartoonChildren, List&lt;CartoonChildren&gt;&gt;() {
    *    {@literal @}Override
    *    public List&lt;CartoonChildren&gt; extract(CartoonCharacter input) {
    *        return input.getChildren();
@@ -1368,7 +1367,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @throws NullPointerException if one of the {@code Iterable}'s element is null.
    */
   @CheckReturnValue
-  public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> flatExtracting(Extractor<? super ELEMENT, ? extends Collection<V>> extractor) {
+  public <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> flatExtracting(Function<? super ELEMENT, ? extends Collection<V>> extractor) {
     return doFlatExtracting(extractor);
   }
 
@@ -1414,7 +1413,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return doFlatExtracting(extractor);
   }
 
-  private <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> doFlatExtracting(Extractor<? super ELEMENT, ? extends Collection<V>> extractor) {
+  private <V> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> doFlatExtracting(Function<? super ELEMENT, ? extends Collection<V>> extractor) {
     List<V> result = FieldsOrPropertiesExtractor.extract(actual, extractor).stream()
                                                 .flatMap(Collection::stream)
                                                 .collect(toList());
@@ -1422,7 +1421,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   }
 
   /**
-   * Extract multiple values from each {@code Iterable}'s element according to the given {@code Extractor}s
+   * Extract multiple values from each {@code Iterable}'s element according to the given {@code Function}s
    * and concatenate/flatten the extracted values in a list that is used as the new object under test.
    * <p>
    * If extracted values were not flattened, instead of a simple list like (given 2 extractors) :
@@ -1447,10 +1446,10 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return a new assertion object whose object under test is a flattened list of all extracted values.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(@SuppressWarnings("unchecked") Extractor<? super ELEMENT, ?>... extractors) {
+  public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(@SuppressWarnings("unchecked") Function<? super ELEMENT, ?>... extractors) {
     Stream<? extends ELEMENT> actualStream = stream(actual.spliterator(), false);
     List<Object> result = actualStream.flatMap(element -> Stream.of(extractors)
-                                                                .map(extractor -> extractor.extract(element)))
+                                                                .map(extractor -> extractor.apply(element)))
                                       .collect(Collectors.toList());
     return newListAssertInstanceForMethodsChangingElementType(result);
   }
@@ -1494,7 +1493,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   public <EXCEPTION extends Exception> AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(@SuppressWarnings("unchecked") ThrowingExtractor<? super ELEMENT, ?, EXCEPTION>... extractors) {
     Stream<? extends ELEMENT> actualStream = stream(actual.spliterator(), false);
     List<Object> result = actualStream.flatMap(element -> Stream.of(extractors)
-                                                                .map(extractor -> extractor.extract(element)))
+                                                                .map(extractor -> extractor.apply(element)))
                                       .collect(Collectors.toList());
     return newListAssertInstanceForMethodsChangingElementType(result);
   }

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1425,7 +1425,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    */
   @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(String... keys) {
-    Tuple values = byName(keys).extract(actual);
+    Tuple values = byName(keys).apply(actual);
     List<Object> valuesFlattened = flatten(values.toList());
     String extractedPropertiesOrFieldsDescription = extractedDescriptionOf(keys);
     String description = mostRelevantDescription(info.description(), extractedPropertiesOrFieldsDescription);

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -2224,7 +2224,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the list of Tuples containing the extracted values.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(@SuppressWarnings("unchecked") Function<ELEMENT, ?>... extractors) {
+  public AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(@SuppressWarnings("unchecked") Function<? super ELEMENT, ?>... extractors) {
 
     Function<ELEMENT, Tuple> tupleExtractor = objectToExtractValueFrom -> new Tuple(Stream.of(extractors)
                                                                                           .map(extractor -> extractor.apply(objectToExtractValueFrom))

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -47,7 +47,6 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.condition.Not;
 import org.assertj.core.data.Index;
@@ -2127,7 +2126,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the list of extracted values.
    */
   @CheckReturnValue
-  public <U> AbstractListAssert<?, List<? extends U>, U, ObjectAssert<U>> extracting(Extractor<? super ELEMENT, U> extractor) {
+  public <U> AbstractListAssert<?, List<? extends U>, U, ObjectAssert<U>> extracting(Function<? super ELEMENT, U> extractor) {
     List<U> values = FieldsOrPropertiesExtractor.extract(Arrays.asList(actual), extractor);
     return newListAssertInstance(values).withAssertionState(myself);
   }
@@ -2265,7 +2264,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return a new assertion object whose object under test is the list of values extracted
    */
   @CheckReturnValue
-  public <V, C extends Collection<V>> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> flatExtracting(Extractor<? super ELEMENT, C> extractor) {
+  public <V, C extends Collection<V>> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> flatExtracting(Function<? super ELEMENT, C> extractor) {
     return doFlatExtracting(extractor);
   }
 
@@ -2311,7 +2310,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
     return doFlatExtracting(extractor);
   }
 
-  private <V, C extends Collection<V>> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> doFlatExtracting(Extractor<? super ELEMENT, C> extractor) {
+  private <V, C extends Collection<V>> AbstractListAssert<?, List<? extends V>, V, ObjectAssert<V>> doFlatExtracting(Function<? super ELEMENT, C> extractor) {
     List<V> result = FieldsOrPropertiesExtractor.extract(Arrays.asList(actual), extractor).stream()
                                                 .flatMap(Collection::stream).collect(toList());
     return newListAssertInstance(result).withAssertionState(myself);
@@ -2985,7 +2984,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   /**
    * Create a friendly soft or "hard" assertion.
    * <p>
-   * Implementations need to redefine it so that some methods, such as {@link #extracting(Extractor)}, are able
+   * Implementations need to redefine it so that some methods, such as {@link #extracting(Function)}, are able
    * to build the appropriate list assert (eg: {@link ListAssert} versus {@link ProxyableListAssert}).
    * <p>
    * The default implementation will assume that this concrete implementation is NOT a soft assertion.

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -606,7 +606,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> extracting(String... propertiesOrFields) {
-    Tuple values = byName(propertiesOrFields).extract(actual);
+    Tuple values = byName(propertiesOrFields).apply(actual);
     String extractedPropertiesOrFieldsDescription = extractedDescriptionOf(propertiesOrFields);
     String description = mostRelevantDescription(info.description(), extractedPropertiesOrFieldsDescription);
     return newListAssertInstance(values.toList()).as(description);

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -38,11 +38,11 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.condition.Not;
 import org.assertj.core.data.Index;
@@ -2253,7 +2253,7 @@ public class AtomicReferenceArrayAssert<T>
    *
    *
    * // this extracts the race
-   * Extractor&lt;TolkienCharacter, Race&gt; race = new Extractor&lt;TolkienCharacter, Race&gt;() {
+   * Function&lt;TolkienCharacter, Race&gt; race = new Function&lt;TolkienCharacter, Race&gt;() {
    *    {@literal @}Override
    *    public Race extract(TolkienCharacter input) {
    *        return input.getRace();
@@ -2273,7 +2273,7 @@ public class AtomicReferenceArrayAssert<T>
    * @since 2.7.0 / 3.7.0
    */
   @CheckReturnValue
-  public <U> ObjectArrayAssert<U> extracting(Extractor<? super T, U> extractor) {
+  public <U> ObjectArrayAssert<U> extracting(Function<? super T, U> extractor) {
     U[] extracted = FieldsOrPropertiesExtractor.extract(array, extractor);
 
     return new ObjectArrayAssert<>(extracted);
@@ -2343,7 +2343,7 @@ public class AtomicReferenceArrayAssert<T>
    * CartoonCharacter fred = new CartoonCharacter("Fred Flintstone");
    * fred.getChildren().add(pebbles);
    *
-   * Extractor&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt; childrenOf = new Extractor&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt;() {
+   * Function&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt; childrenOf = new Function&lt;CartoonCharacter, List&lt;CartoonCharacter&gt;&gt;() {
    *    {@literal @}Override
    *    public List&lt;CartoonChildren&gt; extract(CartoonCharacter input) {
    *        return input.getChildren();
@@ -2365,7 +2365,7 @@ public class AtomicReferenceArrayAssert<T>
    * @since 2.7.0 / 3.7.0
    */
   @CheckReturnValue
-  public <U, C extends Collection<U>> ObjectArrayAssert<U> flatExtracting(Extractor<? super T, C> extractor) {
+  public <U, C extends Collection<U>> ObjectArrayAssert<U> flatExtracting(Function<? super T, C> extractor) {
     return doFlatExtracting(extractor);
   }
 
@@ -2411,7 +2411,7 @@ public class AtomicReferenceArrayAssert<T>
     return doFlatExtracting(extractor);
   }
 
-  private <U, C extends Collection<U>> ObjectArrayAssert<U> doFlatExtracting(Extractor<? super T, C> extractor) {
+  private <U, C extends Collection<U>> ObjectArrayAssert<U> doFlatExtracting(Function<? super T, C> extractor) {
     List<U> result = FieldsOrPropertiesExtractor.extract(Arrays.asList(array), extractor).stream()
                                                 .flatMap(Collection::stream).collect(toList());
     return new ObjectArrayAssert<>(IterableUtil.toArray(result));

--- a/src/main/java/org/assertj/core/api/IterableAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableAssert.java
@@ -18,7 +18,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.util.Streams;
@@ -140,7 +139,7 @@ public class IterableAssert<ELEMENT> extends
 
   @Override
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(Extractor<? super ELEMENT, ?>... extractors) {
+  public final AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(Function<? super ELEMENT, ?>... extractors) {
     return super.flatExtracting(extractors);
   }
   

--- a/src/main/java/org/assertj/core/api/IterableAssert.java
+++ b/src/main/java/org/assertj/core/api/IterableAssert.java
@@ -145,7 +145,7 @@ public class IterableAssert<ELEMENT> extends
   
   @Override
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<ELEMENT, ?>... extractors) {
+  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<? super ELEMENT, ?>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -326,7 +326,7 @@ public class ListAssert<ELEMENT> extends
 
   @Override
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<ELEMENT, ?>... extractors) {
+  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<? super ELEMENT, ?>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -26,7 +26,6 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.internal.Failures;
@@ -339,7 +338,7 @@ public class ListAssert<ELEMENT> extends
 
   @Override
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(Extractor<? super ELEMENT, ?>... extractors) {
+  public final AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> flatExtracting(Function<? super ELEMENT, ?>... extractors) {
     return super.flatExtracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/ObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectArrayAssert.java
@@ -51,7 +51,7 @@ public class ObjectArrayAssert<ELEMENT> extends AbstractObjectArrayAssert<Object
 
   @Override
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<ELEMENT, ?>... extractors) {
+  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extracting(Function<? super ELEMENT, ?>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/iterable/Extractor.java
+++ b/src/main/java/org/assertj/core/api/iterable/Extractor.java
@@ -12,20 +12,29 @@
  */
 package org.assertj.core.api.iterable;
 
-import org.assertj.core.api.ListAssert;
-import org.assertj.core.api.ObjectArrayAssert;
+import java.util.function.Function;
+
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.AbstractObjectArrayAssert;
 import org.assertj.core.api.AtomicReferenceArrayAssert;
 
 /**
- * Function converting an element to another element. Used in {@link ListAssert#extracting(Extractor)},
- * {@link ObjectArrayAssert#extracting(Extractor)} and {@link AtomicReferenceArrayAssert#extracting(Extractor)}.
+ * Function converting an element to another element. Used in {@link AbstractIterableAssert#extracting(Function)},
+ * {@link AbstractObjectArrayAssert#extracting(Function)} and {@link AtomicReferenceArrayAssert#extracting(Function)}.
  * 
  * @author Mateusz Haligowski
  *
  * @param <F> type of element from which the conversion happens
  * @param <T> target element type
+ * @deprecated use {@link Function} instead
  */
 @FunctionalInterface
-public interface Extractor<F, T> {
+public interface Extractor<F, T> extends Function<F, T> {
+
+  @Override
+  default T apply(F f) {
+    return extract(f);
+  }
+
   T extract(F input);
 }

--- a/src/main/java/org/assertj/core/api/iterable/ThrowingExtractor.java
+++ b/src/main/java/org/assertj/core/api/iterable/ThrowingExtractor.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api.iterable;
 
+import java.util.function.Function;
+
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.ObjectArrayAssert;
 import org.assertj.core.api.AtomicReferenceArrayAssert;
@@ -26,10 +28,10 @@ import org.assertj.core.api.AtomicReferenceArrayAssert;
  * @param <EXCEPTION> type of exception which might be thrown during conversion
  */
 @FunctionalInterface
-public interface ThrowingExtractor<F, T, EXCEPTION extends Exception> extends Extractor<F, T> {
+public interface ThrowingExtractor<F, T, EXCEPTION extends Exception> extends Function<F, T> {
 
   @Override
-  default T extract(final F input) {
+  default T apply(final F input) {
     try {
       return extractThrows(input);
     } catch (final RuntimeException e) {

--- a/src/main/java/org/assertj/core/extractor/ByNameMultipleExtractor.java
+++ b/src/main/java/org/assertj/core/extractor/ByNameMultipleExtractor.java
@@ -17,11 +17,11 @@ import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.groups.Tuple;
 
-public class ByNameMultipleExtractor<T> implements Extractor<T, Tuple>{
+public class ByNameMultipleExtractor<T> implements Function<T, Tuple>{
 
   private final String[] fieldsOrProperties;
 
@@ -30,22 +30,22 @@ public class ByNameMultipleExtractor<T> implements Extractor<T, Tuple>{
   }
 
   @Override
-  public Tuple extract(T input) {
+  public Tuple apply(T input) {
     checkArgument(fieldsOrProperties != null, "The names of the fields/properties to read should not be null");
     checkArgument(fieldsOrProperties.length > 0, "The names of the fields/properties to read should not be empty");
     checkArgument(input != null, "The object to extract fields/properties from should not be null");
 
-    List<Extractor<T, Object>> extractors = buildExtractors();
+    List<Function<T, Object>> extractors = buildExtractors();
     List<Object> values = extractValues(input, extractors);
     
     return new Tuple(values.toArray());
   }
 
-  private List<Object> extractValues(T input, List<Extractor<T, Object>> singleExtractors) {
-    return singleExtractors.stream().map(extractor -> extractor.extract(input)).collect(toList());
+  private List<Object> extractValues(T input, List<Function<T, Object>> singleExtractors) {
+    return singleExtractors.stream().map(extractor -> extractor.apply(input)).collect(toList());
   }
 
-  private List<Extractor<T, Object>> buildExtractors() {
+  private List<Function<T, Object>> buildExtractors() {
     return Arrays.stream(fieldsOrProperties).map(ByNameSingleExtractor<T>::new).collect(toList());
   }
 

--- a/src/main/java/org/assertj/core/extractor/ByNameSingleExtractor.java
+++ b/src/main/java/org/assertj/core/extractor/ByNameSingleExtractor.java
@@ -15,12 +15,12 @@ package org.assertj.core.extractor;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Map;
+import java.util.function.Function;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 
-class ByNameSingleExtractor<T> implements Extractor<T, Object> {
+class ByNameSingleExtractor<T> implements Function<T, Object> {
 
   private final String propertyOrFieldName;
 
@@ -30,7 +30,7 @@ class ByNameSingleExtractor<T> implements Extractor<T, Object> {
   }
 
   @Override
-  public Object extract(T input) {
+  public Object apply(T input) {
     checkArgument(propertyOrFieldName != null, "The name of the field/property to read should not be null");
     checkArgument(propertyOrFieldName.length() > 0, "The name of the field/property to read should not be empty");
     checkArgument(input != null, "The object to extract field/property from should not be null");

--- a/src/main/java/org/assertj/core/extractor/Extractors.java
+++ b/src/main/java/org/assertj/core/extractor/Extractors.java
@@ -14,9 +14,9 @@ package org.assertj.core.extractor;
 
 import static java.lang.String.format;
 
+import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.util.Strings;
 
@@ -34,9 +34,9 @@ import org.assertj.core.util.Strings;
 public class Extractors {
   /**
    * Provides extractor for extracting {@link java.lang.Object#toString} from any object
-   * @return the built {@link Extractor}
+   * @return the built {@link Function}
    */
-  public static Extractor<Object, String> toStringMethod() {
+  public static Function<Object, String> toStringMethod() {
     return new ToStringExtractor();
   }
   
@@ -44,9 +44,9 @@ public class Extractors {
    * Provides extractor for extracting single field or property from any object using reflection
    * @param <F> type to extract property from
    * @param fieldOrProperty the name of the field/property to extract 
-   * @return the built {@link Extractor}
+   * @return the built {@link Function}
    */
-  public static <F> Extractor<F, Object> byName(String fieldOrProperty) {
+  public static <F> Function<F, Object> byName(String fieldOrProperty) {
     return new ByNameSingleExtractor<>(fieldOrProperty);
   }
   
@@ -54,9 +54,9 @@ public class Extractors {
    * Provides extractor for extracting multiple fields or properties from any object using reflection
    * @param <F> type to extract property from
    * @param fieldsOrProperties the name of the fields/properties to extract 
-   * @return the built {@link Extractor}
+   * @return the built {@link Function}
    */
-  public static <F> Extractor<F, Tuple> byName(String... fieldsOrProperties) {
+  public static <F> Function<F, Tuple> byName(String... fieldsOrProperties) {
     return new ByNameMultipleExtractor<>(fieldsOrProperties);
   }
 
@@ -64,9 +64,9 @@ public class Extractors {
    * Provides extractor for extracting values by method name from any object using reflection
    * @param <F> type to extract property from
    * @param methodName the name of the method to execute
-   * @return the built {@link Extractor}
+   * @return the built {@link Function}
    */
-  public static <F> Extractor<F, Object> resultOf(String methodName) {
+  public static <F> Function<F, Object> resultOf(String methodName) {
     return new ResultOfExtractor<>(methodName);
   }
 

--- a/src/main/java/org/assertj/core/extractor/ResultOfExtractor.java
+++ b/src/main/java/org/assertj/core/extractor/ResultOfExtractor.java
@@ -12,7 +12,8 @@
  */
 package org.assertj.core.extractor;
 
-import org.assertj.core.api.iterable.Extractor;
+import java.util.function.Function;
+
 import org.assertj.core.util.introspection.MethodSupport;
 
 /**
@@ -22,7 +23,7 @@ import org.assertj.core.util.introspection.MethodSupport;
  * @author Michał Piotrkowski
  * @author Mateusz Haligowski
  */
-class ResultOfExtractor<F> implements Extractor<F, Object> {
+class ResultOfExtractor<F> implements Function<F, Object> {
 
   private final String methodName;
   
@@ -34,7 +35,7 @@ class ResultOfExtractor<F> implements Extractor<F, Object> {
    * Behavior is described in {@link MethodSupport#methodResultFor(Object, String)}
    */
   @Override
-  public Object extract(F input) {
+  public Object apply(F input) {
     return MethodSupport.methodResultFor(input, methodName);
   }
 

--- a/src/main/java/org/assertj/core/extractor/ToStringExtractor.java
+++ b/src/main/java/org/assertj/core/extractor/ToStringExtractor.java
@@ -15,7 +15,7 @@
  */
 package org.assertj.core.extractor;
 
-import org.assertj.core.api.iterable.Extractor;
+import java.util.function.Function;
 
 /**
  * Extracts {@link Object#toString()} from any object
@@ -23,9 +23,9 @@ import org.assertj.core.api.iterable.Extractor;
  * @author Mateusz Haligowski
  *
  */
-public class ToStringExtractor implements Extractor<Object, String> {
+public class ToStringExtractor implements Function<Object, String> {
   @Override
-  public String extract(Object input) {
+  public String apply(Object input) {
     return input.toString();
   }
   

--- a/src/main/java/org/assertj/core/groups/FieldsOrPropertiesExtractor.java
+++ b/src/main/java/org/assertj/core/groups/FieldsOrPropertiesExtractor.java
@@ -18,15 +18,15 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Streams.stream;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractObjectArrayAssert;
-import org.assertj.core.api.iterable.Extractor;
 
 /**
  * Understands how to retrieve fields or values from a collection/array of objects.
  * <p>
- * You just have to give the field/property name or an {@link Extractor} implementation, a collection/array of objects
+ * You just have to give the field/property name or a {@link Function} implementation, a collection/array of objects
  * and it will extract the list of field/values from the given objects.
  *
  * @author Joel Costigliola
@@ -36,32 +36,32 @@ import org.assertj.core.api.iterable.Extractor;
 public class FieldsOrPropertiesExtractor {
 
   /**
-   * Call {@link #extract(Iterable, Extractor)} after converting objects to an iterable.
+   * Call {@link #extract(Iterable, Function)} after converting objects to an iterable.
    * <p>
-   * Behavior is described in javadoc {@link AbstractObjectArrayAssert#extracting(Extractor)}
+   * Behavior is described in javadoc {@link AbstractObjectArrayAssert#extracting(Function)}
    * @param <F> type of elements to extract a value from
    * @param <T> the extracted value type
    * @param objects the elements to extract a value from
    * @param extractor the extractor function
    * @return the extracted values
    */
-  public static <F, T> T[] extract(F[] objects, Extractor<? super F, T> extractor) {
+  public static <F, T> T[] extract(F[] objects, Function<? super F, T> extractor) {
     checkObjectToExtractFromIsNotNull(objects);
     List<T> result = extract(newArrayList(objects), extractor);
     return toArray(result);
   }
 
   /**
-   * Behavior is described in {@link AbstractIterableAssert#extracting(Extractor)}
+   * Behavior is described in {@link AbstractIterableAssert#extracting(Function)}
    * @param <F> type of elements to extract a value from
    * @param <T> the extracted value type
    * @param objects the elements to extract a value from
    * @param extractor the extractor function
    * @return the extracted values
    */
-  public static <F, T> List<T> extract(Iterable<? extends F> objects, Extractor<? super F, T> extractor) {
+  public static <F, T> List<T> extract(Iterable<? extends F> objects, Function<? super F, T> extractor) {
     checkObjectToExtractFromIsNotNull(objects);
-    return stream(objects).map(extractor::extract).collect(toList());
+    return stream(objects).map(extractor).collect(toList());
   }
 
   private static void checkObjectToExtractFromIsNotNull(Object object) {

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -22,8 +22,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.assertj.core.api.iterable.Extractor;
+import java.util.function.Function;
 
 /**
  * Utility methods related to <code>{@link Throwable}</code>s.
@@ -36,7 +35,7 @@ public final class Throwables {
   private static final String JAVA_LANG_REFLECT_CONSTRUCTOR = "java.lang.reflect.Constructor";
   private static final String ORG_ASSERTJ = "org.assert";
 
-  private static final Extractor<Throwable, String> ERROR_DESCRIPTION_EXTRACTOR = throwable -> {
+  private static final Function<Throwable, String> ERROR_DESCRIPTION_EXTRACTOR = throwable -> {
     Throwable cause = throwable.getCause();
     if (cause == null) return throwable.getMessage();
     // error has a cause, display the cause message and the first stack trace elements.

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -73,7 +73,6 @@ import java.util.stream.Stream;
 import org.assertj.core.api.ClassAssertBaseTest.AnnotatedClass;
 import org.assertj.core.api.ClassAssertBaseTest.AnotherAnnotation;
 import org.assertj.core.api.ClassAssertBaseTest.MyAnnotation;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.api.test.ComparableExample;
 import org.assertj.core.data.MapEntry;
@@ -100,12 +99,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
 
   private ThrowingExtractor<Name, String, Exception> throwingFirstNameExtractor;
   private ThrowingExtractor<Name, String, Exception> throwingLastNameExtractor;
-  private Extractor<Name, String> firstNameExtractor;
-  private Extractor<Name, String> lastNameExtractor;
   private Function<Name, String> firstNameFunction;
   private Function<Name, String> lastNameFunction;
 
-  private Extractor<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor;
+  private Function<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor;
 
   @BeforeEach
   public void setup() {
@@ -139,8 +136,6 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     throwingLastNameExtractor = Name::getLast;
     firstNameFunction = Name::getFirst;
     lastNameFunction = Name::getLast;
-    firstNameExtractor = Name::getFirst;
-    lastNameExtractor = Name::getLast;
 
     childrenExtractor = CartoonCharacter::getChildren;
   }
@@ -1038,7 +1033,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("John", "Doe"))
           .contains(tuple("Bilbo", "Baggins"));
     softly.then(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.then(names)
@@ -1050,10 +1045,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .hasSize(123);
     softly.then(names)
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.then(names)
-          .flatExtracting(firstNameExtractor, lastNameExtractor)
+          .flatExtracting(firstNameFunction, lastNameFunction)
           .as("flatExtracting with multiple Extractors")
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
@@ -1192,7 +1187,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("John", "Doe"))
           .contains(tuple("Bilbo", "Baggins"));
     softly.then(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.then(names)
@@ -1204,10 +1199,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .hasSize(123);
     softly.then(names)
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.then(names)
-          .flatExtracting(firstNameExtractor, lastNameExtractor)
+          .flatExtracting(firstNameFunction, lastNameFunction)
           .as("flatExtracting with multiple Extractors")
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
@@ -1346,7 +1341,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("John", "Doe"))
           .contains(tuple("Bilbo", "Baggins"));
     softly.then(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.then(names)
@@ -1358,7 +1353,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .hasSize(123);
     softly.then(names)
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.then(names)
           .extractingResultOf("getFirst")

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -78,7 +78,6 @@ import org.assertj.core.api.ClassAssertBaseTest.AnnotatedClass;
 import org.assertj.core.api.ClassAssertBaseTest.AnotherAnnotation;
 import org.assertj.core.api.ClassAssertBaseTest.MyAnnotation;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.api.test.ComparableExample;
 import org.assertj.core.data.MapEntry;
@@ -110,14 +109,12 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
 
   private Map<String, Object> iterableMap;
 
-  private static final ThrowingExtractor<Name, String, Exception> throwingFirstNameExtractor = Name::getFirst;
-  private static final ThrowingExtractor<Name, String, Exception> throwingLastNameExtractor = Name::getLast;
-  private static final Extractor<Name, String> firstNameExtractor = Name::getFirst;
-  private static final Extractor<Name, String> lastNameExtractor = Name::getLast;
+  private static final ThrowingExtractor<Name, String, Exception> throwingfirstNameFunction = Name::getFirst;
+  private static final ThrowingExtractor<Name, String, Exception> throwinglastNameFunction = Name::getLast;
   private static final Function<Name, String> firstNameFunction = Name::getFirst;
   private static final Function<Name, String> lastNameFunction = Name::getLast;
 
-  private static final Extractor<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor = CartoonCharacter::getChildren;
+  private static final Function<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor = CartoonCharacter::getChildren;
 
   @BeforeEach
   public void setup() {
@@ -1013,9 +1010,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     Iterable<CartoonCharacter> characters = asList(homer, fred);
     // WHEN
     softly.assertThat(names)
-          .as("extracting(throwingFirstNameExtractor)")
+          .as("extracting(throwingfirstNameFunction)")
           .overridingErrorMessage("error message")
-          .extracting(throwingFirstNameExtractor)
+          .extracting(throwingfirstNameFunction)
           .contains("gandalf")
           .contains("frodo");
     softly.assertThat(names)
@@ -1068,8 +1065,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("Bilbo", "Baggins"));
     softly.assertThat(names)
           .overridingErrorMessage("error message")
-          .as("extracting(firstNameExtractor)")
-          .extracting(firstNameExtractor)
+          .as("extracting(firstNameFunction)")
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.assertThat(names)
@@ -1087,18 +1084,18 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .as("name.first.startsWith(\"Jo\")")
           .overridingErrorMessage("error message")
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.assertThat(names)
           .overridingErrorMessage("error message")
           .as("flatExtracting with multiple Extractors")
-          .flatExtracting(firstNameExtractor, lastNameExtractor)
+          .flatExtracting(firstNameFunction, lastNameFunction)
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
     softly.assertThat(names)
           .overridingErrorMessage("error message")
           .as("flatExtracting with multiple ThrowingExtractors")
-          .flatExtracting(throwingFirstNameExtractor, throwingLastNameExtractor)
+          .flatExtracting(throwingfirstNameFunction, throwinglastNameFunction)
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
     softly.assertThat(names)
@@ -1153,8 +1150,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
     assertThat(errorsCollected).hasSize(33);
-    assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingFirstNameExtractor)] error message");
-    assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingFirstNameExtractor)] error message");
+    assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingfirstNameFunction)] error message");
+    assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingfirstNameFunction)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[extracting(\"last\")] error message");
     assertThat(errorsCollected.get(3)).hasMessage("[using flatExtracting on Iterable] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[using flatExtracting on Iterable] error message");
@@ -1171,7 +1168,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(15)).hasMessageContaining(bart.toString());
     assertThat(errorsCollected.get(16)).hasMessage("[extracting(firstNameFunction, lastNameFunction)] error message");
     assertThat(errorsCollected.get(17)).hasMessage("[extracting(\"first\", \"last\")] error message");
-    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameExtractor)] error message");
+    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameFunction)] error message");
     assertThat(errorsCollected.get(19)).hasMessage("[extracting(\"first\", String.class)] error message");
     assertThat(errorsCollected.get(20)).hasMessage("[filteredOn(name -> name.first.startsWith(\"Jo\"))] error message");
     assertThat(errorsCollected.get(21)).hasMessage("[name.first.startsWith(\"Jo\")] error message");
@@ -1197,9 +1194,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     List<CartoonCharacter> characters = asList(homer, fred);
     // WHEN
     softly.assertThat(names)
-          .as("extracting(throwingFirstNameExtractor)")
+          .as("extracting(throwingfirstNameFunction)")
           .overridingErrorMessage("error message")
-          .extracting(throwingFirstNameExtractor)
+          .extracting(throwingfirstNameFunction)
           .contains("gandalf")
           .contains("frodo");
     softly.assertThat(names)
@@ -1251,9 +1248,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("John", "Doe"))
           .contains(tuple("Bilbo", "Baggins"));
     softly.assertThat(names)
-          .as("extracting(firstNameExtractor)")
+          .as("extracting(firstNameFunction)")
           .overridingErrorMessage("error message")
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.assertThat(names)
@@ -1271,18 +1268,18 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .as("name.first.startsWith(\"Jo\")")
           .overridingErrorMessage("error message")
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.assertThat(names)
           .overridingErrorMessage("error message")
           .as("flatExtracting with multiple Extractors")
-          .flatExtracting(firstNameExtractor, lastNameExtractor)
+          .flatExtracting(firstNameFunction, lastNameFunction)
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
     softly.assertThat(names)
           .overridingErrorMessage("error message")
           .as("flatExtracting with multiple ThrowingExtractors")
-          .flatExtracting(throwingFirstNameExtractor, throwingLastNameExtractor)
+          .flatExtracting(throwingfirstNameFunction, throwinglastNameFunction)
           .contains("John", "Jane", "Doe")
           .contains("Sauron");
     softly.assertThat(names)
@@ -1337,8 +1334,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
     assertThat(errorsCollected).hasSize(33);
-    assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingFirstNameExtractor)] error message");
-    assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingFirstNameExtractor)] error message");
+    assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingfirstNameFunction)] error message");
+    assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingfirstNameFunction)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[extracting(\"last\")] error message");
     assertThat(errorsCollected.get(3)).hasMessage("[using flatExtracting on Iterable] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[using flatExtracting on Iterable] error message");
@@ -1355,7 +1352,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(15)).hasMessageContaining(bart.toString());
     assertThat(errorsCollected.get(16)).hasMessage("[extracting(firstNameFunction, lastNameFunction)] error message");
     assertThat(errorsCollected.get(17)).hasMessage("[extracting(\"first\", \"last\")] error message");
-    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameExtractor)] error message");
+    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameFunction)] error message");
     assertThat(errorsCollected.get(19)).hasMessage("[extracting(\"first\", String.class)] error message");
     assertThat(errorsCollected.get(20)).hasMessage("[filteredOn(name -> name.first.startsWith(\"Jo\"))] error message");
     assertThat(errorsCollected.get(21)).hasMessage("[name.first.startsWith(\"Jo\")] error message");
@@ -1436,8 +1433,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .contains(tuple("Bilbo", "Baggins"));
     softly.assertThat(names)
           .overridingErrorMessage("error message")
-          .as("extracting(firstNameExtractor)")
-          .extracting(firstNameExtractor)
+          .as("extracting(firstNameFunction)")
+          .extracting(firstNameFunction)
           .contains("John")
           .contains("sam");
     softly.assertThat(names)
@@ -1455,7 +1452,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .as("filteredOn + extracting")
           .overridingErrorMessage("error message")
           .filteredOn(name -> name.first.startsWith("Jo"))
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .contains("Sauron");
     softly.assertThat(names)
           .as("extractingResultOf(\"getFirst\")")
@@ -1521,7 +1518,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(15)).hasMessageContaining(bart.toString());
     assertThat(errorsCollected.get(16)).hasMessage("[extracting(Name::getFirst, Name::getLast)] error message");
     assertThat(errorsCollected.get(17)).hasMessage("[extracting(\"first\", \"last\")] error message");
-    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameExtractor)] error message");
+    assertThat(errorsCollected.get(18)).hasMessage("[extracting(firstNameFunction)] error message");
     assertThat(errorsCollected.get(19)).hasMessage("[extracting(\"first\", String.class)] error message");
     assertThat(errorsCollected.get(20)).hasMessage("[filteredOn(name -> name.first.startsWith(\"Jo\"))] error message");
     assertThat(errorsCollected.get(21)).hasMessage("[filteredOn + extracting] error message");
@@ -1769,7 +1766,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(names)
           .as("unicode")
           .withRepresentation(UNICODE_REPRESENTATION)
-          .extracting(throwingFirstNameExtractor)
+          .extracting(throwingfirstNameFunction)
           .contains("ó");
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
@@ -1784,17 +1781,17 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     Iterable<Name> names = asList(name("Manu", "Ginobili"), name("Magic", "Johnson"));
     // WHEN
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(string -> string.startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(new Condition<>(string -> string.startsWith("Ma"), "starts with Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOnAssertions(string -> assertThat(string).startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");
@@ -1821,17 +1818,17 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     List<Name> names = asList(name("Manu", "Ginobili"), name("Magic", "Johnson"));
     // WHEN
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(string -> string.startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(new Condition<>(string -> string.startsWith("Ma"), "starts with Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOnAssertions(string -> assertThat(string).startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");
@@ -1858,17 +1855,17 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     Name[] names = array(name("Manu", "Ginobili"), name("Magic", "Johnson"));
     // WHEN
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(string -> string.startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOn(new Condition<>(string -> string.startsWith("Ma"), "starts with Ma"))
           .containsExactly("MANU", "MAGIC");
     softly.assertThat(names)
-          .extracting(firstNameExtractor)
+          .extracting(firstNameFunction)
           .usingElementComparator(CaseInsensitiveStringComparator.instance)
           .filteredOnAssertions(string -> assertThat(string).startsWith("Ma"))
           .containsExactly("MANU", "MAGIC");

--- a/src/test/java/org/assertj/core/api/assumptions/BaseAssumptionsRunnerTest.java
+++ b/src/test/java/org/assertj/core/api/assumptions/BaseAssumptionsRunnerTest.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
 import org.assertj.core.data.TolkienCharacter;
 import org.assertj.core.data.TolkienCharacter.Race;
@@ -47,11 +46,11 @@ public abstract class BaseAssumptionsRunnerTest {
   protected static CartoonCharacter bart;
   protected static ThrowingExtractor<? super TolkienCharacter, String, Exception> throwingNameExtractor;
   protected static ThrowingExtractor<? super TolkienCharacter, Integer, Exception> throwingAgeExtractor;
-  protected static Extractor<? super TolkienCharacter, String> nameExtractor;
-  protected static Extractor<? super TolkienCharacter, Integer> ageExtractor;
+  protected static Function<? super TolkienCharacter, String> nameExtractor;
+  protected static Function<? super TolkienCharacter, Integer> ageExtractor;
   protected static Function<TolkienCharacter, String> nameExtractorFunction;
   protected static Function<TolkienCharacter, Integer> ageExtractorFunction;
-  protected static Extractor<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor;
+  protected static Function<? super CartoonCharacter, ? extends Collection<CartoonCharacter>> childrenExtractor;
 
   private static void setupData() {
     bart = new CartoonCharacter("Bart Simpson");

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_extracting_Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.util.Arrays.array;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Function;
 
 import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
@@ -119,6 +120,17 @@ public class AtomicReferenceArrayAssert_extracting_Test {
     assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(employees).extracting(new Extractor<Employee, String>() {
       @Override
       public String extract(Employee employee) {
+        if (employee.getAge() > 100) throw new RuntimeException("age > 100");
+        return employee.getName().getFirst();
+      }
+    })).withMessage("age > 100");
+  }
+
+  @Test
+  public void should_let_anonymous_class_function_runtime_exception_bubble_up() {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> assertThat(employees).extracting(new Function<Employee, String>() {
+      @Override
+      public String apply(Employee employee) {
         if (employee.getAge() > 100) throw new RuntimeException("age > 100");
         return employee.getName().getFirst();
       }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_flatExtracting_Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Function;
 
 import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.api.iterable.ThrowingExtractor;
@@ -34,7 +35,10 @@ public class AtomicReferenceArrayAssert_flatExtracting_Test {
   private CartoonCharacter pebbles;
   private CartoonCharacter fred;
 
-  private final Extractor<CartoonCharacter, List<CartoonCharacter>> children = new Extractor<CartoonCharacter, List<CartoonCharacter>>() {
+  private final Function<CartoonCharacter, List<CartoonCharacter>> children = CartoonCharacter::getChildren;
+
+  @SuppressWarnings("deprecation")
+  private final Extractor<CartoonCharacter, List<CartoonCharacter>> childrenExtractor = new Extractor<CartoonCharacter, List<CartoonCharacter>>() {
     @Override
     public List<CartoonCharacter> extract(CartoonCharacter input) {
       return input.getChildren();
@@ -56,15 +60,32 @@ public class AtomicReferenceArrayAssert_flatExtracting_Test {
   }
 
   @Test
+  public void should_allow_assertions_on_joined_lists_when_extracting_children_with_extractor() {
+    AtomicReferenceArray<CartoonCharacter> cartoonCharacters = new AtomicReferenceArray<>(array(homer, fred));
+    assertThat(cartoonCharacters).flatExtracting(childrenExtractor).containsOnly(bart, lisa, maggie, pebbles);
+  }
+
+  @Test
   public void should_allow_assertions_on_joined_lists_when_extracting_children() {
     AtomicReferenceArray<CartoonCharacter> cartoonCharacters = new AtomicReferenceArray<>(array(homer, fred));
     assertThat(cartoonCharacters).flatExtracting(children).containsOnly(bart, lisa, maggie, pebbles);
   }
 
   @Test
+  public void should_allow_assertions_on_empty_result_lists_with_extractor() {
+    AtomicReferenceArray<CartoonCharacter> childCharacters = new AtomicReferenceArray<>(array(bart, lisa, maggie));
+    assertThat(childCharacters).flatExtracting(childrenExtractor).isEmpty();
+  }
+
+  @Test
   public void should_allow_assertions_on_empty_result_lists() {
     AtomicReferenceArray<CartoonCharacter> childCharacters = new AtomicReferenceArray<>(array(bart, lisa, maggie));
     assertThat(childCharacters).flatExtracting(children).isEmpty();
+  }
+
+  @Test
+  public void should_throw_null_pointer_exception_when_extracting_from_null_with_extractor() {
+    assertThatNullPointerException().isThrownBy(() -> assertThat(new AtomicReferenceArray<>(array(homer, null))).flatExtracting(childrenExtractor));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -37,6 +37,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -63,6 +64,7 @@ public class IterableAssert_extracting_Test {
   private Iterable<Employee> jedis;
   private final List<TolkienCharacter> fellowshipOfTheRing = new ArrayList<>();
 
+  @SuppressWarnings("deprecation")
   private static final Extractor<Employee, String> firstName = new Extractor<Employee, String>() {
     @Override
     public String extract(Employee input) {
@@ -70,12 +72,7 @@ public class IterableAssert_extracting_Test {
     }
   };
 
-  private static final Extractor<Employee, Integer> age = new Extractor<Employee, Integer>() {
-    @Override
-    public Integer extract(Employee input) {
-      return input.getAge();
-    }
-  };
+  private static final Function<Employee, Integer> age = Employee::getAge;
 
   private static final ThrowingExtractor<Employee, Object, Exception> throwingExtractor = new ThrowingExtractor<Employee, Object, Exception>() {
     @Override

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -274,6 +274,23 @@ public class IterableAssert_extracting_Test {
   }
 
   @Test
+  public void should_allow_assertions_on_two_extracted_values_from_given_iterable_by_using_a_generic_function() {
+    Function<? super TolkienCharacter, String> name = TolkienCharacter::getName;
+    Function<? super TolkienCharacter, Integer> age = TolkienCharacter::getAge;
+
+    assertThat(fellowshipOfTheRing).extracting(name,
+                                               age)
+                                   .containsOnly(tuple("Frodo", 33),
+                                                 tuple("Sam", 38),
+                                                 tuple("Gandalf", 2020),
+                                                 tuple("Legolas", 1000),
+                                                 tuple("Pippin", 28),
+                                                 tuple("Gimli", 139),
+                                                 tuple("Aragorn", 87),
+                                                 tuple("Boromir", 37));
+  }
+
+  @Test
   public void should_allow_assertions_on_two_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
@@ -40,6 +40,7 @@ import static org.assertj.core.util.Lists.list;
 import java.sql.Timestamp;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.data.TolkienCharacter;
@@ -58,6 +59,7 @@ public class IterableAssert_extracting_with_SortedSet_Test {
   private SortedSet<Employee> jedis;
   private SortedSet<TolkienCharacter> fellowshipOfTheRing;
 
+  @SuppressWarnings("deprecation")
   private static final Extractor<Employee, String> firstName = new Extractor<Employee, String>() {
     @Override
     public String extract(Employee input) {
@@ -65,12 +67,7 @@ public class IterableAssert_extracting_with_SortedSet_Test {
     }
   };
 
-  private static final Extractor<Employee, Integer> age = new Extractor<Employee, Integer>() {
-    @Override
-    public Integer extract(Employee input) {
-      return input.getAge();
-    }
-  };
+  private static final Function<Employee, Integer> age = Employee::getAge;
 
   private static final ThrowingExtractor<Employee, Object, Exception> throwingExtractor = new ThrowingExtractor<Employee, Object, Exception>() {
     @Override

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for
- * <code>{@link org.assertj.core.api.AbstractIterableAssert#flatExtracting(org.assertj.core.api.iterable.Extractor)}</code>
+ * <code>{@link org.assertj.core.api.AbstractIterableAssert#flatExtracting(String)}</code>
  *
  * @author Alexander Bischof
  */

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
@@ -30,6 +30,7 @@ import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_TIMESTAMP
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.data.TolkienCharacter;
@@ -41,8 +42,9 @@ public class IterableAssert_flatExtracting_with_multiple_extractors_Test {
 
   private final List<TolkienCharacter> fellowshipOfTheRing = new ArrayList<>();
 
+  @SuppressWarnings("deprecation")
   private static final Extractor<TolkienCharacter, String> name = TolkienCharacter::getName;
-  private static final Extractor<TolkienCharacter, Integer> age = TolkienCharacter::getAge;
+  private static final Function<TolkienCharacter, Integer> age = TolkienCharacter::getAge;
   private static final ThrowingExtractor<TolkienCharacter, String, Exception> nameThrowingExtractor = TolkienCharacter::getName;
   private static final ThrowingExtractor<TolkienCharacter, Integer, Exception> ageThrowingExtractor = TolkienCharacter::getAge;
 

--- a/src/test/java/org/assertj/core/api/iterable/Iterable_generics_with_varargs_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/Iterable_generics_with_varargs_Test.java
@@ -14,8 +14,10 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -45,4 +47,22 @@ public class Iterable_generics_with_varargs_Test {
     // does not compile as Java 8 is stricter with generics ...
     // assertThat(strings).contains("a", "b");
   }
+
+  @Test
+  public void testListAssertWithGenericsAndExtracting() {
+    List<? extends String> strings = asList("a", "b", "c");
+    Function<? super String, String> doubleFunction = new Function<String, String>() {
+      @Override
+      public String apply(String s) {
+        return s + s;
+      }
+    };
+    assertThat(strings)
+      .extracting(doubleFunction, doubleFunction)
+      .contains(
+        tuple("aa", "aa"),
+        tuple("bb", "bb")
+      );
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
@@ -36,6 +36,7 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -170,6 +171,24 @@ public class ObjectArrayAssert_extracting_Test {
       }
     }).containsOnly("Yoda", "Luke");
   }
+
+  @Test
+  public void should_allow_assertions_on_two_extracted_values_from_given_iterable_by_using_a_generic_function() {
+    Function<? super TolkienCharacter, String> name = TolkienCharacter::getName;
+    Function<? super TolkienCharacter, Integer> age = TolkienCharacter::getAge;
+
+    assertThat(fellowshipOfTheRing).extracting(name,
+                                               age)
+                                   .containsOnly(tuple("Frodo", 33),
+                                                 tuple("Sam", 38),
+                                                 tuple("Gandalf", 2020),
+                                                 tuple("Legolas", 1000),
+                                                 tuple("Pippin", 28),
+                                                 tuple("Gimli", 139),
+                                                 tuple("Aragorn", 87),
+                                                 tuple("Boromir", 37));
+  }
+
 
   @Test
   public void should_allow_assertions_on_two_extracted_values_from_given_iterable_by_using_a_function() {

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
@@ -26,6 +26,7 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.iterable.Extractor;
@@ -44,7 +45,11 @@ public class ObjectArrayAssert_flatExtracting_Test {
   private CartoonCharacter fred;
 
   private static final ThrowingExtractor<CartoonCharacter, List<CartoonCharacter>, Exception> childrenThrowingExtractor = CartoonCharacter::getChildren;
-  private static final Extractor<CartoonCharacter, List<CartoonCharacter>> children = new Extractor<CartoonCharacter, List<CartoonCharacter>>() {
+
+  private static final Function<CartoonCharacter, List<CartoonCharacter>> children = CartoonCharacter::getChildren;
+
+  @SuppressWarnings("deprecation")
+  private static final Extractor<CartoonCharacter, List<CartoonCharacter>> childrenExtractor = new Extractor<CartoonCharacter, List<CartoonCharacter>>() {
     @Override
     public List<CartoonCharacter> extract(CartoonCharacter input) {
       return input.getChildren();
@@ -66,13 +71,28 @@ public class ObjectArrayAssert_flatExtracting_Test {
   }
 
   @Test
+  public void should_allow_assertions_on_joined_lists_when_extracting_children_with_extractor() {
+    assertThat(array(homer, fred)).flatExtracting(childrenExtractor).containsOnly(bart, lisa, maggie, pebbles);
+  }
+
+  @Test
   public void should_allow_assertions_on_joined_lists_when_extracting_children() {
     assertThat(array(homer, fred)).flatExtracting(children).containsOnly(bart, lisa, maggie, pebbles);
   }
 
   @Test
+  public void should_allow_assertions_on_empty_result_lists_with_extractor() {
+    assertThat(array(bart, lisa, maggie)).flatExtracting(childrenExtractor).isEmpty();
+  }
+
+  @Test
   public void should_allow_assertions_on_empty_result_lists() {
     assertThat(array(bart, lisa, maggie)).flatExtracting(children).isEmpty();
+  }
+
+  @Test
+  public void should_throw_null_pointer_exception_when_extracting_from_null_with_extractor() {
+    assertThatNullPointerException().isThrownBy(() -> assertThat(array(homer, null)).flatExtracting(childrenExtractor));
   }
 
   @Test
@@ -87,7 +107,7 @@ public class ObjectArrayAssert_flatExtracting_Test {
 
   @Test
   public void should_keep_existing_description_if_set_when_extracting_using_extractor() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(array(homer)).as("expected description").flatExtracting(children).isEmpty()).withMessageContaining("[expected description]");
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(array(homer)).as("expected description").flatExtracting(childrenExtractor).isEmpty()).withMessageContaining("[expected description]");
   }
 
   @Test
@@ -127,6 +147,32 @@ public class ObjectArrayAssert_flatExtracting_Test {
         return cartoonCharacter.getChildren();
       }
     }).containsOnly(bart, lisa, maggie, pebbles);
+  }
+
+  @Test
+  public void flatExtracting_should_keep_assertion_state_with_extractor() {
+    // GIVEN
+    AlwaysEqualComparator<CartoonCharacter> cartoonCharacterAlwaysEqualComparator = alwaysEqual();
+    // WHEN
+    // not all comparators are used but we want to test that they are passed correctly after extracting
+    // @format:off
+    AbstractListAssert<?, ?, ?, ?> assertion
+             = assertThat(array(homer, fred)).as("test description")
+                                             .withFailMessage("error message")
+                                             .withRepresentation(UNICODE_REPRESENTATION)
+                                             .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+                                             .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+                                             .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
+                                             .flatExtracting(childrenExtractor)
+                                             .contains(bart, lisa, new CartoonCharacter("Unknown"));
+    // @format:on
+    // THEN
+    assertThat(assertion.descriptionText()).isEqualTo("test description");
+    assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
+    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/extractor/ByNameMultipleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameMultipleExtractorTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
-import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
@@ -32,38 +32,38 @@ public class ByNameMultipleExtractorTest {
 
   @Test
   public void should_extract_tuples_from_fields_or_properties() {
-	Extractor<Employee, Tuple> extractor = new ByNameMultipleExtractor<>("id", "age");
+	Function<Employee, Tuple> extractor = new ByNameMultipleExtractor<>("id", "age");
 
-	Tuple extractedValue = extractor.extract(yoda);
+	Tuple extractedValue = extractor.apply(yoda);
 	assertThat(extractedValue).isEqualTo(tuple(1L, 800));
   }
 
   @Test
   public void should_extract_tuples_with_consistent_iteration_order() {
-	Extractor<Employee, Tuple> extractor = new ByNameMultipleExtractor<>("id", "name.first", "age");
+	Function<Employee, Tuple> extractor = new ByNameMultipleExtractor<>("id", "name.first", "age");
 
-	Tuple extractedValues = extractor.extract(yoda);
+	Tuple extractedValues = extractor.apply(yoda);
 	assertThat(extractedValues).isEqualTo(tuple(1L, "Yoda", 800));
   }
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_one_of_given_names() {
-	assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameMultipleExtractor<Employee>("id", "name.first", "unknown").extract(yoda));
+	assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameMultipleExtractor<Employee>("id", "name.first", "unknown").apply(yoda));
   }
 
   @Test
   public void should_throw_exception_when_given_name_is_null() {
-	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>((String[]) null).extract(yoda)).withMessage("The names of the fields/properties to read should not be null");
+	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>((String[]) null).apply(yoda)).withMessage("The names of the fields/properties to read should not be null");
   }
 
   @Test
   public void should_throw_exception_when_given_name_is_empty() {
-	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>(new String[0]).extract(yoda)).withMessage("The names of the fields/properties to read should not be empty");
+	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>(new String[0]).apply(yoda)).withMessage("The names of the fields/properties to read should not be empty");
   }
 
   @Test
   public void should_throw_exception_when_no_object_is_given() {
-	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>("id", "name.first", "age").extract(null)).withMessage("The object to extract fields/properties from should not be null");
+	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameMultipleExtractor<Employee>("id", "name.first", "age").apply(null)).withMessage("The object to extract fields/properties from should not be null");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -32,50 +32,50 @@ public class ByNameSingleExtractorTest {
 
   @Test
   public void should_extract_field_values_even_if_property_does_not_exist() {
-	Object extractedValues = idExtractor().extract(yoda);
+	Object extractedValues = idExtractor().apply(yoda);
 
 	assertThat(extractedValues).isEqualTo(1L);
   }
 
   @Test
   public void should_extract_property_values_when_no_public_field_match_given_name() {
-	Object extractedValues = ageExtractor().extract(yoda);
+	Object extractedValues = ageExtractor().apply(yoda);
 
 	assertThat(extractedValues).isEqualTo(800);
   }
 
   @Test
   public void should_extract_pure_property_values() {
-	Object extractedValues = adultExtractor().extract(yoda);
+	Object extractedValues = adultExtractor().apply(yoda);
 
 	assertThat(extractedValues).isEqualTo(true);
   }
 
   @Test
   public void should_throw_error_when_no_property_nor_public_field_match_given_name() {
-    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameSingleExtractor<Employee>("unknown").extract(yoda));
+    assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> new ByNameSingleExtractor<Employee>("unknown").apply(yoda));
   }
 
   @Test
   public void should_throw_exception_when_given_name_is_null() {
-	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameSingleExtractor<Employee>(null).extract(yoda)).withMessage("The name of the field/property to read should not be null");
+	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameSingleExtractor<Employee>(null).apply(yoda)).withMessage("The name of the field/property to read should not be null");
   }
 
   @Test
   public void should_throw_exception_when_given_name_is_empty() {
-	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameSingleExtractor<Employee>("").extract(yoda)).withMessage("The name of the field/property to read should not be empty");
+	assertThatIllegalArgumentException().isThrownBy(() -> new ByNameSingleExtractor<Employee>("").apply(yoda)).withMessage("The name of the field/property to read should not be empty");
   }
 
   @Test
   public void should_fallback_to_field_if_exception_has_been_thrown_on_property_access() {
-	Object extractedValue = nameExtractor().extract(new EmployeeWithBrokenName("Name"));
+	Object extractedValue = nameExtractor().apply(new EmployeeWithBrokenName("Name"));
 
 	assertThat(extractedValue).isEqualTo(new Name("Name"));
   }
 
   @Test
   public void should_prefer_properties_over_fields() {
-    Object extractedValue = nameExtractor().extract(new EmployeeWithOverriddenName("Overridden Name"));
+    Object extractedValue = nameExtractor().apply(new EmployeeWithOverriddenName("Overridden Name"));
 
     assertThat(extractedValue).isEqualTo(new Name("Overridden Name"));
   }
@@ -84,13 +84,13 @@ public class ByNameSingleExtractorTest {
   public void should_throw_exception_if_property_cannot_be_extracted_due_to_runtime_exception_during_property_access() {
     assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
       Employee employee = new BrokenEmployee();
-      adultExtractor().extract(employee);
+      adultExtractor().apply(employee);
     });
   }
 
   @Test
   public void should_throw_exception_if_no_object_is_given() {
-	assertThatIllegalArgumentException().isThrownBy(() -> idExtractor().extract(null));
+	assertThatIllegalArgumentException().isThrownBy(() -> idExtractor().apply(null));
   }
 
   @Test
@@ -121,7 +121,7 @@ public class ByNameSingleExtractorTest {
     darth.field = luke;
     luke.field = darth;
     luke.surname = new Name("Young", "Padawan");
-    Object extracted = byName("me.field.me.field.me.field.surname.name").extract(darth);
+    Object extracted = byName("me.field.me.field.me.field.surname.name").apply(darth);
     assertThat(extracted).isEqualTo("Young Padawan");
   }
 

--- a/src/test/java/org/assertj/core/extractor/ToStringExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ToStringExtractorTest.java
@@ -27,7 +27,7 @@ public class ToStringExtractorTest {
   public void should_extract_toString() {
     Employee someEmployee = new Employee(1, new Name("John Doe"), 28);
     
-    String result = toStringExtractor.extract(someEmployee);
+    String result = toStringExtractor.apply(someEmployee);
     
     assertThat(result).isEqualTo("Employee[id=1, name=Name[first='John Doe', last='null'], age=28]");
   }


### PR DESCRIPTION
#### Check List:
* Fixes #1348 
* Unit tests : YES 
* Javadoc with a code example (API only) : NA

I was not sure whether you want to completely remove all places where `Extractor` is being used. For example from `Extractors`, make `ThrowingExtractor` extend `Function` and whether you want to keep tests with `Extractor`. I have no problem in completely removing all places that use that.


