### PR TITLE
Single parameter optimizations for extracting methods

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1499,14 +1499,12 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * If a given key is not present in the map under test, a null value is extracted.
    * <p>
    * Example:
-   * <pre><code class='java'>
-   * Map&lt;String, Object&gt; map = new HashMap&lt;&gt;();
+   * <pre><code class='java'> Map&lt;String, Object&gt; map = new HashMap&lt;&gt;();
    * map.put("name", "kawhi");
    * map.put("age", 25);
    *
    * assertThat(map).extracting("name", "age")
-   *                .contains("kawhi", 25);
-   * </code></pre>
+   *                .contains("kawhi", 25);</code></pre>
    * <p>
    * Note that the order of extracted keys value is consistent with the iteration order of the array under test.
    * <p>
@@ -1533,13 +1531,11 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * If a given key is not present in the map under test, a null value is extracted.
    * <p>
    * Example:
-   * <pre><code class='java'>
-   * Map&lt;String, Object&gt; map = new HashMap&lt;&gt;();
+   * <pre><code class='java'> Map&lt;String, Object&gt; map = new HashMap&lt;&gt;();
    * map.put("name", "kawhi");
    *
    * assertThat(map).extracting("name")
-   *                .isEqualTo("kawhi");
-   * </code></pre>
+   *                .isEqualTo("kawhi");</code></pre>
    * <p>
    * Nested keys are not yet supported, passing "name.first" won't get a value for "name" and then try to extract
    * "first" from the previously extracted value, instead it will simply look for a value under "name.first" key.

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -674,7 +674,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @return a new assertion object whose object under test is the list containing the extracted values
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, Object>... extractors) {
+  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, ?>... extractors) {
     List<Object> values = Stream.of(extractors)
                                 .map(extractor -> extractor.apply(actual))
                                 .collect(toList());

--- a/src/main/java/org/assertj/core/api/MapAssert.java
+++ b/src/main/java/org/assertj/core/api/MapAssert.java
@@ -96,7 +96,7 @@ public class MapAssert<KEY, VALUE> extends AbstractMapAssert<MapAssert<KEY, VALU
 
   @SafeVarargs
   @Override
-  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super Map<KEY, VALUE>, Object>... extractors) {
+  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super Map<KEY, VALUE>, ?>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/ObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectAssert.java
@@ -43,7 +43,7 @@ public class ObjectAssert<ACTUAL> extends AbstractObjectAssert<ObjectAssert<ACTU
   @Override
   @CheckReturnValue
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Object>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, Object>... extractors) {
+  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, Object>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/main/java/org/assertj/core/api/ObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectAssert.java
@@ -43,7 +43,7 @@ public class ObjectAssert<ACTUAL> extends AbstractObjectAssert<ObjectAssert<ACTU
   @Override
   @CheckReturnValue
   @SafeVarargs
-  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, Object>... extractors) {
+  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, ?>... extractors) {
     return super.extracting(extractors);
   }
 

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -270,7 +271,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
       throw new Exception("something was wrong");
     }).hasMessage("something was good");
     softly.then(mapOf(MapEntry.entry("54", "55"))).contains(MapEntry.entry("1", "2"));
-    softly.then(LocalTime.of(12, 00)).isEqualTo(LocalTime.of(13, 00));
+    softly.then(LocalTime.of(12, 0)).isEqualTo(LocalTime.of(13, 0));
     softly.then(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC))
           .isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
     softly.then(Optional.of("not empty")).isEqualTo("empty");
@@ -733,7 +734,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
   @Test
   public void should_propagate_AssertionError_from_nested_proxied_calls() {
     // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
-    softly.then(asList()).first();
+    softly.then(emptyList()).first();
     // nested proxied call to throwAssertionError when checking that is optional is present
     softly.then(Optional.empty()).contains("Foo");
     // nested proxied call to isNotNull
@@ -910,7 +911,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
             .containsExactly("1", "2");
       softly.then(numbers)
             .extracting("one")
-            .containsExactly("1");
+            .isEqualTo("1");
     }
   }
 

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -289,18 +290,13 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
 
       final IllegalArgumentException illegalArgumentException = new IllegalArgumentException("IllegalArgumentException message");
       softly.assertThat(illegalArgumentException).hasMessage("NullPointerException message");
-      softly.assertThatThrownBy(new ThrowingCallable() {
-
-        @Override
-        public void call() throws Exception {
-          throw new Exception("something was wrong");
-        }
-
+      softly.assertThatThrownBy(() -> {
+        throw new Exception("something was wrong");
       }).hasMessage("something was good");
 
       softly.assertThat(mapOf(MapEntry.entry("54", "55"))).contains(MapEntry.entry("1", "2"));
 
-      softly.assertThat(LocalTime.of(12, 00)).isEqualTo(LocalTime.of(13, 00));
+      softly.assertThat(LocalTime.of(12, 0)).isEqualTo(LocalTime.of(13, 0));
       softly.assertThat(OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC))
             .isEqualTo(OffsetTime.of(13, 0, 0, 0, ZoneOffset.UTC));
 
@@ -780,7 +776,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   public void should_propagate_AssertionError_from_nested_proxied_calls() {
     // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
-    softly.assertThat(asList()).first();
+    softly.assertThat(emptyList()).first();
     // nested proxied call to throwAssertionError when checking that is optional is present
     softly.assertThat(Optional.empty()).contains("Foo");
     // nested proxied call to isNotNull
@@ -911,7 +907,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
             .containsExactly("1", "2");
       softly.assertThat(numbers)
             .extracting("one")
-            .containsExactly("1");
+            .isEqualTo("1");
     }
   }
 

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
@@ -63,7 +63,7 @@ public class Assumptions_assumeThat_with_extracting_Test {
 
   @Test
   public void should_run_test_when_assumption_using_extracting_on_object_passes() {
-    assertThatCode(() -> assumeThat(yoda).extracting("name").containsExactly("Yoda")).doesNotThrowAnyException();
+    assertThatCode(() -> assumeThat(yoda).extracting("name").isEqualTo("Yoda")).doesNotThrowAnyException();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
@@ -62,8 +62,14 @@ public class Assumptions_assumeThat_with_extracting_Test {
   }
 
   @Test
-  public void should_run_test_when_assumption_using_extracting_on_object_passes() {
+  public void should_run_test_when_assumption_using_extracting_on_object_with_single_parameter_passes() {
     assertThatCode(() -> assumeThat(yoda).extracting("name").isEqualTo("Yoda")).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void should_run_test_when_assumption_using_extracting_on_object_with_multiple_parameters_passes() {
+    assertThatCode(() -> assumeThat(yoda).extracting("name", "class")
+                                         .containsOnly("Yoda", Jedi.class)).doesNotThrowAnyException();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_extracting_Test.java
@@ -69,7 +69,7 @@ public class Assumptions_assumeThat_with_extracting_Test {
   @Test
   public void should_run_test_when_assumption_using_extracting_on_object_with_multiple_parameters_passes() {
     assertThatCode(() -> assumeThat(yoda).extracting("name", "class")
-                                         .containsOnly("Yoda", Jedi.class)).doesNotThrowAnyException();
+                                         .containsExactly("Yoda", Jedi.class)).doesNotThrowAnyException();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
@@ -48,10 +48,9 @@ public class IterableAssert_containsAnyElementsOf_Test extends IterableAssertBas
   @Test
   public void should_compile_as_containsAnyElementsOf_declares_bounded_wildcard_parameter() {
     // GIVEN
-    Map<String, String> map = newHashMap("some_key", "some_value");
-    Iterable<Map<String, String>> iterable = list(map);
+    Iterable<String> iterable = list("some_value", "some_different_value");
     // THEN
-    assertThat(iterable).extracting("some_key").containsAnyElementsOf(list("some_value", "some_other_value"));
+    assertThat(iterable).containsAnyElementsOf(list("some_value", "some_other_value"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_containsAnyElementsOf_Test.java
@@ -49,8 +49,9 @@ public class IterableAssert_containsAnyElementsOf_Test extends IterableAssertBas
   public void should_compile_as_containsAnyElementsOf_declares_bounded_wildcard_parameter() {
     // GIVEN
     Map<String, String> map = newHashMap("some_key", "some_value");
+    Iterable<Map<String, String>> iterable = list(map);
     // THEN
-    assertThat(map).extracting("some_key").containsAnyElementsOf(list("some_value", "some_other_value"));
+    assertThat(iterable).extracting("some_key").containsAnyElementsOf(list("some_value", "some_other_value"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extracting_Test.java
@@ -42,21 +42,45 @@ public class MapAssert_extracting_Test {
   }
 
   @Test
+  public void should_allow_object_assertions_on_value_extracted_from_given_map_key() {
+    assertThat(map).extracting(NAME)
+                   .isEqualTo("kawhi");
+  }
+
+  @Test
   public void should_allow_assertions_on_values_extracted_from_given_extractors() {
     assertThat(map).extracting(m -> m.get(NAME), m -> m.get("age"))
                    .contains("kawhi", 25);
   }
 
   @Test
-  public void should_extract_null_from_unknown_key() {
-    assertThat(map).extracting(NAME, "id")
+  public void should_allow_object_assertions_on_value_extracted_from_given_extractor() {
+    assertThat(map).extracting(m -> m.get(NAME))
+                   .isEqualTo("kawhi");
+  }
+
+  @Test
+  public void should_extract_null_element_from_unknown_key() {
+    assertThat(map).extracting(NAME, "unknown")
                    .contains("kawhi", (Object) null);
+  }
+
+  @Test
+  public void should_extract_null_object_from_unknown_key() {
+    assertThat(map).extracting("unknown")
+                   .isNull();
   }
 
   @Test
   public void should_use_key_names_as_description() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(map).extracting(NAME, "age").isEmpty())
                                                    .withMessageContaining("[Extracted: name, age]");
+  }
+
+  @Test
+  public void should_use_key_name_as_description() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(map).extracting(NAME).isNull())
+                                                   .withMessageContaining("[Extracted: name]");
   }
 
   @Test
@@ -67,11 +91,28 @@ public class MapAssert_extracting_Test {
   }
 
   @Test
-  public void should_fail_if_actual_is_null() {
+  public void should_keep_existing_description_if_set_when_extracting_value_object() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(map).as("check name")
+                                                                                    .extracting(NAME).isNull())
+                                                   .withMessageContaining("[check name]");
+  }
+
+  @Test
+  public void should_fail_with_key_list_if_actual_is_null() {
     // GIVEN
     map = null;
     // WHEN
     Throwable error = catchThrowable(() -> assertThat(map).extracting(NAME, "age"));
+    // THEN
+    assertThat(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_with_single_key_if_actual_is_null() {
+    // GIVEN
+    map = null;
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(map).extracting(NAME));
     // THEN
     assertThat(error).hasMessage(actualIsNull());
   }

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
@@ -21,11 +21,13 @@ import java.math.BigDecimal;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link ObjectAssert#extracting(String[])}</code>.
+ * Tests for <code>{@link ObjectAssert#extracting(String)}</code> and
+ * <code>{@link ObjectAssert#extracting(String[])}</code>.
  */
 public class ObjectAssert_extracting_Test {
 
@@ -34,6 +36,14 @@ public class ObjectAssert_extracting_Test {
   @BeforeEach
   public void setup() {
     luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+  }
+
+  @Test
+  public void should_allow_assertions_on_property_extracted_from_given_object_by_name() {
+    assertThat(luke).extracting("id")
+                    .isNotNull();
+    assertThat(luke).extracting("name.first")
+                    .isEqualTo("Luke");
   }
 
   @Test
@@ -57,6 +67,15 @@ public class ObjectAssert_extracting_Test {
   }
 
   @Test
+  public void should_use_property_field_name_as_description_when_extracting_single_property() {
+    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(luke).extracting("name.first")
+                                                                                     .isNull())
+                                                   .withMessageContaining("[Extracted: name.first]");
+  }
+
+  @Test
   public void should_use_property_field_names_as_description_when_extracting_tuples_list() {
     Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
 
@@ -64,6 +83,16 @@ public class ObjectAssert_extracting_Test {
                                                                                                  "name.last")
                                                                                      .isEmpty())
                                                    .withMessageContaining("[Extracted: name.first, name.last]");
+  }
+
+  @Test
+  public void should_keep_existing_description_if_set_when_extracting_single_property() {
+    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(luke).as("check luke first name")
+                                                                                     .extracting("name.first")
+                                                                                     .isNull())
+                                                   .withMessageContaining("[check luke first name]");
   }
 
   @Test
@@ -76,8 +105,18 @@ public class ObjectAssert_extracting_Test {
                                                    .withMessageContaining("[check luke first and last name]");
   }
 
+  @Ignore
+  public void should_allow_to_specify_type_comparator_after_using_extracting_with_single_parameter_on_object() {
+    Person obiwan = new Person("Obi-Wan");
+    obiwan.setHeight(new BigDecimal("1.820"));
+
+    assertThat(obiwan).extracting("height")
+                      .usingComparatorForType(BIG_DECIMAL_COMPARATOR, BigDecimal.class) // FIXME not working
+                      .isEqualTo(new BigDecimal("1.82"));
+  }
+
   @Test
-  public void should_allow_to_specify_type_comparator_after_using_extracting_on_object() {
+  public void should_allow_to_specify_type_comparator_after_using_extracting_with_multiple_parameters_on_object() {
     Person obiwan = new Person("Obi-Wan");
     obiwan.setHeight(new BigDecimal("1.820"));
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
@@ -70,10 +70,10 @@ public class ObjectAssert_extracting_Test {
   public void should_keep_existing_description_if_set_when_extracting_tuples_list() {
     Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
 
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(luke).as("check luke first name")
-                                                                                     .extracting("name.first")
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(luke).as("check luke first and last name")
+                                                                                     .extracting("name.first", "name.last")
                                                                                      .isEmpty())
-                                                   .withMessageContaining("[check luke first name]");
+                                                   .withMessageContaining("[check luke first and last name]");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link ObjectAssert#extracting(String)}</code> and
- * <code>{@link ObjectAssert#extracting(String[])}</code>.
+ * Tests for <code>{@link ObjectAssert#extracting(String)}</code> and <code>{@link ObjectAssert#extracting(String[])}</code>.
  */
 public class ObjectAssert_extracting_Test {
 
@@ -52,16 +51,6 @@ public class ObjectAssert_extracting_Test {
                     .hasSize(2)
                     .doesNotContainNull();
     assertThat(luke).extracting("name.first", "name.last")
-                    .hasSize(2)
-                    .containsExactly("Luke", "Skywalker");
-  }
-
-  @Test
-  public void should_allow_assertions_on_array_of_properties_extracted_from_given_object_with_lambdas() {
-    assertThat(luke).extracting(Employee::getName, Employee::getAge)
-                    .hasSize(2)
-                    .doesNotContainNull();
-    assertThat(luke).extracting(employee -> employee.getName().first, employee -> employee.getName().getLast())
                     .hasSize(2)
                     .containsExactly("Luke", "Skywalker");
   }
@@ -111,7 +100,7 @@ public class ObjectAssert_extracting_Test {
     obiwan.setHeight(new BigDecimal("1.820"));
 
     assertThat(obiwan).extracting("height")
-                      .usingComparatorForType(BIG_DECIMAL_COMPARATOR, BigDecimal.class) // FIXME not working
+                      .usingComparatorForType(BIG_DECIMAL_COMPARATOR, BigDecimal.class) // FIXME not working for objects
                       .isEqualTo(new BigDecimal("1.82"));
   }
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.util.BigDecimalComparator.BIG_DECIMAL_COMPARATOR;
 
 import java.math.BigDecimal;
+import java.util.Comparator;
 
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.test.Employee;
@@ -94,13 +95,19 @@ public class ObjectAssert_extracting_Test {
                                                    .withMessageContaining("[check luke first and last name]");
   }
 
-  @Ignore
+  @Test
   public void should_allow_to_specify_type_comparator_after_using_extracting_with_single_parameter_on_object() {
     Person obiwan = new Person("Obi-Wan");
     obiwan.setHeight(new BigDecimal("1.820"));
 
+    // Workaround to overcome the lack of BigDecimal type in the result of extracting(String)
+    Comparator<Object> heightComparator = (o1, o2) -> {
+      if (o1 instanceof BigDecimal) return BIG_DECIMAL_COMPARATOR.compare((BigDecimal) o1, (BigDecimal) o2);
+      throw new IllegalStateException("only supported for BigDecimal");
+    };
+
     assertThat(obiwan).extracting("height")
-                      .usingComparatorForType(BIG_DECIMAL_COMPARATOR, BigDecimal.class) // FIXME not working for objects
+                      .usingComparator(heightComparator)
                       .isEqualTo(new BigDecimal("1.82"));
   }
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_Test.java
@@ -33,24 +33,33 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link ObjectAssert#extracting(Function)}</code> and
- * <code>{@link ObjectAssert#extracting(Function[])}</code>.
+ * Tests for <code>{@link ObjectAssert#extracting(Function)}</code> and <code>{@link ObjectAssert#extracting(Function[])}</code>.
  */
 public class ObjectAssert_extracting_with_function_Test {
 
-  private Employee yoda;
+  private Employee luke;
 
   private static final Function<Employee, String> firstName = employee -> employee.getName().getFirst();
 
   @BeforeEach
   public void setUp() {
-    yoda = new Employee(1L, new Name("Yoda"), 800);
+    luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
   }
 
   @Test
   public void should_allow_extracting_a_value_using_a_single_extractor() {
-    assertThat(yoda).extracting(firstName).isEqualTo("Yoda");
-    assertThat(yoda).extracting(Employee::getAge).isEqualTo(800);
+    assertThat(luke).extracting(firstName).isEqualTo("Luke");
+    assertThat(luke).extracting(Employee::getAge).isEqualTo(26);
+  }
+
+  @Test
+  public void should_allow_extracting_values_using_multiple_extractors() {
+    assertThat(luke).extracting(Employee::getName, Employee::getAge)
+      .hasSize(2)
+      .doesNotContainNull();
+    assertThat(luke).extracting(firstName, employee -> employee.getName().getLast())
+      .hasSize(2)
+      .containsExactly("Luke", "Skywalker");
   }
 
   @Test
@@ -70,7 +79,7 @@ public class ObjectAssert_extracting_with_function_Test {
     // GIVEN
     Function<Employee, Object> extractor = null;
     // WHEN
-    Throwable error = catchThrowable(() -> assertThat(yoda).extracting(extractor));
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(extractor));
     // THEN
     assertThat(error).isInstanceOf(NullPointerException.class)
                      .hasMessage("The given java.util.function.Function extractor must not be null");
@@ -78,7 +87,7 @@ public class ObjectAssert_extracting_with_function_Test {
 
   @Test
   public void extracting_should_honor_registered__comparator() {
-    assertThat(yoda).usingComparator(ALWAY_EQUALS)
+    assertThat(luke).usingComparator(ALWAY_EQUALS)
                     .extracting(firstName)
                     .isEqualTo("YODA");
   }
@@ -87,14 +96,14 @@ public class ObjectAssert_extracting_with_function_Test {
   public void extracting_should_keep_assertion_state() {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
-    AbstractObjectAssert<?, ?> assertion = assertThat(yoda).as("test description")
+    AbstractObjectAssert<?, ?> assertion = assertThat(luke).as("test description")
                                                            .withFailMessage("error message")
                                                            .withRepresentation(UNICODE_REPRESENTATION)
                                                            .usingComparator(ALWAY_EQUALS)
                                                            .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
                                                            .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
                                                            .extracting(firstName)
-                                                           .isEqualTo("YODA");
+                                                           .isEqualTo("LUKE");
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_Test.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.test.Employee;
@@ -31,6 +32,10 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for <code>{@link ObjectAssert#extracting(Function)}</code> and
+ * <code>{@link ObjectAssert#extracting(Function[])}</code>.
+ */
 public class ObjectAssert_extracting_with_function_Test {
 
   private Employee yoda;

--- a/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
+++ b/src/test/java/org/assertj/core/extractor/ByNameSingleExtractorTest.java
@@ -133,7 +133,7 @@ public class ByNameSingleExtractorTest {
   public void should_extract_property_with_barename_method() {
     BareOptionalIntHolder holder = new BareOptionalIntHolder(42);
     assertThat(holder).extracting("value")
-                      .containsExactly(OptionalInt.of(42));
+                      .isEqualTo(OptionalInt.of(42));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class ByNameSingleExtractorTest {
     BareOptionalIntHolder holder = new BareOptionalIntHolder(42);
     Assertions.setExtractBareNamePropertyMethods(false);
     assertThat(holder).extracting("value")
-                      .containsExactly(42);
+                      .isEqualTo(42);
     Assertions.setExtractBareNamePropertyMethods(true);
   }
 


### PR DESCRIPTION
Several times I had the use case where a single private field was extracted and assertions were done on the resulting value, especially using `isInstanceOfSatisfying()`.

Previously, a call to `extracting("field").first()` was needed to obtain the corresponding `AbstractObjectAssert`.

This PR allows `extracting()` calls with only one string parameter to return an `AbstractObjectAssert` directly, in case of both field/property and map value extraction. The idea is similar to the existing `extracting` method which takes a single extractor `Function`.

Miror changes are also added in this PR (typos, warning suppressions and deletion of redundant `extends`).

#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (API only) : YES