### PR TITLE
Add assertion to check that a map contains exactly all entries of another map

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -52,6 +52,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Mikhail Mazursky
  * @author Nicolas François
  * @author dorzey
+ * @author Filip Hrisafov
  */
 public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACTUAL, K, V>, ACTUAL extends Map<K, V>, K, V>
     extends AbstractObjectAssert<SELF, ACTUAL> implements EnumerableAssert<SELF, Map.Entry<? extends K, ? extends V>> {
@@ -506,6 +507,43 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
     Map.Entry<? extends K, ? extends V>[] entries = other.entrySet().toArray(new Map.Entry[other.size()]);
     maps.assertContains(info, actual, entries);
     return myself;
+  }
+
+  /**
+   * Same as {@link #containsExactly(Map.Entry[])} but handles the conversion of {@link Map#entrySet()} to array.
+   * <p>
+   * Verifies that the actual map contains only the entries of the given map and nothing else, <b>in order</b>.<br>
+   * This assertion should only be used with maps that have a consistent iteration order (i.e. don't use it with
+   * {@link java.util.HashMap}, prefer {@link #containsOnly(java.util.Map.Entry...)} in that case).
+   * <p>
+   * Example :
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = newLinkedHashMap(entry(oneRing, frodo),
+   *                                                            entry(nenya, galadriel),
+   *                                                            entry(narya, gandalf));
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).containsExactlyEntriesOf(newLinkedHashMap(entry(oneRing, frodo),
+   *                                         entry(nenya, galadriel),
+   *                                         entry(narya, gandalf)));
+   *
+   * // assertion will fail as actual and expected order differ
+   * assertThat(ringBearers).containsExactlyEntriesOf(newLinkedHashMap(entry(nenya, galadriel),
+   *                                         entry(narya, gandalf),
+   *                                         entry(oneRing, frodo)));</code></pre>
+   *
+   * @param map the given {@link Map} that will give the entires.
+   * @return {@code this} assertions object
+   * @throws NullPointerException if the given map is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws IllegalArgumentException if the given map is empty.
+   * @throws AssertionError if the actual map does not contain the entries of the given map with same order, i.e
+   *    .      the actual map contains some or none of the entries of the given map, or the actual map contains more
+   *           entries than the entries of the given map or entries are the same but the order is not.
+   */
+  public SELF containsExactlyEntriesOf(Map<? extends K, ? extends V> map) {
+    @SuppressWarnings("unchecked")
+    Map.Entry<? extends K, ? extends V>[] entries = map.entrySet().toArray(new Map.Entry[0]);
+    return containsExactly(entries);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1501,10 +1501,14 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     softly.then(iterableMap)
           .flatExtracting("name", "job", "city", "rank")
           .contains("Unexpected", "Builder", "Dover", "Boston", "Paris", 1, 2, 3);
+    Map<String, String> exactlyEntriesMap = new LinkedHashMap<>();
+    exactlyEntriesMap.put("kl", "KL");
+    exactlyEntriesMap.put("mn", "MN");
+    softly.then(map).containsExactlyEntriesOf(exactlyEntriesMap);
     // softly.then(map).size().isGreaterThan(1000); not yet supported
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(12);
+    assertThat(errors).hasSize(13);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1518,6 +1522,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(9)).hasMessageContaining("b");
     assertThat(errors.get(10)).hasMessageContaining("456");
     assertThat(errors.get(11)).hasMessageContaining("Unexpected");
+    assertThat(errors.get(12)).hasMessageContaining("\"a\"=\"1\"");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1628,9 +1628,13 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .overridingErrorMessage("error message")
           .size()
           .isGreaterThan(1000);
+    Map<String, String> exactlyEntriesMap = new LinkedHashMap<>();
+    exactlyEntriesMap.put("kl", "KL");
+    exactlyEntriesMap.put("mn", "MN");
+    softly.assertThat(map).containsExactlyEntriesOf(exactlyEntriesMap);
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(13);
+    assertThat(errors).hasSize(14);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1645,6 +1649,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(10)).hasMessage("[extracting(\"a\", \"b\")] error message");
     assertThat(errors.get(11)).hasMessage("[flatExtracting(\"name\", \"job\", \"city\", \"rank\")] error message");
     assertThat(errors.get(12)).hasMessage("[size()] error message");
+    assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/assumptions/Map_special_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Map_special_assertion_methods_in_assumptions_Test.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.ProxyableMapAssert;
@@ -93,7 +94,18 @@ public class Map_special_assertion_methods_in_assumptions_Test extends BaseAssum
         run(map,
             value -> assumeThat(value).size().isPositive().returnToMap().size().isPositive(),
             value -> assumeThat(value).size().isPositive().returnToMap().size().isNegative()),
+      run(map,
+          value -> assumeThat(value).containsExactlyEntriesOf(newLinkedHashMap(entry("a", "1"), entry("b", "2"), entry("c", "3"))),
+          value -> assumeThat(value).containsExactlyEntriesOf(newLinkedHashMap(entry("b", "2"), entry("a", "1"), entry("c", "3")))),
     };
+  }
+
+  private static Map<String, String> newLinkedHashMap(Map.Entry<String, String>... entries) {
+    Map<String, String> map = new LinkedHashMap<>();
+    for (Entry<String, String> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+    return map;
   }
 
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyEntriesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyEntriesOf_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link MapAssert#containsExactlyEntriesOf(Map)}</code>.
+ *
+ * @author Filip Hrisafov
+ */
+public class MapAssert_containsExactlyEntriesOf_Test extends MapAssertBaseTest {
+
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsExactlyEntriesOf(newLinkedHashMap(entry("key1", "value1"), entry("key2", "value2")));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertContainsExactly(getInfo(assertions), getActual(assertions), entries);
+  }
+  
+  @Test
+  public void invoke_api_like_user() {
+     assertThat(map("key1", "value1", "key2", "value2")).containsExactlyEntriesOf(newLinkedHashMap(entry("key1", "value1"), entry("key2", "value2")));
+  }
+
+  @SafeVarargs
+  private static Map<String, String> newLinkedHashMap(Map.Entry<String, String>... entries) {
+    Map<String, String> map = new LinkedHashMap<>();
+    for (Entry<String, String> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+    return map;
+  }
+}


### PR DESCRIPTION

#### Check List:
* Fixes #1367
* Unit tests : YES 
* Javadoc with a code example (API only) : YES 


