### PR TITLE
noneSatisfy should report all failing elements

### DIFF
--- a/src/main/java/org/assertj/core/error/NoElementsShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/NoElementsShouldSatisfy.java
@@ -22,7 +22,7 @@ public class NoElementsShouldSatisfy extends BasicErrorMessageFactory {
     super("%n" +
           "Expecting no elements of:%n" +
           "  <%s>%n" +
-          "to satisfy the given assertions requirements but this one did:%n" +
+          "to satisfy the given assertions requirements but these elements did:%n" +
           "  <%s>",
           actual, faultyElement);
   }

--- a/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
@@ -16,7 +16,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.NoElementsShouldSatisfy.noElementsShouldSatisfy;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Lists.list;
 
 import org.assertj.core.description.TextDescription;
 import org.junit.jupiter.api.Test;
@@ -26,14 +26,14 @@ public class NoElementsShouldSatisfy_create_Test {
   @Test
   public void should_create_error_message_any() {
     // GIVEN
-    ErrorMessageFactory factory = noElementsShouldSatisfy(newArrayList("Luke", "Yoda"), "Vader");
+    ErrorMessageFactory factory = noElementsShouldSatisfy(list("Luke", "Leia", "Yoda"), list("Luke", "Leia"));
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     assertThat(message).isEqualTo(format("[Test] %n" +
                                          "Expecting no elements of:%n" +
-                                         "  <[\"Luke\", \"Yoda\"]>%n" +
-                                         "to satisfy the given assertions requirements but this one did:%n" +
-                                         "  <\"Vader\">"));
+                                         "  <[\"Luke\", \"Leia\", \"Yoda\"]>%n" +
+                                         "to satisfy the given assertions requirements but these elements did:%n" +
+                                         "  <[\"Luke\", \"Leia\"]>"));
   }
 }

--- a/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class NoElementsShouldSatisfy_create_Test {
 
   @Test
-  public void should_create_error_message_any() {
+  public void should_create_error_message() {
     // GIVEN
     ErrorMessageFactory factory = noElementsShouldSatisfy(list("Luke", "Leia", "Yoda"), list("Luke", "Leia"));
     // WHEN

--- a/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/NoElementsShouldSatisfy_create_Test.java
@@ -36,4 +36,18 @@ public class NoElementsShouldSatisfy_create_Test {
                                          "to satisfy the given assertions requirements but these elements did:%n" +
                                          "  <[\"Luke\", \"Leia\"]>"));
   }
+
+  @Test
+  public void should_create_error_message_percent() {
+    // GIVEN
+    ErrorMessageFactory factory = noElementsShouldSatisfy(list("Luke", "Leia%s", "Yoda"), list("Luke", "Leia%s"));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    assertThat(message).isEqualTo(format("[Test] %n" +
+                                         "Expecting no elements of:%n" +
+                                         "  <[\"Luke\", \"Leia%%s\", \"Yoda\"]>%n" +
+                                         "to satisfy the given assertions requirements but these elements did:%n" +
+                                         "  <[\"Luke\", \"Leia%%s\"]>"));
+  }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneSatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneSatisfy_Test.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.NoElementsShouldSatisfy.noElementsShouldSatisfy;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Lists.list;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 public class Iterables_assertNoneSatisfy_Test extends IterablesBaseTest {
 
-  private List<String> actual = newArrayList("Luke", "Leia", "Yoda");
+  private List<String> actual = list("Luke", "Leia", "Yoda");
 
   @Test
   public void should_pass_when_no_elements_satisfy_the_given_single_restriction() {
@@ -67,7 +67,18 @@ public class Iterables_assertNoneSatisfy_Test extends IterablesBaseTest {
     // WHEN
     Throwable assertionError = catchThrowable(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
     // THEN
-    verify(failures).failure(info, noElementsShouldSatisfy(actual, "Yoda"));
+    verify(failures).failure(info, noElementsShouldSatisfy(actual, list("Yoda")));
+    assertThat(assertionError).isNotNull();
+  }
+
+  @Test
+  public void should_fail_when_two_elements_satisfy_the_given_restrictions() {
+    // GIVEN
+    Consumer<String> restrictions = name -> assertThat(name).startsWith("L");
+    // WHEN
+    Throwable assertionError = catchThrowable(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
+    // THEN
+    verify(failures).failure(info, noElementsShouldSatisfy(actual, list("Luke", "Leia")));
     assertThat(assertionError).isNotNull();
   }
 
@@ -79,7 +90,7 @@ public class Iterables_assertNoneSatisfy_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->{
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
       List<String> nullActual = null;
       iterables.assertNoneSatisfy(someInfo(), nullActual, name -> assertThat(name).startsWith("Y"));
     }).withMessage(actualIsNull());

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneSatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneSatisfy_Test.java
@@ -15,9 +15,9 @@ package org.assertj.core.internal.iterables;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.NoElementsShouldSatisfy.noElementsShouldSatisfy;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.list;
 import static org.mockito.Mockito.verify;
@@ -65,7 +65,7 @@ public class Iterables_assertNoneSatisfy_Test extends IterablesBaseTest {
     // GIVEN
     Consumer<String> restrictions = name -> assertThat(name).startsWith("Y");
     // WHEN
-    Throwable assertionError = catchThrowable(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
+    Throwable assertionError = expectAssertionError(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
     // THEN
     verify(failures).failure(info, noElementsShouldSatisfy(actual, list("Yoda")));
     assertThat(assertionError).isNotNull();
@@ -76,7 +76,7 @@ public class Iterables_assertNoneSatisfy_Test extends IterablesBaseTest {
     // GIVEN
     Consumer<String> restrictions = name -> assertThat(name).startsWith("L");
     // WHEN
-    Throwable assertionError = catchThrowable(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
+    Throwable assertionError = expectAssertionError(() -> iterables.assertNoneSatisfy(someInfo(), actual, restrictions));
     // THEN
     verify(failures).failure(info, noElementsShouldSatisfy(actual, list("Luke", "Leia")));
     assertThat(assertionError).isNotNull();


### PR DESCRIPTION
#### Check List:
* Fixes #1415 
* Unit tests : YES
* Javadoc with a code example (API only) : NA

The example from #1415 now results in:

```
java.lang.AssertionError: 
Expecting no elements of:
  <[1, 2, 3]>
to satisfy the given assertions requirements but these elements did:
  <[2, 3]>
```


