### PR TITLE
#1611: rewrite CompletableFutureAssert test classes to use assertThatAssertionErrorIsThrownBy

### DIFF
--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailedWithThrowableThat_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailedWithThrowableThat_Test.java
@@ -12,24 +12,32 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.error.ShouldBeInstance.shouldBeInstance;
 import static org.assertj.core.error.future.ShouldHaveFailed.shouldHaveFailed;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert hasFailedWithThrowableThat")
 public class CompletableFutureAssert_hasFailedWithThrowableThat_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_has_failed() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.completeExceptionally(new RuntimeException("some random error"));
-
+    // THEN
     assertThat(future).hasFailedWithThrowableThat()
                       .isInstanceOf(RuntimeException.class)
                       .hasMessage("some random error");
@@ -37,47 +45,54 @@ public class CompletableFutureAssert_hasFailedWithThrowableThat_Test extends Bas
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).hasFailedWithThrowableThat()).isInstanceOf(AssertionError.class)
-                                                                                                       .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailedWithThrowableThat();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_has_failed_with_wrong_throwable() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-    future.completeExceptionally(new RuntimeException("some random error"));
-
-    // @format:off
-    assertThatThrownBy(() -> assertThat(future).hasFailedWithThrowableThat().isInstanceOf(IllegalArgumentException.class))
-               .isInstanceOf(AssertionError.class)
-               .hasMessageContaining(format("%nExpecting:%n" +
-                                            "  <java.lang.RuntimeException: some random error>%n" +
-                                            "to be an instance of:%n" +
-                                            "  <java.lang.IllegalArgumentException>%n"));
-    // @format:on
+    RuntimeException exception = new RuntimeException("some random error");
+    future.completeExceptionally(exception);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailedWithThrowableThat().isInstanceOf(IllegalArgumentException.class);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeInstance(exception, IllegalArgumentException.class).create());
   }
 
   @Test
   public void should_fail_if_completable_future_is_incomplete() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).hasFailedWithThrowableThat()).isInstanceOf(AssertionError.class)
-                                                                             .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailedWithThrowableThat();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 
   @Test
   public void should_fail_if_completable_future_is_completed() {
+    // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
-
-    assertThatThrownBy(() -> assertThat(future).hasFailedWithThrowableThat()).isInstanceOf(AssertionError.class)
-                                                                             .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailedWithThrowableThat();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 
   @Test
   public void should_fail_if_completable_future_was_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
-
-    assertThatThrownBy(() -> assertThat(future).hasFailedWithThrowableThat()).isInstanceOf(AssertionError.class)
-                                                                             .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailedWithThrowableThat();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailed_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailed_Test.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.future.ShouldHaveFailed.shouldHaveFailed;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailed_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasFailed_Test.java
@@ -14,53 +14,71 @@ package org.assertj.core.api.future;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldHaveFailed.shouldHaveFailed;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert hasFailed")
 public class CompletableFutureAssert_hasFailed_Test extends BaseTest {
 
   @Test
-  public void assertion_should_pass_if_completable_future_has_failed() {
+  public void should_pass_if_completable_future_has_failed() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.completeExceptionally(new RuntimeException());
-
+    // THEN
     assertThat(future).hasFailed();
   }
 
   @Test
-  public void assertion_should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).hasFailed()).isInstanceOf(AssertionError.class)
-                                                                                      .hasMessage(format(actualIsNull()));
+  public void should_fail_when_completable_future_is_null() {
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
-  public void assertion_should_fail_if_completable_future_is_incomplete() {
+  public void should_fail_if_completable_future_is_incomplete() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).hasFailed()).isInstanceOf(AssertionError.class)
-                                                            .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 
   @Test
-  public void assertion_should_fail_if_completable_future_is_completed() {
+  public void should_fail_if_completable_future_is_completed() {
+    // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
-
-    assertThatThrownBy(() -> assertThat(future).hasFailed()).isInstanceOf(AssertionError.class)
-                                                            .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 
   @Test
-  public void assertion_should_fail_if_completable_future_was_cancelled() {
+  public void should_fail_if_completable_future_was_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
-
-    assertThatThrownBy(() -> assertThat(future).hasFailed()).isInstanceOf(AssertionError.class)
-                                                            .hasMessage(shouldHaveFailed(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveFailed(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasNotFailed_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_hasNotFailed_Test.java
@@ -14,50 +14,70 @@ package org.assertj.core.api.future;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.Warning.WARNING;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert hasNotFailed")
 public class CompletableFutureAssert_hasNotFailed_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_incomplete() {
-    assertThat(new CompletableFuture<>()).hasNotFailed();
+    // WHEN
+    CompletableFuture<Object> future = new CompletableFuture<>();
+    // THEN
+    assertThat(future).hasNotFailed();
   }
 
   @Test
   public void should_pass_if_completable_future_is_completed() {
-    assertThat(CompletableFuture.completedFuture("done")).hasNotFailed();
+    // WHEN
+    CompletableFuture<String> future = CompletableFuture.completedFuture("done");
+    // THEN
+    assertThat(future).hasNotFailed();
   }
 
   @Test
   public void should_pass_if_completable_future_was_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.cancel(true);
-
+    // THEN
     assertThat(future).hasNotFailed();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).hasNotFailed()).isInstanceOf(AssertionError.class)
-                                                                                         .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasNotFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_has_failed() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException());
-
-    assertThatThrownBy(() -> assertThat(future).hasNotFailed()).isInstanceOf(AssertionError.class)
-                                                               .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
-                                                               .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                                                               .hasMessageEndingWith("to not have failed.%n%s", WARNING);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).hasNotFailed();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
+                                            .withMessageContaining("Caused by: java.lang.RuntimeException")
+                                            .withMessageEndingWith("to not have failed.%n%s", WARNING);
 
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCancelled_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCancelled_Test.java
@@ -12,38 +12,51 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCancelled.shouldBeCancelled;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isCancelled")
 public class CompletableFutureAssert_isCancelled_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.cancel(true);
-
+    // THEN
     assertThat(future).isCancelled();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isCancelled()).isInstanceOf(AssertionError.class)
-                                                                                        .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCancelled();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_not_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).isCancelled()).isInstanceOf(AssertionError.class)
-                                                              .hasMessage(shouldBeCancelled(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCancelled();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeCancelled(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCompletedExceptionally.shouldHaveCompletedExceptionally;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompletedExceptionally_Test.java
@@ -12,38 +12,52 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCompletedExceptionally.shouldHaveCompletedExceptionally;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isCompletedExceptionally")
 public class CompletableFutureAssert_isCompletedExceptionally_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_completed_exceptionally() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.completeExceptionally(new RuntimeException());
-
+    // THEN
     assertThat(future).isCompletedExceptionally();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isCompletedExceptionally()).isInstanceOf(AssertionError.class)
-                                                                                                     .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompletedExceptionally();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_not_completed_exceptionally() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).isCompletedExceptionally()).isInstanceOf(AssertionError.class)
-                                                                           .hasMessage(shouldHaveCompletedExceptionally(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompletedExceptionally();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldHaveCompletedExceptionally(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
@@ -14,7 +14,6 @@ package org.assertj.core.api.future;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 import static org.assertj.core.error.future.Warning.WARNING;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isCompleted_Test.java
@@ -17,51 +17,71 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeCompleted.shouldBeCompleted;
 import static org.assertj.core.error.future.Warning.WARNING;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isCompleted")
 public class CompletableFutureAssert_isCompleted_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_completed() {
-    assertThat(CompletableFuture.completedFuture("done")).isCompleted();
+    // GIVEN
+    CompletableFuture<String> future = CompletableFuture.completedFuture("done");
+    // THEN
+    assertThat(future).isCompleted();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isCompleted()).isInstanceOf(AssertionError.class)
-                                                                                        .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_incomplete() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).isCompleted()).isInstanceOf(AssertionError.class)
-                                                              .hasMessage(shouldBeCompleted(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeCompleted(future).create());
   }
 
   @Test
   public void should_fail_if_completable_future_has_failed() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException());
-
-    assertThatThrownBy(() -> assertThat(future).isCompleted()).isInstanceOf(AssertionError.class)
-                                                              .hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
-                                                              .hasMessageContaining("Caused by: java.lang.RuntimeException")
-                                                              .hasMessageEndingWith("to be completed.%n%s", WARNING);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed: java.lang.RuntimeException]%n"))
+                                            .withMessageContaining("Caused by: java.lang.RuntimeException")
+                                            .withMessageEndingWith("to be completed.%n%s", WARNING);
   }
 
   @Test
   public void should_fail_if_completable_future_was_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
-
-    assertThatThrownBy(() -> assertThat(future).isCompleted()).isInstanceOf(AssertionError.class)
-                                                              .hasMessage(shouldBeCompleted(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeCompleted(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isDone_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isDone_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeDone.shouldBeDone;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isDone_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isDone_Test.java
@@ -12,35 +12,50 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldBeDone.shouldBeDone;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isDone")
 public class CompletableFutureAssert_isDone_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_done() {
-    assertThat(CompletableFuture.completedFuture("done")).isDone();
+    // WHEN
+    CompletableFuture<String> future = CompletableFuture.completedFuture("done");
+    // THEN
+    assertThat(future).isDone();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isDone()).isInstanceOf(AssertionError.class)
-                                                                                   .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isDone();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_not_done() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
-    assertThatThrownBy(() -> assertThat(future).isDone()).isInstanceOf(AssertionError.class)
-                                                         .hasMessage(shouldBeDone(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isDone();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeDone(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCancelled_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCancelled_Test.java
@@ -12,38 +12,51 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeCancelled.shouldNotBeCancelled;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isNotCancelled")
 public class CompletableFutureAssert_isNotCancelled_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_cancelled() {
+    // WHEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
+    // THEN
     assertThat(future).isNotCancelled();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isNotCancelled()).isInstanceOf(AssertionError.class)
-                                                                                           .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotCancelled();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_not_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
     future.cancel(true);
-
-    assertThatThrownBy(() -> assertThat(future).isNotCancelled()).isInstanceOf(AssertionError.class)
-                                                                 .hasMessage(shouldNotBeCancelled(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotCancelled();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeCancelled(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCancelled_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCancelled_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeCancelled.shouldNotBeCancelled;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompleted_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompleted_Test.java
@@ -12,53 +12,70 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeCompleted.shouldNotBeCompleted;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isNotCompleted")
 public class CompletableFutureAssert_isNotCompleted_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_incomplete() {
+    // WHEN
     CompletableFuture<String> future = new CompletableFuture<>();
-
+    // THEN
     assertThat(future).isNotCompleted();
   }
 
   @Test
   public void should_pass_if_completable_future_has_failed() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.completeExceptionally(new RuntimeException());
-
+    // THEN
     assertThat(future).isNotCompleted();
   }
 
   @Test
   public void should_pass_if_completable_future_was_cancelled() {
+    // GIVEN
     CompletableFuture<String> future = new CompletableFuture<>();
+    // WHEN
     future.cancel(true);
-
+    // THEN
     assertThat(future).isNotCompleted();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isNotCompleted()).isInstanceOf(AssertionError.class)
-                                                                                           .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_completed() {
+    // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
-
-    assertThatThrownBy(() -> assertThat(future).isNotCompleted()).isInstanceOf(AssertionError.class)
-                                                                 .hasMessage(shouldNotBeCompleted(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotCompleted();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeCompleted(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompleted_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotCompleted_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeCompleted.shouldNotBeCompleted;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotDone_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotDone_Test.java
@@ -12,35 +12,50 @@
  */
 package org.assertj.core.api.future;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeDone.shouldNotBeDone;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CompletableFutureAssert isNotDone")
 public class CompletableFutureAssert_isNotDone_Test extends BaseTest {
 
   @Test
   public void should_pass_if_completable_future_is_not_done() {
-    assertThat(new CompletableFuture<>()).isNotDone();
+    // WHEN
+    CompletableFuture<Object> future = new CompletableFuture<>();
+    // THEN
+    assertThat(future).isNotDone();
   }
 
   @Test
   public void should_fail_when_completable_future_is_null() {
-    assertThatThrownBy(() -> assertThat((CompletableFuture<String>) null).isNotDone()).isInstanceOf(AssertionError.class)
-                                                                                      .hasMessage(format(actualIsNull()));
+    // GIVEN
+    CompletableFuture<String> future = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotDone();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_completable_future_is_done() {
+    // GIVEN
     CompletableFuture<String> future = CompletableFuture.completedFuture("done");
-
-    assertThatThrownBy(() -> assertThat(future).isNotDone()).isInstanceOf(AssertionError.class)
-                                                            .hasMessage(shouldNotBeDone(future).create());
+    // WHEN
+    ThrowingCallable code = () -> assertThat(future).isNotDone();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeDone(future).create());
   }
 }

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotDone_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_isNotDone_Test.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api.future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.error.future.ShouldNotBeDone.shouldNotBeDone;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;


### PR DESCRIPTION
#### Check List:
* part of #1661 (multiple parts per Assertion class tests)
* Unit tests : NA
* Javadoc with a code example (on API only) : NA


