### PR TITLE
anySatisfy: do not continue evaluating elements once we found a match

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -81,6 +81,7 @@ import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Streams.stream;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -1162,14 +1163,16 @@ public class Iterables {
     assertNotNull(info, actual);
     requireNonNull(requirements, "The Consumer<T> expressing the assertions requirements must not be null");
 
-    List<UnsatisfiedRequirement> unsatisfiedRequirements = stream(actual).map(element -> failsRequirements(requirements, element))
-                                                                         .filter(Optional::isPresent)
-                                                                         .map(Optional::get)
-                                                                         .collect(toList());
-    if (unsatisfiedRequirements.size() == sizeOf(actual)) {
-      // all elements have failed the requirements!
-      throw failures.failure(info, elementsShouldSatisfyAny(actual, unsatisfiedRequirements, info));
+    List<UnsatisfiedRequirement> unsatisfiedRequirements =  new ArrayList<>();
+    for (E element : actual) {
+      Optional<UnsatisfiedRequirement> result = failsRequirements(requirements, element);
+      if (!result.isPresent()) {
+        return;
+      }
+      unsatisfiedRequirements.add(result.get());
     }
+
+    throw failures.failure(info, elementsShouldSatisfyAny(actual, unsatisfiedRequirements, info));
   }
 
   public <E> void assertAllMatch(AssertionInfo info, Iterable<? extends E> actual, Predicate<? super E> predicate,

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnySatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnySatisfy_Test.java
@@ -24,17 +24,33 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.assertj.core.error.ElementsShouldSatisfy;
 import org.assertj.core.internal.IterablesBaseTest;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class Iterables_assertAnySatisfy_Test extends IterablesBaseTest {
 
   private List<String> actual = newArrayList("Luke", "Leia", "Yoda", "Obiwan");
+
+  @Test
+  public void must_not_check_all_elements() {
+    Consumer<String> consumer = Mockito.mock(Consumer.class);
+
+    // first element does not match -> assertion error, 2nd element does match -> doNothing()
+    doThrow(new AssertionError("some error message")).doNothing().when(consumer).accept(anyString());
+    iterables.assertAnySatisfy(someInfo(), actual, consumer);
+    // make sure that we only evaluated 2 out of 4 elements
+    verify(consumer, times(2)).accept(anyString());
+  }
 
   @Test
   public void should_pass_when_one_element_satisfies_the_single_assertion_requirement() {


### PR DESCRIPTION
#### Check List:
* Fixes #1445 
* Unit tests : YES
* Javadoc with a code example (API only) : NA


