### PR TITLE
Remove release parameter from maven-compiler-plugin base configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <release>8</release>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
The maven build under JDK 8 fails because of the unsupported `release` parameter, which is indeed only supported [since java 9](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#release).

As the right value is already specified in the `java9+` maven profile, I think the `release` parameter should be removed from the base configuration.