### PR TITLE
Ignore static methods when finding property accessors

### DIFF
--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -77,14 +77,15 @@ public final class Introspection {
     String capitalized = propertyName.substring(0, 1).toUpperCase(ENGLISH) + propertyName.substring(1);
     // try to find getProperty
     Method getter = findMethod("get" + capitalized, target);
-    if (getter != null) return getter;
+    if (getter != null && !Modifier.isStatic(getter.getModifiers())) return getter;
     if (bareNamePropertyMethods) {
       // try to find bare name property
       getter = findMethod(propertyName, target);
-      if (getter != null) return getter;
+      if (getter != null && !Modifier.isStatic(getter.getModifiers())) return getter;
     }
     // try to find isProperty for boolean properties
-    return findMethod("is" + capitalized, target);
+    Method isAccessor = findMethod("is" + capitalized, target);
+    return (isAccessor != null && !Modifier.isStatic(isAccessor.getModifiers())) ? isAccessor: null;
   }
 
   private static Method findMethod(String name, Object target) {

--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -34,7 +34,7 @@ public final class Introspection {
 
   /**
    * Returns the getter {@link Method} for a property matching the given name in the given object.
-   * 
+   *
    * @param propertyName the given property name.
    * @param target the given object.
    * @return the getter {@code Method} for a property matching the given name in the given object.
@@ -77,15 +77,19 @@ public final class Introspection {
     String capitalized = propertyName.substring(0, 1).toUpperCase(ENGLISH) + propertyName.substring(1);
     // try to find getProperty
     Method getter = findMethod("get" + capitalized, target);
-    if (getter != null && !Modifier.isStatic(getter.getModifiers())) return getter;
+    if (isValidGetter(getter)) return getter;
     if (bareNamePropertyMethods) {
       // try to find bare name property
       getter = findMethod(propertyName, target);
-      if (getter != null && !Modifier.isStatic(getter.getModifiers())) return getter;
+      if (isValidGetter(getter)) return getter;
     }
     // try to find isProperty for boolean properties
     Method isAccessor = findMethod("is" + capitalized, target);
-    return (isAccessor != null && !Modifier.isStatic(isAccessor.getModifiers())) ? isAccessor: null;
+    return (isValidGetter(isAccessor)) ? isAccessor: null;
+  }
+
+  private static boolean isValidGetter(Method method) {
+    return method != null && !Modifier.isStatic(method.getModifiers());
   }
 
   private static Method findMethod(String name, Object target) {

--- a/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
@@ -151,6 +151,27 @@ public class PropertyOrFieldSupport_getValueOf_Test {
     assertThat(maps).extracting("bad key").containsExactly(null, null);
   }
 
+  @Test
+  public void should_extract_field_value_if_only_static_getter_matches_name() {
+    Object value = propertyOrFieldSupport.getValueOf("city", new StaticPropertyEmployee());
+
+    assertThat(value).isEqualTo("New York");
+  }
+
+  @Test
+  public void should_extract_field_value_if_only_static_is_method_matches_name() {
+    Object value = propertyOrFieldSupport.getValueOf("tall", new StaticBooleanPropertyEmployee());
+
+    assertThat(value).isEqualTo(false);
+  }
+
+  @Test
+  public void should_extract_field_value_if_only_static_bare_method_matches_name() {
+    Object value = propertyOrFieldSupport.getValueOf("city", new StaticBarePropertyEmployee());
+
+    assertThat(value).isEqualTo("New York");
+  }
+
   private Employee employeeWithBrokenName(String name) {
     return new Employee(1L, new Name(name), 0) {
       @Override
@@ -176,6 +197,25 @@ public class PropertyOrFieldSupport_getValueOf_Test {
         throw new IllegalStateException();
       }
     };
+  }
+
+  static class StaticPropertyEmployee extends Employee {
+    public static String getCity() {
+      return "London";
+    }
+  }
+
+  static class StaticBarePropertyEmployee extends Employee {
+    public static String city() {
+      return "London";
+    }
+  }
+
+  static class StaticBooleanPropertyEmployee extends Employee {
+    boolean tall = false;
+    public static boolean isTall() {
+      return true;
+    }
   }
 
 }


### PR DESCRIPTION
Previously, when looking for property accessors, Introspection would consider a static method with a name in the required form as being an accessor for a property. Where such a static method existed, this was likely to result in the wrong value being considered as the static method is unlikely to return the correct value for an instance's property.

This PR updates Introspection so that static methods are ignored when looking for property accessors.

#### Check List:
* Fixes #1458 
* Unit tests : YES
* Javadoc with a code example (API only) : NA


