### PR TITLE
Issue-1390 Double and Float comparator support Infinity

### DIFF
--- a/src/main/java/org/assertj/core/util/DoubleComparator.java
+++ b/src/main/java/org/assertj/core/util/DoubleComparator.java
@@ -33,7 +33,7 @@ public class DoubleComparator extends NullSafeComparator<Double> {
   }
 
   private static boolean closeEnough(Double x, Double y, double epsilon) {
-    return Math.abs(x - y) <= epsilon;
+    return x.doubleValue() == y.doubleValue() || Math.abs(x - y) <= epsilon;
   }
 
   @Override

--- a/src/main/java/org/assertj/core/util/FloatComparator.java
+++ b/src/main/java/org/assertj/core/util/FloatComparator.java
@@ -33,7 +33,7 @@ public class FloatComparator extends NullSafeComparator<Float> {
   }
 
   private boolean closeEnough(Float x, Float y, float epsilon) {
-    return Math.abs(x - y) <= epsilon;
+    return x.floatValue() == y.floatValue() || Math.abs(x - y) <= epsilon;
   }
 
   @Override

--- a/src/test/java/org/assertj/core/util/DoubleComparatorTest.java
+++ b/src/test/java/org/assertj/core/util/DoubleComparatorTest.java
@@ -14,6 +14,7 @@ package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -64,4 +65,26 @@ public class DoubleComparatorTest {
                                           .isFalse();
   }
 
+  @ParameterizedTest
+  @CsvSource({
+      "Infinity, Infinity",
+      "-Infinity, -Infinity"
+  })
+  public void should_be_equal_if_both_values_are_infinity_of_same_sign(Double actual, Double other) {
+    assertThat(nearlyEqual(actual, other)).as("comparing %f to %f", actual, other).isTrue();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "Infinity, -Infinity",
+      "-Infinity, Infinity"
+  })
+  public void should_not_be_equal_if_both_values_are_infinity_of_opposite_signs(Double actual, Double other) {
+    assertThat(nearlyEqual(actual, other)).as("comparing %f to %f", actual, other).isFalse();
+  }
+
+  @Test
+  public void should_not_be_equal_if_not_a_number() {
+    assertThat(nearlyEqual(Double.NaN, Double.NaN)).isFalse();
+  }
 }

--- a/src/test/java/org/assertj/core/util/FloatComparatorTest.java
+++ b/src/test/java/org/assertj/core/util/FloatComparatorTest.java
@@ -14,6 +14,7 @@ package org.assertj.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -62,6 +63,29 @@ public class FloatComparatorTest {
     assertThat(nearlyEqual(actual, other)).as("comparing %f to %f with epsilon %f", actual, other,
                                               comparator.getEpsilon())
                                           .isFalse();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "Infinity, Infinity",
+      "-Infinity, -Infinity"
+  })
+  public void should_be_equal_if_both_values_are_infinity_of_same_sign(Float actual, Float other) {
+    assertThat(nearlyEqual(actual, other)).as("comparing %f to %f", actual, other).isTrue();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "Infinity, -Infinity",
+      "-Infinity, Infinity"
+  })
+  public void should_not_be_equal_if_both_values_are_infinity_of_opposite_signs(Float actual, Float other) {
+    assertThat(nearlyEqual(actual, other)).as("comparing %f to %f", actual, other).isFalse();
+  }
+
+  @Test
+  public void should_not_be_equal_if_not_a_number() {
+    assertThat(nearlyEqual(Float.NaN, Float.NaN)).isFalse();
   }
 
 }


### PR DESCRIPTION
Now floating point numbers with the same infinite values will be
considered equals by default.

#### Check List:
* Fixes: https://github.com/joel-costigliola/assertj-core/issues/1390
* Unit tests : YES
* Javadoc with a code example (API only) : NA


