### PR TITLE
Add hasBinaryContent for InputSteams

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -8,11 +8,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  */
 package org.assertj.core.api;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.security.MessageDigest;
 
 import org.assertj.core.internal.InputStreams;
@@ -101,6 +102,30 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    */
   public SELF hasContent(String expected) {
     inputStreams.assertHasContent(info, actual, expected);
+    return myself;
+  }
+
+  /**
+   * Verifies that the binary content of the actual {@code InputStream} is <b>exactly</b> equal to the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new ByteArrayInputStream(new byte[] {1, 2})).hasContent(new byte[] {1, 2});
+   *
+   * // assertions will fail
+   * assertThat(bin).hasBinaryContent(new byte[] { });
+   * assertThat(bin).hasBinaryContent(new byte[] {0, 0});</code></pre>
+   *
+   * @param expected the expected binary content to compare the actual {@code InputStream}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given content is {@code null}.
+   * @throws AssertionError if the actual {@code InputStream} is {@code null}.
+   * @throws AssertionError if the content of the actual {@code InputStream} is not equal to the given binary content.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws InputStreamsException if an I/O error occurs.
+   */
+  public SELF hasBinaryContent(byte[] expected) {
+    inputStreams.assertHasBinaryContent(info, actual, expected);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveBinaryContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveBinaryContent.java
@@ -8,11 +8,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  */
 package org.assertj.core.error;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Path;
 
 import org.assertj.core.internal.BinaryDiffResult;
@@ -20,7 +21,7 @@ import org.assertj.core.internal.BinaryDiffResult;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a file/path has a given binary content failed.
- * 
+ *
  * @author Olivier Michallat
  */
 public class ShouldHaveBinaryContent extends BasicErrorMessageFactory {
@@ -34,7 +35,7 @@ public class ShouldHaveBinaryContent extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
     return new ShouldHaveBinaryContent(actual, diff);
   }
-  
+
   /**
    * Creates a new <code>{@link ShouldHaveBinaryContent}</code>.
    * @param actual the actual path in the failed assertion.
@@ -45,13 +46,28 @@ public class ShouldHaveBinaryContent extends BasicErrorMessageFactory {
     return new ShouldHaveBinaryContent(actual, diff);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldHaveBinaryContent}</code>.
+   * @param actual the actual input stream in the failed assertion.
+   * @param diff the differences between {@code actual} and the given binary content.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveBinaryContent(InputStream actual, BinaryDiffResult diff) {
+    return new ShouldHaveBinaryContent(actual, diff);
+  }
+
   private ShouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
     super("%nFile:%n <%s>%ndoes not have expected binary content at offset <%s>, expecting:%n <%s>%nbut was:%n <%s>", actual,
         diff.offset, diff.expected, diff.actual);
   }
-  
+
   private ShouldHaveBinaryContent(Path actual, BinaryDiffResult diff) {
     super("%nPath:%n <%s>%ndoes not have expected binary content at offset <%s>, expecting:%n <%s>%nbut was:%n <%s>", actual,
+        diff.offset, diff.expected, diff.actual);
+  }
+
+  private ShouldHaveBinaryContent(InputStream actual, BinaryDiffResult diff) {
+    super("%nInputStream does not have expected binary content at offset <%s>, expecting:%n <%s>%nbut was:%n <%s>", actual,
         diff.offset, diff.expected, diff.actual);
   }
 }

--- a/src/main/java/org/assertj/core/internal/BinaryDiff.java
+++ b/src/main/java/org/assertj/core/internal/BinaryDiff.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -24,7 +24,7 @@ import org.assertj.core.util.VisibleForTesting;
 
 /**
  * Compares the binary content of two inputStreams/paths.
- * 
+ *
  * @author Olivier Michallat
  */
 @VisibleForTesting
@@ -37,10 +37,16 @@ public class BinaryDiff {
 
   @VisibleForTesting
   public BinaryDiffResult diff(Path actual, byte[] expected) throws IOException {
-    try (InputStream expectedStream = new ByteArrayInputStream(expected);
-        InputStream actualStream = Files.newInputStream(actual)) {
-      return diff(actualStream, expectedStream);
+    try (InputStream actualStream = Files.newInputStream(actual)) {
+      return diff(actualStream, expected);
     }
+  }
+
+  @VisibleForTesting
+  public BinaryDiffResult diff(InputStream actualStream, byte[] expected) throws IOException {
+    try (InputStream expectedStream = new ByteArrayInputStream(expected)) {
+		  return diff(actualStream, expectedStream);
+	  }
   }
 
   @VisibleForTesting

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -8,11 +8,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  */
 package org.assertj.core.internal;
 
 import static java.lang.String.format;
+import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.internal.Digests.digestDiff;
@@ -47,6 +48,8 @@ public class InputStreams {
 
   @VisibleForTesting
   Diff diff = new Diff();
+  @VisibleForTesting
+  BinaryDiff binaryDiff = new BinaryDiff();
   @VisibleForTesting
   Failures failures = Failures.instance();
 
@@ -98,6 +101,31 @@ public class InputStreams {
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {
       String msg = format("Unable to compare contents of InputStream:%n  <%s>%nand String:%n  <%s>", actual, expected);
+      throw new InputStreamsException(msg, e);
+    }
+  }
+
+  /**
+   * Asserts that the given InputStream has the given binary content.
+   * @param info contains information about the assertion.
+   * @param actual the actual InputStream.
+   * @param expected the expected binary content.
+   * @throws NullPointerException if {@code expected} is {@code null}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the given InputStream does not have the same content as the given String.
+   * @throws UncheckedIOException if an I/O error occurs.
+   * @throws InputStreamsException if an I/O error occurs.
+   */
+  public void assertHasBinaryContent(AssertionInfo info, InputStream actual, byte[] expected) {
+    checkNotNull(expected, "The binary content to compare to should not be null");
+    assertNotNull(info, actual);
+
+    try {
+      BinaryDiffResult result = binaryDiff.diff(actual, expected);
+      if (result.hasNoDiff()) return;
+      throw failures.failure(info, shouldHaveBinaryContent(actual, result));
+    } catch (IOException e) {
+      String msg = String.format("Unable to verify binary contents of InputStream:%n  <%s>", actual);
       throw new InputStreamsException(msg, e);
     }
   }

--- a/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_hasBinaryContent_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.assertj.core.api.InputStreamAssertBaseTest;
+import org.junit.jupiter.api.BeforeAll;
+
+
+/**
+ * Tests for <code>{@link InputStreamAssert#hasContent(String)}</code>.
+ */
+public class InputStreamAssert_hasBinaryContent_Test extends InputStreamAssertBaseTest {
+
+  private static byte[] expected;
+
+  @BeforeAll
+  public static void setUpOnce() {
+    expected = new byte[] {1, 2};
+  }
+
+  @Override
+  protected InputStreamAssert invoke_api_method() {
+    return assertions.hasBinaryContent(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(inputStreams).assertHasBinaryContent(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/InputStreamsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/InputStreamsBaseTest.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  */
 package org.assertj.core.internal;
 
@@ -39,26 +39,31 @@ public class InputStreamsBaseTest {
   protected static final AssertionInfo INFO = someInfo();
 
   protected Diff diff;
+  protected BinaryDiff binaryDiff;
   protected Failures failures;
   protected InputStreams inputStreams;
 
   protected static InputStream actual;
   protected static InputStream expected;
   protected static String expectedString;
+  protected static byte[] expectedContent;
 
   @BeforeAll
   public static void setUpOnce() {
     actual = new ByteArrayInputStream(new byte[0]);
     expected = new ByteArrayInputStream(new byte[0]);
     expectedString = "";
+    expectedContent = new byte[0];
   }
 
   @BeforeEach
   public void setUp() {
     diff = mock(Diff.class);
+    binaryDiff = mock(BinaryDiff.class);
     failures = spy(new Failures());
     inputStreams = new InputStreams();
     inputStreams.diff = diff;
+    inputStreams.binaryDiff = binaryDiff;
     inputStreams.failures = failures;
   }
 

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasBinaryContent_Test.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.inputstreams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
+import static org.assertj.core.internal.BinaryDiffResult.noDiff;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.BinaryDiffResult;
+import org.assertj.core.internal.InputStreams;
+import org.assertj.core.internal.InputStreamsBaseTest;
+import org.assertj.core.internal.InputStreamsException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link InputStreams#assertHasBinaryContent(AssertionInfo, InputStream, byte[])}</code>.
+ */
+public class InputStreams_assertHasBinaryContent_Test extends InputStreamsBaseTest {
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+    assertThatNullPointerException().isThrownBy(() -> inputStreams.assertHasBinaryContent(someInfo(), actual, null))
+                                    .withMessage("The binary content to compare to should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> inputStreams.assertHasBinaryContent(someInfo(), null, new byte[0]))
+                                                   .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_pass_if_inputstream_has_expected_binary_content() throws IOException {
+    // GIVEN
+    given(binaryDiff.diff(actual, expectedContent)).willReturn(noDiff());
+    // THEN
+    inputStreams.assertHasBinaryContent(someInfo(), actual, expectedContent);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_caught_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(binaryDiff.diff(actual, expectedContent)).willThrow(cause);
+    // WHEN
+    Throwable error = catchThrowable(() -> inputStreams.assertHasBinaryContent(someInfo(), actual, expectedContent));
+    // THEN
+    assertThat(error).isInstanceOf(InputStreamsException.class)
+                     .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_inputstream_and_string_do_not_have_equal_content() throws IOException {
+    // GIVEN
+    BinaryDiffResult diff = new BinaryDiffResult(1, 2, 3);
+    given(binaryDiff.diff(actual, expectedContent)).willReturn(diff);
+    AssertionInfo info = someInfo();
+    // WHEN
+    catchThrowable(() -> inputStreams.assertHasBinaryContent(someInfo(), actual, new byte[0]));
+    // THEN
+    verify(failures).failure(info, shouldHaveBinaryContent(actual, diff));
+  }
+}


### PR DESCRIPTION
Add a method `hasBinaryContent` for input streams, following the
implementation of the corresponding method in `AbstractFileAssert`.

#### Check List:
* Fixes #1395
* Unit tests : YES
* Javadoc with a code example (API only) : YES