### PR TITLE
Add support for combined millisecond and timezone parsing (#1487)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -63,7 +63,8 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   /**
    * the default DateFormat used to parse any String date representation.
    */
-  private static final List<DateFormat> DEFAULT_DATE_FORMATS = newArrayList(newIsoDateTimeWithMsFormat(),
+  private static final List<DateFormat> DEFAULT_DATE_FORMATS = newArrayList(newIsoDateTimeWithMsAndUtcTimeZoneFormat(),
+                                                                            newIsoDateTimeWithMsFormat(),
                                                                             newTimestampDateFormat(),
                                                                             newIsoDateTimeWithUtcTimeZoneFormat(),
                                                                             newIsoDateTimeFormat(),

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2431,7 +2431,8 @@ public class Assertions {
    *   assertThat(date).isEqualTo("2003/04/26");
    * } catch (AssertionError e) {
    *   assertThat(e).hasMessage("Failed to parse 2003/04/26 with any of these date formats: " +
-   *                            "[yyyy-MM-dd'T'HH:mm:ss.SSS, yyyy-MM-dd'T'HH:mm:ssX, " +
+   *                            "[yyyy-MM-dd'T'HH:mm:ss.SSSX, yyyy-MM-dd'T'HH:mm:ss.SSS, " +
+   *                            "yyyy-MM-dd'T'HH:mm:ssX, " +
    *                            "yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd]");
    * }
    *
@@ -2477,7 +2478,8 @@ public class Assertions {
    *   assertThat(date).isEqualTo("2003/04/26");
    * } catch (AssertionError e) {
    *   assertThat(e).hasMessage("Failed to parse 2003/04/26 with any of these date formats: " +
-   *                            "[yyyy-MM-dd'T'HH:mm:ss.SSS, yyyy-MM-dd'T'HH:mm:ssX, " +
+   *                            "[yyyy-MM-dd'T'HH:mm:ss.SSSX, yyyy-MM-dd'T'HH:mm:ss.SSS, " +
+   *                            "yyyy-MM-dd'T'HH:mm:ssX, " +
    *                            "yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd]");
    * }
    *
@@ -2501,6 +2503,7 @@ public class Assertions {
    * <p>
    * Defaults date format are:
    * <ul>
+   * <li><code>yyyy-MM-dd HH:mm:ss.SSSX</code></li>
    * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
    * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link Timestamp} String representation support)</li>
    * <li><code>yyyy-MM-dd'T'HH:mm:ssX</code></li>

--- a/src/main/java/org/assertj/core/util/DateUtil.java
+++ b/src/main/java/org/assertj/core/util/DateUtil.java
@@ -83,6 +83,15 @@ public class DateUtil {
   }
 
   /**
+   * ISO 8601 date-time format with millisecond and UTC time zone (yyyy-MM-dd'T'HH:mm:ss.SSSX), example :
+   * <code>2003-04-26T03:01:02.758+00:00</code>
+   * @return a {@code yyyy-MM-dd'T'HH:mm:ss.SSSX} {@link DateFormat}
+   */
+  public static DateFormat newIsoDateTimeWithMsAndUtcTimeZoneFormat() {
+    return strictDateFormatForPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+  }
+
+  /**
    * {@link Timestamp} date-time format with millisecond (yyyy-MM-dd HH:mm:ss.SSS), example :
    * <code>2003-04-26 03:01:02.999</code>
    * @return a {@code yyyy-MM-dd HH:mm:ss.SSS} {@link DateFormat}

--- a/src/test/java/org/assertj/core/api/date/AbstractDateAssertWithDateArg_Test.java
+++ b/src/test/java/org/assertj/core/api/date/AbstractDateAssertWithDateArg_Test.java
@@ -85,7 +85,8 @@ public abstract class AbstractDateAssertWithDateArg_Test extends DateAssertBaseT
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertionInvocationWithStringArg(dateAsStringWithBadFormat))
                                                    .withMessage(format("Failed to parse " + dateAsStringWithBadFormat +
                                                                        " with any of these date formats:%n" +
-                                                                       "   [yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                                                                       "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                                                                       "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                                                        "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                                                        "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
                                                                        "    yyyy-MM-dd'T'HH:mm:ss,%n" +

--- a/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
@@ -80,6 +80,15 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
   }
 
   @Test
+  public void date_assertion_should_support_date_with_ms_and_utc_time_zone_string_representation() throws ParseException {
+    SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    Date date = isoFormat.parse("2003-04-26T00:00:00.123");
+
+    assertThat(date).isEqualTo("2003-04-26T00:00:00.123+00:00");
+  }
+
+  @Test
   public void date_assertion_should_support_date_with_utc_time_zone_in_different_time_zone_string_representation() throws ParseException {
     SimpleDateFormat isoDateFormatUtc = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
     isoDateFormatUtc.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -99,7 +108,8 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(new Date()).isEqualTo(dateAsString))
                                                    .withMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n"
                                                                       +
-                                                                      "   [yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                                                                      "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                                                                      "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                                                       "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                                                       "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
                                                                       "    yyyy-MM-dd'T'HH:mm:ss,%n" +
@@ -125,6 +135,7 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
                                                                        +
                                                                        "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
                                                                        "    yyyy/MM/dd,%n" +
+                                                                       "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                                                        "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                                                        "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                                                        "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
@@ -156,6 +167,7 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     } catch (AssertionError e) {
       assertThat(e).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
                                       "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
+                                      "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
@@ -189,7 +201,8 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
       failBecauseExpectedAssertionErrorWasNotThrown();
     } catch (AssertionError e) {
       assertThat(e).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
-                                      "   [yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                                      "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                                      "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ss,%n" +
@@ -210,6 +223,7 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     } catch (AssertionError e) {
       assertThat(e).hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n" +
                                       "   [yyyy/MM/dd,%n" +
+                                      "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
                                       "    yyyy-MM-dd'T'HH:mm:ssX,%n" +


### PR DESCRIPTION
#### Check List:
* Fixes #1487 
* Unit tests : YES 
* Javadoc with a code example (API only) : YES

I had to add new parser to the first place, otherwise regular parser with ms (but without timezone) captures it.

One thing to note is that I could not get all unit tests to pass on my local machine because different regional settings on my PC cause test messages to be different than hardcoded ones. Not sure what I should do in this case.


