### PR TITLE
Adjust LICENSE to make it GitHub friendly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
This should allow GitHub to dislay the nicer Apache-2.0 license title like in [assertj/doc](https://github.com/assertj/doc/tree/master).

