### PR TITLE
Adds representation handeling to ZipSatisfyError

### DIFF
--- a/src/main/java/org/assertj/core/error/ZippedElementsShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ZippedElementsShouldSatisfy.java
@@ -17,29 +17,32 @@ import static org.assertj.core.util.Strings.escapePercent;
 
 import java.util.List;
 
+import org.assertj.core.api.AssertionInfo;
+
 public class ZippedElementsShouldSatisfy extends BasicErrorMessageFactory {
 
   private static final String DELIMITER = String.format("%n%n- ");
 
-  public static ErrorMessageFactory zippedElementsShouldSatisfy(Object actual, Object other,
+  public static ErrorMessageFactory zippedElementsShouldSatisfy(AssertionInfo info, 
+                                                                Iterable<?> actual, Iterable<?> other,
                                                                 List<ZipSatisfyError> zipSatisfyErrors) {
-    return new ZippedElementsShouldSatisfy(actual, other, zipSatisfyErrors);
+    return new ZippedElementsShouldSatisfy(info, actual, other, zipSatisfyErrors);
   }
 
-  private ZippedElementsShouldSatisfy(Object actual, Object other, List<ZipSatisfyError> zipSatisfyErrors) {
+  private ZippedElementsShouldSatisfy(AssertionInfo info, Iterable<?> actual, Iterable<?> other, List<ZipSatisfyError> zipSatisfyErrors) {
     // no use of %s for describe(zipSatisfyErrors) to avoid extra "" but need to make sure there is no extra/unwanted format flag
     super("%n" +
           "Expecting zipped elements of:%n" +
           "  <%s>%n" +
           "and:%n" +
           "  <%s>%n" +
-          "to satisfy given requirements but these zipped elements did not:" + describe(zipSatisfyErrors),
+          "to satisfy given requirements but these zipped elements did not:" + describe(info, zipSatisfyErrors),
           actual, other);
   }
-
-  private static String describe(List<ZipSatisfyError> zipSatisfyErrors) {
+ 
+  private static String describe(AssertionInfo info, List<ZipSatisfyError> zipSatisfyErrors) {
     List<String> errorsToStrings = zipSatisfyErrors.stream()
-                                                   .map(ZipSatisfyError::toString)
+                                                   .map(e -> ZipSatisfyError.describe(info, e))
                                                    .collect(toList());
     return escapePercent(DELIMITER + String.join(DELIMITER, errorsToStrings));
   }
@@ -54,10 +57,11 @@ public class ZippedElementsShouldSatisfy extends BasicErrorMessageFactory {
       this.otherElement = otherElement;
       this.error = error;
     }
-
-    @Override
-    public String toString() {
-      return String.format("(%s, %s) error: %s", actualElement, otherElement, error);
+    
+    public static String describe(AssertionInfo info, ZipSatisfyError satisfyError) {
+      return String.format("(%s, %s) error: %s", 
+                           info.representation().toStringOf(satisfyError.actualElement),
+                           info.representation().toStringOf(satisfyError.otherElement), satisfyError.error);
     }
 
   }

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1143,12 +1143,13 @@ public class Iterables {
                                                  .filter(Optional::isPresent)
                                                  .map(Optional::get)
                                                  .collect(toList());
-    if (!errors.isEmpty()) throw failures.failure(info, zippedElementsShouldSatisfy(actual, other, errors));
+    if (!errors.isEmpty()) throw failures.failure(info, zippedElementsShouldSatisfy(info, actual, other, errors));
   }
 
   private <ACTUAL_ELEMENT, OTHER_ELEMENT> Optional<ZipSatisfyError> failsZipRequirements(ACTUAL_ELEMENT actualElement,
                                                                                          OTHER_ELEMENT otherElement,
-                                                                                         BiConsumer<ACTUAL_ELEMENT, OTHER_ELEMENT> zipRequirements) {
+                                                                                         BiConsumer<ACTUAL_ELEMENT, OTHER_ELEMENT> zipRequirements
+                                                                                         ) {
     try {
       zipRequirements.accept(actualElement, otherElement);
       return Optional.empty();

--- a/src/test/java/org/assertj/core/error/ElementsShouldZipSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ElementsShouldZipSatisfy_create_Test.java
@@ -16,26 +16,34 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ZippedElementsShouldSatisfy.zippedElementsShouldSatisfy;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Lists.list;
 
 import java.util.List;
 
+import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ZippedElementsShouldSatisfy.ZipSatisfyError;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ElementsShouldZipSatisfy_create_Test {
-
+  protected AssertionInfo info;
+  
+  @BeforeEach
+  public void setUp() {
+    info = someInfo();
+  }
   @Test
   public void should_create_error_message() {
     // GIVEN
     List<ZipSatisfyError> errors = list(new ZipSatisfyError("Luke", "LUKE", "error luke"),
                                         new ZipSatisfyError("Yo-da", "YODA", "error yoda"));
-    ErrorMessageFactory factory = zippedElementsShouldSatisfy(list("Luke", "Yo-da"),
+    ErrorMessageFactory factory = zippedElementsShouldSatisfy(info, list("Luke", "Yo-da"),
                                                               list("LUKE", "YODA"),
                                                               errors);
     // WHEN
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), info.representation());
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting zipped elements of:%n" +
@@ -43,8 +51,8 @@ public class ElementsShouldZipSatisfy_create_Test {
                                          "and:%n" +
                                          "  <[\"LUKE\", \"YODA\"]>%n" +
                                          "to satisfy given requirements but these zipped elements did not:" +
-                                         "%n%n- (Luke, LUKE) error: error luke" +
-                                         "%n%n- (Yo-da, YODA) error: error yoda"));
+                                         "%n%n- (\"Luke\", \"LUKE\") error: error luke" +
+                                         "%n%n- (\"Yo-da\", \"YODA\") error: error yoda"));
   }
 
   @Test
@@ -52,11 +60,11 @@ public class ElementsShouldZipSatisfy_create_Test {
     // GIVEN
     List<ZipSatisfyError> errors = list(new ZipSatisfyError("Luke", "LU%dKE", "error luke"),
                                         new ZipSatisfyError("Yo-da", "YODA", "error yoda"));
-    ErrorMessageFactory factory = zippedElementsShouldSatisfy(list("Luke", "Yo-da"),
+    ErrorMessageFactory factory = zippedElementsShouldSatisfy(info, list("Luke", "Yo-da"),
                                                               list("LU%dKE", "YODA"),
                                                               errors);
     // WHEN
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), info.representation());
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting zipped elements of:%n" +
@@ -64,7 +72,7 @@ public class ElementsShouldZipSatisfy_create_Test {
                                          "and:%n" +
                                          "  <[\"LU%%dKE\", \"YODA\"]>%n" +
                                          "to satisfy given requirements but these zipped elements did not:" +
-                                         "%n%n- (Luke, LU%%dKE) error: error luke" +
-                                         "%n%n- (Yo-da, YODA) error: error yoda"));
+                                         "%n%n- (\"Luke\", \"LU%%dKE\") error: error luke" +
+                                         "%n%n- (\"Yo-da\", \"YODA\") error: error yoda"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertZipSatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertZipSatisfy_Test.java
@@ -69,7 +69,7 @@ public class Iterables_assertZipSatisfy_Test extends IterablesBaseTest {
     List<ZipSatisfyError> errors = list(new ZipSatisfyError("Luke", "LUKE", shouldStartWith("Luke", "LUKE").create()),
                                         new ZipSatisfyError("Yoda", "YODA", shouldStartWith("Yoda", "YODA").create()),
                                         new ZipSatisfyError("Leia", "LEIA", shouldStartWith("Leia", "LEIA").create()));
-    verify(failures).failure(info, zippedElementsShouldSatisfy(actual, other, errors));
+    verify(failures).failure(info, zippedElementsShouldSatisfy(info, actual, other, errors));
   }
 
   @Test


### PR DESCRIPTION
When displaying errors from ZipSatisfyError, use the configured representation of the objects, rather than the toString().

#### Check List:
* Fixes #1407 
* Unit tests : YES (updated existing tests)
* Javadoc with a code example (API only) : NO (internal only, no API change)

