### PR TITLE
Get rid of deprecated Double and Float constructor usage

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -44,7 +44,7 @@ import org.assertj.core.util.VisibleForTesting;
 public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SELF>> extends
     AbstractComparableAssert<SELF, Double> implements FloatingPointNumberAssert<SELF, Double> {
 
-  private static final Double NEGATIVE_ZERO = new Double(-0.0);
+  private static final Double NEGATIVE_ZERO = Double.valueOf(-0.0);
 
   @VisibleForTesting
   Doubles doubles = Doubles.instance();

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -42,7 +42,7 @@ import org.assertj.core.util.VisibleForTesting;
 public abstract class AbstractFloatAssert<SELF extends AbstractFloatAssert<SELF>> extends AbstractComparableAssert<SELF, Float>
     implements FloatingPointNumberAssert<SELF, Float> {
 
-  private static final Float NEGATIVE_ZERO = new Float(-0.0);
+  private static final Float NEGATIVE_ZERO = Float.valueOf(-0.0f);
 
   @VisibleForTesting
   Floats floats = Floats.instance();


### PR DESCRIPTION
see e.g. [Double java doc](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Double.html#%3Cinit%3E(double)) for details.


