### PR TITLE
#1611: rewrite InstantAssert test classes to use assertThatAssertionErrorIsThrownBy and be more compliant with current guidelines

### DIFF
--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_IsBeforeOrEqualTo_Test.java
@@ -13,57 +13,86 @@
 package org.assertj.core.api.instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isBeforeOrEqualTo")
 public class InstantAssert_IsBeforeOrEqualTo_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isBeforeOrEqual_assertion() {
-    // WHEN
+  public void should_pass_if_actual_is_before_date_parameter() {
     assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
-    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
-    // THEN
-    verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test
-  public void test_isBeforeOrEqual_assertion_error_message() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(REFERENCE).isBeforeOrEqualTo(BEFORE))
-                                                   .withMessage(shouldBeBeforeOrEqualTo(REFERENCE, BEFORE).create());
+  public void should_pass_if_actual_is_before_date_as_string_parameter() {
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_date_parameter() {
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_date_as_string_parameter() {
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_after_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBeforeOrEqualTo(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBeforeOrEqualTo(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_after_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBeforeOrEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBeforeOrEqualTo(AFTER, REFERENCE).create());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
-      Instant actual = null;
-      assertThat(actual).isBeforeOrEqualTo(Instant.now());
-    }).withMessage(actualIsNull());
+    // GIVEN
+    Instant instant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(instant).isBeforeOrEqualTo(Instant.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_date_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isBeforeOrEqualTo((Instant) null))
+    // GIVEN
+    Instant otherInstant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isBeforeOrEqualTo(otherInstant);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The Instant to compare actual with should not be null");
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isBeforeOrEqualTo((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isBeforeOrEqualTo(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
-  }
-
-  private static void verify_that_isBeforeOrEqual_assertion_fails_and_throws_AssertionError(Instant dateToCheck,
-                                                                                            Instant reference) {
-    assertThatThrownBy(() -> assertThat(dateToCheck).isBeforeOrEqualTo(reference)).isInstanceOf(AssertionError.class);
-    assertThatThrownBy(() -> assertThat(dateToCheck).isBeforeOrEqualTo(reference.toString())).isInstanceOf(AssertionError.class);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfterOrEqual_Test.java
@@ -13,59 +13,86 @@
 package org.assertj.core.api.instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isAfterOrEqual")
 public class InstantAssert_isAfterOrEqual_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isAfterOrEqual_assertion() {
-    // WHEN
+  public void should_pass_if_actual_is_after_date_parameter() {
     assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
-    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
-    // THEN
-    verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(BEFORE, REFERENCE);
   }
 
   @Test
-  public void test_isAfterOrEqual_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isAfterOrEqualTo(instantAfter))
-                                                   .withMessage(shouldBeAfterOrEqualTo(instantReference, instantAfter).create());
+  public void should_pass_if_actual_is_after_date_as_string_parameter() {
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_date_parameter() {
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  public void should_pass_if_actual_is_equal_to_date_as_string_parameter() {
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_before_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfterOrEqualTo(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfterOrEqualTo(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_before_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfterOrEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfterOrEqualTo(BEFORE, REFERENCE).create());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
-      Instant actual = null;
-      assertThat(actual).isAfterOrEqualTo(Instant.now());
-    }).withMessage(actualIsNull());
+    // GIVEN
+    Instant instant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(instant).isAfterOrEqualTo(Instant.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_date_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isAfterOrEqualTo((Instant) null))
+    // GIVEN
+    Instant otherInstant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isAfterOrEqualTo(otherInstant);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The Instant to compare actual with should not be null");
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isAfterOrEqualTo((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isAfterOrEqualTo(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
-  }
-
-  private static void verify_that_isAfterOrEqual_assertion_fails_and_throws_AssertionError(Instant dateToCheck,
-                                                                                           Instant reference) {
-    assertThatThrownBy(() -> assertThat(dateToCheck).isAfterOrEqualTo(reference)).isInstanceOf(AssertionError.class);
-    assertThatThrownBy(() -> assertThat(dateToCheck).isAfterOrEqualTo(reference.toString())).isInstanceOf(AssertionError.class);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isAfter_Test.java
@@ -12,66 +12,93 @@
  */
 package org.assertj.core.api.instant;
 
-
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isAfter")
 public class InstantAssert_isAfter_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isAfter_assertion() {
-    // WHEN
+  public void should_pass_if_actual_is_after_date_parameter() {
     assertThat(AFTER).isAfter(REFERENCE);
-    assertThat(AFTER).isAfter(REFERENCE.toString());
-    // THEN
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
-    verify_that_isAfter_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
   }
 
   @Test
-  public void test_isAfter_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isAfter(instantAfter))
-                                                   .withMessage(format("%n" +
-                                                                       "Expecting:%n" +
-                                                                       "  <2007-12-03T10:15:30Z>%n" +
-                                                                       "to be strictly after:%n" +
-                                                                       "  <2007-12-03T10:15:35Z>"));
+  public void should_pass_if_actual_is_after_date_as_string_parameter() {
+    assertThat(AFTER).isAfter(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_before_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfter(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_before_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfter(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_equal_to_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isAfter(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_equal_to_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isAfter(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(REFERENCE, REFERENCE).create());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
-      Instant actual = null;
-      assertThat(actual).isAfter(Instant.now());
-    }).withMessage(actualIsNull());
+    // GIVEN
+    Instant instant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(instant).isAfter(Instant.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_date_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isAfter((Instant) null))
+    // GIVEN
+    Instant otherInstant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isAfter(otherInstant);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The Instant to compare actual with should not be null");
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isAfter((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isAfter(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
-  }
-
-  private static void verify_that_isAfter_assertion_fails_and_throws_AssertionError(Instant dateToCheck,
-                                                                                    Instant reference) {
-    assertThatThrownBy(() -> assertThat(dateToCheck).isAfter(reference)).isInstanceOf(AssertionError.class);
-    assertThatThrownBy(() -> assertThat(dateToCheck).isAfter(reference.toString())).isInstanceOf(AssertionError.class);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isBefore_Test.java
@@ -12,61 +12,93 @@
  */
 package org.assertj.core.api.instant;
 
-
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isBefore")
 public class InstantAssert_isBefore_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isBefore_assertion() {
-    // WHEN
+  public void should_pass_if_actual_is_before_date_parameter() {
     assertThat(BEFORE).isBefore(REFERENCE);
-    // THEN
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(REFERENCE, REFERENCE);
-    verify_that_isBefore_assertion_fails_and_throws_AssertionError(AFTER, REFERENCE);
   }
 
   @Test
-  public void test_isBefore_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantAfter).isBefore(instantReference))
-                                                   .withMessage(format("%nExpecting:%n  <2007-12-03T10:15:35Z>%nto be strictly before:%n  <2007-12-03T10:15:30Z>"));
+  public void should_pass_if_actual_is_before_date_as_string_parameter() {
+    assertThat(BEFORE).isBefore(REFERENCE.toString());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_after_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBefore(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_after_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBefore(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_equal_to_date_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isBefore(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_equal_to_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isBefore(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(REFERENCE, REFERENCE).create());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
-      Instant actual = null;
-      assertThat(actual).isBefore(Instant.now());
-    }).withMessage(actualIsNull());
+    // GIVEN
+    Instant instant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(instant).isBefore(Instant.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_date_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isBefore((Instant) null))
+    // GIVEN
+    Instant otherInstant = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isBefore(otherInstant);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The Instant to compare actual with should not be null");
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isBefore((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isBefore(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
-  }
-
-  private static void verify_that_isBefore_assertion_fails_and_throws_AssertionError(Instant dateToTest,
-                                                                                     Instant reference) {
-    assertThatThrownBy(() -> assertThat(dateToTest).isBefore(reference)).isInstanceOf(AssertionError.class);
-    assertThatThrownBy(() -> assertThat(dateToTest).isBefore(reference.toString())).isInstanceOf(AssertionError.class);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isEqualTo_Test.java
@@ -14,38 +14,40 @@ package org.assertj.core.api.instant;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import java.time.Instant;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isEqualTo")
 public class InstantAssert_isEqualTo_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isEqualTo_assertion() {
-    // WHEN
+  public void should_pass_if_actual_is_equal_to_date_as_string_parameter() {
     assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
-    // WHEN
-    ThrowingCallable assertionCode = () -> assertThat(REFERENCE).isEqualTo(REFERENCE.plusSeconds(1).toString());
-    // THEN
-    assertThatThrownBy(assertionCode).isInstanceOf(AssertionError.class);
   }
 
   @Test
-  public void test_isEqualTo_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isEqualTo(instantAfter.toString()))
-                                                   .withMessage(format("%nExpecting:%n <2007-12-03T10:15:30Z>%nto be equal to:%n <2007-12-03T10:15:35Z>%nbut was not."));
+  public void should_fail_if_actual_is_not_equal_to_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isEqualTo(AFTER.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(format("%nExpecting:%n <%s>%nto be equal to:%n <%s>%nbut was not.",
+                                                                REFERENCE, AFTER));
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isEqualTo((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isEqualTo(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
   }
 

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isIn_Test.java
@@ -12,46 +12,53 @@
  */
 package org.assertj.core.api.instant;
 
-
-import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.error.ShouldBeIn.shouldBeIn;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isIn")
 public class InstantAssert_isIn_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isIn_assertion() {
-    // WHEN
-    assertThat(REFERENCE).isIn(REFERENCE.toString(), REFERENCE.plusSeconds(1).toString());
-    // THEN
-    assertThatThrownBy(() -> assertThat(REFERENCE).isIn(REFERENCE.plusSeconds(1).toString(),
-                                                        REFERENCE.plusSeconds(2).toString()))
-                                                                                                     .isInstanceOf(AssertionError.class);
+  public void should_pass_if_actual_is_in_dates_as_string_array_parameter() {
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), AFTER.toString());
   }
 
   @Test
-  public void test_isIn_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isIn(instantAfter.toString()))
-                                                   .withMessage(format("%nExpecting:%n <2007-12-03T10:15:30Z>%nto be in:%n <[2007-12-03T10:15:35Z]>%n"));
+  public void should_fail_if_actual_is_not_in_dates_as_string_array_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isIn(AFTER.toString(), BEFORE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeIn(REFERENCE, asList(AFTER, BEFORE)).create());
   }
 
   @Test
   public void should_fail_if_dates_as_string_array_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isIn((String[]) null))
+    // GIVEN
+    String[] otherInstantsAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isIn(otherInstantsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The given Instant array should not be null");
   }
 
   @Test
   public void should_fail_if_dates_as_string_array_parameter_is_empty() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isIn(new String[0]))
+    // GIVEN
+    String[] otherInstantsAsString = new String[0];
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isIn(otherInstantsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The given Instant array should not be empty");
   }
 

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotEqualTo_Test.java
@@ -12,36 +12,41 @@
  */
 package org.assertj.core.api.instant;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isNotEqualTo")
 public class InstantAssert_isNotEqualTo_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isNotEqualTo_assertion() {
-    // WHEN
-    assertThat(REFERENCE).isNotEqualTo(REFERENCE.plusSeconds(1).toString());
-    // THEN
-    assertThatThrownBy(() -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString())).isInstanceOf(AssertionError.class);
+  public void should_pass_if_actual_is_not_equal_to_date_as_string_parameter() {
+    assertThat(REFERENCE).isNotEqualTo(AFTER.toString());
   }
 
   @Test
-  public void test_isNotEqualTo_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isNotEqualTo(instantReference.toString()))
-                                                   .withMessage(format("%nExpecting:%n <2007-12-03T10:15:30Z>%nnot to be equal to:%n <2007-12-03T10:15:30Z>%n"));
+  public void should_fail_if_actual_is_equal_to_date_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeEqual(REFERENCE, REFERENCE).create());
   }
 
   @Test
   public void should_fail_if_date_as_string_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isNotEqualTo((String) null))
+    // GIVEN
+    String otherInstantAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isNotEqualTo(otherInstantAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
                                         .withMessage("The String representing the Instant to compare actual with should not be null");
   }
 

--- a/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/core/api/instant/InstantAssert_isNotIn_Test.java
@@ -12,45 +12,52 @@
  */
 package org.assertj.core.api.instant;
 
-
-import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.error.ShouldNotBeIn.shouldNotBeIn;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import java.time.Instant;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("InstantAssert isNotIn")
 public class InstantAssert_isNotIn_Test extends InstantAssertBaseTest {
 
   @Test
-  public void test_isNotIn_assertion() {
-    // WHEN
-    assertThat(REFERENCE).isNotIn(REFERENCE.plusSeconds(1).toString(), REFERENCE.plusSeconds(2).toString());
-    // THEN
-    assertThatThrownBy(() -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), REFERENCE.plusSeconds(1).toString())).isInstanceOf(AssertionError.class);
+  public void should_pass_if_actual_is_not_in_dates_as_string_parameter() {
+    assertThat(REFERENCE).isNotIn(AFTER.toString(), BEFORE.toString());
   }
 
   @Test
-  public void test_isNotIn_assertion_error_message() {
-    Instant instantReference = Instant.parse("2007-12-03T10:15:30.00Z");
-    Instant instantAfter = Instant.parse("2007-12-03T10:15:35.00Z");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(instantReference).isNotIn(instantReference.toString(), instantAfter.toString()))
-                                                   .withMessage(format("%nExpecting:%n <2007-12-03T10:15:30Z>%nnot to be in:%n <[2007-12-03T10:15:30Z, 2007-12-03T10:15:35Z]>%n"));
+  public void should_fail_if_actual_is_in_dates_as_string_array_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), AFTER.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeIn(REFERENCE, asList(REFERENCE, AFTER)).create());
   }
 
   @Test
   public void should_fail_if_dates_as_string_array_parameter_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isNotIn((String[]) null))
-                                        .withMessage("The given Instant array should not be null");
+    // GIVEN
+    String[] otherInstantsAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isNotIn(otherInstantsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code).withMessage("The given Instant array should not be null");
   }
 
   @Test
   public void should_fail_if_dates_as_string_array_parameter_is_empty() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(Instant.now()).isNotIn(new String[0]))
-                                        .withMessage("The given Instant array should not be empty");
+    // GIVEN
+    String[] otherInstantsAsString = new String[0];
+    // WHEN
+    ThrowingCallable code = () -> assertThat(Instant.now()).isNotIn(otherInstantsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code).withMessage("The given Instant array should not be empty");
   }
 
 }


### PR DESCRIPTION
#### Check List:
* relates to #1611 (multiple parts per Assertion class tests)
* Unit tests : NA
* Javadoc with a code example (on API only) : NA


