### PR TITLE
Remove skipping of JaCoCo on Java 11 which is no longer necessary aft…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,15 +333,5 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
       </properties>
     </profile>
-    <profile>
-      <id>java12+</id>
-      <activation>
-        <jdk>[12,)</jdk>
-      </activation>
-      <properties>
-        <!-- currently fails with "javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module." -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-      </properties>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -328,8 +328,6 @@
         <jdk>[11,)</jdk>
       </activation>
       <properties>
-        <!-- jacoco does not work with java 11 yet, see https://github.com/jacoco/jacoco/issues/663 -->
-        <jacoco.skip>true</jacoco.skip>
         <sonar.skip>true</sonar.skip>
         <!-- currently fails with "javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module." -->
         <maven.javadoc.skip>true</maven.javadoc.skip>


### PR DESCRIPTION
…er the upgrade to JaCoCo version 0.8.3.


