### PR TITLE
Update the maven-javadoc-plugin to version 3.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <!-- (1) CSS file location -->
           <stylesheetfile>src/main/javadoc/assertj-javadoc.css</stylesheetfile>
@@ -343,9 +344,6 @@
       </activation>
       <properties>
         <sonar.skip>true</sonar.skip>
-        <!-- currently fails with "javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/
-          are in the unnamed module." -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Let's see if it fixes javadoc on Java 11+.

