### PR TITLE
Travis CI: Add Java 13 build and restore Java EA build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 jdk:
   - openjdk11
   - openjdk12
+  - openjdk13
   # fails the build https://travis-ci.org/joel-costigliola/assertj-core/builds/547178151
   # - openjdk-ea
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ jdk:
   - openjdk11
   - openjdk12
   - openjdk13
-  # fails the build https://travis-ci.org/joel-costigliola/assertj-core/builds/547178151
-  # - openjdk-ea
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+  - jdk: openjdk-ea
 
 script:
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./mvnw clean verify javadoc:javadoc; fi'

--- a/src/test/java/org/assertj/core/internal/paths/MockPathsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/paths/MockPathsBaseTest.java
@@ -33,6 +33,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Spliterators;
 import java.util.function.Predicate;
 
 import org.assertj.core.api.AssertionInfo;
@@ -77,14 +78,14 @@ public class MockPathsBaseTest extends PathsBaseTest {
   static DirectoryStream<Path> directoryStream(List<Path> directoryItems) {
     DirectoryStream<Path> stream = mock(DirectoryStream.class);
     given(stream.iterator()).will(inv -> directoryItems.iterator());
-    given(stream.spliterator()).willCallRealMethod();
+    given(stream.spliterator()).will(inv -> Spliterators.spliteratorUnknownSize(directoryItems.iterator(), 0));
     return stream;
   }
 
   private DirectoryStream<Path> filterStream(Predicate<Path> filter, DirectoryStream<Path> source) throws IOException {
     DirectoryStream<Path> stream = mock(DirectoryStream.class);
     given(stream.iterator()).will(inv -> Iterators.filter(source.iterator(), filter::test));
-    given(stream.spliterator()).willCallRealMethod();
+    given(stream.spliterator()).will(inv -> Spliterators.spliteratorUnknownSize(Iterators.filter(source.iterator(), filter::test), 0));
     willAnswer(inv -> {
       source.close();
       return null;


### PR DESCRIPTION
I do not know if we should keep https://github.com/joel-costigliola/assertj-core/pull/1531/commits/eea3712e4aa0f0237a0c3dab1d1757d6707feec2

No idea if this is bug in the first Java 14 EA build or a deliberate change in Java 14 (that may require changes in mockito).



