### PR TITLE
Support var-arg throwable message assertions (#1501)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -195,6 +195,30 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Verifies that the message of the actual {@code Throwable} contains all the given values.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   * Throwable throwableWithoutMessage = new IllegalArgumentException();
+   *
+   * // assertion will pass:
+   * assertThat(throwableWithMessage).hasMessageContaining("amount", "123");
+   *
+   * // assertions will fail:
+   * assertThat(throwableWithoutMessage).hasMessageContaining("123");
+   * assertThat(throwableWithMessage).hasMessageContaining("234"); </code></pre>
+   *
+   * @param values the Strings expected to be contained in the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not contain the given description.
+   */
+  public SELF hasMessageContainingAll(CharSequence... values) {
+    throwables.assertHasMessageContainingAll(info, actual, values);
+    return myself;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} does not contain the given content or is {@code null}.
    * <p>
    * Examples:
@@ -216,6 +240,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasMessageNotContaining(String content) {
     throwables.assertHasMessageNotContaining(info, actual, content);
+    return myself;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} does not contain any of the given values or is {@code null}.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   * Throwable throwableWithoutMessage = new IllegalArgumentException();
+   *
+   * // assertions will pass:
+   * assertThat(throwableWithMessage).hasMessageNotContaining("234");
+   * assertThat(throwableWithoutMessage).hasMessageNotContaining("foo");
+   *
+   * // assertion will fail:
+   * assertThat(throwableWithMessage).hasMessageNotContaining("foo", "amount");</code></pre>
+   *
+   * @param values the contents expected to not be contained in the actual {@code Throwables}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} contains the given content.
+   * @since 3.12.0
+   */
+  public SELF hasMessageNotContainingAny(CharSequence... values) {
+    throwables.assertHasMessageNotContainingAny(info, actual, values);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -16,7 +16,7 @@ import org.assertj.core.description.Description;
 import org.assertj.core.util.CheckReturnValue;
 
 /**
- * Assertion methods for {@link java.lang.Throwable} similar to {@link ThrowableAssert} but with assertions methods named 
+ * Assertion methods for {@link java.lang.Throwable} similar to {@link ThrowableAssert} but with assertions methods named
  * differently to make testing code fluent (ex : <code>withMessage</code> instead of <code>hasMessage</code>.
  * <pre><code class='java'> assertThatExceptionOfType(IOException.class)
  *           .isThrownBy(() -&gt; { throw new IOException("boom! tcha!"); });
@@ -97,25 +97,25 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    * Throwable wrappingException = new Throwable(illegalArgumentException);
    *
    * // This assertion succeeds:
-   * 
+   *
    * assertThatExceptionOfType(Throwable.class)
    *           .isThrownBy(() -&gt; {throw wrappingException;})
    *           .withCause(illegalArgumentException);
    *
    * // These assertions fail:
-   * 
+   *
    * assertThatExceptionOfType(Throwable.class)
    *           .isThrownBy(() -&gt; {throw wrappingException;})
    *           .withCause(new IllegalArgumentException("bad arg"));
-   *           
+   *
    * assertThatExceptionOfType(Throwable.class)
    *           .isThrownBy(() -&gt; {throw wrappingException;})
    *           .withCause(new NullPointerException());
-   *           
+   *
    * assertThatExceptionOfType(Throwable.class)
    *           .isThrownBy(() -&gt; {throw wrappingException;})
    *           .withCause(null);</code></pre>
-   * 
+   *
    * @param cause the expected cause.
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Throwable} is {@code null}.
@@ -139,7 +139,7 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    *           .withNoCause();
    *
    * // These assertion fails:
-   * Throwable illegalArgumentException = new Throwable(exception); 
+   * Throwable illegalArgumentException = new Throwable(exception);
    * assertThatExceptionOfType(Throwable.class)
    *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
    *           .withNoCause();</code></pre>
@@ -209,6 +209,33 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
   }
 
   /**
+   * Verifies that the message of the actual {@code Throwable} contains all the given values.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageContaining("amount", "123");
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageContaining("456");</code></pre>
+   *
+   * @param values the Strings expected to be contained in the actual {@code Throwable}'s message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not contain the given description.
+   * @see AbstractThrowableAssert#hasMessageContaining(CharSequence...)
+   */
+  public ThrowableAssertAlternative<T> withMessageContainingAll(CharSequence... values) {
+    delegate.hasMessageContainingAll(values);
+    return this;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} does not contain the given content or is null.
    * <p>
    * Examples:
@@ -234,6 +261,35 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    */
   public ThrowableAssertAlternative<T> withMessageNotContaining(String content) {
     delegate.hasMessageNotContaining(content);
+    return this;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} does not contain any of the given values or is {@code null}.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> //assertions will pass
+   * assertThatExceptionOfType(Exception.class)
+   *           .isThrownBy(codeThrowing(new Exception("boom")))
+   *           .withMessageNotContaining("bam");
+   *
+   * assertThatExceptionOfType(Exception.class)
+   *           .isThrownBy(codeThrowing(new Exception()))
+   *           .withMessageNotContaining("bam");
+   *
+   * //assertion will fail
+   * assertThatExceptionOfType(Exception.class)
+   *           .isThrownBy(codeThrowing(new Exception("boom")))
+   *           .withMessageNotContaining("bam", "boom");</code></pre>
+   *
+   * @param values the contents expected to not be contained in the actual {@code Throwables}'s message.
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} contains the given content.
+   * @see AbstractThrowableAssert#hasMessageNotContaining(CharSequence...)
+   */
+  public ThrowableAssertAlternative<T> withMessageNotContainingAny(CharSequence... values) {
+    delegate.hasMessageNotContainingAny(values);
     return this;
   }
 
@@ -377,7 +433,7 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    * @throws AssertionError if the actual {@code Throwable} has no cause.
    * @throws AssertionError if the cause of the actual {@code Throwable} is not <b>exactly</b> an instance of the given
    *           type.
-   * @see AbstractThrowableAssert#hasCauseExactlyInstanceOf(Class)          
+   * @see AbstractThrowableAssert#hasCauseExactlyInstanceOf(Class)
    */
   public ThrowableAssertAlternative<T> withCauseExactlyInstanceOf(Class<? extends Throwable> type) {
     delegate.hasCauseExactlyInstanceOf(type);

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -83,9 +83,9 @@ public class Assertions_assertThat_with_Throwable_Test {
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> catchThrowableOfType(codeThrowingException, IOException.class));
     // THEN
-    assertThat(assertionError).hasMessageContaining(IOException.class.getName())
-                              .hasMessageContaining(Exception.class.getName())
-                              .hasMessageContaining(getStackTrace(exception));
+    assertThat(assertionError).hasMessageContainingAll(IOException.class.getName(),
+                                                    Exception.class.getName(),
+                                                    getStackTrace(exception));
   }
 
   @Test
@@ -107,9 +107,21 @@ public class Assertions_assertThat_with_Throwable_Test {
   @Test
   public void should_fail_with_good_message_when_assertion_is_failing() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatThrownBy(raisingException("boom")).hasMessage("bam"))
-                                                   .withMessageContaining("Expecting message:")
-                                                   .withMessageContaining("<\"bam\">").withMessageContaining("but was:")
-                                                   .withMessageContaining("<\"boom\">");
+                                                   .withMessageContainingAll("Expecting message:",
+                                                                          "<\"bam\">",
+                                                                          "but was:",
+                                                                          "<\"boom\">");
+  }
+  
+  @Test
+  public void should_fail_with_good_message_when_vararg_has_message_containing_assertion_is_failing() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatThrownBy(raisingException("boom")).hasMessageContaining("bam")
+                                                   .hasMessageContainingAll("boom",
+                                                                         "Expecting:",
+                                                                         "<\"boom\">",
+                                                                         "<[\"bam\", \"boom\"]>",
+                                                                         "but could not find:",
+                                                                         "<[\"bam\"]>"));
   }
 
   private ThrowingCallable raisingException(final String reason) {

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageContainingAll_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageContainingAll_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasMessageContainingAll(CharSequence...)}</code>.
+ * 
+ * @author Phillip Webb
+ */
+public class ThrowableAssert_hasMessageContainingAll_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasMessageContainingAll("able", "message");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageContainingAll(getInfo(assertions), getActual(assertions), "able", "message");
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageNotContainingAny_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageNotContainingAny_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasMessageNotContainingAny(String)}</code>.
+ * 
+ * @author Phillip Webb
+ */
+public class ThrowableAssert_hasMessageNotContainingAny_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasMessageNotContainingAny("catchable", "message");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageNotContainingAny(getInfo(assertions), getActual(assertions), "catchable", "message");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
+import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNull;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Throwables;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Tests for <code>{@link Throwables#assertHasMessageContainingAll(AssertionInfo, Throwable, CharSequence...)}</code>.
+ * 
+ * @author Phillip Webb
+ */
+public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
+
+  @Test
+  public void should_pass_if_actual_has_message_containing_the_given_string() {
+    throwables.assertHasMessageContainingAll(someInfo(), actual, "able");
+  }
+
+  @Test
+  public void should_pass_if_actual_has_message_containing_all_the_given_strings() {
+    throwables.assertHasMessageContainingAll(someInfo(), actual, "able", "message");
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> throwables.assertHasMessageContainingAll(someInfo(), null, "Throwable"))
+                                                   .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_fail_if_actual_has_message_not_containing_all_with_expected_description() {
+    // GIVEN
+    String content = "expected description part";
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageContainingAll(INFO, actual, content));
+    // THEN
+    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content), actual.getMessage(), content);
+  }
+
+  @Test
+  public void should_fail_if_actual_has_message_not_containing_some_with_expected_description() {
+    // GIVEN
+    String[] content = { "catchable", "message" };
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageContainingAll(INFO, actual, content));
+    // THEN
+    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content, Collections.singleton("catchable")), actual.getMessage(), content);
+  }
+
+  @Test
+  public void should_throw_error_if_values_are_null() {
+    assertThatNullPointerException().isThrownBy(() -> throwables.assertHasMessageContainingAll(INFO, actual, (String) null))
+                                                 .withMessage(charSequenceToLookForIsNull());
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
@@ -14,9 +14,9 @@ package org.assertj.core.internal.throwables;
 
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -29,8 +29,11 @@ import org.junit.jupiter.api.Test;
  * Tests for <code>{@link Throwables#assertHasMessageContaining(AssertionInfo, Throwable, String)}</code>.
  * 
  * @author Joel Costigliola
+ * @author Phillip Webb
  */
 public class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
 
   @Test
   public void should_pass_if_actual_has_message_containing_with_expected_description() {
@@ -45,12 +48,12 @@ public class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTe
 
   @Test
   public void should_fail_if_actual_has_message_not_containing_with_expected_description() {
-    AssertionInfo info = someInfo();
-    try {
-      throwables.assertHasMessageContaining(info, actual, "expected description part");
-      fail("AssertionError expected");
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldContain(actual.getMessage(), "expected description part"));
-    }
+    // GIVEN
+    String content = "expected description part";
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageContaining(INFO, actual, content));
+    // THEN
+    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content));
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Throwables;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Throwables#assertHasMessageNotContaining(AssertionInfo, Throwable, String)}</code>.
+ *
+ * @author Phillip Webb
+ */
+class Throwables_assertHasMessageNotContainingAny_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
+
+  @Test
+  void should_pass_if_actual_has_a_message_not_containing_the_given_string() {
+    throwables.assertHasMessageNotContainingAny(INFO, actual, "catchable");
+  }
+
+  @Test
+  void should_pass_if_actual_has_a_message_not_containing_any_the_given_strings() {
+    throwables.assertHasMessageNotContainingAny(INFO, actual, "catchable", "foo");
+  }
+
+  @Test
+  void should_pass_if_actual_has_no_message() {
+    throwables.assertHasMessageNotContainingAny(INFO, new NullPointerException(), "some description");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    ThrowingCallable code = () -> throwables.assertHasMessageNotContainingAny(INFO, null, "foo");
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_has_a_message_containing_the_given_string() {
+    // GIVEN
+    String content = "message";
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageNotContainingAny(INFO, actual, content));
+    // THEN
+    verify(failures).failure(INFO, shouldNotContain(actual.getMessage(), content), actual.getMessage(), content);
+  }
+
+  @Test
+  void should_fail_if_actual_has_a_message_containing_some_of_the_given_strings() {
+    // GIVEN
+    String[] content = { "catchable", "message" };
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageNotContainingAny(INFO, actual, content));
+    // THEN
+    verify(failures).failure(INFO, shouldNotContain(actual.getMessage(), content, Collections.singleton("message"), StandardComparisonStrategy.instance()), actual.getMessage(), content);
+  }
+}


### PR DESCRIPTION
Update AbstractThrowableAssert and ThrowableAssertAlternative so
that the hasMessageContaining and hasMessageNotContaining now accepts
a var-arg String array.

This unifies the API with the existing String assertions and allows
calls such as this:

	assertThatExceptionOfType(MyException.class).isThrownBy(service::call)
		.withMessageContaining("very")
		.withMessageContaining("bad")
		.withMessageContaining("stuff");

to be simplified to:

	assertThatExceptionOfType(MyException.class).isThrownBy(service::call)
		.withMessageContaining("very", "'bad'", "'stuff'");

#### Check List:
* Fixes #1501
* Unit tests : YES
* Javadoc with a code example (API only) : YES


