### PR TITLE
Disable example test cases for SoftAssertionsExtension

### DIFF
--- a/src/test/java/org/assertj/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
@@ -68,10 +68,11 @@ abstract class AbstractSoftAssertionsExtensionIntegrationTests {
   private void assertExecutionResults(Class<?> testClass, boolean nested) {
     EngineTestKit.engine("junit-jupiter")
                  .selectors(selectClass(testClass))
+                 .configurationParameter("junit.jupiter.conditions.deactivate", "*")
                  .execute().tests()
                  .assertStatistics(stats -> stats.started(nested ? 8 : 4).succeeded(nested ? 4 : 2).failed(nested ? 4 : 2))
                  .failed()
-                 // @format:off
+                 // @formatter:off
                  .assertThatEvents().haveExactly(nested ? 2 : 1,
                                                  event(test("multipleFailures"),
                                                        finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class),
@@ -80,7 +81,7 @@ abstract class AbstractSoftAssertionsExtensionIntegrationTests {
                                                  event(test("parameterizedTest"),
                                                        finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class), 
                                                                            message(msg -> msg.contains("Multiple Failures (1 failure)")))));
-    // @format:on
+                 // @formatter:on
   }
 
 }

--- a/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 
 import org.assertj.core.api.BDDSoftAssertions;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
@@ -33,14 +34,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Integration tests for {@link SoftAssertionsExtension} with {@link BDDSoftAssertions}.
  *
- * <p>This class is effectively a copy of {@link SoftAssertionsExtensionTest}
+ * <p>This class is effectively a copy of {@link SoftAssertionsExtensionIntegrationTest}
  * with {@link SoftAssertions} replaced by {@link BDDSoftAssertions}.
  *
  * @author Sam Brannen
  * @since 3.13
  * @see SoftAssertionsExtensionIntegrationTest
  */
-@DisplayName(value = "JUnit 5 BDD Soft Assertions extension integration tests")
+@DisplayName("JUnit Jupiter BDD Soft Assertions extension integration tests")
 class BDDSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 
 	@Override
@@ -94,29 +95,31 @@ class BDDSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsEx
 	}
 
 	@TestInstance(PER_METHOD)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerMethodExample extends AbstractSoftAssertionsExample {
 	}
 
 	@TestInstance(PER_CLASS)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerClassExample extends AbstractSoftAssertionsExample {
 	}
 
 	@TestInstance(PER_METHOD)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerMethodNestedExample extends AbstractSoftAssertionsExample {
 
 		@Nested
+		@Disabled("Executed via the JUnit Platform Test Kit")
 		class InnerExample extends AbstractSoftAssertionsExample {
 		}
 	}
 
 	@TestInstance(PER_CLASS)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerClassNestedExample extends AbstractSoftAssertionsExample {
 
 		@Nested
+		@Disabled("Executed via the JUnit Platform Test Kit")
 		class InnerExample extends AbstractSoftAssertionsExample {
 		}
 	}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import java.util.Arrays;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
@@ -36,7 +37,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  * @since 3.13
  * @see BDDSoftAssertionsExtensionIntegrationTest
  */
-@DisplayName(value = "JUnit 5 Soft Assertions extension integration tests")
+@DisplayName("JUnit Jupiter Soft Assertions extension integration tests")
 class SoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 
 	@Override
@@ -90,29 +91,31 @@ class SoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExten
 	}
 
 	@TestInstance(PER_METHOD)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerMethodExample extends AbstractSoftAssertionsExample {
 	}
 
 	@TestInstance(PER_CLASS)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled
 	static class TestInstancePerClassExample extends AbstractSoftAssertionsExample {
 	}
 
 	@TestInstance(PER_METHOD)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerMethodNestedExample extends AbstractSoftAssertionsExample {
 
 		@Nested
+		@Disabled("Executed via the JUnit Platform Test Kit")
 		class InnerExample extends AbstractSoftAssertionsExample {
 		}
 	}
 
 	@TestInstance(PER_CLASS)
-	// Uses "Example" suffix to ensure that this class is not executed as part of the Maven build.
+	@Disabled("Executed via the JUnit Platform Test Kit")
 	static class TestInstancePerClassNestedExample extends AbstractSoftAssertionsExample {
 
 		@Nested
+		@Disabled("Executed via the JUnit Platform Test Kit")
 		class InnerExample extends AbstractSoftAssertionsExample {
 		}
 	}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * @see BDDSoftAssertionsExtensionIntegrationTest
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DisplayName(value = "JUnit 5 Soft Assertions extension")
+@DisplayName("JUnit Jupiter Soft Assertions extension")
 class SoftAssertionsExtensionUnitTest {
 
   private final SoftAssertionsExtension extension = new SoftAssertionsExtension();


### PR DESCRIPTION
Prior to this commit, the example test cases used to test the `SoftAssertionsExtension` were properly excluded from the Maven build by intentionally not following the "*Test" naming convention; however, those test cases were executed within IDEs, resulting in failures.

This commit addresses this inconvenience by annotating all example test cases with `@Disabled` and deactivating the `DisabledCondition` when actually executing the test cases via the `EngineTestKit`.

See #1418