### PR TITLE
Add method to use SoftAssertions with any custom Assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -36,13 +36,11 @@ public class AbstractSoftAssertions {
    *
    * @param assertion an assertion call.
    */
-  public void check(ThrowingRunnable assertion) {
+  public void check(ThrowingRunnable assertion) throws Exception {
     try {
       assertion.run();
     } catch (AssertionError error) {
       proxies.collectError(error);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -41,6 +41,14 @@ public class AbstractSoftAssertions {
     AssertionError error = Failures.instance().failure(failureMessage);
     proxies.collectError(error);
   }
+  
+  public void assertThat(Runnable scope) {
+      try {
+        scope.run();
+      } catch (AssertionError error) {
+        proxies.collectError(error);
+      }
+  }
 
   /**
    * Fails with the given message built like {@link String#format(String, Object...)}.

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -42,9 +42,9 @@ public class AbstractSoftAssertions {
     proxies.collectError(error);
   }
   
-  public void check(ThrowingCallable assertion) {
+  public void check(ThrowingRunnable assertion) {
       try {
-        assertion.call();
+        assertion.run();
       } catch (AssertionError error) {
         proxies.collectError(error);
       }
@@ -196,7 +196,7 @@ public class AbstractSoftAssertions {
     return className.contains("$ByteBuddy$");
   }
   
-  public interface ThrowingCallable {
-    void call() throws Throwable;
+  public interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -44,7 +44,7 @@ public class AbstractSoftAssertions {
   
   public void check(ThrowingCallable assertion) {
       try {
-        assertion.run();
+        assertion.call();
       } catch (AssertionError error) {
         proxies.collectError(error);
       }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -42,7 +42,7 @@ public class AbstractSoftAssertions {
     proxies.collectError(error);
   }
   
-  public void check(Runnable assertion) {
+  public void check(ThrowingCallable assertion) {
       try {
         assertion.run();
       } catch (AssertionError error) {
@@ -194,5 +194,9 @@ public class AbstractSoftAssertions {
 
   private boolean isProxiedAssertionClass(String className) {
     return className.contains("$ByteBuddy$");
+  }
+  
+  public interface ThrowingCallable {
+    void call() throws Throwable;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -32,7 +32,16 @@ public class AbstractSoftAssertions {
   }
 
   /**
-   * Catch and collect assertion errors of any assertion call.
+   * Catch and collect assertion errors of any assertion call,
+   * e.g in case you want to handle different or custom assertions:
+   * <pre>
+   * {@code
+   *     SoftAssertions softly = new SoftAssertions();
+   *     softly.check(() -> Assertions.assertThat(…).…);
+   *     softly.check(() -> CustomAssertions.assertThat(…).…);
+   *     softly.assertAll();
+   * }
+   * </pre>
    *
    * @param assertion an assertion call.
    */

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -42,7 +42,7 @@ public class AbstractSoftAssertions {
     proxies.collectError(error);
   }
   
-  public void $(Runnable assertion) {
+  public void check(Runnable assertion) {
       try {
         assertion.run();
       } catch (AssertionError error) {

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -42,7 +42,7 @@ public class AbstractSoftAssertions {
     proxies.collectError(error);
   }
   
-  public void check(ThrowingRunnable assertion) {
+  public void check(ThrowingRunnable assertion) throws Exception{
       try {
         assertion.run();
       } catch (AssertionError error) {

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -32,6 +32,21 @@ public class AbstractSoftAssertions {
   }
 
   /**
+   * Catch and collect assertion errors of any assertion call.
+   *
+   * @param assertion an assertion call.
+   */
+  public void check(ThrowingRunnable assertion) {
+    try {
+      assertion.run();
+    } catch (AssertionError error) {
+      proxies.collectError(error);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Fails with the given message.
    *
    * @param failureMessage error message.
@@ -40,14 +55,6 @@ public class AbstractSoftAssertions {
   public void fail(String failureMessage) {
     AssertionError error = Failures.instance().failure(failureMessage);
     proxies.collectError(error);
-  }
-  
-  public void check(ThrowingRunnable assertion) throws Exception{
-      try {
-        assertion.run();
-      } catch (AssertionError error) {
-        proxies.collectError(error);
-      }
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -42,9 +42,9 @@ public class AbstractSoftAssertions {
     proxies.collectError(error);
   }
   
-  public void assertThat(Runnable scope) {
+  public void $(Runnable assertion) {
       try {
-        scope.run();
+        assertion.run();
       } catch (AssertionError error) {
         proxies.collectError(error);
       }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -163,23 +163,17 @@ public class SoftAssertions extends AbstractStandardSoftAssertions {
       assertions.assertAll();
   }
  
-  private static void assertSoftly(Runnable... softAssertions) {
-      List<AssertionError> errors = new LinkedList<>();
-      for (Runnable scope : softAssertions) {
-          try {
-              scope.run();
-          } catch (AssertionError error) {
-              errors.add(error);
-          }
+  private static void assertSoftly(Runnable... scopes) {
+    List<AssertionError> errors = new LinkedList<>();
+    for (Runnable scope : scopes) {
+      try {
+        scope.run();
+      } catch (AssertionError error) {
+        errors.add(error);
       }
-      if (!errors.isEmpty()) {
-          throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
-      }
+    }
+    if (!errors.isEmpty()) {
+      throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
+    }
   }
-  
-  @FunctionalInterface
-  public interface SoftAssertionScope {
-      void execute() throws Exception;
-  }
-
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -156,9 +156,29 @@ public class SoftAssertions extends AbstractStandardSoftAssertions {
   * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
   * @since 3.6.0
   */
-public static void assertSoftly(Consumer<SoftAssertions> softly) {
+  public static void assertSoftly(Consumer<SoftAssertions> softly) {
       SoftAssertions assertions = new SoftAssertions();
       softly.accept(assertions);
       assertions.assertAll();
   }
+ 
+  private static void assertSoftly(SoftAssertionScope... softAssertions) {
+      List<Throwable> errors = new LinkedList<>();
+      for (SoftAssertionScope scope : softAssertions) {
+          try {
+              scope.execute();
+          } catch (Throwable error) {
+              errors.add(error);
+          }
+      }
+      if (!errors.isEmpty()) {
+          throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
+      }
+  }
+  
+  @FunctionalInterface
+  public interface SoftAssertionScope {
+      void execute() throws Exception;
+  }
+
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.api;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -157,7 +157,7 @@ public class SoftAssertions extends AbstractStandardSoftAssertions {
   * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
   * @since 3.6.0
   */
-  public static void assertSoftly(Consumer<SoftAssertions> softly) {
+public static void assertSoftly(Consumer<SoftAssertions> softly) {
       SoftAssertions assertions = new SoftAssertions();
       softly.accept(assertions);
       assertions.assertAll();

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -163,12 +163,12 @@ public class SoftAssertions extends AbstractStandardSoftAssertions {
       assertions.assertAll();
   }
  
-  private static void assertSoftly(SoftAssertionScope... softAssertions) {
-      List<Throwable> errors = new LinkedList<>();
-      for (SoftAssertionScope scope : softAssertions) {
+  private static void assertSoftly(Runnable... softAssertions) {
+      List<AssertionError> errors = new LinkedList<>();
+      for (Runnable scope : softAssertions) {
           try {
-              scope.execute();
-          } catch (Throwable error) {
+              scope.run();
+          } catch (AssertionError error) {
               errors.add(error);
           }
       }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -160,5 +161,20 @@ public static void assertSoftly(Consumer<SoftAssertions> softly) {
       SoftAssertions assertions = new SoftAssertions();
       softly.accept(assertions);
       assertions.assertAll();
+  }
+  
+  private static void assertSoftly(Runnable... scopes) {
+    List<AssertionError> errors = new ArrayList<>();;
+    for (Runnable scope : scopes) {
+      try {
+        scope.run();
+      } catch (AssertionError error) {
+        // TODO call AbstractSoftAssertions.addLineNumberToErrorMessage(error), but it is not static nor public
+        errors.add(error);
+      }
+    }
+    if (!errors.isEmpty()) {
+      throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
+    }
   }
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -162,19 +162,4 @@ public static void assertSoftly(Consumer<SoftAssertions> softly) {
       softly.accept(assertions);
       assertions.assertAll();
   }
-  
-  private static void assertSoftly(Runnable... scopes) {
-    List<AssertionError> errors = new ArrayList<>();;
-    for (Runnable scope : scopes) {
-      try {
-        scope.run();
-      } catch (AssertionError error) {
-        // TODO call AbstractSoftAssertions.addLineNumberToErrorMessage(error), but it is not static nor public
-        errors.add(error);
-      }
-    }
-    if (!errors.isEmpty()) {
-      throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
-    }
-  }
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -162,18 +162,4 @@ public static void assertSoftly(Consumer<SoftAssertions> softly) {
       softly.accept(assertions);
       assertions.assertAll();
   }
- 
-  private static void assertSoftly(Runnable... scopes) {
-    List<AssertionError> errors = new LinkedList<>();
-    for (Runnable scope : scopes) {
-      try {
-        scope.run();
-      } catch (AssertionError error) {
-        errors.add(error);
-      }
-    }
-    if (!errors.isEmpty()) {
-      throw new AssertionErrorCreator().multipleSoftAssertionsError(errors);
-    }
-  }
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.api;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -152,7 +152,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   @Test
-  public void should_collect_soft_check_assertion() {
+  public void should_collect_soft_check_assertion() throws Exception {
     softly.check(() -> assertThat(true).isFalse());
     softly.check(() -> assertThat(true).isTrue());
     assertThat(softly.errorsCollected()).hasSize(1);

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -152,6 +152,13 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   @Test
+  public void should_collect_soft_check_assertion() {
+    softly.check(() -> assertThat(true).isFalse());
+    softly.check(() -> assertThat(true).isTrue());
+    assertThat(softly.errorsCollected()).hasSize(1);
+  }
+
+  @Test
   public void all_assertions_should_pass() {
     softly.assertThat(1).isEqualTo(1);
     softly.assertThat(Lists.newArrayList(1, 2)).containsOnly(1, 2);


### PR DESCRIPTION
Add static `assertSoftly` method to be able to use  any common and custom assertion side by side within on assertSoftly call/scope e.g.
```java
        SoftAssertions.assertSoftly(
                () -> Assertions.assertThat("test1").isEqualTo("bar"),
                () -> GuavaAssertions.assertThat(...).contains(...),
                () -> MyAssertion.assertThat(...).contains(...)
        );
```

#### Check List:
* Unit tests : NO
* Javadoc with a code example (API only) : NO


