### PR TITLE
Add 'hasCauseSameAs' assertion for Throwables

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -35,6 +35,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  * @author Jack Gough
+ * @author Mike Gilchrist
  */
 public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAssert<SELF, ACTUAL>, ACTUAL extends Throwable>
     extends AbstractObjectAssert<SELF, ACTUAL> {
@@ -116,6 +117,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasCause(Throwable cause) {
     throwables.assertHasCause(info, actual, cause);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Throwable} has a cause that refers to the given one, i.e. using == comparison
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("invalid arg");
+   * Throwable throwable = new Throwable(invalidArgException);
+   *
+   * // This assertion succeeds:
+   * assertThat(throwable).hasCauseReference(invalidArgException);
+   *
+   * // These assertions fail:
+   * assertThat(throwable).hasCauseReference(new IllegalArgumentException("invalid arg"));
+   * assertThat(throwable).hasCauseReference(new NullPointerException());
+   * assertThat(throwable).hasCauseReference(null); // prefer hasNoCause()</code></pre>
+   *
+   * @param expected the expected cause
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has a cause that does not refer to the given (i.e. actual.getCause() != cause)
+   */
+  public SELF hasCauseReference(Throwable expected) {
+    throwables.assertHasCauseReference(info, actual, expected);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveCauseReference.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveCauseReference.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+public class ShouldHaveCauseReference extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHaveCauseReference(Throwable actualCause, Throwable expectedCause) {
+    return new ShouldHaveCauseReference(actualCause, expectedCause);
+  }
+
+  private ShouldHaveCauseReference(Throwable actualCause, Throwable expectedCause) {
+    super("%nExpecting actual cause reference to be:%n <\"%s\">%nbut was:%n <\"%s\">.", expectedCause, actualCause);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
+import static org.assertj.core.error.ShouldHaveCauseReference.shouldHaveCauseReference;
 import static org.assertj.core.error.ShouldHaveCauseExactlyInstance.shouldHaveCauseExactlyInstance;
 import static org.assertj.core.error.ShouldHaveCauseInstance.shouldHaveCauseInstance;
 import static org.assertj.core.error.ShouldHaveMessage.shouldHaveMessage;
@@ -44,6 +45,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Libor Ondrusek
  * @author Jack Gough
+ * @author Mike Gilchrist
  */
 public class Throwables {
 
@@ -90,6 +92,20 @@ public class Throwables {
     if (actualCause == null) throw failures.failure(info, shouldHaveCause(actualCause, expectedCause));
     if (!compareThrowable(actualCause, expectedCause))
       throw failures.failure(info, shouldHaveCause(actualCause, expectedCause));
+  }
+
+  /**
+   * Asserts that the actual {@code Throwable} has a cause that refers to the expected one.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @param expectedCause the expected cause.
+   */
+  public void assertHasCauseReference(AssertionInfo info, Throwable actual, Throwable expectedCause) {
+    Throwable actualCause = actual.getCause();
+    if (actualCause != expectedCause) {
+      throw failures.failure(info, shouldHaveCauseReference(actualCause, expectedCause));
+    }
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasCauseReference_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasCauseReference_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+public class ThrowableAssert_hasCauseReference_Test extends ThrowableAssertBaseTest {
+
+  private Throwable npe = new NullPointerException();
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasCauseReference(npe);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasCauseReference(getInfo(assertions), getActual(assertions), npe);
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveCauseReference_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveCauseReference_create_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveCauseReference.shouldHaveCauseReference;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ShouldHaveCauseReference#shouldHaveCauseReference(Throwable, Throwable)}</code>.
+ *
+ * @author Mike Gilchrist
+ */
+public class ShouldHaveCauseReference_create_Test {
+
+  private static final TestDescription DESCRIPTION = new TestDescription("TEST");
+
+  @Test
+  public void should_create_error_message_for_expected_without_actual() {
+    // GIVEN
+    Throwable actualCause = null;
+    Throwable expectedCause = new RuntimeException("hello");
+
+    // WHEN
+    String actual = shouldHaveCauseReference(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting actual cause reference to be:%n"
+                                        + " <\"java.lang.RuntimeException: hello\">%n"
+                                        + "but was:%n"
+                                        + " <\"null\">."));
+  }
+
+  @Test
+  public void should_create_error_message_for_expected_with_actual() {
+    // GIVEN
+    Throwable actualCause = new NullPointerException();
+    Throwable expectedCause = new RuntimeException("hello");
+
+    // WHEN
+    String actual = shouldHaveCauseReference(actualCause, expectedCause).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n"
+                                        + "Expecting actual cause reference to be:%n"
+                                        + " <\"java.lang.RuntimeException: hello\">%n"
+                                        + "but was:%n"
+                                        + " <\"java.lang.NullPointerException\">."));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseReference_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseReference_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import static org.assertj.core.error.ShouldHaveCauseReference.shouldHaveCauseReference;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.verify;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class Throwables_assertHasCauseReference_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
+
+  @Test
+  public void should_pass_if_actual_cause_and_expected_cause_are_the_same_instance() {
+    // GIVEN
+    Throwable cause = new IllegalArgumentException("wibble");
+    Throwable throwable = withCause(cause);
+
+    // WHEN
+    throwables.assertHasCauseReference(INFO, throwable, cause);
+
+    // THEN
+    // no exception thrown
+  }
+
+  @Test
+  public void should_pass_if_both_actual_and_expected_causes_are_null() {
+    // GIVEN
+    Throwable cause = null;
+    Throwable throwable = withCause(cause);
+
+    // WHEN
+    throwables.assertHasCauseReference(INFO, throwable, cause);
+
+    // THEN
+    // no exception thrown
+  }
+
+  @SuppressWarnings("unused")
+  @ParameterizedTest(name = "{2}: cause = {0} / expected = {1}")
+  @MethodSource("failingData")
+  public void should_fail_if_cause_is_not_same_as_expected(final Throwable cause,
+                                                           final Throwable expected,
+                                                           String testDescription) {
+    // GIVEN
+    final Throwable throwable = withCause(cause);
+
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasCauseReference(INFO, throwable, expected));
+
+    // THEN
+    verify(failures).failure(INFO, shouldHaveCauseReference(cause, expected));
+  }
+
+  // @format:off
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> failingData() {
+    return Stream.of(Arguments.of(null, new Throwable(), "no actual cause"),
+                     Arguments.of(new Throwable(), new Throwable(), "same type different instance"),
+                     Arguments.of(new Throwable(), null, "expecting null cause"),
+                     Arguments.of(new IllegalArgumentException(), new IndexOutOfBoundsException(), "different types"));
+  }
+  // @format:on
+
+  private static Throwable withCause(Throwable cause) {
+    return new Throwable("bang!", cause);
+  }
+}


### PR DESCRIPTION
This adds an assertion to check that a `Throwable`'s cause is identical to an expected cause.

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES


