### PR TITLE
Add asInstanceOf(Class) to AbstractObjectAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.description.Description.mostRelevantDescription;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.extractor.Extractors.byName;
 import static org.assertj.core.extractor.Extractors.extractedDescriptionOf;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
@@ -919,6 +920,39 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   SELF withComparatorByPropertyOrField(Map<String, Comparator<?>> comparatorsToPropaget) {
     this.comparatorByPropertyOrField = comparatorsToPropaget;
     return myself;
+  }
+
+  /**
+   * Verifies that the actual value is an instance of the given type and creates a new {@link ObjectAssert} using the
+   * new type. This does not provide a new {@link Assert} narrowed to the input type but allows type specific operations
+   * (e.g., {@link AbstractObjectAssert#extracting(Function)}), which can be handy for types not having dedicated assert
+   * classes.
+   * <p>
+   * <b>To obtain a new {@code Assert} narrowed to the input type, {@link #asInstanceOf(InstanceOfAssertFactory)} should be used.</b>
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * Object string = &quot;abc&quot;;
+   * assertThat(string).asInstanceOf(String.class).extracting(String::length).isEqualTo(3);
+   *
+   * Object integer = 1;
+   * assertThat(integer).asInstanceOf(Integer.class).extracting(Integer::doubleValue).isEqualTo(1.0);
+   *
+   * // assertion will fail
+   * assertThat(&quot;abc&quot;).asInstanceOf(Integer.class);</code></pre>
+   *
+   * @param type the class instance of the target type.
+   * @param <T> the type to check the actual value against.
+   * @return a new {@code ObjectAssert} instance.
+   *
+   * @see #asInstanceOf(InstanceOfAssertFactory)
+   *
+   * @since 3.13.0
+   */
+  @CheckReturnValue
+  public <T> AbstractObjectAssert<?, T> asInstanceOf(Class<T> type) {
+    requireNonNull(type, shouldNotBeNull("type").create());
+    return asInstanceOf(InstanceOfAssertFactories.type(type));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -32,6 +32,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ *  @author Stefano Cordio
+ */
 class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertionsTest {
 
   private static final Class<?>[] FIELD_FACTORIES_IGNORED_TYPES = {
@@ -57,8 +60,7 @@ class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertions
     // WHEN
     Map<Type, Type> fieldFactories = findFieldFactoryTypes();
     // THEN
-    then(fieldFactories).containsAllEntriesOf(assertThatMethods)
-                        .hasSameSizeAs(assertThatMethods);
+    then(fieldFactories).containsExactlyInAnyOrderEntriesOf(assertThatMethods);
   }
 
   @Test
@@ -68,8 +70,7 @@ class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertions
     // WHEN
     Map<Type, Type> methodFactories = findMethodFactoryTypes();
     // THEN
-    then(methodFactories).containsAllEntriesOf(assertThatMethods)
-                         .hasSameSizeAs(assertThatMethods);
+    then(methodFactories).containsExactlyInAnyOrderEntriesOf(assertThatMethods);
   }
 
   private Map<Type, Type> findAssertThatParameterAndReturnTypes() {

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_asInstanceOf_with_class_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_asInstanceOf_with_class_Test.java
@@ -10,62 +10,64 @@
  *
  * Copyright 2012-2019 the original author or authors.
  */
-package org.assertj.core.api.abstract_;
+package org.assertj.core.api.object;
 
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractAssertBaseTest;
-import org.assertj.core.api.AbstractLongAssert;
-import org.assertj.core.api.ConcreteAssert;
-import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ObjectAssertBaseTest;
 import org.assertj.core.presentation.UnicodeRepresentation;
+import org.assertj.core.test.Jedi;
+import org.assertj.core.test.Person;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Tests for <code>{@link AbstractAssert#asInstanceOf(InstanceOfAssertFactory)}</code>.
+ * Tests for <code>{@link AbstractObjectAssert#asInstanceOf(Class)}</code>.
  *
  * @author Stefano Cordio
  */
-class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends AbstractAssertBaseTest {
+class ObjectAssert_asInstanceOf_with_class_Test extends ObjectAssertBaseTest {
 
   @Override
-  protected ConcreteAssert invoke_api_method() {
-    assertions.asInstanceOf(LONG);
+  protected ObjectAssert<Jedi> invoke_api_method() {
+    assertions.asInstanceOf(Person.class);
     return null;
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(objects).assertIsInstanceOf(getInfo(assertions), getActual(assertions), Long.class);
+    verify(objects).assertIsInstanceOf(getInfo(assertions), getActual(assertions), Person.class);
   }
 
   @Override
   public void should_return_this() {
-    // Test disabled since asInstanceOf(InstanceOfAssertFactory) does not return this.
+    // Test disabled since asInstanceOf(Class) does not return this.
   }
 
   @Test
-  void should_throw_npe_if_no_factory_is_given() {
+  void should_throw_npe_if_no_type_is_given() {
     // GIVEN
-    InstanceOfAssertFactory<?, ?> factory = null;
+    Class<?> type = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> assertions.asInstanceOf(factory));
+    Throwable thrown = catchThrowable(() -> assertions.asInstanceOf(type));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
-                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());
+                .hasMessage(shouldNotBeNull("type").create());
   }
 
   @Test
-  void should_return_narrowed_assert_type() {
+  void should_return_new_object_assert_with_updated_actual_type() {
     // WHEN
-    AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);
+    AbstractAssert<?, Person> result = assertions.asInstanceOf(Person.class);
     // THEN
-    then(result).isInstanceOf(AbstractLongAssert.class);
+    then(result).isInstanceOf(AbstractObjectAssert.class);
   }
 
   @Test
@@ -75,7 +77,7 @@ class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends Abst
               .overridingErrorMessage("error message")
               .withRepresentation(new UnicodeRepresentation());
     // WHEN
-    AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);
+    AbstractAssert<?, ?> result = assertions.asInstanceOf(Person.class);
     // THEN
     then(result).hasFieldOrPropertyWithValue("objects", objects)
                 .extracting(AbstractAssert::getWritableAssertionInfo)


### PR DESCRIPTION
I imagine that the [`type()`](https://github.com/joel-costigliola/assertj-core/blob/94307cabbfce604becf260b01dadc6e628b386f6/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java#L342-L354) factory can be used mostly to obtain a new `ObjectAssert` for types which do not have a dedicated `Assert` class. For example, the result of an `extracting("myField")` provides an `ObjectAssert<Object>`, making it difficult to perform other operations which need to have the real type (e.g., a chained `extracting(Function)` with a class getter).

This PR is meant to be a shortcut for these use cases where, starting from an `ObjectAssert`, `asInstanceOf(type(MyClass.class))` would be used. E.g., (using String just for demonstration):
```java
Object value = "string";

// Bad
assertThat(value) // ObjectAssert<Object>
    .extracting(String::length); // not compiling

// Good 
assertThat(value) // ObjectAssert<Object>
     .asInstanceOf(type(String.class)) // ObjectAssert<String>
     .extracting(String::length); // compiling

// Better 
assertThat(value) // ObjectAssert<Object>
     .asInstanceOf(String.class) // ObjectAssert<String>
     .extracting(String::length); // compiling
```

I decided to put the new method under `AbstractObjectAssert` instead of `Assert`/`AbstractAssert` because I think there is no realistic use case which starts from assertions not inheriting from `AbstractObjectAssert`. E.g.:
```java
List list = Arrays.asList(1,2,3);
assertThat(list) // ListAssert<Integer>
     .asInstanceOf(List.class); // ObjectAssert<List> - What?
```

#### Questions
* Opinions about the overall idea?
* As this method delegates to `asInstanceOf(InstanceOfAssertFactories.type(type))`, is any change needed for `SoftAssertionsTest` and `BDDSoftAssertionsTest`?
* Similar to the previous point, are additional `Assumptions_assumeThat_with_instanceOf_*` tests needed?

#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (API only) : YES