### PR TITLE
Convert InstanceOfAssertFactories no param methods to static fields

### DIFF
--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -68,13 +68,11 @@ public interface InstanceOfAssertFactories {
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link Predicate}, assuming {@code Object} as input type.
-   *
-   * @return the factory instance.
+   * 
+   * @see #predicate(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Predicate, PredicateAssert<Object>> predicate() {
-    return predicate(Object.class);
-  }
+  InstanceOfAssertFactory<Predicate, PredicateAssert<Object>> PREDICATE = predicate(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link Predicate}.
@@ -82,6 +80,8 @@ public interface InstanceOfAssertFactories {
    * @param <T>  the {@code Predicate} input type.
    * @param type the input type instance.
    * @return the factory instance.
+   * 
+   * @see #PREDICATE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <T> InstanceOfAssertFactory<Predicate, PredicateAssert<T>> predicate(Class<T> type) {
@@ -109,12 +109,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link CompletableFuture}, assuming {@code Object} as result type.
    *
-   * @return the factory instance.
+   * @see #completableFuture(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<Object>> completableFuture() {
-    return completableFuture(Object.class);
-  }
+  InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<Object>> COMPLETABLE_FUTURE = completableFuture(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link CompletableFuture}.
@@ -122,6 +120,8 @@ public interface InstanceOfAssertFactories {
    * @param <RESULT>   the {@code CompletableFuture} result type.
    * @param resultType the result type instance.
    * @return the factory instance.
+   *
+   * @see #COMPLETABLE_FUTURE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <RESULT> InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<RESULT>> completableFuture(Class<RESULT> resultType) {
@@ -131,12 +131,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link CompletionStage}, assuming {@code Object} as result type.
    *
-   * @return the factory instance.
+   * @see #completionStage(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<Object>> completionStage() {
-    return completionStage(Object.class);
-  }
+  InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<Object>> COMPLETION_STAGE = completionStage(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link CompletionStage}.
@@ -144,6 +142,8 @@ public interface InstanceOfAssertFactories {
    * @param <RESULT>   the {@code CompletionStage} result type.
    * @param resultType the result type instance.
    * @return the factory instance.
+   *
+   * @see #COMPLETION_STAGE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <RESULT> InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<RESULT>> completionStage(Class<RESULT> resultType) {
@@ -153,12 +153,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link Optional}, assuming {@code Object} as value type.
    *
-   * @return the factory instance.
+   * @see #optional(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Optional, OptionalAssert<Object>> optional() {
-    return optional(Object.class);
-  }
+  InstanceOfAssertFactory<Optional, OptionalAssert<Object>> OPTIONAL = optional(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link Optional}.
@@ -166,6 +164,8 @@ public interface InstanceOfAssertFactories {
    * @param <VALUE>    the {@code Optional} value type.
    * @param resultType the value type instance.
    * @return the factory instance.
+   *
+   * @see #OPTIONAL
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <VALUE> InstanceOfAssertFactory<Optional, OptionalAssert<VALUE>> optional(Class<VALUE> resultType) {
@@ -278,12 +278,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Future}, assuming {@code Object} as result type.
    *
-   * @return the factory instance.
+   * @see #future(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Future, FutureAssert<Object>> future() {
-    return future(Object.class);
-  }
+  InstanceOfAssertFactory<Future, FutureAssert<Object>> FUTURE = future(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link Future}.
@@ -291,6 +289,8 @@ public interface InstanceOfAssertFactories {
    * @param <RESULT>   the {@code Future} result type.
    * @param resultType the result type instance.
    * @return the factory instance.
+   *
+   * @see #FUTURE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <RESULT> InstanceOfAssertFactory<Future, FutureAssert<RESULT>> future(Class<RESULT> resultType) {
@@ -356,11 +356,9 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an array of {@link Object}.
    *
-   * @return the factory instance.
+   * @see #array(Class)
    */
-  static InstanceOfAssertFactory<Object[], ObjectArrayAssert<Object>> array() {
-    return array(Object[].class);
-  }
+  InstanceOfAssertFactory<Object[], ObjectArrayAssert<Object>> ARRAY = array(Object[].class);
 
   /**
    * {@link InstanceOfAssertFactory} for an array of elements.
@@ -368,6 +366,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT> the element type.
    * @param arrayType the element type instance.
    * @return the factory instance.
+   * 
+   * @see #ARRAY
    */
   static <ELEMENT> InstanceOfAssertFactory<ELEMENT[], ObjectArrayAssert<ELEMENT>> array(Class<ELEMENT[]> arrayType) {
     return new InstanceOfAssertFactory<>(arrayType, Assertions::assertThat);
@@ -454,12 +454,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}, assuming {@code Object} as object type.
    *
-   * @return the factory instance.
+   * @see #atomicIntegerFieldUpdater(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<Object>> atomicIntegerFieldUpdater() {
-    return atomicIntegerFieldUpdater(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<Object>> ATOMIC_INTEGER_FIELD_UPDATER = atomicIntegerFieldUpdater(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}.
@@ -467,6 +465,8 @@ public interface InstanceOfAssertFactories {
    * @param <OBJECT>   the {@code AtomicIntegerFieldUpdater} object type.
    * @param objectType the object type instance.
    * @return the factory instance.
+   * 
+   * @see #ATOMIC_INTEGER_FIELD_UPDATER
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <OBJECT> InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<OBJECT>> atomicIntegerFieldUpdater(Class<OBJECT> objectType) {
@@ -488,12 +488,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicLongFieldUpdater}, assuming {@code Object} as object type.
    *
-   * @return the factory instance.
+   * @see #atomicLongFieldUpdater(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<Object>> atomicLongFieldUpdater() {
-    return atomicLongFieldUpdater(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<Object>> ATOMIC_LONG_FIELD_UPDATER = atomicLongFieldUpdater(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}.
@@ -501,6 +499,8 @@ public interface InstanceOfAssertFactories {
    * @param <OBJECT>   the {@code AtomicLongFieldUpdater} object type.
    * @param objectType the object type instance.
    * @return the factory instance.
+   *
+   * @see #ATOMIC_LONG_FIELD_UPDATER
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <OBJECT> InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<OBJECT>> atomicLongFieldUpdater(Class<OBJECT> objectType) {
@@ -510,12 +510,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReference}, assuming {@code Object} as value type.
    *
-   * @return the factory instance.
+   * @see #atomicReference(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<Object>> atomicReference() {
-    return atomicReference(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<Object>> ATOMIC_REFERENCE = atomicReference(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReference}.
@@ -523,6 +521,8 @@ public interface InstanceOfAssertFactories {
    * @param <VALUE>   the {@code AtomicReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
+   *
+   * @see #ATOMIC_REFERENCE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <VALUE> InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<VALUE>> atomicReference(Class<VALUE> valueType) {
@@ -532,12 +532,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceArray}, assuming {@code Object} as element type.
    *
-   * @return the factory instance.
+   * @see #atomicReferenceArray(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<Object>> atomicReferenceArray() {
-    return atomicReferenceArray(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<Object>> ATOMIC_REFERENCE_ARRAY = atomicReferenceArray(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceArray}.
@@ -545,6 +543,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT>   the {@code AtomicReferenceArray} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
+   *
+   * @see #ATOMIC_REFERENCE_ARRAY
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<ELEMENT>> atomicReferenceArray(Class<ELEMENT> elementType) {
@@ -554,12 +554,11 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceFieldUpdater}, assuming {@code Object} as field and object types.
    *
-   * @return the factory instance.
+   * @see #atomicReferenceFieldUpdater(Class, Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<Object, Object>> atomicReferenceFieldUpdater() {
-    return atomicReferenceFieldUpdater(Object.class, Object.class);
-  }
+  InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<Object, Object>> ATOMIC_REFERENCE_FIELD_UPDATER = atomicReferenceFieldUpdater(Object.class,
+                                                                                                                                                                       Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceFieldUpdater}.
@@ -569,6 +568,8 @@ public interface InstanceOfAssertFactories {
    * @param fieldType  the field type instance.
    * @param objectType the object type instance.
    * @return the factory instance.
+   *
+   * @see #ATOMIC_REFERENCE_FIELD_UPDATER
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <FIELD, OBJECT> InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT>> atomicReferenceFieldUpdater(Class<FIELD> fieldType,
@@ -579,12 +580,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicMarkableReference}, assuming {@code Object} as value type.
    *
-   * @return the factory instance.
+   * @see #atomicMarkableReference(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<Object>> atomicMarkableReference() {
-    return atomicMarkableReference(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<Object>> ATOMIC_MARKABLE_REFERENCE = atomicMarkableReference(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicMarkableReference}.
@@ -592,6 +591,8 @@ public interface InstanceOfAssertFactories {
    * @param <VALUE>   the {@code AtomicMarkableReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
+   *
+   * @see #ATOMIC_MARKABLE_REFERENCE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <VALUE> InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<VALUE>> atomicMarkableReference(Class<VALUE> valueType) {
@@ -601,12 +602,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicStampedReference}, assuming {@code Object} as value type.
    *
-   * @return the factory instance.
+   * @see #atomicStampedReference(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<Object>> atomicStampedReference() {
-    return atomicStampedReference(Object.class);
-  }
+  InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<Object>> ATOMIC_STAMPED_REFERENCE = atomicStampedReference(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicStampedReference}.
@@ -614,6 +613,8 @@ public interface InstanceOfAssertFactories {
    * @param <VALUE>   the {@code AtomicStampedReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
+   * 
+   * @see #ATOMIC_STAMPED_REFERENCE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <VALUE> InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<VALUE>> atomicStampedReference(Class<VALUE> valueType) {
@@ -653,12 +654,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link Iterable}, assuming {@code Object} as element type.
    *
-   * @return the factory instance.
+   * @see #iterable(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Iterable, IterableAssert<Object>> iterable() {
-    return iterable(Object.class);
-  }
+  InstanceOfAssertFactory<Iterable, IterableAssert<Object>> ITERABLE = iterable(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link Iterable}.
@@ -666,6 +665,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT>   the {@code Iterable} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
+   *
+   * @see #ITERABLE
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<Iterable, IterableAssert<ELEMENT>> iterable(Class<ELEMENT> elementType) {
@@ -675,12 +676,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link Iterator}, assuming {@code Object} as element type.
    *
-   * @return the factory instance.
+   * @see #iterator(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Iterator, IteratorAssert<Object>> iterator() {
-    return iterator(Object.class);
-  }
+  InstanceOfAssertFactory<Iterator, IteratorAssert<Object>> ITERATOR = iterator(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link Iterator}.
@@ -688,6 +687,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT>   the {@code Iterator} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
+   *
+   * @see #ITERATOR
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<Iterator, IteratorAssert<ELEMENT>> iterator(Class<ELEMENT> elementType) {
@@ -697,12 +698,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link List}, assuming {@code Object} as element type.
    *
-   * @return the factory instance.
+   * @see #list(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<List, ListAssert<Object>> list() {
-    return list(Object.class);
-  }
+  InstanceOfAssertFactory<List, ListAssert<Object>> LIST = list(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link List}.
@@ -710,6 +709,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT>   the {@code List} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
+   *
+   * @see #LIST
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<List, ListAssert<ELEMENT>> list(Class<ELEMENT> elementType) {
@@ -719,12 +720,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Stream}, assuming {@code Object} as element type.
    *
-   * @return the factory instance.
+   * @see #stream(Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Stream, ListAssert<Object>> stream() {
-    return stream(Object.class);
-  }
+  InstanceOfAssertFactory<Stream, ListAssert<Object>> STREAM = stream(Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link Stream}.
@@ -732,6 +731,8 @@ public interface InstanceOfAssertFactories {
    * @param <ELEMENT>   the {@code Stream} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
+   *
+   * @see #STREAM
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<Stream, ListAssert<ELEMENT>> stream(Class<ELEMENT> elementType) {
@@ -765,12 +766,10 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Map}, assuming {@code Object} as key and value types.
    *
-   * @return the factory instance.
+   * @see #map(Class, Class)
    */
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
-  static InstanceOfAssertFactory<Map, MapAssert<Object, Object>> map() {
-    return map(Object.class, Object.class);
-  }
+  InstanceOfAssertFactory<Map, MapAssert<Object, Object>> MAP = map(Object.class, Object.class);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link Map}.
@@ -780,6 +779,8 @@ public interface InstanceOfAssertFactories {
    * @param keyType   the key type instace.
    * @param valueType the value type instace.
    * @return the factory instance.
+   *
+   * @see #MAP
    */
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <K, V> InstanceOfAssertFactory<Map, MapAssert<K, V>> map(Class<K> keyType, Class<V> valueType) {

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -16,7 +16,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.InstanceOfAssertFactories.array;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.data.MapEntry.entry;
 
@@ -50,9 +50,10 @@ class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertions
     Map<Type, Type> factories = Stream.of(findFieldFactoryTypes(), findMethodFactoryTypes())
                                       .map(Map::entrySet)
                                       .flatMap(Collection::stream)
+                                      .distinct()
                                       .collect(toMap(Entry::getKey, Entry::getValue));
     // THEN
-    then(assertThatMethods).containsOnly(factories.entrySet().toArray(new Map.Entry[0]));
+    then(factories).containsOnly(assertThatMethods.entrySet().toArray(new Map.Entry[0]));
   }
 
   private Map<Type, Type> findAssertThatParameterAndReturnTypes() {
@@ -95,14 +96,13 @@ class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertions
                  .map(Method::getGenericReturnType)
                  .map(this::extractTypeParameters)
                  .filter(not(this::ignoredFactory))
-                 .distinct()
                  .collect(toMap(Entry::getKey, Entry::getValue));
   }
 
   private Entry<Type, Type> extractTypeParameters(Type type) {
     assertThat(type).asInstanceOf(type(ParameterizedType.class))
                     .returns(InstanceOfAssertFactory.class, from(ParameterizedType::getRawType))
-                    .extracting(ParameterizedType::getActualTypeArguments).asInstanceOf(array()).hasSize(2);
+                    .extracting(ParameterizedType::getActualTypeArguments).asInstanceOf(ARRAY).hasSize(2);
     Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
     return entry(normalize(typeArguments[0]), normalize(typeArguments[1]));
   }

--- a/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -16,11 +16,19 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_BOOLEAN;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_INTEGER_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_INTEGER_FIELD_UPDATER;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_LONG;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_LONG_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_LONG_FIELD_UPDATER;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_MARKABLE_REFERENCE;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_REFERENCE;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_REFERENCE_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_REFERENCE_FIELD_UPDATER;
+import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_STAMPED_REFERENCE;
 import static org.assertj.core.api.InstanceOfAssertFactories.BIG_DECIMAL;
 import static org.assertj.core.api.InstanceOfAssertFactories.BIG_INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
@@ -31,6 +39,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.CHARACTER;
 import static org.assertj.core.api.InstanceOfAssertFactories.CHAR_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.CHAR_SEQUENCE;
 import static org.assertj.core.api.InstanceOfAssertFactories.CLASS;
+import static org.assertj.core.api.InstanceOfAssertFactories.COMPLETABLE_FUTURE;
+import static org.assertj.core.api.InstanceOfAssertFactories.COMPLETION_STAGE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_ARRAY;
@@ -39,12 +49,16 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_STREAM;
 import static org.assertj.core.api.InstanceOfAssertFactories.FILE;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.FUTURE;
 import static org.assertj.core.api.InstanceOfAssertFactories.INPUT_STREAM;
 import static org.assertj.core.api.InstanceOfAssertFactories.INSTANT;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.INT_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.INT_PREDICATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.INT_STREAM;
+import static org.assertj.core.api.InstanceOfAssertFactories.ITERABLE;
+import static org.assertj.core.api.InstanceOfAssertFactories.ITERATOR;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.LOCAL_DATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.LOCAL_DATE_TIME;
 import static org.assertj.core.api.InstanceOfAssertFactories.LOCAL_TIME;
@@ -52,14 +66,18 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG_PREDICATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG_STREAM;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.assertj.core.api.InstanceOfAssertFactories.OFFSET_DATE_TIME;
 import static org.assertj.core.api.InstanceOfAssertFactories.OFFSET_TIME;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
 import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL_DOUBLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL_INT;
 import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL_LONG;
 import static org.assertj.core.api.InstanceOfAssertFactories.PATH;
+import static org.assertj.core.api.InstanceOfAssertFactories.PREDICATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.STREAM;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUFFER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUILDER;
@@ -145,7 +163,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = (Predicate<Object>) Objects::isNull;
     // WHEN
-    PredicateAssert<Object> result = assertThat(value).asInstanceOf(predicate());
+    PredicateAssert<Object> result = assertThat(value).asInstanceOf(PREDICATE);
     // THEN
     result.accepts((Object) null);
   }
@@ -195,7 +213,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = completedFuture("done");
     // WHEN
-    CompletableFutureAssert<Object> result = assertThat(value).asInstanceOf(completableFuture());
+    CompletableFutureAssert<Object> result = assertThat(value).asInstanceOf(COMPLETABLE_FUTURE);
     // THEN
     result.isDone();
   }
@@ -215,7 +233,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = completedFuture("done");
     // WHEN
-    CompletableFutureAssert<Object> result = assertThat(value).asInstanceOf(completionStage());
+    CompletableFutureAssert<Object> result = assertThat(value).asInstanceOf(COMPLETION_STAGE);
     // THEN
     result.isDone();
   }
@@ -235,7 +253,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = Optional.of("something");
     // WHEN
-    OptionalAssert<Object> result = assertThat(value).asInstanceOf(optional());
+    OptionalAssert<Object> result = assertThat(value).asInstanceOf(OPTIONAL);
     // THEN
     result.isPresent();
   }
@@ -425,7 +443,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = mock(Future.class);
     // WHEN
-    FutureAssert<Object> result = assertThat(value).asInstanceOf(future());
+    FutureAssert<Object> result = assertThat(value).asInstanceOf(FUTURE);
     // THEN
     result.isNotDone();
   }
@@ -525,7 +543,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = new Object[] { 0, "" };
     // WHEN
-    ObjectArrayAssert<Object> result = assertThat(value).asInstanceOf(array());
+    ObjectArrayAssert<Object> result = assertThat(value).asInstanceOf(ARRAY);
     // THEN
     result.containsExactly(0, "");
   }
@@ -675,7 +693,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = AtomicIntegerFieldUpdater.newUpdater(VolatileFieldContainer.class, "intField");
     // WHEN
-    AtomicIntegerFieldUpdaterAssert<Object> result = assertThat(value).asInstanceOf(atomicIntegerFieldUpdater());
+    AtomicIntegerFieldUpdaterAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_INTEGER_FIELD_UPDATER);
     // THEN
     result.hasValue(0, new VolatileFieldContainer());
   }
@@ -715,7 +733,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = AtomicLongFieldUpdater.newUpdater(VolatileFieldContainer.class, "longField");
     // WHEN
-    AtomicLongFieldUpdaterAssert<Object> result = assertThat(value).asInstanceOf(atomicLongFieldUpdater());
+    AtomicLongFieldUpdaterAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_LONG_FIELD_UPDATER);
     // THEN
     result.hasValue(0L, new VolatileFieldContainer());
   }
@@ -735,7 +753,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = new AtomicReference<>();
     // WHEN
-    AtomicReferenceAssert<Object> result = assertThat(value).asInstanceOf(atomicReference());
+    AtomicReferenceAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_REFERENCE);
     // THEN
     result.hasValue(null);
   }
@@ -755,7 +773,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = new AtomicReferenceArray<>(new Object[] { 0, "" });
     // WHEN
-    AtomicReferenceArrayAssert<Object> result = assertThat(value).asInstanceOf(atomicReferenceArray());
+    AtomicReferenceArrayAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_REFERENCE_ARRAY);
     // THEN
     result.containsExactly(0, "");
   }
@@ -775,7 +793,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = AtomicReferenceFieldUpdater.newUpdater(VolatileFieldContainer.class, String.class, "stringField");
     // WHEN
-    AtomicReferenceFieldUpdaterAssert<Object, Object> result = assertThat(value).asInstanceOf(atomicReferenceFieldUpdater());
+    AtomicReferenceFieldUpdaterAssert<Object, Object> result = assertThat(value).asInstanceOf(ATOMIC_REFERENCE_FIELD_UPDATER);
     // THEN
     result.hasValue(null, new VolatileFieldContainer());
   }
@@ -796,7 +814,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = new AtomicMarkableReference<>(null, false);
     // WHEN
-    AtomicMarkableReferenceAssert<Object> result = assertThat(value).asInstanceOf(atomicMarkableReference());
+    AtomicMarkableReferenceAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_MARKABLE_REFERENCE);
     // THEN
     result.hasReference(null);
   }
@@ -816,7 +834,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = new AtomicStampedReference<>(null, 0);
     // WHEN
-    AtomicStampedReferenceAssert<Object> result = assertThat(value).asInstanceOf(atomicStampedReference());
+    AtomicStampedReferenceAssert<Object> result = assertThat(value).asInstanceOf(ATOMIC_STAMPED_REFERENCE);
     // THEN
     result.hasReference(null);
   }
@@ -886,7 +904,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = asList("Homer", "Marge", "Bart", "Lisa", "Maggie");
     // WHEN
-    IterableAssert<Object> result = assertThat(value).asInstanceOf(iterable());
+    IterableAssert<Object> result = assertThat(value).asInstanceOf(ITERABLE);
     // THEN
     result.contains("Bart", "Lisa");
   }
@@ -906,7 +924,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = asList("Homer", "Marge", "Bart", "Lisa", "Maggie").iterator();
     // WHEN
-    IteratorAssert<Object> result = assertThat(value).asInstanceOf(iterator());
+    IteratorAssert<Object> result = assertThat(value).asInstanceOf(ITERATOR);
     // THEN
     result.hasNext();
   }
@@ -926,7 +944,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = asList("Homer", "Marge", "Bart", "Lisa", "Maggie");
     // WHEN
-    ListAssert<Object> result = assertThat(value).asInstanceOf(list());
+    ListAssert<Object> result = assertThat(value).asInstanceOf(LIST);
     // THEN
     result.contains("Bart", "Lisa");
   }
@@ -946,7 +964,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = Stream.of(1, 2, 3);
     // WHEN
-    ListAssert<Object> result = assertThat(value).asInstanceOf(stream());
+    ListAssert<Object> result = assertThat(value).asInstanceOf(STREAM);
     // THEN
     result.containsExactly(1, 2, 3);
   }
@@ -1006,7 +1024,7 @@ class InstanceOfAssertFactoriesTest {
     // GIVEN
     Object value = mapOf(entry("key", "value"));
     // WHEN
-    MapAssert<Object, Object> result = assertThat(value).asInstanceOf(map());
+    MapAssert<Object, Object> result = assertThat(value).asInstanceOf(MAP);
     // THEN
     result.containsExactly(entry("key", "value"));
   }


### PR DESCRIPTION
Follows https://github.com/joel-costigliola/assertj-core/pull/1498#issuecomment-500118663.

In case you have time to take a look at #1513, it could help to clean a bit the `THEN` of  `Assertions_sync_with_InstanceOfAssertFactories_Test#each_standard_assertion_should_have_an_instance_of_assert_factory()` :-)

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (API only) : YES