### PR TITLE
Fix #1610: replace catchThrowable + isInstanceOf(AssertionError.class) by expectAssertionError

### DIFF
--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -42,12 +42,11 @@ public class Assertions_assertThat_with_Throwable_Test {
 
   @Test
   public void should_be_able_to_pass_a_description_to_assertThatThrownBy() {
-    Throwable assertionError = catchThrowable(() -> {
+    AssertionError assertionError = expectAssertionError(() -> {
       // make assertThatThrownBy fail to verify the description afterwards
       assertThatThrownBy(raisingException("boom"), "Test %s", "code").hasMessage("bam");
     });
-    assertThat(assertionError).isInstanceOf(AssertionError.class)
-                              .hasMessageContaining("[Test code]");
+    assertThat(assertionError).hasMessageContaining("[Test code]");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
@@ -14,7 +14,6 @@ package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.TolkienCharacter.Race.DWARF;
 import static org.assertj.core.data.TolkienCharacter.Race.ELF;
 import static org.assertj.core.data.TolkienCharacter.Race.HOBBIT;
@@ -103,10 +102,10 @@ public class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
     Consumer<String> isEmpty = string -> assertThat(string).isEmpty();
     Consumer<String> endsWithZ = string -> assertThat(string).endsWith("Z");
     // THEN
-    Throwable thrown = catchThrowable(() -> assertThat("abc").as("String checks").satisfiesAnyOf(isEmpty, endsWithZ));
+    AssertionError assertionError = expectAssertionError(() -> assertThat("abc").as("String checks").satisfiesAnyOf(isEmpty,
+                                                                                                                    endsWithZ));
     // THEN
-    assertThat(thrown).isInstanceOf(AssertionError.class)
-                      .hasMessageContaining("String checks");
+    assertThat(assertionError).hasMessageContaining("String checks");
   }
 
   @Test
@@ -115,10 +114,10 @@ public class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
     Consumer<String> isEmpty = string -> assertThat(string).isEmpty();
     Consumer<String> endsWithZ = string -> assertThat(string).endsWith("Z");
     // THEN
-    Throwable thrown = catchThrowable(() -> assertThat("abc").as("String checks").satisfiesAnyOf(isEmpty, endsWithZ));
+    AssertionError assertionError = expectAssertionError(() -> assertThat("abc").as("String checks").satisfiesAnyOf(isEmpty,
+                                                                                                                    endsWithZ));
     // THEN
-    assertThat(thrown).isInstanceOf(AssertionError.class)
-                      .hasMessageContaining("String checks");
+    assertThat(assertionError).hasMessageContaining("String checks");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValueMatching_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValueMatching_Test.java
@@ -15,9 +15,9 @@ package org.assertj.core.api.future;
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 import static org.assertj.core.error.future.Warning.WARNING;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -40,10 +40,9 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     // GIVEN
     CompletableFuture<String> future = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(format(actualIsNull()));
+    assertThat(assertionError).hasMessage(format(actualIsNull()));
   }
 
   @Test
@@ -51,12 +50,11 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("foo"),
-                                                                                               "is foo"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("foo"),
+                                                                                                               "is foo"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessageContaining("<\"done\">")
-                         .hasMessageContaining("to match 'is foo' predicate");
+    assertThat(assertionError).hasMessageContaining("<\"done\">")
+                              .hasMessageContaining("to match 'is foo' predicate");
   }
 
   @Test
@@ -64,12 +62,11 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("foo")));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("foo")));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessageContaining("<\"done\">")
-                         .hasMessageContaining("to match given predicate")
-                         .hasMessageContaining("a better error message");
+    assertThat(assertionError).hasMessageContaining("<\"done\">")
+                              .hasMessageContaining("to match given predicate")
+                              .hasMessageContaining("a better error message");
   }
 
   @Test
@@ -77,10 +74,9 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(shouldBeCompleted(future).create());
+    assertThat(assertionError).hasMessage(shouldBeCompleted(future).create());
   }
 
   @Test
@@ -89,12 +85,11 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException());
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
-                         .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                         .hasMessageEndingWith("to be completed.%n%s", WARNING);
+    assertThat(assertionError).hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
+                              .hasMessageContaining("Caused by: java.lang.RuntimeException")
+                              .hasMessageEndingWith("to be completed.%n%s", WARNING);
 
   }
 
@@ -104,9 +99,8 @@ public class CompletableFutureAssert_isCompletedWithValueMatching_Test extends B
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValueMatching(result -> result.equals("done")));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(shouldBeCompleted(future).create());
+    assertThat(assertionError).hasMessage(shouldBeCompleted(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValue_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedWithValue_Test.java
@@ -14,9 +14,9 @@ package org.assertj.core.api.future;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 import static org.assertj.core.error.future.Warning.WARNING;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -39,10 +39,9 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     // GIVEN
     CompletableFuture<String> future = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValue("foo"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValue("foo"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(format(actualIsNull()));
+    assertThat(assertionError).hasMessage(format(actualIsNull()));
   }
 
   @Test
@@ -50,11 +49,10 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValue("foo"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValue("foo"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessageContaining("foo")
-                         .hasMessageContaining("done");
+    assertThat(assertionError).hasMessageContaining("foo")
+                              .hasMessageContaining("done");
   }
 
   @Test
@@ -62,10 +60,9 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValue("done"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValue("done"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(shouldBeCompleted(future).create());
+    assertThat(assertionError).hasMessage(shouldBeCompleted(future).create());
   }
 
   @Test
@@ -74,12 +71,11 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException());
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValue("done"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValue("done"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
-                         .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                         .hasMessageEndingWith("to be completed.%n%s", WARNING);
+    assertThat(assertionError).hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
+                              .hasMessageContaining("Caused by: java.lang.RuntimeException")
+                              .hasMessageEndingWith("to be completed.%n%s", WARNING);
 
   }
 
@@ -89,9 +85,8 @@ public class CompletableFutureAssert_isCompletedWithValue_Test extends BaseTest 
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(future).isCompletedWithValue("done"));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(future).isCompletedWithValue("done"));
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(shouldBeCompleted(future).create());
+    assertThat(assertionError).hasMessage(shouldBeCompleted(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_containsInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_containsInstanceOf_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.core.api.optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.Optional;
 
@@ -28,12 +28,11 @@ public class OptionalAssert_containsInstanceOf_Test extends BaseTest {
   public void should_fail_if_optional_is_empty() {
     Optional<Object> actual = Optional.empty();
 
-    Throwable thrown = catchThrowable(() -> {
+    AssertionError assertionError = expectAssertionError(() -> {
       assertThat(actual).containsInstanceOf(Object.class);
     });
 
-    assertThat(thrown).isInstanceOf(AssertionError.class)
-                      .hasMessage(shouldBePresent(actual).create());
+    assertThat(assertionError).hasMessage(shouldBePresent(actual).create());
   }
 
   @Test
@@ -51,12 +50,11 @@ public class OptionalAssert_containsInstanceOf_Test extends BaseTest {
   public void should_fail_if_optional_contains_other_type_than_required() {
     Optional<ParentClass> actual = Optional.of(new ParentClass());
 
-    Throwable thrown = catchThrowable(() -> {
+    AssertionError assertionError = expectAssertionError(() -> {
       assertThat(actual).containsInstanceOf(OtherClass.class);
     });
 
-    assertThat(thrown).isInstanceOf(AssertionError.class)
-                      .hasMessage(shouldContainInstanceOf(actual, OtherClass.class).create());
+    assertThat(assertionError).hasMessage(shouldContainInstanceOf(actual, OtherClass.class).create());
   }
 
   private static class ParentClass {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
@@ -54,10 +54,10 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
     Throwable throwable1 = catchThrowable(() -> assertThat(yoda).isEqualToComparingFieldByFieldRecursively(noname));
     Throwable throwable2 = catchThrowable(() -> assertThat(noname).isEqualToComparingFieldByFieldRecursively(yoda));
     // THEN
-    assertThat(throwable1).isInstanceOf(AssertionError.class)
-                          .isNotInstanceOf(NullPointerException.class);
-    assertThat(throwable2).isInstanceOf(AssertionError.class)
-                          .isNotInstanceOf(NullPointerException.class);
+    assertThat(throwable1).isNotInstanceOf(NullPointerException.class)
+                          .isInstanceOf(AssertionError.class);
+    assertThat(throwable2).isNotInstanceOf(NullPointerException.class)
+                          .isInstanceOf(AssertionError.class);
   }
 
   @Test
@@ -300,7 +300,7 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
   }
 
   private List<ComparisonDifference> computeDifferences(Object actual, Object expected,
-                                                          RecursiveComparisonConfiguration recursiveComparisonConfiguration) {
+                                                        RecursiveComparisonConfiguration recursiveComparisonConfiguration) {
     return new RecursiveComparisonDifferenceCalculator().determineDifferences(actual, expected, recursiveComparisonConfiguration);
   }
 


### PR DESCRIPTION
#### Check List:
* Fixes #1610 
* Unit tests : NA
* Javadoc with a code example (API only) : NA

I did not replace it in one instant because the resulting statement did not feel right. I just reordered the checks of the assertion so it does not look that weird. The File in question here is: ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java.
