### PR TITLE
Fail with error message if the given expectedStringTemplate is null

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import static java.lang.String.format;
+import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.util.Comparator;
 
@@ -307,6 +308,7 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
    * @since 3.12.0
    */
   public SELF isEqualTo(String expectedStringTemplate, Object... args) {
+    checkNotNull(expectedStringTemplate, "The expectedStringTemplate must not be null");
     return super.isEqualTo(format(expectedStringTemplate, args));
   }
 

--- a/src/test/java/org/assertj/core/api/string_/StringAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/string_/StringAssert_isEqualTo_Test.java
@@ -52,7 +52,7 @@ public class StringAssert_isEqualTo_Test extends StringAssertBaseTest {
     // WHEN
     Throwable exception = catchThrowable(() -> assertThat("foo").isEqualTo(template, 1));
     // THEN
-    assertThat(exception).isInstanceOf(NullPointerException.class);
+    assertThat(exception).isInstanceOf(NullPointerException.class).hasMessageContaining("The expectedStringTemplate must not be null");
   }
 
   @Test


### PR DESCRIPTION
let's fail with a proper error message if the given 'expectedStringTemplate' is null.
note: this one is not the same as in #1440 


