### PR TITLE
Fix #1607: Improve HamcrestCondition generic type inference

### DIFF
--- a/src/main/java/org/assertj/core/api/HamcrestCondition.java
+++ b/src/main/java/org/assertj/core/api/HamcrestCondition.java
@@ -32,14 +32,14 @@ import org.hamcrest.StringDescription;
 */
 public class HamcrestCondition<T> extends Condition<T> {
 
-  private Matcher<T> matcher;
+  private Matcher<? extends T> matcher;
 
   /**
    * Constructs a {@link Condition} using the matcher given as a parameter.
    * 
    * @param matcher the Hamcrest matcher to use as a condition
    */
- public HamcrestCondition(Matcher<T> matcher) {
+ public HamcrestCondition(Matcher<? extends T> matcher) {
     this.matcher = matcher;
     as(describeMatcher());
   }

--- a/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
+++ b/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
@@ -13,9 +13,13 @@
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.StringContains.containsString;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
 
 public class HamcrestConditionTest {
 
@@ -27,5 +31,15 @@ public class HamcrestConditionTest {
                      .has(aStringContainingA)
                      .satisfies(aStringContainingA);
     assertThat("bc").isNot(aStringContainingA);
+  }
+
+  @Test
+  public void should_be_able_to_use_a_hamcrest_matcher_with_generic() {
+    Collection<? extends CharSequence> emptyIterable = Collections.emptyList();
+    Collection<? extends CharSequence> oneElementIterable = Collections.singletonList("item");
+    assertThat(emptyIterable).is(new HamcrestCondition<>(empty()))
+      .has(new HamcrestCondition<>(empty()))
+      .satisfies(new HamcrestCondition<>(empty()));
+    assertThat(oneElementIterable).isNot(new HamcrestCondition<>(empty()));
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1607
* Unit tests : YES
* Javadoc with a code example (API only) : NA


