### PR TITLE
Allow return values of WithAssertions#fail methods to be ignored

### DIFF
--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -158,6 +158,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return nothing, it's just to be used in doSomething(optional.orElse(() -&gt; fail("boom")));.
    * @throws AssertionError with the given message.
    */
+  @CanIgnoreReturnValue
   default <T> T fail(final String failureMessage) {
     return Assertions.fail(failureMessage);
   }
@@ -172,6 +173,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @throws AssertionError with the given built message.
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   default <T> T fail(String failureMessage, Object... args) {
     return Assertions.fail(failureMessage, args);
   }
@@ -185,6 +187,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return nothing, it's just to be used in doSomething(optional.orElse(() -&gt; fail("boom", cause)));.
    * @throws AssertionError with the given message and with the {@link Throwable} that caused the failure.
    */
+  @CanIgnoreReturnValue
   default <T> T fail(final String failureMessage, final Throwable realCause) {
     return Assertions.fail(failureMessage, realCause);
   }
@@ -1792,6 +1795,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
    */
+  @CanIgnoreReturnValue
   default <T> T failBecauseExceptionWasNotThrown(final Class<? extends Throwable> throwableClass) {
     return Assertions.failBecauseExceptionWasNotThrown(throwableClass);
   }
@@ -1806,6 +1810,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    *           not been.
    * @since 3.9.0
    */
+  @CanIgnoreReturnValue
   default <T> T shouldHaveThrown(Class<? extends Throwable> throwableClass) {
     return Assertions.shouldHaveThrown(throwableClass);
   }


### PR DESCRIPTION
#### Check List:
* Fixes #1533
* Unit tests : NA
* Javadoc with a code example (API only) : NA


