### PR TITLE
Add shouldHaveRootCause

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -33,6 +33,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Jack Gough
  */
 public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAssert<SELF, ACTUAL>, ACTUAL extends Throwable>
     extends AbstractObjectAssert<SELF, ACTUAL> {
@@ -94,7 +95,7 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   /**
    * Verifies that the actual {@code Throwable} has a cause similar to the given one, that is with the same type and message
    * (it does not use the {@link Throwable#equals(Object) equals} method for comparison).
-   *
+   * <p>
    * Example:
    * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("invalid arg");
    * Throwable throwable = new Throwable(invalidArgException);
@@ -291,6 +292,32 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Verifies that the actual {@code Throwable} has a root cause similar to the given one, that is with the same type and message
+   * (it does not use the {@link Throwable#equals(Object) equals} method for comparison).
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("invalid arg");
+   * Throwable throwable = new Throwable(new RuntimeException(invalidArgException));
+   *
+   * // This assertion succeeds:
+   * assertThat(throwable).hasRootCause(invalidArgException);
+   *
+   * // These assertions fail:
+   * assertThat(throwable).hasRootCause(new IllegalArgumentException("bad arg"));
+   * assertThat(throwable).hasRootCause(new RuntimeException());
+   * assertThat(throwable).hasRootCause(null); // prefer hasNoCause()</code></pre>
+   *
+   * @param cause the expected root cause
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has not the given cause.
+   */
+  public SELF hasRootCause(Throwable cause) {
+    throwables.assertHasRootCause(info, actual, cause);
+    return myself;
+  }
+
+  /**
    * Verifies that the root cause of the actual {@code Throwable} is an instance of the given type.
    * <p>
    * Example:
@@ -366,7 +393,7 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   /**
    * Verifies that the actual {@code Throwable} has a suppressed exception similar to the given one, that is with the same type and message
    * (it does not use the {@link Throwable#equals(Object) equals} method for comparison).
-   *
+   * <p>
    * Example:
    * <pre><code class='java'> Throwable throwable = new Throwable();
    * Throwable invalidArgException = new IllegalArgumentException("invalid argument");

--- a/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.util.Objects.areEqual;
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+public class ShouldHaveRootCause extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHaveRootCause(Throwable actualCause, Throwable expectedCause) {
+    checkArgument(expectedCause != null, "expected cause should not be null");
+    // actualCause has no cause
+    if (actualCause == null) return new ShouldHaveRootCause(expectedCause);
+    // same message => different type
+    if (areEqual(actualCause.getMessage(), expectedCause.getMessage()))
+      return new ShouldHaveRootCause(actualCause, expectedCause.getClass());
+    // same type => different message
+    if (areEqual(actualCause.getClass(), expectedCause.getClass()))
+      return new ShouldHaveRootCause(actualCause, expectedCause.getMessage());
+    return new ShouldHaveRootCause(actualCause, expectedCause);
+  }
+
+  private ShouldHaveRootCause(Throwable actualCause, Throwable expectedCause) {
+    super("%n" +
+        "Expecting a root cause with type:%n" +
+        "  <%s>%n" +
+        "and message:%n" +
+        "  <%s>%n" +
+        "but type was:%n" +
+        "  <%s>%n" +
+        "and message was:%n" +
+        "  <%s>.",
+      expectedCause.getClass().getName(), expectedCause.getMessage(),
+      actualCause.getClass().getName(), actualCause.getMessage());
+  }
+
+  private ShouldHaveRootCause(Throwable expectedCause) {
+    super("%n" +
+        "Expecting a root cause with type:%n" +
+        "  <%s>%n" +
+        "and message:%n" +
+        "  <%s>%n" +
+        "but actual had no root cause.",
+      expectedCause.getClass().getName(), expectedCause.getMessage());
+  }
+
+  private ShouldHaveRootCause(Throwable actualCause, Class<? extends Throwable> expectedCauseClass) {
+    super("%n" +
+        "Expecting a root cause with type:%n" +
+        "  <%s>%n" +
+        "but type was:%n" +
+        "  <%s>.",
+      expectedCauseClass.getName(), actualCause.getClass().getName());
+  }
+
+  private ShouldHaveRootCause(Throwable actualCause, String expectedCauseMessage) {
+    super("%n" +
+        "Expecting a root cause with message:%n" +
+        "  <%s>%n" +
+        "but message was:%n" +
+        "  <%s>.",
+      expectedCauseMessage, actualCause.getMessage());
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -21,6 +21,7 @@ import static org.assertj.core.error.ShouldHaveMessage.shouldHaveMessage;
 import static org.assertj.core.error.ShouldHaveMessageMatchingRegex.shouldHaveMessageMatchingRegex;
 import static org.assertj.core.error.ShouldHaveNoCause.shouldHaveNoCause;
 import static org.assertj.core.error.ShouldHaveNoSuppressedExceptions.shouldHaveNoSuppressedExceptions;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
 import static org.assertj.core.error.ShouldHaveRootCauseExactlyInstance.shouldHaveRootCauseExactlyInstance;
 import static org.assertj.core.error.ShouldHaveRootCauseInstance.shouldHaveRootCauseInstance;
 import static org.assertj.core.error.ShouldHaveSuppressedException.shouldHaveSuppressedException;
@@ -39,6 +40,7 @@ import org.assertj.core.util.VisibleForTesting;
  *
  * @author Joel Costigliola
  * @author Libor Ondrusek
+ * @author Jack Gough
  */
 public class Throwables {
 
@@ -85,6 +87,26 @@ public class Throwables {
     if (actualCause == null) throw failures.failure(info, shouldHaveCause(actualCause, expectedCause));
     if (!compareThrowable(actualCause, expectedCause))
       throw failures.failure(info, shouldHaveCause(actualCause, expectedCause));
+  }
+
+  /**
+   * Asserts that the actual {@code Throwable} has a root cause similar to the given one.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @param expectedRootCause the expected root cause.
+   */
+  public void assertHasRootCause(AssertionInfo info, Throwable actual, Throwable expectedRootCause) {
+    assertNotNull(info, actual);
+    Throwable actualRootCause = getRootCause(actual);
+    if (actualRootCause == expectedRootCause) return;
+    if (null == expectedRootCause) {
+      assertHasNoCause(info, actual);
+      return;
+    }
+    if (actualRootCause == null) throw failures.failure(info, shouldHaveRootCause(null, expectedRootCause));
+    if (!compareThrowable(actualRootCause, expectedRootCause))
+      throw failures.failure(info, shouldHaveRootCause(actualRootCause, expectedRootCause));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCause_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCause_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+import org.junit.jupiter.api.Test;
+
+public class ThrowableAssert_hasRootCause_Test extends ThrowableAssertBaseTest {
+
+  private Throwable npe = new NullPointerException();
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasRootCause(npe);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasRootCause(getInfo(assertions), getActual(assertions), npe);
+  }
+
+  @Test
+  public void should_fail_if_actual_and_expected_root_cause_have_different_types() {
+    // GIVEN
+    Throwable rootCause = new IllegalStateException();
+    Throwable cause = new RuntimeException(rootCause);
+    final Throwable throwable = new IllegalArgumentException(cause);
+
+    // WHEN
+    AssertionError actual = expectAssertionError(() -> assertThat(throwable).hasRootCause(new NullPointerException()));
+
+    // THEN
+    assertThat(actual)
+      .hasMessage(format("%n"
+                         + "Expecting a root cause with type:%n"
+                         + "  <\"java.lang.NullPointerException\">%n"
+                         + "but type was:%n"
+                         + "  <\"java.lang.IllegalStateException\">."));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
+
+/**
+ * Tests for
+ * <code>{@link ShouldHaveRootCause#shouldHaveRootCause(Throwable, Throwable)}</code>
+ *
+ * @author Jack Gough
+ */
+public class ShouldHaveRootCause_create_Test {
+
+  private static final TestDescription DESCRIPTION = new TestDescription("TEST");
+
+  @Test
+  public void should_create_error_message_for_expected_without_actual() {
+    // GIVEN
+    Throwable actualCause = null;
+    Throwable expectedCause = new RuntimeException("hello");
+
+    // WHEN
+    String actual = shouldHaveRootCause(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting a root cause with type:%n"
+                                        + "  <\"java.lang.RuntimeException\">%n"
+                                        + "and message:%n"
+                                        + "  <\"hello\">%n"
+                                        + "but actual had no root cause."));
+  }
+
+  @Test
+  public void should_create_error_message_for_unequal_types() {
+    // GIVEN
+    Throwable actualCause = new IllegalArgumentException("one");
+    Throwable expectedCause = new RuntimeException("one");
+
+    // WHEN
+    String actual = shouldHaveRootCause(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting a root cause with type:%n"
+                                        + "  <\"java.lang.RuntimeException\">%n"
+                                        + "but type was:%n"
+                                        + "  <\"java.lang.IllegalArgumentException\">."));
+  }
+
+  @Test
+  public void should_create_error_message_for_unequal_messages() {
+    // GIVEN
+    Throwable actualCause = new RuntimeException("wibble");
+    Throwable expectedCause = new RuntimeException("wobble");
+
+    // WHEN
+    String actual = shouldHaveRootCause(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting a root cause with message:%n"
+                                        + "  <\"wobble\">%n"
+                                        + "but message was:%n"
+                                        + "  <\"wibble\">."));
+  }
+
+  @Test
+  public void should_create_error_message_for_unequal_types_and_messages() {
+    // GIVEN
+    Throwable actualCause = new RuntimeException("wibble");
+    Throwable expectedCause = new IllegalArgumentException("wobble");
+
+    // WHEN
+    String actual = shouldHaveRootCause(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting a root cause with type:%n"
+                                        + "  <\"java.lang.IllegalArgumentException\">%n"
+                                        + "and message:%n"
+                                        + "  <\"wobble\">%n"
+                                        + "but type was:%n"
+                                        + "  <\"java.lang.RuntimeException\">%n"
+                                        + "and message was:%n"
+                                        + "  <\"wibble\">."));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCause_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCause_Test.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2018 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveNoCause.shouldHaveNoCause;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class Throwables_assertHasRootCause_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
+
+  private static Stream<Arguments> passingData() {
+    return Stream.of(
+      Arguments.of(withRootCause(new IllegalArgumentException("bang")), new IllegalArgumentException("bang"), "same root cause"),
+      Arguments.of(withCause(new IllegalArgumentException("wibble")), new IllegalArgumentException("wibble"), "same cause"),
+      Arguments.of(new Throwable(), null, "no cause"));
+  }
+
+  @SuppressWarnings("unused")
+  @ParameterizedTest(name = "{2}: throwable = {0} / expected = {1}")
+  @MethodSource("passingData")
+  public void should_pass_if_root_cause_is_expected(Throwable throwable,
+                                                    Throwable expected,
+                                                    String testDescription) {
+    // WHEN
+    throwables.assertHasRootCause(INFO, throwable, expected);
+
+    // THEN
+    // no exception thrown
+  }
+
+  private static Stream<Arguments> failingData() {
+    return Stream.of(
+      Arguments.of(null, new RuntimeException(), "no actual cause"),
+      Arguments.of(new IllegalArgumentException(), new NullPointerException(), "different root cause type"),
+      Arguments.of(new IllegalArgumentException("right"), new IllegalArgumentException("wrong"), "different root cause message"),
+      Arguments.of(new IllegalArgumentException(), new IllegalArgumentException("wrong"), "no root cause message"),
+      Arguments.of(new IllegalArgumentException("one"), new IllegalArgumentException("two"), "different root cause type and message")
+    );
+  }
+
+  @SuppressWarnings("unused")
+  @ParameterizedTest(name = "{2}: throwable = {0} / expected = {1}")
+  @MethodSource("failingData")
+  public void should_fail_if_root_cause_is_unexpected(final Throwable rootCause,
+                                                      final Throwable expected,
+                                                      String testDescription) {
+    // GIVEN
+    final Throwable throwable = withRootCause(rootCause);
+
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasRootCause(INFO, throwable, expected));
+
+    // THEN
+    verify(failures).failure(INFO, shouldHaveRootCause(rootCause, expected));
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    // GIVEN
+    final Throwable throwable = null;
+    final Throwable expected = new Throwable();
+
+    // WHEN
+    AssertionError actual = expectAssertionError(() -> throwables.assertHasRootCause(INFO, throwable, expected));
+
+    // THEN
+    assertThat(actual).hasMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_if_expected_root_cause_is_null() {
+    // GIVEN
+    Throwable rootCause = new NullPointerException();
+    final Throwable throwable = withRootCause(rootCause);
+    final Throwable expected = null;
+
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasRootCause(INFO, throwable, expected));
+
+    // THEN
+    verify(failures).failure(INFO, shouldHaveNoCause(throwable));
+  }
+
+  private static Throwable withRootCause(Throwable rootCause) {
+    Throwable cause = rootCause == null ? null : new RuntimeException("cause", rootCause);
+    return withCause(cause);
+  }
+
+  private static Throwable withCause(Throwable cause) {
+    return new IllegalStateException("throwable", cause);
+  }
+}


### PR DESCRIPTION
Allows testing for contents of a root cause, similar to hasCause()

Most of this code (including tests) was based on what hasCause() already does

#### Check List:
* Fixes: N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES