### PR TITLE
Propagate value type with extracting(Function)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.description.Description.mostRelevantDescription;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.extractor.Extractors.byName;
 import static org.assertj.core.extractor.Extractors.extractedDescriptionOf;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
@@ -646,6 +647,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    *
    * @since 3.13.0
    */
+  @CheckReturnValue
   public AbstractObjectAssert<?, ?> extracting(String propertyOrField) {
     Object value = byName(propertyOrField).apply(actual);
     String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
@@ -677,10 +679,11 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(@SuppressWarnings("unchecked") Function<? super ACTUAL, ?>... extractors) {
+    requireNonNull(extractors, shouldNotBeNull("extractors").create());
     List<Object> values = Stream.of(extractors)
                                 .map(extractor -> extractor.apply(actual))
                                 .collect(toList());
-    return newListAssertInstance(values).as(info.description());
+    return newListAssertInstance(values).withAssertionState(myself);
   }
 
   /**
@@ -706,9 +709,10 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    *
    * @since 3.11.0
    */
-  public AbstractObjectAssert<?, ?> extracting(Function<? super ACTUAL, ?> extractor) {
-    requireNonNull(extractor, "The given java.util.function.Function extractor must not be null");
-    Object extractedValue = extractor.apply(actual);
+  @CheckReturnValue
+  public <T> AbstractObjectAssert<?, T> extracting(Function<? super ACTUAL, T> extractor) {
+    requireNonNull(extractor, shouldNotBeNull("extractor").create());
+    T extractedValue = extractor.apply(actual);
     return newObjectAssert(extractedValue).withAssertionState(myself);
   }
 
@@ -896,7 +900,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   }
 
   // override for proxyable friendly AbstractObjectAssert
-  protected AbstractObjectAssert<?, ?> newObjectAssert(Object objectUnderTest) {
+  protected <T> AbstractObjectAssert<?, T> newObjectAssert(T objectUnderTest) {
     return new ObjectAssert<>(objectUnderTest);
   }
 

--- a/src/main/java/org/assertj/core/api/ProxyableObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/ProxyableObjectAssert.java
@@ -34,7 +34,7 @@ public class ProxyableObjectAssert<ACTUAL> extends AbstractObjectAssert<Proxyabl
   }
 
   @Override
-  protected AbstractObjectAssert<?, ?> newObjectAssert(Object objectUnderTest) {
+  protected <T> AbstractObjectAssert<?, T> newObjectAssert(T objectUnderTest) {
     return new ProxyableObjectAssert<>(objectUnderTest);
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AbstractAssert;
@@ -74,7 +75,7 @@ class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends Abst
     // GIVEN
     assertions.as("description")
               .overridingErrorMessage("error message")
-              .withRepresentation(new UnicodeRepresentation());
+              .withRepresentation(UNICODE_REPRESENTATION);
     // WHEN
     AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);
     // THEN

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_array_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_function_array_Test.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.object;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
+import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.internal.Objects;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.PropertyOrFieldSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ObjectAssert#extracting(Function[])}</code>.
+ */
+class ObjectAssert_extracting_with_function_array_Test {
+
+  private Employee luke;
+
+  private static final Function<Employee, String> firstName = employee -> employee.getName().getFirst();
+
+  @BeforeEach
+  void setUp() {
+    luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+  }
+
+  @Test
+  void should_allow_extracting_values_using_multiple_lambda_extractors() {
+    // GIVEN
+    Function<Employee, Object> lastName = employee -> employee.getName().getLast();
+    // WHEN
+    AbstractListAssert<?, ?, Object, ?> result = assertThat(luke).extracting(firstName, lastName);
+    // THEN
+    result.hasSize(2)
+          .containsExactly("Luke", "Skywalker");
+  }
+
+  @Test
+  void should_allow_extracting_values_using_multiple_method_reference_extractors() {
+    // WHEN
+    AbstractListAssert<?, ?, Object, ?> result = assertThat(luke).extracting(Employee::getName, Employee::getAge);
+    // THEN
+    result.hasSize(2)
+          .doesNotContainNull();
+  }
+
+  @Test
+  void should_rethrow_any_extractor_function_exception() {
+    // GIVEN
+    RuntimeException explosion = new RuntimeException("boom!");
+    Function<Employee, Object> bomb = employee -> {
+      throw explosion;
+    };
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(firstName, bomb));
+    // THEN
+    then(error).isSameAs(explosion);
+  }
+
+  @Test
+  void should_throw_a_NullPointerException_if_the_given_extractor_array_is_null() {
+    // GIVEN
+    Function<? super Employee, ?>[] extractors = null;
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(extractors));
+    // THEN
+    then(error).isInstanceOf(NullPointerException.class)
+               .hasMessage(shouldNotBeNull("extractors").create());
+  }
+
+  @Test
+  void extracting_should_keep_assertion_state() {
+    // GIVEN
+    // not all comparators are used but we want to test that they are passed correctly after extracting
+    ObjectAssert<Employee> assertion = assertThat(luke).as("test description")
+                                                       .withFailMessage("error message")
+                                                       .withRepresentation(UNICODE_REPRESENTATION)
+                                                       .usingComparator(ALWAY_EQUALS)
+                                                       .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
+                                                       .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
+    // WHEN
+    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertion.extracting(firstName, Employee::getName);
+    // THEN
+    then(result.descriptionText()).isEqualTo("test description");
+    then(result.info.overridingErrorMessage()).isEqualTo("error message");
+    then(result.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    then(comparatorOf(result).getComparator()).isSameAs(ALWAY_EQUALS);
+  }
+
+  private static Objects comparatorOf(AbstractListAssert<?, ?, ?, ?> assertion) {
+    return (Objects) PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  }
+
+}


### PR DESCRIPTION
In case of `extracting(Function)`, the type parameter of the resulting `ObjectAssert` can be inferred from the input `Function`, allowing then to chain other type aware methods (e.g., additional `extracting`).

### Example
```java
Person yoda = new Person("Yoda");

// Old implementation
assertThat(yoda)
  .extracting(Jedi::getName) // ObjectAssert<Object>
  .extracting(String::length) // Not compiling
  .isEqualTo(4);

// New implementation
assertThat(yoda)
  .extracting(Jedi::getName) // ObjectAssert<String>
  .extracting(String::length)  // Compiling!
  .isEqualTo(4);
```

While the implementation changes are trivial, I used the occasion for some test refactoring.

#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (API only) : YES (already existing)