### PR TITLE
Fix JavaDoc regarding `AnyOf` and `AllOf`

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1981,7 +1981,7 @@ public class Assertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given array is {@code null}.
    * @throws NullPointerException if any of the elements in the given array is {@code null}.
    */
@@ -1995,7 +1995,7 @@ public class Assertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given iterable is {@code null}.
    * @throws NullPointerException if any of the elements in the given iterable is {@code null}.
    */

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -1761,7 +1761,7 @@ public class Java6Assertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given array is {@code null}.
    * @throws NullPointerException if any of the elements in the given array is {@code null}.
    */
@@ -1775,7 +1775,7 @@ public class Java6Assertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given iterable is {@code null}.
    * @throws NullPointerException if any of the elements in the given iterable is {@code null}.
    */

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -205,7 +205,7 @@ public interface WithAssertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given iterable is {@code null}.
    * @throws NullPointerException if any of the elements in the given iterable is {@code null}.
    */
@@ -218,7 +218,7 @@ public interface WithAssertions {
    *
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given array is {@code null}.
    * @throws NullPointerException if any of the elements in the given array is {@code null}.
    */

--- a/src/main/java/org/assertj/core/condition/AllOf.java
+++ b/src/main/java/org/assertj/core/condition/AllOf.java
@@ -15,7 +15,7 @@ package org.assertj.core.condition;
 import org.assertj.core.api.Condition;
 
 /**
- * Returns {@code true} if all of the joined conditions is satisfied.
+ * Returns {@code true} if all of the joined conditions are satisfied.
  * @param <T> the type of object this condition accepts.
  * 
  * @author Yvonne Wang
@@ -27,7 +27,7 @@ public class AllOf<T> extends Join<T> {
    * Creates a new <code>{@link AllOf}</code>
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given array is {@code null}.
    * @throws NullPointerException if any of the elements in the given array is {@code null}.
    */
@@ -40,7 +40,7 @@ public class AllOf<T> extends Join<T> {
    * Creates a new <code>{@link AllOf}</code>
    * @param <T> the type of object the given condition accept.
    * @param conditions the conditions to evaluate.
-   * @return the created {@code AnyOf}.
+   * @return the created {@code AllOf}.
    * @throws NullPointerException if the given iterable is {@code null}.
    * @throws NullPointerException if any of the elements in the given iterable is {@code null}.
    */


### PR DESCRIPTION
* Fixes some mixing up between the two types `AnyOf` and `AllOf`.
* Unit tests : NO
* Javadoc with a code example (API only) : NO


