### PR TITLE
HamcrestCondition: Add `matching` fluent helper method

### DIFF
--- a/src/main/java/org/assertj/core/api/HamcrestCondition.java
+++ b/src/main/java/org/assertj/core/api/HamcrestCondition.java
@@ -28,8 +28,11 @@ import org.hamcrest.StringDescription;
  * 
  * // assertion will fail
  * assertThat(&quot;bc&quot;).is(aStringContainingA);</code></pre>
+ *
+ * By static-importing the {@link #matching(Matcher)} method you can do:
+ * <pre><code class='java'>assertThat(&quot;abc&quot;).is(matching(containsString(&quot;a&quot;)));</code></pre>
  * @since 2.9.0 / 3.9.0
-*/
+ */
 public class HamcrestCondition<T> extends Condition<T> {
 
   private Matcher<? extends T> matcher;
@@ -39,14 +42,18 @@ public class HamcrestCondition<T> extends Condition<T> {
    * 
    * @param matcher the Hamcrest matcher to use as a condition
    */
- public HamcrestCondition(Matcher<? extends T> matcher) {
+  public HamcrestCondition(Matcher<? extends T> matcher) {
     this.matcher = matcher;
     as(describeMatcher());
   }
 
- /**
-  * {@inheritDoc}
-  */
+  public static <T> HamcrestCondition<T> matching(Matcher<? extends T> matcher) {
+    return new HamcrestCondition<T>(matcher);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public boolean matches(T value) {
     return matcher.matches(value);

--- a/src/main/java/org/assertj/core/api/HamcrestCondition.java
+++ b/src/main/java/org/assertj/core/api/HamcrestCondition.java
@@ -47,6 +47,11 @@ public class HamcrestCondition<T> extends Condition<T> {
     as(describeMatcher());
   }
 
+  /**
+   * Constructs a {@link Condition} using the matcher given as a parameter.
+   * 
+   * @param matcher the Hamcrest matcher to use as a condition
+   */
   public static <T> HamcrestCondition<T> matching(Matcher<? extends T> matcher) {
     return new HamcrestCondition<T>(matcher);
   }

--- a/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
+++ b/src/test/java/org/assertj/core/api/HamcrestConditionTest.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.HamcrestCondition.matching;
 import static org.assertj.core.util.Lists.list;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.StringContains.containsString;
@@ -32,6 +33,7 @@ public class HamcrestConditionTest {
                      .has(aStringContainingA)
                      .satisfies(aStringContainingA);
     assertThat("bc").isNot(aStringContainingA);
+    assertThat("abc").is(matching(containsString("a")));
   }
 
   @Test


### PR DESCRIPTION
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


