### PR TITLE
Update byte-buddy to version 1.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.9.8</version>
+      <version>1.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
see [release notes](https://github.com/raphw/byte-buddy/blob/master/release-notes.md#4-february-2019-version-199) for details


