### PR TITLE
Set Java module version to project's version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,7 @@
                     <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
                     <compilerArgs>
                       <arg>--patch-module</arg><arg>org.assertj.core=${project.build.outputDirectory}</arg>
+                      <arg>--module-version</arg><arg>${project.version}</arg>
                     </compilerArgs>
                   </configuration>
                 </execution>


### PR DESCRIPTION
`jar --describe-module --file assertj-core-3.13.0-SNAPSHOT.jar --release 9`

yields:
```
releases: 9

org.assertj.core@3.13.0-SNAPSHOT jar:file:///R:/dev/github/sormuras/assertj-core/target/assertj-core-3.13.0-SNAPSHOT.jar/!META-INF/versions/9/module-info.class

exports org.assertj.core.annotations
exports org.assertj.core.api
exports org.assertj.core.api.exception
exports org.assertj.core.api.filter
exports org.assertj.core.api.iterable
exports org.assertj.core.api.recursive.comparison
exports org.assertj.core.condition
exports org.assertj.core.configuration
exports org.assertj.core.data
exports org.assertj.core.description
exports org.assertj.core.error
exports org.assertj.core.error.future
exports org.assertj.core.error.uri
exports org.assertj.core.extractor
exports org.assertj.core.groups
exports org.assertj.core.internal
exports org.assertj.core.matcher
exports org.assertj.core.presentation
exports org.assertj.core.util
exports org.assertj.core.util.diff
exports org.assertj.core.util.diff.myers
exports org.assertj.core.util.introspection
exports org.assertj.core.util.xml

requires java.base mandated
requires java.instrument
```