### PR TITLE
fix possible MissingFormatArgumentException in ShouldContain

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -19,6 +19,8 @@ import java.util.List;
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 
+import static org.assertj.core.util.Strings.escapePercent;
+
 /**
  * Creates an error message indicating that an assertion that verifies a group of elements contains a given set of values failed.
  * A group of elements can be a collection, an array or a {@code String}.<br>
@@ -70,8 +72,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
     // not passing directoryContent and filterDescription as parameter to avoid AssertJ default String formatting
     super("%nExpecting directory:%n" +
           "  <%s>%n" +
-          "to contain at least one file matching " + filterDescription + " but there was none.%n" +
-          "The directory content was:%n  " + directoryContent,
+          "to contain at least one file matching " + escapePercent(filterDescription) + " but there was none.%n" +
+          "The directory content was:%n  " + escapePercent(directoryContent.toString()),
           actual);
   }
 

--- a/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
@@ -137,6 +137,23 @@ public class ShouldContain_create_Test {
   }
 
   @Test
+  void should_create_error_message_for_file_directory_escaping_percent() {
+    // GIVEN
+    File directory = mock(File.class);
+    given(directory.getAbsolutePath()).willReturn("root%dir");
+    factory = directoryShouldContain(directory, list("foo%1.txt", "bar%2.txt"), "glob:**%Test.java");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    assertThat(message).isEqualTo(format("[Test] %n" +
+      "Expecting directory:%n" +
+      "  <root%%dir>%n" +
+      "to contain at least one file matching glob:**%%Test.java but there was none.%n" +
+      "The directory content was:%n" +
+      "  [foo%%1.txt, bar%%2.txt]"));
+  }
+
+  @Test
   public void should_create_error_message_for_path_directory() {
     // GIVEN
     Path directory = mock(Path.class);


### PR DESCRIPTION
As a follow up of #1574 I had a quick look about similar cases like the one described in the linked ticket.

