### PR TITLE
Add support for bare-named property methods

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -99,6 +99,7 @@ import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
+import org.assertj.core.util.introspection.Introspection;
 
 /**
  * Entry point for assertion methods for different types. Each method in this class is a static factory for a
@@ -1483,6 +1484,15 @@ public class Assertions {
    */
   public static void setAllowComparingPrivateFields(boolean allowComparingPrivateFields) {
     FieldSupport.comparison().setAllowUsingPrivateFields(allowComparingPrivateFields);
+  }
+
+  /**
+   * Globally sets whether the extractor considers bare-named property methods like {@code String name()}.
+   * Defaults to enabled.
+   * @param barenamePropertyMethods whether bare-named property methods are found
+   */
+  public static void setExtractBareNamePropertyMethods(boolean barenamePropertyMethods) {
+    Introspection.setExtractBareNamePropertyMethods(barenamePropertyMethods);
   }
 
   // ------------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -1898,6 +1898,15 @@ public interface WithAssertions {
   }
 
   /**
+   * Globally sets whether the extractor considers bare-named property methods like {@code String name()}.
+   * Defaults to enabled.
+   * @param barenamePropertyMethods whether bare-named property methods are found
+   */
+  default void setExtractBareNamePropertyMethods(boolean barenamePropertyMethods) {
+    Assertions.setExtractBareNamePropertyMethods(barenamePropertyMethods);
+  }
+
+  /**
    * Instead of using default strict date/time parsing, it is possible to use lenient parsing mode for default date
    * formats parser to interpret inputs that do not precisely match supported date formats (lenient parsing).
    * <p>

--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -78,6 +78,11 @@ public final class Introspection {
     if (getter != null) {
       return getter;
     }
+    // try to find bare name property
+    getter = findMethod(propertyName, target);
+    if (getter != null) {
+        return getter;
+    }
     // try to find isProperty for boolean properties
     return findMethod("is" + capitalized, target);
   }

--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -30,6 +30,8 @@ import java.lang.reflect.Modifier;
  */
 public final class Introspection {
 
+  private static boolean barenamePropertyMethods = true;
+
   /**
    * Returns the getter {@link Method} for a property matching the given name in the given object.
    * 
@@ -58,6 +60,10 @@ public final class Introspection {
     return getter;
   }
 
+  public static void setExtractBareNamePropertyMethods(boolean barenamePropertyMethods) {
+    Introspection.barenamePropertyMethods = barenamePropertyMethods;
+  }
+
   private static String propertyNotFoundErrorMessage(String propertyName, Object target) {
     String targetTypeName = target.getClass().getName();
     String property = quote(propertyName);
@@ -78,10 +84,12 @@ public final class Introspection {
     if (getter != null) {
       return getter;
     }
-    // try to find bare name property
-    getter = findMethod(propertyName, target);
-    if (getter != null) {
+    if (barenamePropertyMethods) {
+      // try to find bare name property
+      getter = findMethod(propertyName, target);
+      if (getter != null) {
         return getter;
+      }
     }
     // try to find isProperty for boolean properties
     return findMethod("is" + capitalized, target);

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -199,5 +199,10 @@ public class ByNameSingleExtractorTest {
     public OptionalInt value() {
       return OptionalInt.of(value);
     }
+
+    // ensure setter-like methods don't distract us
+    public BareOptionalIntHolder value(int value) {
+      throw new AssertionError("unreached");
+    }
   }
 }

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
 import org.assertj.core.util.introspection.IntrospectionError;
@@ -131,6 +132,15 @@ public class ByNameSingleExtractorTest {
     BareOptionalIntHolder holder = new BareOptionalIntHolder(42);
     assertThat(holder).extracting("value")
       .containsExactly(OptionalInt.of(42));
+  }
+
+  @Test
+  public void should_ignore_property_with_barename_method() {
+    BareOptionalIntHolder holder = new BareOptionalIntHolder(42);
+    Assertions.setExtractBareNamePropertyMethods(false);
+    assertThat(holder).extracting("value")
+      .containsExactly(42);
+    Assertions.setExtractBareNamePropertyMethods(true);
   }
 
   public static class EmployeeWithBrokenName extends Employee {

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.extractor.Extractors.byName;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
@@ -125,6 +126,13 @@ public class ByNameSingleExtractorTest {
     assertThat(extracted).isEqualTo("Young Padawan");
   }
 
+  @Test
+  public void should_extract_property_with_barename_method() {
+    BareOptionalIntHolder holder = new BareOptionalIntHolder(42);
+    assertThat(holder).extracting("value")
+      .containsExactly(OptionalInt.of(42));
+  }
+
   public static class EmployeeWithBrokenName extends Employee {
 
     public EmployeeWithBrokenName(String name) {
@@ -176,4 +184,20 @@ public class ByNameSingleExtractorTest {
 	return new ByNameSingleExtractor<>("name");
   }
 
+  /** This style of Optional handling is emitted by Immutables code gen library. */
+  static class BareOptionalIntHolder {
+    private final Integer value;
+
+    BareOptionalIntHolder() {
+      value = null;
+    }
+
+    BareOptionalIntHolder(int value) {
+      this.value = value;
+    }
+
+    public OptionalInt value() {
+      return OptionalInt.of(value);
+    }
+  }
 }


### PR DESCRIPTION
[Immutables](https://immutables.github.io/) is a wonderful code generator for value types.  It has support for `Optional` types, but creates the wrapper object from a nullable field under the hood.

Immutables also encourages bare-named property methods as opposed to bean-named.  (i.e. `property()` rather than `getProperty()`)

`assertj` provides great support for extracting values from types.

In the case of mixing `immutables`, `assertj`, and optional types, some confusing behavior emerges!  For a property `OptionalInt property()`, the implementation will store `Integer property;` and implement `property() { return OptionalInt.ofNullable(property); }`.  `assertj` does not consider bare-named property methods for extraction, and instead cracks open the field.  But the field is a different type than the programmer expected!  This leads to confusing assertion mismatches, "expected OptionalInt(42) got 42 instead" and the like, and it's not at all immediately clear why.

The simplest fix is to add property support for methods that match the property name exactly, without the `get` or `is` prefix.

I authored this code and release it under Apache 2.0 to the project.