### PR TITLE
Add extracting(Function, InstanceOfAssertFactory) to AbstractObjectAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -659,7 +659,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
     Object value = byName(propertyOrField).apply(actual);
     String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
     String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
-    return newObjectAssert(value).as(description);
+    return newObjectAssert(value).withAssertionState(myself).as(description);
   }
 
   /**
@@ -699,16 +699,10 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    *
    * @since 3.14.0
    */
-  @SuppressWarnings("unchecked")
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
                                                                  InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    requireNonNull(assertFactory, shouldNotBeNull("assertFactory").create());
-    Object value = byName(propertyOrField).apply(actual);
-    objects.assertIsInstanceOf(info, value, assertFactory.getType());
-    String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
-    String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
-    return (ASSERT) assertFactory.createAssert(value).as(description);
+    return extracting(propertyOrField).asInstanceOf(assertFactory);
   }
 
   /**
@@ -758,6 +752,10 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * // The extracted value being a String, we would like to use String assertions but we can't due to Java generics limitations.
    * // The following assertion does NOT compile:
    * assertThat(frodo).extracting(TolkienCharacter::getName)
+   *                  .startsWith(&quot;Fro&quot;);
+   *
+   * // To get String assertions, use {@link #extracting(Function, InstanceOfAssertFactory)}:
+   * assertThat(frodo).extracting(TolkienCharacter::getName, InstanceOfAssertFactories.STRING)
    *                  .startsWith(&quot;Fro&quot;);</code></pre>
    *
    * @param <T> the expected extracted value type.
@@ -765,12 +763,48 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @return a new {@link ObjectAssert} instance whose object under test is the extracted value
    *
    * @since 3.11.0
+   * @see #extracting(Function, InstanceOfAssertFactory)
    */
   @CheckReturnValue
   public <T> AbstractObjectAssert<?, T> extracting(Function<? super ACTUAL, T> extractor) {
     requireNonNull(extractor, shouldNotBeNull("extractor").create());
     T extractedValue = extractor.apply(actual);
     return newObjectAssert(extractedValue).withAssertionState(myself);
+  }
+
+  /**
+   * Uses the given {@link Function} to extract a value from the object under test, the extracted value becoming the new object under test.
+   * <p>
+   * Note that since the value is extracted as an Object, only Object assertions can be chained after extracting.
+   * <p>
+   * The {@code assertFactory} parameter allows to specify an {@link InstanceOfAssertFactory}, which is used to get the
+   * assertions narrowed to the factory type.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // Create frodo, setting its name, age and Race
+   * TolkienCharacter frodo = new TolkienCharacter(&quot;Frodo&quot;, 33, HOBBIT);
+   *
+   * // let's extract and verify Frodo's name:
+   * assertThat(frodo).extracting(TolkienCharacter::getName, InstanceOfAssertFactories.STRING)
+   *                  .startsWith(&quot;Fro&quot;);
+   *
+   * // The following assertion does NOT compile as Frodo's name is not an Integer:
+   * assertThat(frodo).extracting(TolkienCharacter::getName, InstanceOfAssertFactories.INTEGER)
+   *                  .isZero();</code></pre>
+   *
+   * @param <T>           the expected extracted value type
+   * @param <ASSERT>      the type of the resulting {@code Assert}
+   * @param extractor     the extractor function used to extract the value from the object under test
+   * @param assertFactory the factory which verifies the type and creates the new {@code Assert}
+   * @return a new narrowed {@link Assert} instance whose object under test is the extracted value
+   * @throws NullPointerException if the given factory is {@code null}
+   *
+   * @since 3.14.0
+   */
+  @CheckReturnValue
+  public <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super ACTUAL, T> extractor,
+                                                                    InstanceOfAssertFactory<? super T, ASSERT> assertFactory) {
+    return extracting(extractor).asInstanceOf(assertFactory);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -656,6 +656,10 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public AbstractObjectAssert<?, ?> extracting(String propertyOrField) {
+    return internalExtracting(propertyOrField);
+  }
+
+  private AbstractObjectAssert<?, ?> internalExtracting(String propertyOrField) {
     Object value = byName(propertyOrField).apply(actual);
     String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
     String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
@@ -702,7 +706,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
                                                                  InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    return extracting(propertyOrField).asInstanceOf(assertFactory);
+    return internalExtracting(propertyOrField).asInstanceOf(assertFactory);
   }
 
   /**
@@ -767,6 +771,10 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public <T> AbstractObjectAssert<?, T> extracting(Function<? super ACTUAL, T> extractor) {
+    return internalExtracting(extractor);
+  }
+
+  private <T> AbstractObjectAssert<?, T> internalExtracting(Function<? super ACTUAL, T> extractor) {
     requireNonNull(extractor, shouldNotBeNull("extractor").create());
     T extractedValue = extractor.apply(actual);
     return newObjectAssert(extractedValue).withAssertionState(myself);
@@ -804,7 +812,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super ACTUAL, T> extractor,
                                                                     InstanceOfAssertFactory<? super T, ASSERT> assertFactory) {
-    return extracting(extractor).asInstanceOf(assertFactory);
+    return internalExtracting(extractor).asInstanceOf(assertFactory);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -659,13 +659,6 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
     return internalExtracting(propertyOrField);
   }
 
-  private AbstractObjectAssert<?, ?> internalExtracting(String propertyOrField) {
-    Object value = byName(propertyOrField).apply(actual);
-    String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
-    String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
-    return newObjectAssert(value).withAssertionState(myself).as(description);
-  }
-
   /**
    * Extracts the value of given field/property from the object under test, the extracted value becoming the new object under test.
    * <p>
@@ -707,6 +700,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
                                                                  InstanceOfAssertFactory<?, ASSERT> assertFactory) {
     return internalExtracting(propertyOrField).asInstanceOf(assertFactory);
+  }
+
+  private AbstractObjectAssert<?, ?> internalExtracting(String propertyOrField) {
+    Object value = byName(propertyOrField).apply(actual);
+    String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
+    String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
+    return newObjectAssert(value).withAssertionState(myself).as(description);
   }
 
   /**
@@ -774,12 +774,6 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
     return internalExtracting(extractor);
   }
 
-  private <T> AbstractObjectAssert<?, T> internalExtracting(Function<? super ACTUAL, T> extractor) {
-    requireNonNull(extractor, shouldNotBeNull("extractor").create());
-    T extractedValue = extractor.apply(actual);
-    return newObjectAssert(extractedValue).withAssertionState(myself);
-  }
-
   /**
    * Uses the given {@link Function} to extract a value from the object under test, the extracted value becoming the new object under test.
    * <p>
@@ -796,7 +790,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * assertThat(frodo).extracting(TolkienCharacter::getName, InstanceOfAssertFactories.STRING)
    *                  .startsWith(&quot;Fro&quot;);
    *
-   * // The following assertion does NOT compile as Frodo's name is not an Integer:
+   * // The following assertion will fail as Frodo's name is not an Integer:
    * assertThat(frodo).extracting(TolkienCharacter::getName, InstanceOfAssertFactories.INTEGER)
    *                  .isZero();</code></pre>
    *
@@ -811,8 +805,14 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super ACTUAL, T> extractor,
-                                                                    InstanceOfAssertFactory<? super T, ASSERT> assertFactory) {
+                                                                    InstanceOfAssertFactory<?, ASSERT> assertFactory) {
     return internalExtracting(extractor).asInstanceOf(assertFactory);
+  }
+
+  private <T> AbstractObjectAssert<?, T> internalExtracting(Function<? super ACTUAL, T> extractor) {
+    requireNonNull(extractor, shouldNotBeNull("extractor").create());
+    T extractedValue = extractor.apply(actual);
+    return newObjectAssert(extractedValue).withAssertionState(myself);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -433,6 +433,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(name)
           .extracting(Name::getFirst)
           .isEqualTo("John");
+    softly.assertThat(name)
+          .extracting(Name::getFirst, STRING)
+          .startsWith("Jo");
     // THEN
     assertThat(softly.errorsCollected()).isEmpty();
   }
@@ -676,9 +679,13 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .overridingErrorMessage("error 5")
           .extracting(TolkienCharacter::getName)
           .isEqualTo("Foo");
+    softly.assertThat(frodo)
+          .overridingErrorMessage("error 6")
+          .extracting(TolkienCharacter::getName, STRING)
+          .startsWith("Bar");
     // THEN
     assertThat(softly.errorsCollected()).extracting(Throwable::getMessage)
-                                        .containsExactly("error 1", "error 2", "error 3", "error 4", "error 5");
+                                        .containsExactly("error 1", "error 2", "error 3", "error 4", "error 5", "error 6");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test.java
@@ -74,7 +74,7 @@ class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends Abst
   void should_keep_existing_assertion_state() {
     // GIVEN
     assertions.as("description")
-              .overridingErrorMessage("error message")
+              .withFailMessage("error message")
               .withRepresentation(UNICODE_REPRESENTATION);
     // WHEN
     AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);

--- a/src/test/java/org/assertj/core/api/assumptions/Object_special_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Object_special_assertion_methods_in_assumptions_Test.java
@@ -42,6 +42,11 @@ public class Object_special_assertion_methods_in_assumptions_Test extends BaseAs
                                       value -> assumeThat(value).extracting(TolkienCharacter::getName)
                                                                 .isEqualTo("Gandalf")),
                      assumptionRunner(TolkienCharacter.of("Frodo", 33, Race.HOBBIT),
+                                      value -> assumeThat(value).extracting(TolkienCharacter::getName, STRING)
+                                                                .startsWith("Fro"),
+                                      value -> assumeThat(value).extracting(TolkienCharacter::getName, STRING)
+                                                                .startsWith("Gan")),
+                     assumptionRunner(TolkienCharacter.of("Frodo", 33, Race.HOBBIT),
                                       value -> assumeThat(value).extracting("name", "age")
                                                                 .contains("Frodo", 33),
                                       value -> assumeThat(value).extracting("name", "age")

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
@@ -15,92 +15,107 @@ package org.assertj.core.api.object;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.InstanceOfAssertFactories.BIG_DECIMAL;
-import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
+import static org.assertj.core.api.InstanceOfAssertFactories.CHAR_SEQUENCE;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
-import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
-import static org.assertj.core.util.BigDecimalComparator.BIG_DECIMAL_COMPARATOR;
 
-import java.math.BigDecimal;
-import java.util.Comparator;
+import java.util.function.Function;
 
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractBigDecimalAssert;
-import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
-import org.assertj.core.util.introspection.IntrospectionError;
 import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link ObjectAssert#extracting(String, InstanceOfAssertFactory)}</code>.
+ * Tests for <code>{@link ObjectAssert#extracting(Function, InstanceOfAssertFactory)}</code>.
+ *
+ * @author Stefano Cordio
  */
-class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
+class ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test {
 
   private Employee luke;
 
+  private static final Function<Employee, String> firstName = employee -> employee.getName().getFirst();
+
   @BeforeEach
-  void setup() {
+  void setUp() {
     luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+  }
+
+  @Test
+  void should_throw_npe_if_the_given_extractor_is_null() {
+    // GIVEN
+    Function<Employee, String> extractor = null;
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(extractor, STRING));
+    // THEN
+    then(error).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void should_throw_npe_if_the_given_assert_factory_is_null() {
     // WHEN
-    Throwable thrown = catchThrowable(() -> assertThat(luke).extracting("id", null));
+    Throwable thrown = catchThrowable(() -> assertThat(luke).extracting(Employee::getName, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  void should_throw_IntrospectionError_if_given_field_name_cannot_be_read() {
+  void should_allow_type_narrowed_assertions_on_value_extracted_with_lambda() {
     // WHEN
-    Throwable thrown = catchThrowable(() -> assertThat(luke).extracting("foo", LONG));
-    // THEN
-    then(thrown).isInstanceOf(IntrospectionError.class)
-                .hasMessageContaining("Can't find any field or property with name 'foo'.");
-  }
-
-  @Test
-  void should_allow_type_narrowed_assertions_on_property_extracted_by_name() {
-    // WHEN
-    AbstractLongAssert<?> result = assertThat(luke).extracting("id", LONG);
-    // THEN
-    result.isPositive();
-  }
-
-  @Test
-  void should_allow_narrowed_assertions_on_inner_property_extracted_by_name() {
-    // WHEN
-    AbstractStringAssert<?> result = assertThat(luke).extracting("name.first", STRING);
+    AbstractStringAssert<?> result = assertThat(luke).extracting(firstName, STRING);
     // THEN
     result.startsWith("Lu");
   }
 
   @Test
-  void should_fail_when_the_wrong_factory_type_is_used() {
+  void should_allow_parent_type_narrowed_assertions_on_value_extracted_with_parent_type_factory() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> assertThat(luke).extracting("name.first", LONG));
+    AbstractCharSequenceAssert<?, ?> result = assertThat(luke).extracting(firstName, CHAR_SEQUENCE);
     // THEN
-    then(error).hasMessageContainingAll("Expecting:", "to be an instance of:", "but was instance of:");
+    result.startsWith("Lu");
   }
 
   @Test
-  void should_use_property_field_name_as_description_when_extracting_single_property() {
+  void should_allow_type_narrowed_assertions_on_value_extracted_with_method_reference() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> assertThat(luke).extracting("name.first", STRING)
-                                                                      .isNull());
+    AbstractIntegerAssert<?> result = assertThat(luke).extracting(Employee::getAge, INTEGER);
     // THEN
-    then(error).hasMessageContaining("[Extracted: name.first]");
+    result.isPositive();
+  }
+
+  @Test
+  void should_rethrow_any_extractor_function_exception() {
+    // GIVEN
+    RuntimeException explosion = new RuntimeException("boom!");
+    Function<Employee, String> bomb = employee -> {
+      throw explosion;
+    };
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(bomb, STRING));
+    // THEN
+    then(error).isSameAs(explosion);
+  }
+
+  @Test
+  void should_honor_registered_comparator() {
+    // GIVEN
+    ObjectAssert<Employee> assertion = assertThat(luke).usingComparator(ALWAY_EQUALS);
+    // WHEN
+    AbstractStringAssert<?> result = assertion.extracting(firstName, STRING);
+    // THEN
+    result.isEqualTo("YODA");
   }
 
   @Test
@@ -113,7 +128,7 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
                                                                   .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
                                                                   .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
     // WHEN
-    AbstractStringAssert<?> result = assertion.extracting("name.first", STRING);
+    AbstractStringAssert<?> result = assertion.extracting(firstName, STRING);
     // THEN
     then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
                 .extracting(AbstractAssert::getWritableAssertionInfo)
@@ -124,35 +139,4 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
     return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
   }
 
-  @Test
-  void should_allow_to_specify_type_comparator_after_using_extracting_with_single_parameter_on_object() {
-    // GIVEN
-    Person obiwan = new Person("Obi-Wan");
-    obiwan.setHeight(new BigDecimal("1.820"));
-
-    Comparator<Object> heightComparator = (o1, o2) -> {
-      if (o1 instanceof BigDecimal) return BIG_DECIMAL_COMPARATOR.compare((BigDecimal) o1, (BigDecimal) o2);
-      throw new IllegalStateException("only supported for BigDecimal");
-    };
-    // WHEN
-    AbstractBigDecimalAssert<?> result = assertThat(obiwan).extracting("height", BIG_DECIMAL)
-                                                           .usingComparator(heightComparator);
-    // THEN
-    result.isEqualTo(new BigDecimal("1.82"));
-  }
-
-  @SuppressWarnings("unused")
-  private static class Person {
-
-    private final String name;
-    private BigDecimal height;
-
-    public Person(String name) {
-      this.name = name;
-    }
-
-    public void setHeight(BigDecimal height) {
-      this.height = height;
-    }
-  }
 }

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.function.Function;
 
@@ -93,6 +94,24 @@ class ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test {
     AbstractIntegerAssert<?> result = assertThat(luke).extracting(Employee::getAge, INTEGER);
     // THEN
     result.isPositive();
+  }
+
+  @Test
+  void should_allow_actual_type_narrowed_assertions_on_value_extracted_as_an_object() {
+    // GIVEN
+    final Function<Employee, Object> ageAsObject = Employee::getAge;
+    // WHEN
+    AbstractIntegerAssert<?> result = assertThat(luke).extracting(ageAsObject, INTEGER);
+    // THEN
+    result.isPositive();
+  }
+
+  @Test
+  void should_fail_when_the_wrong_factory_type_is_used() {
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThat(luke).extracting(Employee::getAge, STRING));
+    // THEN
+    then(error).hasMessageContainingAll("Expecting:", "to be an instance of:", "but was instance of:");
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #1490
* Unit tests : YES
* Javadoc with a code example (API only) : YES

#### Open issue

Instead of writing the inner implementation from scratch like in:
https://github.com/joel-costigliola/assertj-core/blob/167c63e4a901d598ea9418eef6a6e885aa7ba279/src/main/java/org/assertj/core/api/AbstractObjectAssert.java#L704-L712
I tried to delegate the actual logic to the existing `extracting` methods, but I'm having issues in `SoftAssertionsTest`. E.g., when executing `should_pass_when_using_extracting_with_object()`, I get:
```
java.lang.NullPointerException
	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:59)
	at org.assertj.core.api.StringAssert$ByteBuddy$RyD7qQEf$ByteBuddy$WbC2sF8N.assertj$setup(Unknown Source)
	at org.assertj.core.api.SoftProxies.createSoftAssertionProxy(SoftProxies.java:109)
	at org.assertj.core.api.ProxifyMethodChangingTheObjectUnderTest.createAssertProxy(ProxifyMethodChangingTheObjectUnderTest.java:55)
	at org.assertj.core.api.ProxifyMethodChangingTheObjectUnderTest.intercept(ProxifyMethodChangingTheObjectUnderTest.java:45)
	at org.assertj.core.api.ProxyableObjectAssert$ByteBuddy$yrZx1PLg.extracting(Unknown Source)
	at org.assertj.core.api.SoftAssertionsTest.should_pass_when_using_extracting_with_object(SoftAssertionsTest.java:428)
```

I guess the ByteBuddy configuration should be adjusted somehow, maybe to avoid proxying `extracting(..., InstanceOfAssertFactory)` methods, but I am not very familiar with ByteBuddy.

Any suggestion?