### PR TITLE
Fix javadoc and reenable Javadoc doclint verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,6 @@
               hljs.initHighlightingOnLoad();
             </script>
           ]]></footer>
-          <!-- some jdk don't support nested li tags :( -->
-          <doclint>none</doclint>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -813,12 +813,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * <ul>
    * <li>actual and expected objects and their fields were compared field by field recursively even if they were not of the same type, this allows for example to compare a Person to a PersonDto (call {@link RecursiveComparisonAssert#withStrictTypeChecking() withStrictTypeChecking()} to change that behavior). </li>
    * <li>overridden equals methods were used in the comparison (unless stated otherwise)</li>
-   * <li>these types were compared with the following comparators: </li>
+   * <li>these types were compared with the following comparators:
    *   <ul>
    *   <li>java.lang.Double -&gt; DoubleComparator[precision=1.0E-15] </li>
    *   <li>java.lang.Float -&gt; FloatComparator[precision=1.0E-6] </li>
    *   <li>any comparators previously registered with {@link AbstractObjectAssert#usingComparatorForType(Comparator, Class)} </li>
    *   </ul>
+   * </li>
    * </ul>
    *
    * @return a new {@link RecursiveComparisonAssert} instance

--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -666,7 +666,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    *                  .withComparatorForType(closeEnough, Double.class)
    *                  .isEqualTo(reallyTallFrodo);</code></pre>
    *
-   * @param T the class type to register a comparator for
+   * @param <T> the class type to register a comparator for
    * @param comparator the {@link java.util.Comparator Comparator} to use to compare the given fields
    * @param type the type to be compared with the given comparator.
    *

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -190,6 +190,7 @@ public class RecursiveComparisonConfiguration {
    * <p>
    * See {@link RecursiveComparisonAssert#withComparatorForType(Comparator, Class)} for examples.
    *
+   * @param <T> the class type to register a comparator for
    * @param comparator the {@link java.util.Comparator Comparator} to use to compare the given field
    * @param type the type to be compared with the given comparator.
    */


### PR DESCRIPTION
@joel-costigliola It took me a while to figure it out, but I think the nested list error is not a bug in Javadoc. The usage of list tags was actually "incorrect" (browsers do not care, but Javadoc is more strict).

With the change below the error disappeared when using Javadoc on Java 11.0.1.
