### PR TITLE
Add specialized directory asserts

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -18,7 +18,9 @@ import static org.assertj.core.util.Preconditions.checkNotNull;
 import java.io.File;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
 import java.security.MessageDigest;
+import java.util.function.Predicate;
 
 import org.assertj.core.internal.Files;
 import org.assertj.core.util.CheckReturnValue;
@@ -38,6 +40,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Olivier Demeijer
  * @author Mikhail Mazursky
  * @author Jean-Christophe Gay
+ * @author Valeriy Vyrva
  */
 public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> extends AbstractAssert<SELF, File> {
 
@@ -720,6 +723,244 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    */
   public SELF hasDigest(String algorithm, String expected) {
     files.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and contains at least one file that matched with the given {@code filter}.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getName().startsWith("sub-dir"));
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getName().startsWith("sub-file"));
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getName().endsWith(".ext"));
+   * assertThat(tested).isDirectoryContaining(File::isDirectory);
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getName().startsWith("dir"));
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getName().endsWith(".bin"));
+   * </code></pre>
+   *
+   * @param filter the filter for files located inside {@code actual}'s directory.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryContaining(Predicate<File> filter) {
+    files.assertIsDirectoryContaining(info, actual, filter);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and contains at least one file that matched with the given {@code filter}.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryContaining("glob:sub-dir*");
+   * assertThat(tested).isDirectoryContaining("glob:sub-file*");
+   * assertThat(tested).isDirectoryContaining("glob:*.ext");
+   * assertThat(tested).isDirectoryContaining("glob:*.{ext,bin");
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryContaining("glob:dir");
+   * assertThat(tested).isDirectoryContaining("glob:.bin");
+   * assertThat(tested).isDirectoryContaining("glob:*.{java,class}");
+   * </code></pre>
+   *
+   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @see FileSystem#getPathMatcher(String)
+   * @since 3.13.0
+   */
+  public SELF isDirectoryContaining(String syntaxAndPattern) {
+    files.assertIsDirectoryContaining(info, actual, syntaxAndPattern);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and does not contains any file that matched with the given {@code filter}.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getName().startsWith("dir"));
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getName().endsWith(".bin"));
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getName().startsWith("sub-dir"));
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getName().startsWith("sub-file"));
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getName().endsWith(".ext"));
+   * assertThat(tested).isDirectoryNotContaining(File::isDirectory);
+   * </code></pre>
+   *
+   * @param filter the filter for files located inside {@code actual}'s directory.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotContaining(Predicate<File> filter) {
+    files.assertIsDirectoryNotContaining(info, actual, filter);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and does not contains any file that matched with the given {@code filter}.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotContaining("glob:dir");
+   * assertThat(tested).isDirectoryNotContaining("glob:.bin");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.{java,class}");
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryNotContaining("glob:sub-dir*");
+   * assertThat(tested).isDirectoryNotContaining("glob:sub-file*");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.ext");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.{ext,bin");
+   * </code></pre>
+   *
+   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @see FileSystem#getPathMatcher(String)
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotContaining(String syntaxAndPattern) {
+    files.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and does not contains any files.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-dir-2]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(new File(tested, "sub-dir-2")).isDirectoryEmpty();
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryEmpty();
+   * assertThat(new File(tested, "sub-dir-1")).isDirectoryEmpty();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryEmpty() {
+    files.assertIsDirectoryEmpty(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link File} is directory and does not contains any files.
+   *
+   * Note that the {@link File} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-dir-2]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotEmpty();
+   * assertThat(new File(tested, "sub-dir-1")).isDirectoryNotEmpty();
+   *
+   * // The following assertions fail:
+   * assertThat(new File(tested, "sub-dir-2")).isDirectoryNotEmpty();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotEmpty() {
+    files.assertIsDirectoryNotEmpty(info, actual);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
 import java.nio.file.spi.FileSystemProvider;
 import java.security.MessageDigest;
+import java.util.function.Predicate;
 
 import org.assertj.core.api.exception.PathsException;
 import org.assertj.core.internal.Paths;
@@ -78,6 +79,8 @@ import org.assertj.core.util.VisibleForTesting;
  * @see FileSystem#getPath(String, String...)
  * @see java.nio.file.FileSystems#getDefault()
  * @see Files
+ *
+ * @author Valeriy Vyrva
  */
 public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> extends AbstractComparableAssert<SELF, Path> {
 
@@ -1312,6 +1315,244 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    */
   public SELF hasDigest(String algorithm, String expected) {
     paths.assertHasDigest(info, actual, algorithm, expected);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and contains at least one file that matched with the given {@code filter}.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * Path tested = Paths.get("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryContaining(path -&gt; path.getFileName().toString().startsWith("sub-dir"));
+   * assertThat(tested).isDirectoryContaining(path -&gt; path.getFileName().toString().startsWith("sub-file"));
+   * assertThat(tested).isDirectoryContaining(path -&gt; path.getFileName().toString().endsWith(".ext"));
+   * assertThat(tested).isDirectoryContaining(Files::isDirectory);
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getFileName().toString().startsWith("dir"));
+   * assertThat(tested).isDirectoryContaining(file -&gt; file.getFileName().toString().endsWith(".bin"));
+   * </code></pre>
+   *
+   * @param filter the filter for files located inside {@code actual}'s directory.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryContains(Predicate<Path> filter) {
+    paths.assertIsDirectoryContaining(info, actual, filter);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and contains at least one file that matched with the given {@code filter}.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryContaining("glob:sub-dir*");
+   * assertThat(tested).isDirectoryContaining("glob:sub-file*");
+   * assertThat(tested).isDirectoryContaining("glob:*.ext");
+   * assertThat(tested).isDirectoryContaining("glob:*.{ext,bin");
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryContaining("glob:dir");
+   * assertThat(tested).isDirectoryContaining("glob:.bin");
+   * assertThat(tested).isDirectoryContaining("glob:*.{java,class}");
+   * </code></pre>
+   *
+   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @see FileSystem#getPathMatcher(String)
+   * @since 3.13.0
+   */
+  public SELF isDirectoryContains(String syntaxAndPattern) {
+    paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and does not contains any file that matched with the given {@code filter}.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * Path tested = Paths.get("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getFileName().toString().startsWith("dir"));
+   * assertThat(tested).isDirectoryNotContaining(file -&gt; file.getFileName().toString().endsWith(".bin"));
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryNotContaining(path -&gt; path.getFileName().toString().startsWith("sub-dir"));
+   * assertThat(tested).isDirectoryNotContaining(path -&gt; path.getFileName().toString().startsWith("sub-file"));
+   * assertThat(tested).isDirectoryNotContaining(path -&gt; path.getFileName().toString().endsWith(".ext"));
+   * assertThat(tested).isDirectoryNotContaining(Files::isDirectory);
+   * </code></pre>
+   *
+   * @param filter the filter for files located inside {@code actual}'s directory.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotContaining(Predicate<Path> filter) {
+    paths.assertIsDirectoryNotContaining(info, actual, filter);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and does not contains any file that matched with the given {@code filter}.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotContaining("glob:dir");
+   * assertThat(tested).isDirectoryNotContaining("glob:.bin");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.{java,class}");
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryNotContaining("glob:sub-dir*");
+   * assertThat(tested).isDirectoryNotContaining("glob:sub-file*");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.ext");
+   * assertThat(tested).isDirectoryNotContaining("glob:*.{ext,bin");
+   * </code></pre>
+   *
+   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @see FileSystem#getPathMatcher(String)
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotContaining(String syntaxAndPattern) {
+    paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and does not contains any files.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-dir-2]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(new File(tested, "sub-dir-2")).isDirectoryEmpty();
+   *
+   * // The following assertions fail:
+   * assertThat(tested).isDirectoryEmpty();
+   * assertThat(new File(tested, "sub-dir-1")).isDirectoryEmpty();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryEmpty() {
+    paths.assertIsDirectoryEmpty(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verify that tested {@link Path} is directory and does not contains any files.
+   *
+   * Note that the {@link Path} must exists and denote to directory.
+   *
+   * Examples:
+   * <pre><code class="java"> // assume that we have such directory structure:
+   * // [root]
+   * // [root/sub-dir-1]
+   * // [root/sub-dir-1/file-1.ext]
+   * // [root/sub-dir-1/file-2.ext]
+   * // [root/sub-dir-2]
+   * // [root/sub-file-1.ext]
+   * // [root/sub-file-2.ext]
+   *
+   * File tested = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(tested).isDirectoryNotEmpty();
+   * assertThat(new File(tested, "sub-dir-1")).isDirectoryNotEmpty();
+   *
+   * // The following assertions fail:
+   * assertThat(new File(tested, "sub-dir-2")).isDirectoryNotEmpty();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if the actual {@code File} is {@code null}.
+   * @throws AssertionError       if the actual {@code File} does not exist.
+   * @throws AssertionError       if the actual {@code File} is not an directory.
+   * @since 3.13.0
+   */
+  public SELF isDirectoryNotEmpty() {
+    paths.assertIsDirectoryNotEmpty(info, actual);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/internal/NioFilesWrapper.java
+++ b/src/main/java/org/assertj/core/internal/NioFilesWrapper.java
@@ -14,10 +14,12 @@ package org.assertj.core.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.util.function.Predicate;
 
 import org.assertj.core.util.VisibleForTesting;
 
@@ -73,5 +75,9 @@ public class NioFilesWrapper {
 
   public InputStream newInputStream(Path path, OpenOption... options) throws IOException {
     return Files.newInputStream(path, options);
+  }
+
+  public DirectoryStream<Path> newDirectoryStream(Path path, Predicate<Path> matcher) throws IOException {
+    return Files.newDirectoryStream(path, matcher::test);
   }
 }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryContaining_Predicate_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import java.io.File;
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryContaining(Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryContaining_Predicate_Test extends FileAssertBaseTest {
+
+  private final Predicate<File> filter = path -> path.getParent() != null;
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryContaining(filter);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryContaining(getInfo(assertions), getActual(assertions), filter);
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryContaining(String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryContaining_SyntaxAndPattern_Test extends FileAssertBaseTest {
+
+  private final String syntaxAndPattern = "glob:*.java";
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryContaining(syntaxAndPattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryContaining(getInfo(assertions), getActual(assertions), syntaxAndPattern);
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryEmpty_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryEmpty_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryEmpty()}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryEmpty_Test extends FileAssertBaseTest {
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryEmpty();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryEmpty(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotContaining_Predicate_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import java.io.File;
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryNotContaining(Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryNotContaining_Predicate_Test extends FileAssertBaseTest {
+
+  private final Predicate<File> filter = path -> path.getParent() != null;
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryNotContaining(filter);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryNotContaining(getInfo(assertions), getActual(assertions), filter);
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryNotContaining(String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryNotContaining_SyntaxAndPattern_Test extends FileAssertBaseTest {
+
+  private final String syntaxAndPattern = "glob:*.java";
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryNotContaining(syntaxAndPattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryNotContaining(getInfo(assertions), getActual(assertions), syntaxAndPattern);
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryNotEmpty_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryNotEmpty()}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class FileAssert_isDirectoryNotEmpty_Test extends FileAssertBaseTest {
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryNotEmpty();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryNotEmpty(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryContaining_Predicate_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryContains(Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryContaining_Predicate_Test extends PathAssertBaseTest {
+
+  private final Predicate<Path> filter = path -> path.getParent() != null;
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryContains(filter);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryContaining(getInfo(assertions), getActual(assertions), filter);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryContains(String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryContaining_SyntaxAndPattern_Test extends PathAssertBaseTest {
+
+  private final String syntaxAndPattern = "glob:*.java";
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryContains(syntaxAndPattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryContaining(getInfo(assertions), getActual(assertions), syntaxAndPattern);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryEmpty_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryEmpty_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryEmpty()}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryEmpty_Test extends PathAssertBaseTest {
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryEmpty();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryEmpty(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotContaining_Predicate_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryNotContaining(Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryNotContaining_Predicate_Test extends PathAssertBaseTest {
+
+  private final Predicate<Path> filter = path -> path.getParent() != null;
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryNotContaining(filter);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryNotContaining(getInfo(assertions), getActual(assertions), filter);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryNotContaining(String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryNotContaining_SyntaxAndPattern_Test extends PathAssertBaseTest {
+
+  private final String syntaxAndPattern = "glob:*.java";
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryNotContaining(syntaxAndPattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryNotContaining(getInfo(assertions), getActual(assertions), syntaxAndPattern);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_isDirectoryNotEmpty_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#isDirectoryNotEmpty()}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+public class PathAssert_isDirectoryNotEmpty_Test extends PathAssertBaseTest {
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.isDirectoryNotEmpty();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertIsDirectoryNotEmpty(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_Predicate_Test.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryContaining(AssertionInfo, File, Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
+
+  private static final Predicate<File> javaSource = file -> file.getName().endsWith(".java");
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, (Predicate<File>) null))
+      .withMessage("The files filter should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_expected() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldContainAnyOf(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource
+    ));
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_single_not_expected() {
+    // GIVEN
+    File file = mockRegularFile("Test.java");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_only_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.java");
+    File file2 = mockRegularFile("Utils.java");
+    List<File> items = Arrays.asList(file1, file2);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.class");
+    File file2 = mockRegularFile("Test.java");
+    File file3 = mockRegularFile("Utils.class");
+    File file4 = mockRegularFile("Utils.java");
+    File file5 = mockRegularFile("application.yml");
+    List<File> items = Arrays.asList(file1, file2, file3, file4, file5);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryContaining(AssertionInfo, File, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseTest {
+
+  private static final String javaSource = "regex:.+\\.java";
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, (String) null))
+      .withMessage("The syntax and pattern for build PathMatcher should not be null");
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void mockPathMatcher(File actual) {
+    FileSystem fileSystem = mock(FileSystem.class);
+    given(fileSystem.getPathMatcher(anyString())).will(inv -> {
+      String regex = inv.getArgument(0).toString().split(":")[1];
+      Pattern pattern = Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+      return (PathMatcher) path -> Optional
+        .ofNullable(path.getFileName())
+        .map(Path::toString)
+        .filter(pattern.asPredicate())
+        .isPresent();
+    });
+    Path path = actual.toPath();
+    if (path == null) {
+      path = mock(Path.class);
+      given(actual.toPath()).willReturn(path);
+      given(path.toFile()).willReturn(actual);
+    }
+    given(path.getFileSystem()).willReturn(fileSystem);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_expected() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldContainAnyOf(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource
+    ));
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_single_not_expected() {
+    // GIVEN
+    File file = mockRegularFile("Test.java");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_only_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.java");
+    File file2 = mockRegularFile("Utils.java");
+    List<File> items = Arrays.asList(file1, file2);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.class");
+    File file2 = mockRegularFile("Test.java");
+    File file3 = mockRegularFile("Utils.class");
+    File file4 = mockRegularFile("Utils.java");
+    File file5 = mockRegularFile("application.yml");
+    List<File> items = Arrays.asList(file1, file2, file3, file4, file5);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryEmpty_Test.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryEmpty(AssertionInfo, File)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryEmpty_Test extends FilesBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryEmpty(INFO, null))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_empty() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldBeEmpty(
+      items.stream().map(File::getName).collect(Collectors.toList())
+    ));
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_Predicate_Test.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryNotContaining(AssertionInfo, File, Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest {
+
+  private static final Predicate<File> javaSource = file -> file.getName().endsWith(".java");
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, (Predicate<File>) null))
+      .withMessage("The files filter should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_single_not_expected() {
+    // GIVEN
+    File file = mockRegularFile("Test.java");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      items.stream().map(File::getName).collect(Collectors.toList())
+    ));
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_only_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.java");
+    File file2 = mockRegularFile("Utils.java");
+    List<File> items = Arrays.asList(file1, file2);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file1.getName() + '"' + ", "
+        + '"' + file2.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      items.stream().map(File::getName).collect(Collectors.toList())
+    ));
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.class");
+    File file2 = mockRegularFile("Test.java");
+    File file3 = mockRegularFile("Utils.class");
+    File file4 = mockRegularFile("Utils.java");
+    File file5 = mockRegularFile("application.yml");
+    List<File> items = Arrays.asList(file1, file2, file3, file4, file5);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file2.getName() + '"' + ", "
+        + '"' + file4.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      Arrays.asList(file2.getName(), file4.getName())
+    ));
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_expected() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryNotContaining(AssertionInfo, File, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBaseTest {
+
+  private static final String javaSource = "regex:.+\\.java";
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, (String) null))
+      .withMessage("The syntax and pattern for build PathMatcher should not be null");
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void mockPathMatcher(File actual) {
+    FileSystem fileSystem = mock(FileSystem.class);
+    given(fileSystem.getPathMatcher(anyString())).will(inv -> {
+      String regex = inv.getArgument(0).toString().split(":")[1];
+      Pattern pattern = Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+      return (PathMatcher) path -> Optional
+        .ofNullable(path.getFileName())
+        .map(Path::toString)
+        .filter(pattern.asPredicate())
+        .isPresent();
+    });
+    Path path = actual.toPath();
+    if (path == null) {
+      path = mock(Path.class);
+      given(actual.toPath()).willReturn(path);
+      given(path.toFile()).willReturn(actual);
+    }
+    given(path.getFileSystem()).willReturn(fileSystem);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_single_not_expected() {
+    // GIVEN
+    File file = mockRegularFile("Test.java");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      items.stream().map(File::getName).collect(Collectors.toList())
+    ));
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_only_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.java");
+    File file2 = mockRegularFile("Utils.java");
+    List<File> items = Arrays.asList(file1, file2);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file1.getName() + '"' + ", "
+        + '"' + file2.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      items.stream().map(File::getName).collect(Collectors.toList())
+    ));
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    File file1 = mockRegularFile("Test.class");
+    File file2 = mockRegularFile("Test.java");
+    File file3 = mockRegularFile("Utils.class");
+    File file4 = mockRegularFile("Utils.java");
+    File file5 = mockRegularFile("application.yml");
+    List<File> items = Arrays.asList(file1, file2, file3, file4, file5);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + '"' + file2.getName() + '"' + ", "
+        + '"' + file4.getName() + '"' + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(
+      items.stream().map(File::getName).collect(Collectors.toList()),
+      javaSource,
+      Arrays.asList(file2.getName(), file4.getName())
+    ));
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_expected() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotEmpty_Test.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryNotEmpty(AssertionInfo, File)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Files_assertIsDirectoryNotEmpty_Test extends FilesBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> files.assertIsDirectoryNotEmpty(INFO, null))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_be_directory_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(actual.exists()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_on_null_listing() {
+    // GIVEN
+    given(actual.exists()).willReturn(true);
+    given(actual.isDirectory()).willReturn(true);
+    given(actual.list()).willReturn(null);
+    given(actual.listFiles(any(FileFilter.class))).willCallRealMethod();
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Directory listing should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    List<File> items = emptyList();
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining(shouldNotBeEmpty().create());
+    verify(failures).failure(INFO, shouldNotBeEmpty());
+  }
+
+  @Test
+  public void should_pass_if_actual_is_not_empty() {
+    // GIVEN
+    File file = mockRegularFile("root", "Test.class");
+    List<File> items = singletonList(file);
+    File actual = mockDirectory(items, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      files.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_Predicate_Test.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryContaining(AssertionInfo, Path, Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryContaining_Predicate_Test extends MockPathsBaseTest {
+
+  /**
+   * We will check count call to {@link Path#getFileName()}
+   */
+  private static final Predicate<Path> javaSource = path -> Optional
+    .ofNullable(path.getFileName())
+    .map(Path::toString)
+    .filter(s -> s.endsWith(".java"))
+    .isPresent();
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> paths.assertIsDirectoryContaining(INFO, null, (Predicate<Path>) null))
+      .withMessage("The files filter should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryContaining(info, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    List<Path> items = emptyList();
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_expected() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[" + file.toString() + "]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_single_expected() {
+    // GIVEN
+    Path file = mockRegularFile("Test.java");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_only_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.java");
+    Path file2 = mockRegularFile("Utils.java");
+    List<Path> items = Arrays.asList(file1, file2);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file1, times(1)).getFileName();
+    verify(file2, times(0)).getFileName();//Check lazy directory listing processing
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_others_including_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.class");
+    Path file2 = mockRegularFile("Test.java");
+    Path file3 = mockRegularFile("Utils.class");
+    Path file4 = mockRegularFile("Utils.java");
+    Path file5 = mockRegularFile("application.yml");
+    List<Path> items = Arrays.asList(file1, file2, file3, file4, file5);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file1, times(1)).getFileName();
+    verify(file2, times(1)).getFileName();
+    verify(file3, times(0)).getFileName();//Check lazy directory listing processing
+    verify(file4, times(0)).getFileName();
+    verify(file5, times(0)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryContaining(AssertionInfo, Path, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test extends MockPathsBaseTest {
+
+  private static final String javaSource = "regex:.+\\.java";
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> paths.assertIsDirectoryContaining(INFO, null, (String) null))
+      .withMessage("The syntax and pattern for build PathMatcher should not be null");
+  }
+
+  private void mockPathMatcher(Path actual) {
+    FileSystem fileSystem = mock(FileSystem.class);
+    given(fileSystem.getPathMatcher(anyString())).will(inv -> {
+      String regex = inv.getArgument(0).toString().split(":")[1];
+      Pattern pattern = Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+      return (PathMatcher) path -> Optional
+        .ofNullable(path.getFileName())
+        .map(Path::toString)
+        .filter(pattern.asPredicate())
+        .isPresent();
+    });
+    given(actual.getFileSystem()).willReturn(fileSystem);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryContaining(info, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    List<Path> items = emptyList();
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_expected() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[" + file.toString() + "]");
+    verify(failures).failure(INFO, shouldContainAnyOf(items, javaSource));
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_single_expected() {
+    // GIVEN
+    Path file = mockRegularFile("Test.java");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_only_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.java");
+    Path file2 = mockRegularFile("Utils.java");
+    List<Path> items = Arrays.asList(file1, file2);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file1, times(1)).getFileName();
+    verify(file2, times(0)).getFileName();//Check lazy directory listing processing
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_others_including_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.class");
+    Path file2 = mockRegularFile("Test.java");
+    Path file3 = mockRegularFile("Utils.class");
+    Path file4 = mockRegularFile("Utils.java");
+    Path file5 = mockRegularFile("application.yml");
+    List<Path> items = Arrays.asList(file1, file2, file3, file4, file5);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file1, times(1)).getFileName();
+    verify(file2, times(1)).getFileName();
+    verify(file3, times(0)).getFileName();//Check lazy directory listing processing
+    verify(file4, times(0)).getFileName();
+    verify(file5, times(0)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryEmpty_Test.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryEmpty(AssertionInfo, Path)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryEmpty_Test extends MockPathsBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryEmpty(info, null))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_empty() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[" + file.toString() + "]");
+    verify(failures).failure(INFO, shouldBeEmpty(items));
+    verify(file, times(0)).getFileName();//We do not even check
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<Path> items = emptyList();
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error).isNull();
+    failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_Predicate_Test.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryNotContaining(AssertionInfo, Path, Predicate)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryNotContaining_Predicate_Test extends MockPathsBaseTest {
+
+  /**
+   * We will check count call to {@link Path#getFileName()}
+   */
+  private static final Predicate<Path> javaSource = path -> Optional
+    .ofNullable(path.getFileName())
+    .map(Path::toString)
+    .filter(s -> s.endsWith(".java"))
+    .isPresent();
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> paths.assertIsDirectoryNotContaining(INFO, null, (Predicate<Path>) null))
+      .withMessage("The files filter should not be null");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryNotContaining(info, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_single_not_expected() {
+    // GIVEN
+    Path file = mockRegularFile("Test.java");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[" + file.toString() + "]");
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, items));
+    verify(file, times(2)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_only_not_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.java");
+    Path file2 = mockRegularFile("Utils.java");
+    List<Path> items = Arrays.asList(file1, file2);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + file1.toString() + ", "
+        + file2.toString() + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, items));
+    verify(file1, times(2)).getFileName();
+    verify(file2, times(1)).getFileName();//Check lazy directory listing processing
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.class");
+    Path file2 = mockRegularFile("Test.java");
+    Path file3 = mockRegularFile("Utils.class");
+    Path file4 = mockRegularFile("Utils.java");
+    Path file5 = mockRegularFile("application.yml");
+    List<Path> items = Arrays.asList(file1, file2, file3, file4, file5);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + file2.toString() + ", "
+        + file4.toString() + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, Arrays.asList(file2, file4)));
+    verify(file1, times(2)).getFileName();
+    verify(file2, times(2)).getFileName();
+    verify(file3, times(1)).getFileName();//Check lazy directory listing processing
+    verify(file4, times(1)).getFileName();
+    verify(file5, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<Path> items = emptyList();
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_expected() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryNotContaining(AssertionInfo, Path, String)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends MockPathsBaseTest {
+
+  private static final String javaSource = "regex:.+\\.java";
+
+  @Test
+  public void should_throw_error_if_filter_is_null() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> paths.assertIsDirectoryNotContaining(INFO, null, (String) null))
+      .withMessage("The syntax and pattern for build PathMatcher should not be null");
+  }
+
+  private void mockPathMatcher(Path actual) {
+    FileSystem fileSystem = mock(FileSystem.class);
+    given(fileSystem.getPathMatcher(anyString())).will(inv -> {
+      String regex = inv.getArgument(0).toString().split(":")[1];
+      Pattern pattern = Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+      return (PathMatcher) path -> Optional
+        .ofNullable(path.getFileName())
+        .map(Path::toString)
+        .filter(pattern.asPredicate())
+        .isPresent();
+    });
+    given(actual.getFileSystem()).willReturn(fileSystem);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryNotContaining(info, null, javaSource))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_single_not_expected() {
+    // GIVEN
+    Path file = mockRegularFile("Test.java");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("[" + file.toString() + "]");
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, items));
+    verify(file, times(2)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_only_not_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.java");
+    Path file2 = mockRegularFile("Utils.java");
+    List<Path> items = Arrays.asList(file1, file2);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + file1.toString() + ", "
+        + file2.toString() + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, items));
+    verify(file1, times(2)).getFileName();
+    verify(file2, times(1)).getFileName();//Check lazy directory listing processing
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_others_including_not_expected() {
+    // GIVEN
+    Path file1 = mockRegularFile("Test.class");
+    Path file2 = mockRegularFile("Test.java");
+    Path file3 = mockRegularFile("Utils.class");
+    Path file4 = mockRegularFile("Utils.java");
+    Path file5 = mockRegularFile("application.yml");
+    List<Path> items = Arrays.asList(file1, file2, file3, file4, file5);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("["
+        + file2.toString() + ", "
+        + file4.toString() + "]"
+      );
+    verify(failures).failure(INFO, shouldNotContain(items, javaSource, Arrays.asList(file2, file4)));
+    verify(file1, times(2)).getFileName();
+    verify(file2, times(2)).getFileName();
+    verify(file3, times(1)).getFileName();//Check lazy directory listing processing
+    verify(file4, times(1)).getFileName();
+    verify(file5, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_empty() {
+    // GIVEN
+    List<Path> items = emptyList();
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_expected() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    mockPathMatcher(actual);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotContaining(INFO, actual, javaSource)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file, times(1)).getFileName();
+    failIfStreamIsOpen(stream);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotEmpty_Test.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Paths#assertIsDirectoryNotEmpty(AssertionInfo, Path)}</code>
+ *
+ * @author Valeriy Vyrva
+ */
+@SuppressWarnings({"WeakerAccess", "ThrowableNotThrown"})
+public class Paths_assertIsDirectoryNotEmpty_Test extends MockPathsBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> paths.assertIsDirectoryNotEmpty(info, null))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_should_exist_error_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldExist(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_exists_but_is_not_directory() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(false);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    // GIVEN
+    IOException cause = new IOException();
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isDirectory(actual)).willReturn(true);
+    given(nioFilesWrapper.newDirectoryStream(eq(actual), any())).willThrow(cause);
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(cause);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_empty() {
+    // GIVEN
+    DirectoryStream<Path> stream = directoryStream(emptyList());
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining(shouldNotBeEmpty().create());
+    verify(failures).failure(INFO, shouldNotBeEmpty());
+    failIfStreamIsOpen(stream);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_not_empty() {
+    // GIVEN
+    Path file = mockRegularFile("root", "Test.class");
+    List<Path> items = singletonList(file);
+    DirectoryStream<Path> stream = directoryStream(items);
+    Path actual = mockDirectory(stream, "root");
+    // WHEN
+    Throwable error = catchThrowable(() ->
+      paths.assertIsDirectoryNotEmpty(INFO, actual)
+    );
+    // THEN
+    assertThat(error).isNull();
+    verify(file, times(0)).getFileName();//We do not even check
+    failIfStreamIsOpen(stream);
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #1325
* Unit tests : YES
* Javadoc with a code example (API only) : YES

Method names are indicative - if there is a better/rather variants, then I'm ready to rename them.

Which version I should declare at API's JavaDoc?
Currently I declare `3.13.0`.

I plan to add (in a new PR) methods converting `FileAssert`/`PathAssert` to `IterableAssert<File>`/`IterableAssert<Path>` - what do you think about this?