### PR TITLE
Introduce explicit module descriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: java
 install: true
 
 addons:
-  apt:
-    packages:
-      - oracle-java8-installer
   sonarcloud:
     organization: "default"
     token:
@@ -18,8 +15,6 @@ cache:
     - '$HOME/.sonar/cache'
 
 jdk:
-  - openjdk8
-  - oraclejdk8
   - openjdk11
   - openjdk12
   - openjdk-ea

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <release>8</release>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
@@ -143,7 +144,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>org.assertj.core</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
             </manifestEntries>
           </archive>
         </configuration>
@@ -351,6 +352,34 @@
           --add-opens
           java.base/java.io=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED</argLine>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>jdk9</id>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                    <release>9</release>
+                    <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                    </compileSourceRoots>
+                    <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
+                    <compilerArgs>
+                      <arg>--patch-module</arg><arg>org.assertj.core=${project.build.outputDirectory}</arg>
+                    </compilerArgs>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>java11+</id>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+
+module org.assertj.core {
+  exports org.assertj.core.annotations;
+  exports org.assertj.core.api;
+  // TODO Add all "missing exports"...
+  requires java.instrument;
+}


### PR DESCRIPTION
Replaces the `<Automatic-Module-Name>` entry from the manifest.

#1504 draft/scaffold/proof-of-concept PR


