### PR TITLE
Do not proxy 'useComparator' method

### DIFF
--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -59,6 +59,7 @@ class SoftProxies {
                                                                                             .or(named("newObjectArrayAssert"))
                                                                                             .or(named("removeCustomAssertRelatedElementsFromStackTraceIfNeeded"))
                                                                                             .or(named("overridingErrorMessage"))
+                                                                                            .or(named("usingComparator"))
                                                                                             .or(named("usingDefaultComparator"))
                                                                                             .or(named("usingElementComparator"))
                                                                                             .or(named("withComparatorsForElementPropertyOrFieldNames"))


### PR DESCRIPTION
I am working on JsonUnit AssertJ integration. I'd like to add support for soft assertions. My class JsonAssert calls 'useComparator' in the constructor. Since the method is proxied, intercept is called before errorCollector setup and it ends-up in NPE. I can change the behavior or JsonAssert, but I assume that this is better solution.


