### PR TITLE
Exclude assertj-core from junit-platform-testkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-testkit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opentest4j</groupId>


### PR DESCRIPTION
Fixes #1550.