### PR TITLE
Fixes #1432: catchThrowableOfType - stack trace of the original exception is lost

### DIFF
--- a/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -14,6 +14,8 @@ package org.assertj.core.api;
 
 import java.util.concurrent.Callable;
 
+import static org.assertj.core.error.ShouldBeInstance.shouldBeInstance;
+
 /**
  * Assertion methods for {@link Throwable}s.
  * <p>
@@ -26,8 +28,6 @@ import java.util.concurrent.Callable;
  * @author Mikhail Mazursky
  */
 public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Throwable> {
-
-  private static final String WRONG_EXCEPTION_TYPE = "Expecting code to throw <%s> but threw <%s> instead";
 
   public interface ThrowingCallable {
     void call() throws Throwable;
@@ -72,7 +72,7 @@ public class ThrowableAssert extends AbstractThrowableAssert<ThrowableAssert, Th
     Throwable throwable = catchThrowable(shouldRaiseThrowable);
     if (throwable == null) return null;
     // check exception type
-    new ThrowableAssert(throwable).overridingErrorMessage(WRONG_EXCEPTION_TYPE, type, throwable.getClass())
+    new ThrowableAssert(throwable).overridingErrorMessage(shouldBeInstance(throwable, type).create())
                                   .isInstanceOf(type);
     return (THROWABLE) throwable;
   }

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.Fail.fail;
 import static org.assertj.core.api.Fail.shouldHaveThrown;
+import static org.assertj.core.util.Throwables.getStackTrace;
 
 import java.io.IOException;
 
@@ -77,11 +78,13 @@ public class Assertions_assertThat_with_Throwable_Test {
 
   @Test
   public void catchThrowableOfType_should_fail_with_good_message_if_wrong_type() {
+    final Exception exception = new Exception("boom!!");
     try {
-      catchThrowableOfType(raisingException("boom!!"), RuntimeException.class);
+      catchThrowableOfType(codeThrowing(exception), RuntimeException.class);
     } catch (AssertionError e) {
       assertThat(e).hasMessageContaining(RuntimeException.class.getName())
-                   .hasMessageContaining(Exception.class.getName());
+                   .hasMessageContaining(Exception.class.getName())
+                   .hasMessageContaining(getStackTrace(exception));
       return;
     }
     shouldHaveThrown(AssertionError.class);


### PR DESCRIPTION
#### Check List:
* Fixes #1432 
* Unit tests : YES
* Javadoc with a code example (API only) : NA


