### PR TITLE
Generic SoftAssertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -30,6 +30,11 @@ public class AbstractSoftAssertions {
   public <T, V> V proxy(Class<V> assertClass, Class<T> actualClass, T actual) {
     return proxies.createSoftAssertionProxy(assertClass, actualClass, actual);
   }
+  
+  @SuppressWarnings("unchecked")
+  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
+      return proxy(assertClass, (Class<T>) actual.getClass(), actual);
+  }
 
   /**
    * Fails with the given message.

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -32,7 +32,7 @@ public class AbstractSoftAssertions {
   }
   
   @SuppressWarnings("unchecked")
-  public <T, V extends Assert> V assertThat(Class<V> assertClass, T actual) {
+  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
       return proxy(assertClass, (Class<T>) actual.getClass(), actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -32,7 +32,7 @@ public class AbstractSoftAssertions {
   }
   
   @SuppressWarnings("unchecked")
-  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
+  public <T, V extends Assert> V assertThat(Class<V> assertClass, T actual) {
       return proxy(assertClass, (Class<T>) actual.getClass(), actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -31,11 +31,6 @@ public class AbstractSoftAssertions {
     return proxies.createSoftAssertionProxy(assertClass, actualClass, actual);
   }
   
-  @SuppressWarnings("unchecked")
-  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
-      return proxy(assertClass, (Class<T>) actual.getClass(), actual);
-  }
-
   /**
    * Fails with the given message.
    *

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -1512,7 +1514,11 @@ public class Assertions {
    * The following (incomplete) list of methods will be impacted by this change :
    * <ul>
    * <li>
-   * <code>{@link org.assertj.core.api.AbstractIterableAssert#usingElementComparatorOnFields(java.lang.String...)}</code>
+   * <code>{@link org.assertj.core.api.AbstractIterableAssert#usingElementComparatorOnFields(java.
+   
+   
+   
+   .String...)}</code>
    * </li>
    * <li><code>{@link org.assertj.core.api.AbstractObjectAssert#isEqualToComparingFieldByField(Object)}</code></li>
    * </ul>

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -142,6 +142,15 @@ public class Assertions {
    * Creates a new <code>{@link Assertions}</code>.
    */
   protected Assertions() {}
+  
+  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
+    try {
+      Constructor<? extends V> constructor = assertClass.getConstructor(actual.getClass());
+      return constructor.newInstance(actual);
+    } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   /**
    * Create assertion for {@link Predicate}.

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -143,11 +143,6 @@ public class Assertions {
    */
   protected Assertions() {}
   
-  @SuppressWarnings("unchecked")
-  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
-      return proxy(assertClass, (Class<T>) actual.getClass(), actual);
-  }
-
   /**
    * Create assertion for {@link Predicate}.
    *

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -142,7 +142,7 @@ public class Assertions {
    * Creates a new <code>{@link Assertions}</code>.
    */
   protected Assertions() {}
-  
+
   /**
    * Create assertion for {@link Predicate}.
    *

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -142,6 +142,11 @@ public class Assertions {
    * Creates a new <code>{@link Assertions}</code>.
    */
   protected Assertions() {}
+  
+  @SuppressWarnings("unchecked")
+  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
+      return proxy(assertClass, (Class<T>) actual.getClass(), actual);
+  }
 
   /**
    * Create assertion for {@link Predicate}.

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -115,6 +115,10 @@ public class Assumptions {
       }
     }
   }
+  
+  public <T, V extends Assert> V assertThat(T actual, Class<V> assertClass) {
+    return asAssumption(assertClass.class, actual.getClass(), actual);
+  }
 
   /**
    * Creates a new instance of <code>{@link ObjectAssert}</code> assumption.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -101,6 +101,10 @@ public class BDDAssertions extends Assertions {
    * Creates a new <code>{@link org.assertj.core.api.BDDAssertions}</code>.
    */
   protected BDDAssertions() {}
+  
+  public <T, V extends Assert> V then(T actual, Class<V> assertClass) {
+    return assertThat(actual, assertClass);
+  }
 
   /**
    * Create assertion for {@link Predicate}.


### PR DESCRIPTION
I added a generic `assertThat` method to `Assertions` `SoftAssertions` to simplify the usage of custom Assertions  e.g.
```java
// Assertions
Assertions.assertThat(pattern, PatternAssert.class).matches("aaa.xxx.bbb");

// Soft Assertions
SoftAssertions.assertSoftly(softly -> {
    softly.assertThat(pattern, PatternAssert.class).matches("aaa.xxx.bbb");
});
```

#### Check List:
* Unit tests : NO 
* Javadoc with a code example (API only) : NO


