### PR TITLE
Add ignoring collection order to Recursive API

### DIFF
--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -538,8 +538,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * Example:
    * <pre><code class='java'> public class Person {
    *   String name;
-   *   List<Person> friends = new ArrayList<>();
-   *   List<Person> enemies = new ArrayList<>();
+   *   List&lt;Person&gt; friends = new ArrayList<>();
+   *   List&lt;Person&gt; enemies = new ArrayList<>();
    * }
    *
    * Person sherlock1 = new Person("Sherlock Holmes");
@@ -582,8 +582,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * Example:
    * <pre><code class='java'> public class Person {
    *   String name;
-   *   List<Person> friends = new ArrayList<>();
-   *   List<Person> enemies = new ArrayList<>();
+   *   List&lt;Person&gt; friends = new ArrayList<>();
+   *   List&lt;Person&gt; enemies = new ArrayList<>();
    * }
    *
    * Person sherlock1 = new Person("Sherlock Holmes");

--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -538,8 +538,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * Example:
    * <pre><code class='java'> public class Person {
    *   String name;
-   *   List&lt;Person&gt; friends = new ArrayList<>();
-   *   List&lt;Person&gt; enemies = new ArrayList<>();
+   *   List&lt;Person&gt; friends = new ArrayList&lt;&gt;();
+   *   List&lt;Person&gt; enemies = new ArrayList&lt;&gt;();
    * }
    *
    * Person sherlock1 = new Person("Sherlock Holmes");
@@ -582,8 +582,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * Example:
    * <pre><code class='java'> public class Person {
    *   String name;
-   *   List&lt;Person&gt; friends = new ArrayList<>();
-   *   List&lt;Person&gt; enemies = new ArrayList<>();
+   *   List&lt;Person&gt; friends = new ArrayList&lt;&gt;();
+   *   List&lt;Person&gt; enemies = new ArrayList&lt;&gt;();
    * }
    *
    * Person sherlock1 = new Person("Sherlock Holmes");

--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -533,6 +533,91 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
   }
 
   /**
+   * Makes the recursive comparison to ignore collection order in the given the object under test fields. Nested fields can be specified like this: {@code home.address.street}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> public class Person {
+   *   String name;
+   *   List<Person> friends = new ArrayList<>();
+   *   List<Person> enemies = new ArrayList<>();
+   * }
+   *
+   * Person sherlock1 = new Person("Sherlock Holmes");
+   * sherlock1.friends.add(new Person("Dr. John Watson"));
+   * sherlock1.friends.add(new Person("Molly Hooper"));
+   * sherlock1.enemies.add(new Person("Jim Moriarty"));
+   * sherlock1.enemies.add(new Person("Irene Adler"));
+   *
+   * Person sherlock2 = new Person("Sherlock Holmes");
+   * sherlock2.friends.add(new Person("Molly Hooper"));
+   * sherlock2.friends.add(new Person("Dr. John Watson"));
+   * sherlock2.enemies.add(new Person("Irene Adler"));
+   * sherlock2.enemies.add(new Person("Jim Moriarty"));
+   *
+   * // assertion succeeds as friends and enemies fields collection order is ignored in the comparison
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .ignoringCollectionOrderInFields("friends", "enemies")
+   *                      .isEqualTo(sherlock2);
+   *
+   * // assertion fails as enemies field collection order differ and it is not ignored
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .ignoringCollectionOrderInFields("friends")
+   *                      .isEqualTo(sherlock2);</code></pre>
+   *
+   * @param fieldsToIgnoreCollectionOrder the fields of the object under test to ignore collection order in the comparison.
+   * @return this {@link RecursiveComparisonAssert} to chain other methods.
+   */
+  @CheckReturnValue
+  public SELF ignoringCollectionOrderInFields(String... fieldsToIgnoreCollectionOrder) {
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields(fieldsToIgnoreCollectionOrder);
+    return myself;
+  }
+
+  /**
+   * Makes the recursive comparison to ignore collection order in the object under test fields matching the given regexes.
+   * <p>
+   * Nested fields can be specified by using dots like this: {@code home\.address\.street} ({@code \} is used to escape
+   * dots since they have a special meaning in regexes).
+   * <p>
+   * Example:
+   * <pre><code class='java'> public class Person {
+   *   String name;
+   *   List<Person> friends = new ArrayList<>();
+   *   List<Person> enemies = new ArrayList<>();
+   * }
+   *
+   * Person sherlock1 = new Person("Sherlock Holmes");
+   * sherlock1.friends.add(new Person("Dr. John Watson"));
+   * sherlock1.friends.add(new Person("Molly Hooper"));
+   * sherlock1.enemies.add(new Person("Jim Moriarty"));
+   * sherlock1.enemies.add(new Person("Irene Adler"));
+   *
+   * Person sherlock2 = new Person("Sherlock Holmes");
+   * sherlock2.friends.add(new Person("Molly Hooper"));
+   * sherlock2.friends.add(new Person("Dr. John Watson"));
+   * sherlock2.enemies.add(new Person("Irene Adler"));
+   * sherlock2.enemies.add(new Person("Jim Moriarty"));
+   *
+   * // assertion succeeds as friends and enemies fields collection order is ignored in the comparison
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .ignoringCollectionOrderInFieldsMatchingRegexes("friend.", "enemie.")
+   *                      .isEqualTo(sherlock2);
+   *
+   * // assertion fails as enemies field collection order differ and it is not ignored
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .ignoringCollectionOrderInFields("friend.")
+   *                      .isEqualTo(sherlock2);</code></pre>
+   *
+   * @param regexes regexes used to find the object under test fields to ignore collection order in the comparison.
+   * @return this {@link RecursiveComparisonAssert} to chain other methods.
+   */
+  @CheckReturnValue
+  public SELF ignoringCollectionOrderInFieldsMatchingRegexes(String... regexes) {
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes(regexes);
+    return myself;
+  }
+
+  /**
    * Makes the recursive comparison to check that actual's type is compatible with expected's type (and do the same for each field). <br>
    * Compatible means that the expected's type is the same or a subclass of actual's type.
    * <p>

--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -533,7 +533,41 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
   }
 
   /**
-   * Makes the recursive comparison to ignore collection order in the given the object under test fields. Nested fields can be specified like this: {@code home.address.street}.
+   * Makes the recursive comparison to ignore collection order in all fields in the object under test.
+   * <p>
+   * Example:
+   * <pre><code class='java'> public class Person {
+   *   String name;
+   *   List&lt;Person&gt; friends = new ArrayList&lt;&gt;();
+   * }
+   *
+   * Person sherlock1 = new Person("Sherlock Holmes");
+   * sherlock1.friends.add(new Person("Dr. John Watson"));
+   * sherlock1.friends.add(new Person("Molly Hooper"));
+   *
+   * Person sherlock2 = new Person("Sherlock Holmes");
+   * sherlock2.friends.add(new Person("Molly Hooper"));
+   * sherlock2.friends.add(new Person("Dr. John Watson"));
+   *
+   * // assertion succeeds as all fields collection order is ignored in the comparison
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .ignoringCollectionOrder()
+   *                      .isEqualTo(sherlock2);
+   *
+   * // assertion fails as fields collection order is not ignored in the comparison
+   * assertThat(sherlock1).usingRecursiveComparison()
+   *                      .isEqualTo(sherlock2);</code></pre>
+   *
+   * @return this {@link RecursiveComparisonAssert} to chain other methods.
+   */
+  @CheckReturnValue
+  public SELF ignoringCollectionOrder() {
+    recursiveComparisonConfiguration.setIgnoreCollectionOrder(true);
+    return myself;
+  }
+
+  /**
+   * Makes the recursive comparison to ignore collection order in the object under test specified fields. Nested fields can be specified like this: {@code home.address.street}.
    * <p>
    * Example:
    * <pre><code class='java'> public class Person {
@@ -574,7 +608,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
   }
 
   /**
-   * Makes the recursive comparison to ignore collection order in the object under test fields matching the given regexes.
+   * Makes the recursive comparison to ignore collection order in the object under test fields matching the specified regexes.
    * <p>
    * Nested fields can be specified by using dots like this: {@code home\.address\.street} ({@code \} is used to escape
    * dots since they have a special meaning in regexes).

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -53,6 +53,7 @@ public class RecursiveComparisonConfiguration {
   private boolean ignoreAllOverriddenEquals = false;
 
   // ignore order in collections section
+  private boolean ignoreCollectionOrder = false;
   private Set<FieldLocation> ignoredCollectionOrderInFields = new LinkedHashSet<>();
   private List<Pattern> ignoredCollectionOrderInFieldsMatchingRegexes = new ArrayList<>();
 
@@ -187,6 +188,22 @@ public class RecursiveComparisonConfiguration {
     ignoredOverriddenEqualsForTypes.addAll(list(types));
   }
 
+  @VisibleForTesting
+  boolean getIgnoreCollectionOrder() {
+    return ignoreCollectionOrder;
+  }
+
+  /**
+   * Sets whether to ignore collection order in the comparison.
+   * <p>
+   * See {@link RecursiveComparisonAssert#ignoringCollectionOrder()} for code examples.
+   *
+   * @param ignoreCollectionOrder whether to ignore collection order in the comparison.
+   */
+  public void setIgnoreCollectionOrder(boolean ignoreCollectionOrder) {
+    this.ignoreCollectionOrder = ignoreCollectionOrder;
+  }
+
   /**
    * Adds the given fields to the list of the object under test fields to ignore collection order in the recursive comparison.
    * <p>
@@ -216,9 +233,9 @@ public class RecursiveComparisonConfiguration {
    * @param regexes regexes used to find the object under test fields to ignore collection order in in the comparison.
    */
   public void ignoreCollectionOrderInFieldsMatchingRegexes(String... regexes) {
-      ignoredCollectionOrderInFieldsMatchingRegexes.addAll(Stream.of(regexes)
-                                                                 .map(Pattern::compile)
-                                                                 .collect(toList()));
+    ignoredCollectionOrderInFieldsMatchingRegexes.addAll(Stream.of(regexes)
+                                                               .map(Pattern::compile)
+                                                               .collect(toList()));
   }
 
   /**
@@ -310,6 +327,7 @@ public class RecursiveComparisonConfiguration {
     describeIgnoredFields(description);
     describeIgnoredFieldsRegexes(description);
     describeOverriddenEqualsMethodsUsage(description, representation);
+    describeIgnoreCollectionOrder(description);
     describeIgnoredCollectionOrderInFields(description);
     describeIgnoredCollectionOrderInFieldsMatchingRegexes(description);
     describeRegisteredComparatorByTypes(description);
@@ -352,7 +370,8 @@ public class RecursiveComparisonConfiguration {
   }
 
   boolean shouldIgnoreCollectionOrder(DualValue dualKey) {
-    return matchesAnIgnoredCollectionOrderInField(dualKey)
+    return ignoreCollectionOrder
+           || matchesAnIgnoredCollectionOrderInField(dualKey)
            || matchesAnIgnoredCollectionOrderInFieldRegex(dualKey);
   }
 
@@ -411,9 +430,14 @@ public class RecursiveComparisonConfiguration {
     return join(fieldsDescription).with(", ");
   }
 
+  private void describeIgnoreCollectionOrder(StringBuilder description) {
+    if (ignoreCollectionOrder) description.append(format("- collection order were ignored in all fields in the comparison%n"));
+  }
+
   private void describeIgnoredCollectionOrderInFields(StringBuilder description) {
     if (!ignoredCollectionOrderInFields.isEmpty())
-      description.append(format("- collection order in the following fields were ignored in the comparison: %s%n", describeIgnoredCollectionOrderInFields()));
+      description.append(format("- collection order in the following fields were ignored in the comparison: %s%n",
+                                describeIgnoredCollectionOrderInFields()));
   }
 
   private void describeIgnoredCollectionOrderInFieldsMatchingRegexes(StringBuilder description) {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -176,7 +176,7 @@ public class RecursiveComparisonDifferenceCalculator {
 
       // Special handle SortedSets because they are fast to compare
       // because their elements must be in the same order to be equivalent Sets.
-      if (actualFieldValue instanceof SortedSet) {
+      if (actualFieldValue instanceof SortedSet && !recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualValue)) {
         if (!compareOrderedCollection((Collection<?>) actualFieldValue, (Collection<?>) expectedFieldValue, currentPath,
                                       toCompare, visited)) {
           differences.add(new ComparisonDifference(currentPath, actualFieldValue, expectedFieldValue));
@@ -186,7 +186,7 @@ public class RecursiveComparisonDifferenceCalculator {
       }
 
       // Check List, as element order matters this comparison is faster than using unordered comparison.
-      if (actualFieldValue instanceof List) {
+      if (actualFieldValue instanceof List && !recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualValue)) {
         if (!compareOrderedCollection((Collection<?>) actualFieldValue, (Collection<?>) expectedFieldValue, currentPath,
                                       toCompare, visited)) {
           differences.add(new ComparisonDifference(currentPath, actualFieldValue, expectedFieldValue));

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
@@ -159,6 +159,33 @@ public class RecursiveComparisonAssert_fluent_API_Test {
   }
 
   @Test
+  public void should_allow_to_ignore_collection_order_in_fields() {
+    // GIVEN
+    String field1 = "foo";
+    String field2 = "foo.bar";
+    // WHEN
+    RecursiveComparisonConfiguration configuration = assertThat(ACTUAL).usingRecursiveComparison()
+                                                                       .ignoringCollectionOrderInFields(field1, field2)
+                                                                       .getRecursiveComparisonConfiguration();
+    // THEN
+    assertThat(configuration.getIgnoredCollectionOrderInFields()).containsExactly(fielLocation(field1), fielLocation(field2));
+  }
+
+  @Test
+  public void should_allow_to_ignore_collection_order_in_fields_matching_regexes() {
+    // GIVEN
+    String regex1 = "foo";
+    String regex2 = ".*foo.*";
+    // WHEN
+    RecursiveComparisonConfiguration configuration = assertThat(ACTUAL).usingRecursiveComparison()
+                                                                       .ignoringCollectionOrderInFieldsMatchingRegexes(regex1, regex2)
+                                                                       .getRecursiveComparisonConfiguration();
+    // THEN
+    assertThat(configuration.getIgnoredCollectionOrderInFieldsMatchingRegexes()).extracting(Pattern::pattern)
+                                                                                .containsExactly(regex1, regex2);
+  }
+
+  @Test
   public void should_allow_to_register_field_comparators() {
     // GIVEN
     String field1 = "foo";

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
@@ -159,6 +159,16 @@ public class RecursiveComparisonAssert_fluent_API_Test {
   }
 
   @Test
+  public void should_allow_to_ignore_collection_order() {
+    // WHEN
+    RecursiveComparisonConfiguration configuration = assertThat(ACTUAL).usingRecursiveComparison()
+                                                                       .ignoringCollectionOrder()
+                                                                       .getRecursiveComparisonConfiguration();
+    // THEN
+    assertThat(configuration.getIgnoreCollectionOrder()).isTrue();
+  }
+
+  @Test
   public void should_allow_to_ignore_collection_order_in_fields() {
     // GIVEN
     String field1 = "foo";

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrderInFields_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrderInFields_Test.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
+import org.assertj.core.internal.objects.data.FriendlyPerson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrderInFields_Test extends RecursiveComparisonAssert_isEqualTo_BaseTest {
+
+  @ParameterizedTest(name = "{0}: actual={1} / expected={2} / ignore collection order in fields={3}")
+  @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields_source")
+  @SuppressWarnings("unused")
+  public void should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields(String description,
+                                                                                                              Object actual,
+                                                                                                              Object expected,
+                                                                                                              List<String> fieldsToIgnoreCollectionOrder) {
+    assertThat(actual).usingRecursiveComparison()
+                      .ignoringCollectionOrderInFields(arrayOf(fieldsToIgnoreCollectionOrder))
+                      .isEqualTo(expected);
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields_source() {
+    FriendlyPerson friendlyPerson1 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson1.friends.add(new FriendlyPerson("Dr. John Watson"));
+    friendlyPerson1.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson2 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson2.friends.add(new FriendlyPerson("Molly Hooper"));
+    friendlyPerson2.friends.add(new FriendlyPerson("Dr. John Watson"));
+
+    FriendlyPerson friendlyPerson3 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson4 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson4.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson4.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson3.friends.add(friendlyPerson4);
+    friendlyPerson3.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson5 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson6 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson6.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson6.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson5.friends.add(friendlyPerson6);
+    friendlyPerson5.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    return Stream.of(arguments("same data except friends property collection order",
+                               friendlyPerson1, friendlyPerson2, list("friends")),
+                     arguments("same data except friends property order in subfield collection",
+                               friendlyPerson3, friendlyPerson5, list("friends.friends")));
+  }
+
+  @Test
+  public void should_fail_when_actual_differs_from_expected_even_when_collection_order_is_ignored_in_some_fields() {
+    // GIVEN
+    FriendlyPerson actual = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson actualFriend = new FriendlyPerson("Dr. John Watson");
+    actualFriend.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    actualFriend.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    actual.friends.add(actualFriend);
+    actual.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson expected = new FriendlyPerson("Sherlock Holmes");
+    expected.friends.add(new FriendlyPerson("Molly Hooper"));
+    FriendlyPerson expectedFriend = new FriendlyPerson("Dr. John Watson");
+    expectedFriend.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    expectedFriend.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    expected.friends.add(expectedFriend);
+
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields("friends");
+
+    // WHEN
+    compareRecursivelyFailsAsExpected(actual, expected);
+
+    // THEN
+    ComparisonDifference friendsDifference = diff("friends", actual.friends, expected.friends);
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, friendsDifference);
+  }
+
+  @ParameterizedTest(name = "{0}: actual={1} / expected={2} / ignore collection order in fields matching regexes={3}")
+  @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_fields_matching_specified_regexes_source")
+  @SuppressWarnings("unused")
+  public void should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_fields_matching_specified_regexes(String description,
+                                                                                                                               Object actual,
+                                                                                                                               Object expected,
+                                                                                                                               List<String> regexes) {
+    assertThat(actual).usingRecursiveComparison()
+                      .ignoringCollectionOrderInFieldsMatchingRegexes(arrayOf(regexes))
+                      .isEqualTo(expected);
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_fields_matching_specified_regexes_source() {
+    FriendlyPerson friendlyPerson1 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson1.friends.add(new FriendlyPerson("Dr. John Watson"));
+    friendlyPerson1.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson2 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson2.friends.add(new FriendlyPerson("Molly Hooper"));
+    friendlyPerson2.friends.add(new FriendlyPerson("Dr. John Watson"));
+
+    FriendlyPerson friendlyPerson3 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson4 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson4.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson4.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson3.friends.add(friendlyPerson4);
+    friendlyPerson3.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson5 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson6 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson6.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson6.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson5.friends.add(friendlyPerson6);
+    friendlyPerson5.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    return Stream.of(arguments("same data except friends property collection order",
+                               friendlyPerson1, friendlyPerson2, list("friend.")),
+                     arguments("same data except friends property order in subfield collection",
+                               friendlyPerson3, friendlyPerson5, list("friends\\..*")),
+                     arguments("should not stack overflow with regexes",
+                               friendlyPerson3, friendlyPerson5, list("friends[\\D]+")));
+  }
+
+  @Test
+  public void should_fail_when_actual_differs_from_expected_even_when_collection_order_is_ignored_in_fields_matching_some_regexes() {
+    // GIVEN
+    FriendlyPerson actual = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson actualFriend = new FriendlyPerson("Dr. John Watson");
+    actualFriend.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    actualFriend.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    actual.friends.add(actualFriend);
+    actual.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson expected = new FriendlyPerson("Sherlock Holmes");
+    expected.friends.add(new FriendlyPerson("Molly Hooper"));
+    FriendlyPerson expectedFriend = new FriendlyPerson("Dr. John Watson");
+    expectedFriend.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    expectedFriend.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    expected.friends.add(expectedFriend);
+
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("friend.");
+
+    // WHEN
+    compareRecursivelyFailsAsExpected(actual, expected);
+
+    // THEN
+    ComparisonDifference friendsDifference = diff("friends", actual.friends, expected.friends);
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, friendsDifference);
+  }
+
+  private static String[] arrayOf(List<String> list) {
+    return list.toArray(new String[0]);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -26,7 +26,72 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrderInFields_Test extends RecursiveComparisonAssert_isEqualTo_BaseTest {
+public class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
+    extends RecursiveComparisonAssert_isEqualTo_BaseTest {
+
+  @ParameterizedTest(name = "{0}: actual={1} / expected={2}")
+  @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_source")
+  @SuppressWarnings("unused")
+  public void should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored(String description,
+                                                                                          Object actual,
+                                                                                          Object expected) {
+    assertThat(actual).usingRecursiveComparison()
+                      .ignoringCollectionOrder()
+                      .isEqualTo(expected);
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_source() {
+    FriendlyPerson friendlyPerson1 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson1.friends.add(new FriendlyPerson("Dr. John Watson"));
+    friendlyPerson1.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson2 = new FriendlyPerson("Sherlock Holmes");
+    friendlyPerson2.friends.add(new FriendlyPerson("Molly Hooper"));
+    friendlyPerson2.friends.add(new FriendlyPerson("Dr. John Watson"));
+
+    FriendlyPerson friendlyPerson3 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson4 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson4.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson4.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson3.friends.add(friendlyPerson4);
+    friendlyPerson3.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson friendlyPerson5 = new FriendlyPerson("Sherlock Holmes");
+    FriendlyPerson friendlyPerson6 = new FriendlyPerson("Dr. John Watson");
+    friendlyPerson6.friends.add(new FriendlyPerson("Mrs. Hudson"));
+    friendlyPerson6.friends.add(new FriendlyPerson("D.I. Greg Lestrade"));
+    friendlyPerson5.friends.add(friendlyPerson6);
+    friendlyPerson5.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    return Stream.of(arguments("same data except friends property collection order",
+                               friendlyPerson1, friendlyPerson2),
+                     arguments("same data except friends property order in subfield collection",
+                               friendlyPerson3, friendlyPerson5));
+  }
+
+  @Test
+  public void should_fail_when_actual_differs_from_expected_even_when_collection_order_is_ignored() {
+    // GIVEN
+    FriendlyPerson actual = new FriendlyPerson("Sherlock Holmes");
+    actual.home.address.number = 1;
+    actual.friends.add(new FriendlyPerson("Dr. John Watson"));
+    actual.friends.add(new FriendlyPerson("Molly Hooper"));
+
+    FriendlyPerson expected = new FriendlyPerson("Sherlock Holmes");
+    expected.home.address.number = 2;
+    expected.friends.add(new FriendlyPerson("Molly Hooper"));
+    expected.friends.add(new FriendlyPerson("Dr. John Watson"));
+
+    recursiveComparisonConfiguration.setIgnoreCollectionOrder(true);
+
+    // WHEN
+    compareRecursivelyFailsAsExpected(actual, expected);
+
+    // THEN
+    ComparisonDifference comparisonDifference = new ComparisonDifference(list("home.address.number"), 1, 2);
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, comparisonDifference);
+  }
 
   @ParameterizedTest(name = "{0}: actual={1} / expected={2} / ignore collection order in fields={3}")
   @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields_source")

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
@@ -137,6 +137,16 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
   }
 
   @Test
+  public void should_show_the_ignored_collection_order() {
+    // GIVEN
+    recursiveComparisonConfiguration.setIgnoreCollectionOrder(true);
+    // WHEN
+    String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
+    // THEN
+    assertThat(multiLineDescription).contains(format("- collection order were ignored in all fields in the comparison%n"));
+  }
+
+  @Test
   public void should_show_the_ignored_collection_order_in_fields() {
     // GIVEN
     recursiveComparisonConfiguration.ignoreCollectionOrderInFields("foo", "bar", "foo.bar");
@@ -220,6 +230,7 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFieldsMatchingRegexes(".*oo", ".ar", "oo.ba");
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForTypes(String.class, Multimap.class);
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFields("foo", "baz", "foo.baz");
+    recursiveComparisonConfiguration.setIgnoreCollectionOrder(true);
     recursiveComparisonConfiguration.ignoreCollectionOrderInFields("foo", "bar", "foo.bar");
     recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("f.*", "ba.", "foo.*");
     recursiveComparisonConfiguration.registerComparatorForType(new AbsValueComparator<>(), Integer.class);
@@ -238,6 +249,7 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
                "  - the following fields: foo, baz, foo.baz%n" +
                "  - the following types: java.lang.String, com.google.common.collect.Multimap%n" +
                "  - the types matching the following regexes: .*oo, .ar, oo.ba%n" +
+               "- collection order were ignored in all fields in the comparison%n" +
                "- collection order in the following fields were ignored in the comparison: foo, bar, foo.bar%n" +
                "- collection order in the fields matching the following regexes were ignored in the comparison: f.*, ba., foo.*%n" +
                "- these types were compared with the following comparators:%n" +

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
@@ -137,6 +137,26 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
   }
 
   @Test
+  public void should_show_the_ignored_collection_order_in_fields() {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields("foo", "bar", "foo.bar");
+    // WHEN
+    String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
+    // THEN
+    assertThat(multiLineDescription).contains(format("- collection order in the following fields were ignored in the comparison: foo, bar, foo.bar%n"));
+  }
+
+  @Test
+  public void should_show_the_ignored_collection_order_in_fields_matching_regexes() {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("f.*", "ba.", "foo.*");
+    // WHEN
+    String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
+    // THEN
+    assertThat(multiLineDescription).contains(format("- collection order in the fields matching the following regexes were ignored in the comparison: f.*, ba., foo.*%n"));
+  }
+
+  @Test
   public void should_show_the_registered_comparator_by_types_and_the_default_ones() {
     // GIVEN
     recursiveComparisonConfiguration.registerComparatorForType(new AbsValueComparator<>(), Integer.class);
@@ -200,6 +220,8 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFieldsMatchingRegexes(".*oo", ".ar", "oo.ba");
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForTypes(String.class, Multimap.class);
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFields("foo", "baz", "foo.baz");
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields("foo", "bar", "foo.bar");
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("f.*", "ba.", "foo.*");
     recursiveComparisonConfiguration.registerComparatorForType(new AbsValueComparator<>(), Integer.class);
     recursiveComparisonConfiguration.registerComparatorForType(AlwaysEqualComparator.ALWAY_EQUALS_TUPLE, Tuple.class);
     recursiveComparisonConfiguration.registerComparatorForField(ALWAY_EQUALS_TUPLE, fielLocation("foo"));
@@ -216,6 +238,8 @@ public class RecursiveComparisonConfiguration_multiLineDescription_Test {
                "  - the following fields: foo, baz, foo.baz%n" +
                "  - the following types: java.lang.String, com.google.common.collect.Multimap%n" +
                "  - the types matching the following regexes: .*oo, .ar, oo.ba%n" +
+               "- collection order in the following fields were ignored in the comparison: foo, bar, foo.bar%n" +
+               "- collection order in the fields matching the following regexes were ignored in the comparison: f.*, ba., foo.*%n" +
                "- these types were compared with the following comparators:%n" +
                "  - java.lang.Double -> DoubleComparator[precision=1.0E-15]%n" +
                "  - java.lang.Float -> FloatComparator[precision=1.0E-6]%n" +

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test.java
@@ -36,6 +36,23 @@ public class RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test {
     recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
   }
 
+  @ParameterizedTest(name = "{0} collection order should be ignored")
+  @MethodSource("should_ignore_collection_order_source")
+  public void should_ignore_collection_order(DualValue dualKey) {
+    // GIVEN
+    recursiveComparisonConfiguration.setIgnoreCollectionOrder(true);
+    // WHEN
+    boolean ignored = recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualKey);
+    // THEN
+    assertThat(ignored).as("%s collection order should be ignored", dualKey).isTrue();
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_ignore_collection_order_source() {
+    return Stream.of(arguments(dualKeyWithPath("name")),
+                     arguments(dualKeyWithPath("name", "first")));
+  }
+
   @Test
   public void should_register_ignore_collection_order_in_fields_without_duplicates() {
     // GIVEN
@@ -100,8 +117,8 @@ public class RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test {
   }
 
   @ParameterizedTest(name = "{0} collection order should be ignored")
-  @MethodSource("should_ignore_collection_order_source")
-  public void should_ignore_collection_order(DualValue dualKey) {
+  @MethodSource("should_ignore_collection_order_in_fields_source")
+  public void should_ignore_collection_order_in_fields(DualValue dualKey) {
     // GIVEN
     recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes(".*name");
     recursiveComparisonConfiguration.ignoreCollectionOrderInFields("number");
@@ -112,7 +129,7 @@ public class RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test {
   }
 
   @SuppressWarnings("unused")
-  private static Stream<Arguments> should_ignore_collection_order_source() {
+  private static Stream<Arguments> should_ignore_collection_order_in_fields_source() {
     return Stream.of(arguments(dualKeyWithPath("name")),
                      arguments(dualKeyWithPath("number")),
                      arguments(dualKeyWithPath("surname")),

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test {
+
+  private RecursiveComparisonConfiguration recursiveComparisonConfiguration;
+
+  @BeforeEach
+  public void setup() {
+    recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
+  }
+
+  @Test
+  public void should_register_ignore_collection_order_in_fields_without_duplicates() {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields("foo", "bar", "foo.bar", "bar");
+    // WHEN
+    Set<FieldLocation> fields = recursiveComparisonConfiguration.getIgnoredCollectionOrderInFields();
+    // THEN
+    assertThat(fields).containsExactlyInAnyOrder(new FieldLocation("foo"),
+                                                 new FieldLocation("bar"),
+                                                 new FieldLocation("foo.bar"));
+  }
+
+  @ParameterizedTest(name = "{0} collection order should be ignored with these fields {1}")
+  @MethodSource("should_ignore_collection_order_in_specified_fields_source")
+  public void should_ignore_collection_order_in_specified_fields(DualValue dualKey, List<String> ignoredFields) {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields(ignoredFields.toArray(new String[0]));
+    // WHEN
+    boolean ignored = recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualKey);
+    // THEN
+    assertThat(ignored).as("%s collection order should be ignored with these fields %s", dualKey, ignoredFields).isTrue();
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_ignore_collection_order_in_specified_fields_source() {
+    return Stream.of(arguments(dualKeyWithPath("name"), list("name")),
+                     arguments(dualKeyWithPath("name"), list("foo", "name", "foo")),
+                     arguments(dualKeyWithPath("name", "first"), list("name.first")),
+                     arguments(dualKeyWithPath("father", "name", "first"), list("father", "name.first", "father.name.first")));
+  }
+
+  @Test
+  public void should_register_ignore_collection_order_in_fields_matching_regexes_without_replacing_previous() {
+    // WHEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("foo");
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes("bar", "baz");
+    // THEN
+    assertThat(recursiveComparisonConfiguration.getIgnoredCollectionOrderInFieldsMatchingRegexes()).extracting(Pattern::pattern)
+                                                                                                   .containsExactlyInAnyOrder("foo", "bar", "baz");
+  }
+
+  @ParameterizedTest(name = "{0} collection order should be ignored with these regexes {1}")
+  @MethodSource("should_ignore_collection_order_in_fields_matching_specified_regexes_source")
+  public void should_ignore_collection_order_in_fields_matching_specified_regexes(DualValue dualKey, List<String> regexes) {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes(regexes.toArray(new String[0]));
+    // WHEN
+    boolean ignored = recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualKey);
+    // THEN
+    assertThat(ignored).as("%s collection order should be ignored with these regexes %s", dualKey, regexes).isTrue();
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_ignore_collection_order_in_fields_matching_specified_regexes_source() {
+    return Stream.of(arguments(dualKeyWithPath("name"), list(".*name")),
+                     arguments(dualKeyWithPath("name"), list("foo", "n.m.", "foo")),
+                     arguments(dualKeyWithPath("name", "first"), list("name\\.first")),
+                     arguments(dualKeyWithPath("name", "first"), list(".*first")),
+                     arguments(dualKeyWithPath("name", "first"), list("name.*")),
+                     arguments(dualKeyWithPath("father", "name", "first"),
+                               list("father", "name.first", "father\\.name\\.first")));
+  }
+
+  @ParameterizedTest(name = "{0} collection order should be ignored")
+  @MethodSource("should_ignore_collection_order_source")
+  public void should_ignore_collection_order(DualValue dualKey) {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes(".*name");
+    recursiveComparisonConfiguration.ignoreCollectionOrderInFields("number");
+    // WHEN
+    boolean ignored = recursiveComparisonConfiguration.shouldIgnoreCollectionOrder(dualKey);
+    // THEN
+    assertThat(ignored).as("%s collection order should be ignored", dualKey).isTrue();
+  }
+
+  @SuppressWarnings("unused")
+  private static Stream<Arguments> should_ignore_collection_order_source() {
+    return Stream.of(arguments(dualKeyWithPath("name")),
+                     arguments(dualKeyWithPath("number")),
+                     arguments(dualKeyWithPath("surname")),
+                     arguments(dualKeyWithPath("first", "name")));
+  }
+
+  private static DualValue dualKeyWithPath(String... pathElements) {
+    return new DualValue(list(pathElements), new Object(), new Object());
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/objects/data/FriendlyPerson.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/FriendlyPerson.java
@@ -20,4 +20,12 @@ import java.util.Set;
 public class FriendlyPerson extends Person {
   public List<FriendlyPerson> friends = new ArrayList<>();
   public Set<FriendlyPerson> otherFriends = new HashSet<>();
+
+  public FriendlyPerson() {
+      super();
+  }
+
+  public FriendlyPerson(String name) {
+      super(name);
+  }
 }


### PR DESCRIPTION
Add ignoringCollectionOrderInFields() and ignoringCollectionOrderInFieldsMatchingRegexes() to Recursive API.

* Fixes #1494
* Unit tests : YES
* Javadoc with a code example (API only) : YES


