### PR TITLE
Add missing @since for single parameter 'extracting'

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1540,6 +1540,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *
    * @param key the key used to get value from the map under test
    * @return a new {@link ObjectAssert} instance whose object under test is the extracted map value
+   *
+   * @since 3.13.0
    */
   @CheckReturnValue
   public AbstractObjectAssert<?, ?> extracting(Object key) {

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -643,6 +643,8 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @param propertyOrField the property/field to extract from the initial object under test
    * @return a new {@link ObjectAssert} instance whose object under test is the extracted property/field values
    * @throws IntrospectionError if one of the given name does not match a field or property
+   *
+   * @since 3.13.0
    */
   public AbstractObjectAssert<?, ?> extracting(String propertyOrField) {
     Object value = byName(propertyOrField).apply(actual);


### PR DESCRIPTION
Trivial: adding missing `@since` for the methods introduced in #1469.

