### PR TITLE
Decorate with JetBrains' @Language("regexp") annotations for regex arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
       <version>3.9</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>17.0.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -26,6 +26,7 @@ import org.assertj.core.internal.Strings;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.IterableUtil;
 import org.assertj.core.util.VisibleForTesting;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Base class for all implementations of assertions for {@code CharSequence}s.
@@ -1018,7 +1019,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the actual {@code CharSequence} does not match the given regular expression.
    */
-  public SELF matches(CharSequence regex) {
+  public SELF matches(@Language("regexp") CharSequence regex) {
     strings.assertMatches(info, actual, regex);
     return myself;
   }
@@ -1040,7 +1041,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the actual {@code CharSequence} matches the given regular expression.
    */
-  public SELF doesNotMatch(CharSequence regex) {
+  public SELF doesNotMatch(@Language("regexp") CharSequence regex) {
     strings.assertDoesNotMatch(info, actual, regex);
     return myself;
   }
@@ -1397,7 +1398,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given regular expression cannot be found in the actual {@code CharSequence}.
    */
-  public SELF containsPattern(CharSequence regex) {
+  public SELF containsPattern(@Language("regexp") CharSequence regex) {
     strings.assertContainsPattern(info, actual, regex);
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -21,6 +21,7 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Throwables;
 import org.assertj.core.util.VisibleForTesting;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Base class for all implementations of assertions for {@link Throwable}s.
@@ -299,7 +300,7 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    * @throws AssertionError if the message of the actual {@code Throwable} does not match the given regular expression.
    * @throws NullPointerException if the regex is null
    */
-  public SELF hasMessageMatching(String regex) {
+  public SELF hasMessageMatching(@Language("regexp") String regex) {
     throwables.assertHasMessageMatching(info, actual, regex);
     return myself;
   }
@@ -327,7 +328,7 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    * @throws NullPointerException if the regex is null
    * @since 3.12.0
    */
-  public SELF hasMessageFindingMatch(String regex) {
+  public SELF hasMessageFindingMatch(@Language("regexp") String regex) {
     throwables.assertHasMessageFindingMatch(info, actual, regex);
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -29,6 +29,7 @@ import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.introspection.IntrospectionError;
+import org.intellij.lang.annotations.Language;
 
 public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SELF>> extends AbstractAssert<SELF, Object> {
 
@@ -297,7 +298,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * @return this {@link RecursiveComparisonAssert} to chain other methods.
    */
   @CheckReturnValue
-  public SELF ignoringFieldsMatchingRegexes(String... regexes) {
+  public SELF ignoringFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     recursiveComparisonConfiguration.ignoreFieldsMatchingRegexes(regexes);
     return myself;
   }
@@ -527,7 +528,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * @return this {@link RecursiveComparisonAssert} to chain other methods.
    */
   @CheckReturnValue
-  public SELF ignoringOverriddenEqualsForFieldsMatchingRegexes(String... regexes) {
+  public SELF ignoringOverriddenEqualsForFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFieldsMatchingRegexes(regexes);
     return myself;
   }
@@ -646,7 +647,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * @return this {@link RecursiveComparisonAssert} to chain other methods.
    */
   @CheckReturnValue
-  public SELF ignoringCollectionOrderInFieldsMatchingRegexes(String... regexes) {
+  public SELF ignoringCollectionOrderInFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     recursiveComparisonConfiguration.ignoreCollectionOrderInFieldsMatchingRegexes(regexes);
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.util.CheckReturnValue;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Assertion methods for {@link java.lang.Throwable} similar to {@link ThrowableAssert} but with assertions methods named
@@ -343,7 +344,7 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    * @throws NullPointerException if the regex is null
    * @see AbstractThrowableAssert#hasMessageMatching(String)
    */
-  public ThrowableAssertAlternative<T> withMessageMatching(String regex) {
+  public ThrowableAssertAlternative<T> withMessageMatching(@Language("regexp") String regex) {
     delegate.hasMessageMatching(regex);
     return this;
   }

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -34,6 +34,7 @@ import org.assertj.core.api.RecursiveComparisonAssert;
 import org.assertj.core.internal.TypeComparators;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.VisibleForTesting;
+import org.intellij.lang.annotations.Language;
 
 @Beta
 public class RecursiveComparisonConfiguration {
@@ -128,7 +129,7 @@ public class RecursiveComparisonConfiguration {
    *
    * @param regexes regexes used to ignore fields in the comparison.
    */
-  public void ignoreFieldsMatchingRegexes(String... regexes) {
+  public void ignoreFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     ignoredFieldsRegexes.addAll(Stream.of(regexes)
                                       .map(Pattern::compile)
                                       .collect(toList()));
@@ -171,7 +172,7 @@ public class RecursiveComparisonConfiguration {
    *
    * @param regexes regexes used to specify the fields we want to force a recursive comparison on.
    */
-  public void ignoreOverriddenEqualsForFieldsMatchingRegexes(String... regexes) {
+  public void ignoreOverriddenEqualsForFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     ignoredOverriddenEqualsRegexes.addAll(Stream.of(regexes)
                                                 .map(Pattern::compile)
                                                 .collect(toList()));
@@ -232,7 +233,7 @@ public class RecursiveComparisonConfiguration {
    *
    * @param regexes regexes used to find the object under test fields to ignore collection order in in the comparison.
    */
-  public void ignoreCollectionOrderInFieldsMatchingRegexes(String... regexes) {
+  public void ignoreCollectionOrderInFieldsMatchingRegexes(@Language("regexp") String... regexes) {
     ignoredCollectionOrderInFieldsMatchingRegexes.addAll(Stream.of(regexes)
                                                                .map(Pattern::compile)
                                                                .collect(toList()));


### PR DESCRIPTION
This adds `@Language("regexp")` annotations to all public method arguments accepting regexps as `CharSequence`/`String`. This enables IntelliJ IDEA editor to

1. perform regexp syntax hilighting inside string arguments
2. allow unquoted editing of regexps in a separate editor (see https://confluence.jetbrains.com/display/CONTEST/IntelliLang)

BLOCKER: @Language not currently supported for `CharSequence` arguments; created issues https://youtrack.jetbrains.net/issue/IDEA-221169 and https://github.com/JetBrains/java-annotations/issues/16 for this to get resolved.

#### Check List:
* Unit tests : NA
* Javadoc with a code example (API only) : NA


