### PR TITLE
Add sync test between Assertions and InstanceOfAssertFactories

### DIFF
--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -288,8 +288,8 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Future}.
    *
-   * @param <RESULT>    the {@code Future} result type.
-   * @param resultType  the result type instance.
+   * @param <RESULT>   the {@code Future} result type.
+   * @param resultType the result type instance.
    * @return the factory instance.
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
@@ -338,6 +338,20 @@ public interface InstanceOfAssertFactories {
    */
   InstanceOfAssertFactory<long[], AbstractLongArrayAssert<?>> LONG_ARRAY = new InstanceOfAssertFactory<>(long[].class,
                                                                                                          Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for an object of a specific type.
+   * <p>
+   * <b>While this factory ensures that {@code actual} is an instance of the input type, it creates always
+   * an {@link ObjectAssert} with the corresponding type.</b>
+   *
+   * @param <T>  the object type.
+   * @param type the object type instance.
+   * @return the factory instance.
+   */
+  static <T> InstanceOfAssertFactory<T, ObjectAssert<T>> type(Class<T> type) {
+    return new InstanceOfAssertFactory<>(type, Assertions::assertThat);
+  }
 
   /**
    * {@link InstanceOfAssertFactory} for an array of {@link Object}.
@@ -616,6 +630,18 @@ public interface InstanceOfAssertFactories {
    * {@link InstanceOfAssertFactory} for a {@link CharSequence}.
    */
   InstanceOfAssertFactory<CharSequence, AbstractCharSequenceAssert<?, ? extends CharSequence>> CHAR_SEQUENCE = new InstanceOfAssertFactory<>(CharSequence.class,
+                                                                                                                                             Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link StringBuilder}.
+   */
+  InstanceOfAssertFactory<StringBuilder, AbstractCharSequenceAssert<?, ? extends CharSequence>> STRING_BUILDER = new InstanceOfAssertFactory<>(StringBuilder.class,
+                                                                                                                                               Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link StringBuffer}.
+   */
+  InstanceOfAssertFactory<StringBuffer, AbstractCharSequenceAssert<?, ? extends CharSequence>> STRING_BUFFER = new InstanceOfAssertFactory<>(StringBuffer.class,
                                                                                                                                              Assertions::assertThat);
 
   /**

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.from;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.array;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.assertj.core.data.MapEntry.entry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertionsTest {
+
+  private static final Class[] IGNORED_ASSERT_TYPES = {
+      // ObjectArrayAssert is ignored because the comparison of the input GenericArrayTypes will always fail, since
+      // it verifies the inner TypeVariable which returns the defining Method as result of TypeVariable#getGenericDeclaration()
+      ObjectArrayAssert.class
+  };
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void each_standard_assertion_should_have_an_instance_of_assert_factory() {
+    // GIVEN
+    Map<Type, Type> assertThatMethods = findAssertThatParameterAndReturnTypes();
+    // WHEN
+    Map<Type, Type> factories = Stream.of(findFieldFactoryTypes(), findMethodFactoryTypes())
+                                      .map(Map::entrySet)
+                                      .flatMap(Collection::stream)
+                                      .collect(toMap(Entry::getKey, Entry::getValue));
+    // THEN
+    then(assertThatMethods).containsOnly(factories.entrySet().toArray(new Map.Entry[0]));
+  }
+
+  private Map<Type, Type> findAssertThatParameterAndReturnTypes() {
+    return Stream.of(findMethodsWithName(Assertions.class, "assertThat", ignoredReturnTypes()))
+                 .map(m -> entry(normalize(genericParameterType(m)), normalize(m.getGenericReturnType())))
+                 .filter(not(this::isPrimitiveTypeKey))
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private Class<?>[] ignoredReturnTypes() {
+    return Stream.of(SPECIAL_IGNORED_RETURN_TYPES, IGNORED_ASSERT_TYPES)
+                 .flatMap(Stream::of)
+                 .toArray(Class[]::new);
+  }
+
+  private Type genericParameterType(Method method) {
+    Type[] parameterTypes = method.getGenericParameterTypes();
+    assertThat(parameterTypes).hasSize(1);
+    return parameterTypes[0];
+  }
+
+  private <K, V> boolean isPrimitiveTypeKey(Entry<K, V> entry) {
+    if (entry.getKey() instanceof Class) {
+      return ((Class) entry.getKey()).isPrimitive();
+    }
+    return false;
+  }
+
+  private Map<Type, Type> findFieldFactoryTypes() {
+    return Stream.of(InstanceOfAssertFactories.class.getFields())
+                 .filter(not(Field::isSynthetic)) // Exclude $jacocoData - see #590 and jacoco/jacoco#168
+                 .map(Field::getGenericType)
+                 .map(this::extractTypeParameters)
+                 .filter(not(this::ignoredFactory))
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private Map<Type, Type> findMethodFactoryTypes() {
+    return Stream.of(InstanceOfAssertFactories.class.getMethods())
+                 .map(Method::getGenericReturnType)
+                 .map(this::extractTypeParameters)
+                 .filter(not(this::ignoredFactory))
+                 .distinct()
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private Entry<Type, Type> extractTypeParameters(Type type) {
+    assertThat(type).asInstanceOf(type(ParameterizedType.class))
+                    .returns(InstanceOfAssertFactory.class, from(ParameterizedType::getRawType))
+                    .extracting(ParameterizedType::getActualTypeArguments).asInstanceOf(array()).hasSize(2);
+    Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
+    return entry(normalize(typeArguments[0]), normalize(typeArguments[1]));
+  }
+
+  private Type normalize(Type type) {
+    if (type instanceof ParameterizedType) {
+      return ((ParameterizedType) type).getRawType();
+    } else if (type instanceof TypeVariable) {
+      Type[] bounds = ((TypeVariable) type).getBounds();
+      assertThat(bounds).hasSize(1);
+      return normalize(bounds[0]);
+    }
+    return type;
+  }
+
+  private static <T> Predicate<T> not(Predicate<T> target) {
+    return target.negate();
+  }
+
+  private boolean ignoredFactory(Entry<Type, Type> e) {
+    return Stream.of(IGNORED_ASSERT_TYPES).anyMatch(type -> e.getValue().equals(type));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -61,6 +61,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.PATH;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUFFER;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUILDER;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URI;
 import static org.assertj.core.api.InstanceOfAssertFactories.URL;
@@ -84,6 +86,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.assertj.core.api.InstanceOfAssertFactories.optional;
 import static org.assertj.core.api.InstanceOfAssertFactories.predicate;
 import static org.assertj.core.api.InstanceOfAssertFactories.stream;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.mockito.Mockito.mock;
 
@@ -508,6 +511,16 @@ class InstanceOfAssertFactoriesTest {
   }
 
   @Test
+  void type_factory_should_allow_typed_object_assertions() {
+    // GIVEN
+    Object value = "string";
+    // WHEN
+    ObjectAssert<String> result = assertThat(value).asInstanceOf(type(String.class));
+    // THEN
+    result.extracting(String::isEmpty).isEqualTo(false);
+  }
+
+  @Test
   void array_factory_should_allow_array_assertions() {
     // GIVEN
     Object value = new Object[] { 0, "" };
@@ -834,6 +847,26 @@ class InstanceOfAssertFactoriesTest {
     Object value = "string";
     // WHEN
     AbstractCharSequenceAssert<?, ? extends CharSequence> result = assertThat(value).asInstanceOf(CHAR_SEQUENCE);
+    // THEN
+    result.startsWith("str");
+  }
+
+  @Test
+  void string_builder_factory_should_allow_char_sequence_assertions() {
+    // GIVEN
+    Object value = new StringBuilder("string");
+    // WHEN
+    AbstractCharSequenceAssert<?, ? extends CharSequence> result = assertThat(value).asInstanceOf(STRING_BUILDER);
+    // THEN
+    result.startsWith("str");
+  }
+
+  @Test
+  void string_buffer_factory_should_allow_char_sequence_assertions() {
+    // GIVEN
+    Object value = new StringBuffer("string");
+    // WHEN
+    AbstractCharSequenceAssert<?, ? extends CharSequence> result = assertThat(value).asInstanceOf(STRING_BUFFER);
     // THEN
     result.startsWith("str");
   }


### PR DESCRIPTION
Sync test for `InstanceOfAssertFactories` (follows #1498).

Adds also missing factories (spotted by the test, yay!) for `StringBuilder` and `StringBuffer` and a `type(Class)` factory to obtain an `ObjectAssert` with updated type.