### PR TITLE
Add containsExactlyInAnyOrderEntriesOf() to AbstractMapAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -575,8 +575,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map does not contain the given entries.
    */
   public SELF containsAllEntriesOf(Map<? extends K, ? extends V> other) {
-    Map.Entry<? extends K, ? extends V>[] entries = other.entrySet().toArray(new Map.Entry[0]);
-    maps.assertContains(info, actual, entries);
+    maps.assertContains(info, actual, toEntries(other));
     return myself;
   }
 
@@ -585,7 +584,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * <p>
    * Verifies that the actual map contains only the entries of the given map and nothing else, <b>in order</b>.<br>
    * This assertion should only be used with maps that have a consistent iteration order (i.e. don't use it with
-   * {@link java.util.HashMap}, prefer {@link #containsOnly(java.util.Map.Entry...)} in that case).
+   * {@link java.util.HashMap}, prefer {@link #containsExactlyInAnyOrderEntriesOf(java.util.Map)} in that case).
    * <p>
    * Example :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = newLinkedHashMap(entry(oneRing, frodo),
@@ -618,8 +617,51 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @since 3.12.0
    */
   public SELF containsExactlyEntriesOf(Map<? extends K, ? extends V> map) {
-    Map.Entry<? extends K, ? extends V>[] entries = map.entrySet().toArray(new Map.Entry[0]);
-    return containsExactly(entries);
+    return containsExactly(toEntries(map));
+  }
+
+  /**
+   * Same as {@link #containsOnly(Map.Entry[])} but handles the conversion of {@link Map#entrySet()} to array.
+   * <p>
+   * Verifies that the actual map contains only the given entries and nothing else, in any order.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = newLinkedHashMap(entry(oneRing, frodo),
+   *                                                            entry(nenya, galadriel),
+   *                                                            entry(narya, gandalf));
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).containsExactlyInAnyOrderEntriesOf(newLinkedHashMap(entry(oneRing, frodo),
+   *                                                                entry(nenya, galadriel),
+   *                                                                entry(narya, gandalf)));
+   *
+   * // assertion will pass although actual and expected order differ
+   * assertThat(ringBearers).containsExactlyInAnyOrderEntriesOf(newLinkedHashMap(entry(nenya, galadriel),
+   *                                                                entry(narya, gandalf),
+   *                                                                entry(oneRing, frodo)));
+   * // assertion will fail as actual and expected have different sizes
+   * assertThat(ringBearers).containsExactlyInAnyOrderEntriesOf(newLinkedHashMap(entry(oneRing, frodo),
+   *                                                                entry(nenya, galadriel),
+   *                                                                entry(narya, gandalf),
+   *                                                                entry(narya, gandalf)));</code></pre>
+   *
+   * @param map the given {@link Map} with the expected entries to be found in actual.
+   * @return {@code this} assertions object
+   * @throws NullPointerException if the given map is {@code null}.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws IllegalArgumentException if the given map is empty.
+   * @throws AssertionError if the actual map does not contain the entries of the given map, i.e the actual map contains
+   *           some or none of the entries of the given map, or the actual map contains more entries than the entries of
+   *           the given map.
+   * @since 3.13.0
+   */
+  public SELF containsExactlyInAnyOrderEntriesOf(Map<? extends K, ? extends V> map) {
+    return containsOnly(toEntries(map));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map.Entry<? extends K, ? extends V>[] toEntries(Map<? extends K, ? extends V> map) {
+    return map.entrySet().toArray(new Map.Entry[0]);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1512,19 +1512,22 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     softly.then(iterableMap)
           .flatExtracting("name", "job", "city", "rank")
           .contains("Unexpected", "Builder", "Dover", "Boston", "Paris", 1, 2, 3);
-    Map<String, String> exactlyEntriesMap = mapOf(entry("kl", "KL"), entry("mn", "MN"));
-    softly.then(map).containsExactlyEntriesOf(exactlyEntriesMap);
+    softly.then(map)
+          .as("size()")
+          .overridingErrorMessage("error message")
+          .size()
+          .isGreaterThan(1000);
+    softly.then(map).containsExactlyEntriesOf(mapOf(entry("kl", "KL"), entry("mn", "MN")));
+    softly.then(map).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("b", "2")));
     softly.then(map)
           .as("extracting(\"a\")")
           .overridingErrorMessage("error message")
           // convert to Object otherwise will use extracting(String) in AbstractObjectAssert
           .extracting((Object) "a")
           .isEqualTo("456");
-
-    // softly.then(map).size().isGreaterThan(1000); not yet supported
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(14);
+    assertThat(errors).hasSize(16);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1538,8 +1541,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(9)).hasMessageContaining("b");
     assertThat(errors.get(10)).hasMessageContaining("456");
     assertThat(errors.get(11)).hasMessageContaining("Unexpected");
-    assertThat(errors.get(12)).hasMessageContaining("\"a\"=\"1\"");
-    assertThat(errors.get(13)).hasMessage("[extracting(\"a\")] error message");
+    assertThat(errors.get(12)).hasMessage("[size()] error message");
+    assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
+    assertThat(errors.get(14)).hasMessageContaining("to contain only");
+    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1632,10 +1632,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .overridingErrorMessage("error message")
           .size()
           .isGreaterThan(1000);
-    Map<String, String> exactlyEntriesMap = new LinkedHashMap<>();
-    exactlyEntriesMap.put("kl", "KL");
-    exactlyEntriesMap.put("mn", "MN");
-    softly.assertThat(map).containsExactlyEntriesOf(exactlyEntriesMap);
+    softly.assertThat(map).containsExactlyEntriesOf(mapOf(entry("kl", "KL"), entry("mn", "MN")));
+    softly.assertThat(map).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("b", "2")));
     softly.assertThat(map)
           .as("extracting(\"a\")")
           .overridingErrorMessage("error message")
@@ -1644,7 +1642,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .isEqualTo("456");
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(15);
+    assertThat(errors).hasSize(16);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1660,7 +1658,8 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(11)).hasMessage("[flatExtracting(\"name\", \"job\", \"city\", \"rank\")] error message");
     assertThat(errors.get(12)).hasMessage("[size()] error message");
     assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
-    assertThat(errors.get(14)).hasMessage("[extracting(\"a\")] error message");
+    assertThat(errors.get(14)).hasMessageContaining("to contain only");
+    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/assumptions/Map_special_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Map_special_assertion_methods_in_assumptions_Test.java
@@ -97,6 +97,9 @@ public class Map_special_assertion_methods_in_assumptions_Test extends BaseAssum
             value -> assumeThat(value).containsExactlyEntriesOf(mapOf(entry("a", "1"), entry("b", "2"), entry("c", "3"))),
             value -> assumeThat(value).containsExactlyEntriesOf(mapOf(entry("b", "2"), entry("a", "1"), entry("c", "3")))),
         assumptionRunner(map,
+            value -> assumeThat(value).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("c", "3"), entry("b", "2"))),
+            value -> assumeThat(value).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("c", "3")))),
+        assumptionRunner(map,
             value -> assumeThat(value).extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)
                                       .containsExactlyInAnyOrder(tuple("a", "1"), tuple("b", "2"), tuple("c", "3")),
             value -> assumeThat(value).extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyEntriesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyEntriesOf_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link MapAssert#containsExactlyInAnyOrderEntriesOf(Map)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+public class MapAssert_containsOnlyEntriesOf_Test extends MapAssertBaseTest {
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsExactlyInAnyOrderEntriesOf(mapOf(entry("key1", "value1"), entry("key2", "value2")));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    final MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+    verify(maps).assertContainsOnly(getInfo(assertions), getActual(assertions), entries);
+  }
+
+  @Test
+  void invoke_api_like_user() {
+    Map<String, String> actualMap = mapOf(entry("key1", "value1"), entry("key2", "value2"));
+    Map<String, String> expectedMap = mapOf(entry("key2", "value2"), entry("key1", "value1"));
+    assertThat(actualMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
+  }
+
+}


### PR DESCRIPTION
Adds missing `containsOnlyEntriesOf()` to the `containsEntriesOf` family.

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES


