### PR TITLE
Fix typo in Assert's javadoc

### DIFF
--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -419,7 +419,7 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * Verifies that actual {@code actual.toString()} is equal to the given {@code String}.
    * <p>
    * Example :
-   * <pre><code class='java'> CartoonCaracter homer = new CartoonCaracter("Homer");
+   * <pre><code class='java'> CartoonCharacter homer = new CartoonCharacter("Homer");
    *
    * // Instead of writing ...
    * assertThat(homer.toString()).isEqualTo("Homer");


### PR DESCRIPTION
#### Check List:
* Fixes ~~#???~~ a typo
* Unit tests : NA
* Javadoc with a code example (API only) : NA


