### PR TITLE
Enforce assertj-core exclusion in maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,31 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <includes>
+                    <include>net.bytebuddy:byte-buddy</include>
+                  </includes>
+                  <excludes>
+                    <exclude>org.assertj:assertj-core</exclude>
+                    <exclude>*:*:*:jar:compile</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>1.8</source>


### PR DESCRIPTION
Improvement for #1552.

I think the `maven-enforcer-plugin` version should come from the parent POM, I plan to update it soon.