### PR TITLE
Isssue#1502: Support formatting overloads in more AbstractThrowableAssert methods

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -159,6 +159,15 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
 
   /**
    * Verifies that the message of the actual {@code Throwable} starts with the given description.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass:
+   * assertThat(throwableWithMessage).hasMessageStartingWith("wrong amount");
+   *
+   * // assertions will fail:
+   * assertThat(throwableWithMessage).hasMessageStartingWith("right amount"); </code></pre>
    *
    * @param description the description expected to start the actual {@code Throwable}'s message.
    * @return this assertion object.
@@ -167,6 +176,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasMessageStartingWith(String description) {
     throwables.assertHasMessageStartingWith(info, actual, description);
+    return myself;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} starts with the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass:
+   * assertThat(throwableWithMessage).hasMessageStartingWith("%s amount", "wrong");
+   *
+   * // assertions will fail:
+   * assertThat(throwableWithMessage).hasMessageStartingWith("%s amount", "right"); </code></pre>
+   *
+   * @param description the description expected to start the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not start with the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   */
+  public SELF hasMessageStartingWith(String description, Object... parameters) {
+    throwables.assertHasMessageStartingWith(info, actual, String.format(description, parameters));
     return myself;
   }
 
@@ -191,6 +225,33 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasMessageContaining(String description) {
     throwables.assertHasMessageContaining(info, actual, description);
+    return myself;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} contains the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   * Throwable throwableWithoutMessage = new IllegalArgumentException();
+   *
+   * // assertion will pass:
+   * assertThat(throwableWithMessage).hasMessageContaining("amount %d", 123);
+   *
+   * // assertions will fail:
+   * assertThat(throwableWithoutMessage).hasMessageContaining("amount %d", 123);
+   * assertThat(throwableWithMessage).hasMessageContaining("%s amount", "right"); </code></pre>
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not contain the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   */
+  public SELF hasMessageContaining(String description, Object... parameters) {
+    throwables.assertHasMessageContaining(info, actual, String.format(description, parameters));
     return myself;
   }
 
@@ -270,6 +331,15 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
 
   /**
    * Verifies that the stack trace of the actual {@code Throwable} contains the given description.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThat(throwableWithMessage).hasStackTraceContaining("amount 123");
+   *
+   * // assertion will fail
+   * assertThat(throwableWithMessage).hasStackTraceContaining("456");</code></pre>
    *
    * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
    * @return this assertion object.
@@ -278,6 +348,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasStackTraceContaining(String description) {
     throwables.assertHasStackTraceContaining(info, actual, description);
+    return myself;
+  }
+
+  /**
+   * Verifies that the stack trace of the actual {@code Throwable} contains the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThat(throwableWithMessage).hasStackTraceContaining("%s", amount);
+   *
+   * // assertion will fail
+   * assertThat(throwableWithMessage).hasStackTraceContaining("%d", 456);</code></pre>
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the stack trace of the actual {@code Throwable} does not contain the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   */
+  public SELF hasStackTraceContaining(String description, Object... parameters) {
+    throwables.assertHasStackTraceContaining(info, actual, String.format(description, parameters));
     return myself;
   }
 
@@ -334,6 +429,15 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
 
   /**
    * Verifies that the message of the actual {@code Throwable} ends with the given description.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThat(throwableWithMessage).hasMessageEndingWith("123");
+   *
+   * // assertion will fail
+   * assertThat(throwableWithMessage).hasMessageEndingWith("456");</code></pre>
    *
    * @param description the description expected to end the actual {@code Throwable}'s message.
    * @return this assertion object.
@@ -342,6 +446,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    */
   public SELF hasMessageEndingWith(String description) {
     throwables.assertHasMessageEndingWith(info, actual, description);
+    return myself;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} ends with the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable throwableWithMessage = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThat(throwableWithMessage).hasMessageEndingWith("%s 123", "amount");
+   *
+   * // assertion will fail
+   * assertThat(throwableWithMessage).hasMessageEndingWith("amount %d", 456);</code></pre>
+   *
+   * @param description the description expected to end the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not end with the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   */
+  public SELF hasMessageEndingWith(String description, Object... parameters) {
+    throwables.assertHasMessageEndingWith(info, actual, String.format(description, parameters));
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import java.util.IllegalFormatException;
 import org.assertj.core.description.Description;
 import org.assertj.core.util.CheckReturnValue;
 
@@ -182,6 +183,36 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
   }
 
   /**
+   * Verifies that the message of the actual {@code Throwable} starts with the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageStartingWith("%s amount", "wrong");
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageStartingWith("%s amount", "right");</code></pre>
+   *
+   * @param description the description expected to start the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not start with the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   * @see AbstractThrowableAssert#hasMessageStartingWith(String, Object...)
+   */
+  public ThrowableAssertAlternative<T> withMessageStartingWith(String description, Object... parameters) {
+    delegate.hasMessageStartingWith(description, parameters);
+    return this;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} contains the given description.
    * <p>
    * Examples:
@@ -205,6 +236,36 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    */
   public ThrowableAssertAlternative<T> withMessageContaining(String description) {
     delegate.hasMessageContaining(description);
+    return this;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} contains the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageContaining("%s", amount);
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageContaining("%d", 456);</code></pre>
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not contain the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   * @see AbstractThrowableAssert#hasMessageContaining(String, Object...)
+   */
+  public ThrowableAssertAlternative<T> withMessageContaining(String description, Object... parameters) {
+    delegate.hasMessageContaining(description, parameters);
     return this;
   }
 
@@ -321,6 +382,36 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
   }
 
   /**
+   * Verifies that the stack trace of the actual {@code Throwable} contains with the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withStackTraceContaining("%s", amount);
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withStackTraceContaining("%d", 456);</code></pre>
+   *
+   * @param description the description expected to be contained in the actual {@code Throwable}'s stack trace.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the stack trace of the actual {@code Throwable} does not contain the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   * @see AbstractThrowableAssert#hasStackTraceContaining(String, Object...)
+   */
+  public ThrowableAssertAlternative<T> withStackTraceContaining(String description, Object... parameters) {
+    delegate.hasStackTraceContaining(description, parameters);
+    return this;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} matches with the given regular expression.
    * <p>
    * Examples:
@@ -372,6 +463,36 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    */
   public ThrowableAssertAlternative<T> withMessageEndingWith(String description) {
     delegate.hasMessageEndingWith(description);
+    return this;
+  }
+
+  /**
+   * Verifies that the message of the actual {@code Throwable} ends with the given description, after being formatted using
+   * the {@link String#format} method.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable illegalArgumentException = new IllegalArgumentException("wrong amount 123");
+   *
+   * // assertion will pass
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageEndingWith("%d", 123);
+   *
+   * // assertion will fail
+   * assertThatExceptionOfType(Throwable.class)
+   *           .isThrownBy(() -&gt; {throw illegalArgumentException;})
+   *           .withMessageEndingWith("%d", 456);</code></pre>
+   *
+   * @param description the description expected to end the actual {@code Throwable}'s message.
+   * @param parameters argument referenced by the format specifiers in the format string
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} does not end with the given description.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   * @see AbstractThrowableAssert#hasMessageEndingWith(String, Object...)
+   */
+  public ThrowableAssertAlternative<T> withMessageEndingWith(String description, Object... parameters) {
+    delegate.hasMessageEndingWith(description, parameters);
     return this;
   }
 

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatCode_Test.java
@@ -63,7 +63,7 @@ public class Assertions_assertThatCode_Test {
 
     // Then
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatCode(boom).doesNotThrowAnyException())
-                                                   .withMessageContaining("java.lang.Exception: boom")
+                                                   .withMessageContaining("java.lang.Exception: %s", "boom")
                                                    .withMessageContaining("at org.assertj.core.api.Assertions_assertThatCode_Test.error_message_contains_stacktrace");
   }
 

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasNotFailed_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasNotFailed_Test.java
@@ -57,7 +57,7 @@ public class CompletableFutureAssert_hasNotFailed_Test extends BaseTest {
     assertThatThrownBy(() -> assertThat(future).hasNotFailed()).isInstanceOf(AssertionError.class)
                                                                .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
                                                                .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                                                               .hasMessageEndingWith(format("to not have failed.%n%s", WARNING));
+                                                               .hasMessageEndingWith("to not have failed.%n%s", WARNING);
 
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValueMatching_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValueMatching_Test.java
@@ -94,7 +94,7 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     assertThat(throwable).isInstanceOf(AssertionError.class)
                          .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
                          .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                         .hasMessageEndingWith(format("to be completed.%n%s", WARNING));
+                         .hasMessageEndingWith("to be completed.%n%s", WARNING);
 
   }
 

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValue_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValue_Test.java
@@ -79,7 +79,7 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     assertThat(throwable).isInstanceOf(AssertionError.class)
                          .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
                          .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                         .hasMessageEndingWith(format("to be completed.%n%s", WARNING));
+                         .hasMessageEndingWith("to be completed.%n%s", WARNING);
 
   }
 

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
@@ -53,7 +53,7 @@ public class CompletableFutureAssert_isCompleted_Test extends BaseTest {
     assertThatThrownBy(() -> assertThat(future).isCompleted()).isInstanceOf(AssertionError.class)
                                                               .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
                                                               .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                                                              .hasMessageEndingWith(format("to be completed.%n%s", WARNING));
+                                                              .hasMessageEndingWith("to be completed.%n%s", WARNING);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompletedExceptionally_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompletedExceptionally_Test.java
@@ -44,7 +44,7 @@ public class CompletableFutureAssert_isNotCompletedExceptionally_Test extends Ba
     assertThatThrownBy(() -> assertThat(future).isNotCompletedExceptionally()).isInstanceOf(AssertionError.class)
                                                                               .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
                                                                               .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                                                                              .hasMessageEndingWith(format("to not be completed exceptionally.%n%s",
-                                                                                                           WARNING));
+                                                                              .hasMessageEndingWith("to not be completed exceptionally.%n%s",
+                                                                                                           WARNING);
   }
 }

--- a/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
@@ -34,14 +34,17 @@ public class ExpectThrowableAssert_isThrownBy_Test {
   @Test
   public void should_allow_to_check_exception_thrown_by_lambda() {
     // @format:off
-    Throwable exceptionWithCause = new NoSuchElementException("this too").initCause(new IllegalArgumentException("The cause"));
+    Throwable exceptionWithCause = new NoSuchElementException("this too 234").initCause(new IllegalArgumentException("The cause"));
     assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> { throw exceptionWithCause;})
-                                                     .withMessage("this too")
-                                                     .withMessage("this %s", "too")
+                                                     .withMessage("this too 234")
+                                                     .withMessage("this %s %d", "too", 234)
                                                      .withMessageStartingWith("this")
-                                                     .withMessageEndingWith("too")
+                                                     .withMessageStartingWith("%s", "this")
+                                                     .withMessageEndingWith("234")
+                                                     .withMessageEndingWith("too %d", 234)
                                                      .withMessageMatching(".*is.*")
                                                      .withStackTraceContaining("this")
+                                                     .withStackTraceContaining("is %s", "to")
                                                      .withCauseExactlyInstanceOf(IllegalArgumentException.class)
                                                      .withCauseInstanceOf(IllegalArgumentException.class);
     // @format:on

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageContaining_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageContaining_with_String_format_syntax_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasMessageContaining(String, Object...)}</code>.
+ *
+ * @author Krishna Chaithanya Ganta
+ */
+public class ThrowableAssert_hasMessageContaining_with_String_format_syntax_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasMessageContaining("able %s", "message");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageContaining(getInfo(assertions), getActual(assertions), "able message");
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageEndingWith_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageEndingWith_with_String_format_syntax_Test.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasMessageEndingWith(String, Object...)}</code>.
+ *
+ * @author Krishna Chaithanya Ganta
+ */
+public class ThrowableAssert_hasMessageEndingWith_with_String_format_syntax_Test extends ThrowableAssertBaseTest {
+
+  @Override protected ThrowableAssert invoke_api_method() {
+    return assertions.hasMessageEndingWith("%sage", "mess");
+  }
+
+  @Override protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageEndingWith(getInfo(assertions), getActual(assertions), "message");
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageStartingWith_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageStartingWith_with_String_format_syntax_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasMessageStartingWith(String, Object...)}</code>.
+ *
+ * @author Krishna Chaithanya Ganta
+ */
+public class ThrowableAssert_hasMessageStartingWith_with_String_format_syntax_Test extends ThrowableAssertBaseTest {
+
+  @Override protected ThrowableAssert invoke_api_method() {
+    return assertions.hasMessageStartingWith("throw%s", "able");
+  }
+
+  @Override protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageStartingWith(getInfo(assertions), getActual(assertions), "throwable");
+
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasStackTraceContaining_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasStackTraceContaining_with_String_format_syntax_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+
+/**
+ * Tests for <code>{@link ThrowableAssert#hasStackTraceContaining(String, Object...)}</code>.
+ *
+ * @author Krishna Chaithanya Ganta
+ */
+public class ThrowableAssert_hasStackTraceContaining_with_String_format_syntax_Test extends ThrowableAssertBaseTest {
+
+  @Override protected ThrowableAssert invoke_api_method() {
+    return assertions.hasStackTraceContaining("able%s", " message");
+  }
+
+  @Override protected void verify_internal_effects() {
+    verify(throwables).assertHasStackTraceContaining(getInfo(assertions), getActual(assertions), "able message");
+
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasNoCause_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasNoCause_Test.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 
 /**
- * Tests for <code>{@link Throwables#assertHasNoCause(AssertionInfo, Throwable, Class)}</code>.
+ * Tests for <code>{@link Throwables#assertHasNoCause(AssertionInfo, Throwable)}</code>.
  * 
  * @author Joel Costigliola
  */


### PR DESCRIPTION
#### Check List:
* Fixes #1502
* Unit tests : YES
* Javadoc with a code example (API only) : YES


