### PR TITLE
Introduce SoftAssertionsExtension for JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-testkit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opentest4j</groupId>
       <artifactId>opentest4j</artifactId>
       <version>1.1.1</version>

--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.annotation.Testable;
+
+/**
+ * Extension for JUnit Jupiter that provides support for injecting an instance
+ * of {@link SoftAssertions} or {@link BDDSoftAssertions} into test methods.
+ *
+ * <h3>Applicability</h3>
+ *
+ * <p>In this context, the term "test method" refers to any method annotated with
+ * {@code @Test}, {@code @RepeatedTest}, {@code @ParameterizedTest},
+ * {@code @TestFactory}, or {@code @TestTemplate}. This extension does not inject
+ * {@code SoftAssertions} or {@code BDDSoftAssertions} arguments into test
+ * constructors or lifecycle methods.
+ *
+ * <h3>Scope</h3>
+ *
+ * <p>The scope of the {@code SoftAssertions} or {@code BDDSoftAssertions} instance
+ * managed by this extension begins when a parameter of type {@code SoftAssertions}
+ * or {@code BDDSoftAssertions} is resolved for a test method. The scope of the
+ * instance ends after the test method has been executed. When the scope ends,
+ * {@code assertAll()} will be invoked on the instance to verify that no soft
+ * assertions failed.
+ *
+ * <h3>Example with {@code SoftAssertions}</h3>
+ *
+ * <pre class="code">
+ * {@literal @}ExtendWith(SoftAssertionsExtension.class)
+ * class ExampleTestCase {
+ * 
+ *    {@literal @}Test
+ *    void multipleFailures(SoftAssertions softly) {
+ *       softly.assertThat(2 * 3).isEqualTo(0);
+ *       softly.assertThat(Arrays.asList(1, 2)).containsOnly(1);
+ *       softly.assertThat(1 + 1).isEqualTo(2);
+ *    }
+ * }</pre>
+ *
+ * <h3>Example with {@code BDDSoftAssertions}</h3>
+ *
+ * <pre class="code">
+ * {@literal @}ExtendWith(SoftAssertionsExtension.class)
+ * class ExampleTestCase {
+ * 
+ *    {@literal @}Test
+ *    void multipleFailures(BDDSoftAssertions softly) {
+ *       softly.then(2 * 3).isEqualTo(0);
+ *       softly.then(Arrays.asList(1, 2)).containsOnly(1);
+ *       softly.then(1 + 1).isEqualTo(2);
+ *    }
+ * }</pre>
+ *
+ * @author Sam Brannen
+ * @since 3.13
+ */
+public class SoftAssertionsExtension implements ParameterResolver, AfterTestExecutionCallback {
+
+	private static final Namespace namespace = Namespace.create(SoftAssertionsExtension.class);
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		// Abort if parameter type is unsupported.
+		if (isUnsupportedParameterType(parameterContext.getParameter())) {
+			return false;
+		}
+
+		Executable executable = parameterContext.getDeclaringExecutable();
+
+		// @Testable is used as a meta-annotation on @Test, @TestFactory, @TestTemplate, etc.
+		boolean isTestableMethod = (executable instanceof Method) && isAnnotated(executable, Testable.class);
+		if (!isTestableMethod) {
+			throw new ParameterResolutionException(String.format(
+				"Configuration error: cannot resolve SoftAssertions or BDDSoftAssertions for [%s]. Only test methods are supported.",
+				executable));
+		}
+		return true;
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		// The parameter type is guaranteed to be either SoftAssertions or BDDSoftAssertions
+		return getStore(extensionContext).getOrComputeIfAbsent(parameterContext.getParameter().getType());
+	}
+
+	@Override
+	public void afterTestExecution(ExtensionContext extensionContext) {
+		assertAll(extensionContext, SoftAssertions.class, SoftAssertions::assertAll);
+		assertAll(extensionContext, BDDSoftAssertions.class, BDDSoftAssertions::assertAll);
+	}
+
+	/**
+	 * Invoke {@code assertAll} on the object of specified {@code type}, if the
+	 * supplied {@code ExtensionContext} contains the object keyed by its type.
+	 */
+	private static <T> void assertAll(ExtensionContext extensionContext, Class<T> type, Consumer<T> assertAll) {
+		Optional.ofNullable(getStore(extensionContext).remove(type, type)).ifPresent(assertAll);
+	}
+
+	private static boolean isUnsupportedParameterType(Parameter parameter) {
+		Class<?> type = parameter.getType();
+		return type != SoftAssertions.class && type != BDDSoftAssertions.class;
+	}
+
+	private static Store getStore(ExtensionContext extensionContext) {
+		return extensionContext.getStore(namespace);
+	}
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.opentest4j.MultipleFailuresError;
+
+/**
+ * Abstract base class for integration tests involving the {@link SoftAssertionsExtension}.
+ *
+ * @author Sam Brannen
+ * @since 3.13
+ * @see SoftAssertionsExtensionIntegrationTest
+ * @see BDDSoftAssertionsExtensionIntegrationTest
+ */
+abstract class AbstractSoftAssertionsExtensionIntegrationTests {
+
+	@Test
+	final void testInstancePerMethod() {
+		assertExecutionResults(getTestInstancePerMethodTestCase(), false);
+	}
+
+	@Test
+	final void testInstancePerClass() {
+		assertExecutionResults(getTestInstancePerClassTestCase(), false);
+	}
+
+	@Test
+	final void testInstancePerMethodWithNestedTests() {
+		assertExecutionResults(getTestInstancePerMethodNestedTestCase(), true);
+	}
+
+	@Test
+	final void testInstancePerClassWithNestedTests() {
+		assertExecutionResults(getTestInstancePerClassNestedTestCase(), true);
+	}
+
+	protected abstract Class<?> getTestInstancePerMethodTestCase();
+
+	protected abstract Class<?> getTestInstancePerClassTestCase();
+
+	protected abstract Class<?> getTestInstancePerMethodNestedTestCase();
+
+	protected abstract Class<?> getTestInstancePerClassNestedTestCase();
+
+	private void assertExecutionResults(Class<?> testClass, boolean nested) {
+		EngineTestKit.engine("junit-jupiter")
+			.selectors(selectClass(testClass))
+			.execute()
+			.tests()
+			.assertStatistics(stats -> stats.started(nested ? 8 : 4).succeeded(nested ? 4 : 2).failed(nested ? 4 : 2))
+			.failed()
+			// .debug(System.err)
+			.assertThatEvents()
+				.haveExactly(nested ? 2 : 1, event(test("multipleFailures"),
+					finishedWithFailure(
+						instanceOf(MultipleFailuresError.class),
+						message(msg -> msg.startsWith("Multiple Failures (2 failures)")))))
+				.haveExactly(nested ? 2 : 1, event(test("parameterizedTest"),
+					finishedWithFailure(
+						instanceOf(MultipleFailuresError.class),
+						message(msg -> msg.startsWith("Multiple Failures (1 failure)")))));
+	}
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+import java.util.Arrays;
+
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Integration tests for {@link SoftAssertionsExtension} with {@link BDDSoftAssertions}.
+ *
+ * <p>This class is effectively a copy of {@link SoftAssertionsExtensionTest}
+ * with {@link SoftAssertions} replaced by {@link BDDSoftAssertions}.
+ *
+ * @author Sam Brannen
+ * @since 3.13
+ * @see SoftAssertionsExtensionIntegrationTest
+ */
+class BDDSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
+
+	@Override
+	protected Class<?> getTestInstancePerMethodTestCase() {
+		return TestInstancePerMethodExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerClassTestCase() {
+		return TestInstancePerClassExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerMethodNestedTestCase() {
+		return TestInstancePerMethodNestedExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerClassNestedTestCase() {
+		return TestInstancePerClassNestedExample.class;
+	}
+
+	// -------------------------------------------------------------------------
+
+	@ExtendWith(SoftAssertionsExtension.class)
+	@TestMethodOrder(OrderAnnotation.class)
+	private static abstract class AbstractSoftAssertionsExample {
+
+		@Test
+		@Order(1)
+		void multipleFailures(BDDSoftAssertions softly) {
+			softly.then(1).isEqualTo(0);
+			softly.then(2).isEqualTo(2);
+			softly.then(3).isEqualTo(4);
+		}
+
+		@Test
+		@Order(2)
+		void allAssertionsShouldPass(BDDSoftAssertions softly) {
+			softly.then(1).isEqualTo(1);
+			softly.then(Arrays.asList(1, 2)).containsOnly(1, 2);
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "1, 1, 2", "1, 2, 3" })
+		@Order(3)
+		void parameterizedTest(int a, int b, int sum, BDDSoftAssertions softly) {
+			softly.then(a + b).as("sum").isEqualTo(sum);
+			softly.then(a).as("operand 1 is equal to operand 2").isEqualTo(b);
+		}
+	}
+
+	@TestInstance(PER_METHOD)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerMethodExample extends AbstractSoftAssertionsExample {
+	}
+
+	@TestInstance(PER_CLASS)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerClassExample extends AbstractSoftAssertionsExample {
+	}
+
+	@TestInstance(PER_METHOD)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerMethodNestedExample extends AbstractSoftAssertionsExample {
+
+		@Nested
+		class InnerExample extends AbstractSoftAssertionsExample {
+		}
+	}
+
+	@TestInstance(PER_CLASS)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerClassNestedExample extends AbstractSoftAssertionsExample {
+
+		@Nested
+		class InnerExample extends AbstractSoftAssertionsExample {
+		}
+	}
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+import java.util.Arrays;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Integration tests for {@link SoftAssertionsExtension} with {@link SoftAssertions}.
+ *
+ * @author Sam Brannen
+ * @since 3.13
+ * @see BDDSoftAssertionsExtensionIntegrationTest
+ */
+class SoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
+
+	@Override
+	protected Class<?> getTestInstancePerMethodTestCase() {
+		return TestInstancePerMethodExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerClassTestCase() {
+		return TestInstancePerClassExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerMethodNestedTestCase() {
+		return TestInstancePerMethodNestedExample.class;
+	}
+
+	@Override
+	protected Class<?> getTestInstancePerClassNestedTestCase() {
+		return TestInstancePerClassNestedExample.class;
+	}
+
+	// -------------------------------------------------------------------------
+
+	@ExtendWith(SoftAssertionsExtension.class)
+	@TestMethodOrder(OrderAnnotation.class)
+	private static abstract class AbstractSoftAssertionsExample {
+
+		@Test
+		@Order(1)
+		void multipleFailures(SoftAssertions softly) {
+			softly.assertThat(1).isEqualTo(0);
+			softly.assertThat(2).isEqualTo(2);
+			softly.assertThat(3).isEqualTo(4);
+		}
+
+		@Test
+		@Order(2)
+		void allAssertionsShouldPass(SoftAssertions softly) {
+			softly.assertThat(1).isEqualTo(1);
+			softly.assertThat(Arrays.asList(1, 2)).containsOnly(1, 2);
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "1, 1, 2", "1, 2, 3" })
+		@Order(3)
+		void parameterizedTest(int a, int b, int sum, SoftAssertions softly) {
+			softly.assertThat(a + b).as("sum").isEqualTo(sum);
+			softly.assertThat(a).as("operand 1 is equal to operand 2").isEqualTo(b);
+		}
+	}
+
+	@TestInstance(PER_METHOD)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerMethodExample extends AbstractSoftAssertionsExample {
+	}
+
+	@TestInstance(PER_CLASS)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerClassExample extends AbstractSoftAssertionsExample {
+	}
+
+	@TestInstance(PER_METHOD)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerMethodNestedExample extends AbstractSoftAssertionsExample {
+
+		@Nested
+		class InnerExample extends AbstractSoftAssertionsExample {
+		}
+	}
+
+	@TestInstance(PER_CLASS)
+	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	static class TestInstancePerClassNestedExample extends AbstractSoftAssertionsExample {
+
+		@Nested
+		class InnerExample extends AbstractSoftAssertionsExample {
+		}
+	}
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Parameter;
+
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+
+/**
+ * Unit tests for {@link SoftAssertionsExtension}.
+ *
+ * @author Sam Brannen
+ * @since 3.13
+ * @see SoftAssertionsExtensionIntegrationTest
+ * @see BDDSoftAssertionsExtensionIntegrationTest
+ */
+class SoftAssertionsExtensionUnitTest {
+
+	private final SoftAssertionsExtension extension = new SoftAssertionsExtension();
+	private final ParameterContext parameterContext = mock(ParameterContext.class);
+	private final ExtensionContext extensionContext = mock(ExtensionContext.class);
+
+	@Test
+	void supportsSoftAssertions() throws Exception {
+		Executable executable = TestCase.class.getMethod("softAssertions", SoftAssertions.class);
+		Parameter parameter = executable.getParameters()[0];
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		when(parameterContext.getDeclaringExecutable()).thenReturn(executable);
+		assertThat(extension.supportsParameter(parameterContext, extensionContext)).isTrue();
+	}
+
+	@Test
+	void supportsBddSoftAssertions() throws Exception {
+		Executable executable = TestCase.class.getMethod("bddSoftAssertions", BDDSoftAssertions.class);
+		Parameter parameter = executable.getParameters()[0];
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		when(parameterContext.getDeclaringExecutable()).thenReturn(executable);
+		assertThat(extension.supportsParameter(parameterContext, extensionContext)).isTrue();
+	}
+
+	@Test
+	void doesNotSupportString() throws Exception {
+		Executable executable = TestCase.class.getMethod("string", String.class);
+		Parameter parameter = executable.getParameters()[0];
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		when(parameterContext.getDeclaringExecutable()).thenReturn(executable);
+		assertThat(extension.supportsParameter(parameterContext, extensionContext)).isFalse();
+	}
+
+	@Test
+	void doesNotSupportConstructor() throws Exception {
+		Executable executable = TestCase.class.getDeclaredConstructor(SoftAssertions.class);
+		Parameter parameter = executable.getParameters()[0];
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		when(parameterContext.getDeclaringExecutable()).thenReturn(executable);
+		assertThatExceptionOfType(ParameterResolutionException.class)
+			.isThrownBy(() -> extension.supportsParameter(parameterContext, extensionContext))
+			.withMessageStartingWith("Configuration error: cannot resolve SoftAssertions or BDDSoftAssertions for");
+	}
+
+	@Test
+	void doesNotSupportLifecycleMethod() throws Exception {
+		Executable executable = TestCase.class.getMethod("beforeEach", SoftAssertions.class);
+		Parameter parameter = executable.getParameters()[0];
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		when(parameterContext.getDeclaringExecutable()).thenReturn(executable);
+		assertThatExceptionOfType(ParameterResolutionException.class)
+			.isThrownBy(() -> extension.supportsParameter(parameterContext, extensionContext))
+			.withMessageStartingWith("Configuration error: cannot resolve SoftAssertions or BDDSoftAssertions for");
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static class TestCase {
+
+		@SuppressWarnings("unused")
+		public TestCase(SoftAssertions softly) {
+		}
+
+		@BeforeEach
+		public void beforeEach(SoftAssertions softly) {
+		}
+
+		@Test
+		public void softAssertions(SoftAssertions softly) {
+		}
+
+		@Test
+		public void bddSoftAssertions(BDDSoftAssertions softly) {
+		}
+
+		@Test
+		public void string(String text) {
+		}
+	}
+
+}


### PR DESCRIPTION
### Overview

Prior to this commit, AssertJ offered `JUnitJupiterSoftAssertions` and `JUnitJupiterBDDSoftAssertions` for working with `SoftAssertions` or `BDDSoftAssertions` in JUnit Jupiter based tests. Those two extensions unfortunately have several drawbacks as outlined below.

- lacking support for parallel test execution
- lacking support for `@TestInstance(PER_CLASS)` lifecycle semantics

In addition, `JUnitJupiterSoftAssertions` or `JUnitJupiterBDDSoftAssertions` can easily be declared in a manner that leads to undesirable behavior. For example, programmatic registration via `@RegisterExtension` allows an instance of `JUnitJupiterSoftAssertions` or `JUnitJupiterBDDSoftAssertions` to be used in constructors and lifecycle methods, even though `assertAll()` would not be called for the given `JUnitJupiterSoftAssertions` or `JUnitJupiterBDDSoftAssertions` instance until after the test method has been executed. Similarly, with `@Nested` test classes, programmatic registration via `@RegisterExtension` allows an instance of `JUnitJupiterSoftAssertions` or `JUnitJupiterBDDSoftAssertions` to be registered via a field in an enclosing class, but use of that field is not technically supported in a `@Nested` test class.

This commit addresses these shortcomings by introducing a new `SoftAssertionsExtension` for use with JUnit Jupiter. This extension supersedes the existing `JUnitJupiterSoftAssertions` and `JUnitJupiterBDDSoftAssertions` extensions.

Specifically, `SoftAssertionsExtension`:

- supports the injection of an instance of `SoftAssertions` or `BDDSoftAssertions` into "testable" methods such as those annotated with `@Test`, `@TestFacttory`, `@RepeatedTest`, `@ParameterizedTest`, and `@TestTemplate`
- throws an exception if `SoftAssertionsExtension` is used with a test constructor or lifecycle method such as `@BeforeEach` and `@AfterEach`
- invokes `assertAll()` on the instance of `SoftAssertions` or `BDDSoftAssertions` immediately after the "testable" method has been executed (i.e., by implementing the `AfterTestExecutionCallback` API)

The `SoftAssertionsExtension` is tested using the JUnit Platform Test Kit.

#### Check List:

* Fixes #1418
* Unit tests : YES
* Javadoc with a code example (API only) : YES
