### PR TITLE
Add throwable root cause message assertion

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -605,6 +605,63 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Verifies that the message of the root cause of the actual {@code Throwable} is equal to the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException("object")));
+   *
+   * // assertion will pass
+   * assertThat(throwable).hasRootCauseMessage("object");
+   *
+   * // assertions will fail
+   * assertThat((Throwable) null).hasRootCauseMessage("object");
+   * assertThat(throwable).hasRootCauseMessage("another object");
+   * assertThat(new Throwable()).hasRootCauseMessage("object");
+   * assertThat(new Throwable(new NullPointerException())).hasRootCauseMessage("object");</code></pre>
+   *
+   * @param message the expected root cause message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the root cause of the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the root cause of the actual {@code Throwable} is not equal to
+   *                        the given one.
+   * @since 3.14.0
+   */
+  public SELF hasRootCauseMessage(String message) {
+    throwables.assertHasRootCauseMessage(info, actual, message);
+    return myself;
+  }
+
+  /**
+   * Verifies that the message of the root cause of the actual {@code Throwable} is equal to the given one, after
+   * being formatted using {@link String#format(String, Object...)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'>Throwable throwable = new Throwable(new IllegalStateException(new NullPointerException("expected message")));
+   *
+   * // assertion will pass
+   * assertThat(throwable).hasRootCauseMessage("%s %s", "expected", "message");
+   *
+   * // assertions will fail
+   * assertThat((Throwable) null).hasRootCauseMessage("%s %s", "expected", "message");
+   * assertThat(throwable).hasRootCauseMessage("%s", "message");
+   * assertThat(new Throwable()).hasRootCauseMessage("%s %s", "expected", "message");
+   * assertThat(new Throwable(new NullPointerException())).hasRootCauseMessage("%s %s", "expected", "message");</code></pre>
+   *
+   * @param message the expected root cause message.
+   * @param parameters argument referenced by the format specifiers in the format string.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the root cause of the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the root cause of the actual {@code Throwable} is not equal to the given one.
+   * @throws IllegalFormatException if the message contains an illegal syntax according to {@link String#format(String, Object...)}.
+   * @since 3.14.0
+   */
+  public SELF hasRootCauseMessage(String message, Object... parameters) {
+    return hasRootCauseMessage(format(message, parameters));
+  }
+
+  /**
    * Verifies that the actual {@code Throwable} has no suppressed exceptions.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
@@ -14,8 +14,16 @@ package org.assertj.core.error;
 
 import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
+import static org.assertj.core.util.Strings.escapePercent;
+import static org.assertj.core.util.Throwables.getStackTrace;
 
 public class ShouldHaveRootCause extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHaveRootCauseWithMessage(Throwable actualCause, String expectedMessage) {
+    checkArgument(expectedMessage != null, "expected root cause message should not be null");
+    if (actualCause == null) return new ShouldHaveRootCause(expectedMessage);
+    return new ShouldHaveRootCause(actualCause, expectedMessage);
+  }
 
   public static ErrorMessageFactory shouldHaveRootCause(Throwable actualCause, Throwable expectedCause) {
     checkArgument(expectedCause != null, "expected cause should not be null");
@@ -61,6 +69,14 @@ public class ShouldHaveRootCause extends BasicErrorMessageFactory {
           "but type was:%n" +
           "  <%s>.",
           expectedCauseClass.getName(), actualCause.getClass().getName());
+  }
+
+  private ShouldHaveRootCause(String expectedMessage) {
+    super("%n" +
+        "Expecting a root cause with message:%n" +
+        "  <%s>%n" +
+        "but actual had no root cause.",
+      expectedMessage);
   }
 
   private ShouldHaveRootCause(Throwable actualCause, String expectedCauseMessage) {

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -26,6 +26,7 @@ import static org.assertj.core.error.ShouldHaveMessageMatchingRegex.shouldHaveMe
 import static org.assertj.core.error.ShouldHaveNoCause.shouldHaveNoCause;
 import static org.assertj.core.error.ShouldHaveNoSuppressedExceptions.shouldHaveNoSuppressedExceptions;
 import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCauseWithMessage;
 import static org.assertj.core.error.ShouldHaveRootCauseExactlyInstance.shouldHaveRootCauseExactlyInstance;
 import static org.assertj.core.error.ShouldHaveRootCauseInstance.shouldHaveRootCauseInstance;
 import static org.assertj.core.error.ShouldHaveSuppressedException.shouldHaveSuppressedException;
@@ -131,6 +132,21 @@ public class Throwables {
     if (actualRootCause == null) throw failures.failure(info, shouldHaveRootCause(null, expectedRootCause));
     if (!compareThrowable(actualRootCause, expectedRootCause))
       throw failures.failure(info, shouldHaveRootCause(actualRootCause, expectedRootCause));
+  }
+
+  /**
+   * Asserts that the message of the root cause of the actual {@code Throwable} is equal to the given one.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @param expectedMessage the expected message of the root cause.
+   */
+  public void assertHasRootCauseMessage(AssertionInfo info, Throwable actual, String expectedMessage) {
+    assertNotNull(info, actual);
+    Throwable rootCause = getRootCause(actual);
+    if (null == rootCause) throw failures.failure(info, shouldHaveRootCauseWithMessage(rootCause, expectedMessage));
+    if (areEqual(rootCause.getMessage(), expectedMessage)) return;
+    throw failures.failure(info, shouldHaveRootCauseWithMessage(rootCause, expectedMessage), rootCause.getMessage(), expectedMessage);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCauseMessage_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCauseMessage_Test.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ThrowableAssert hasRootCauseMessage")
+public class ThrowableAssert_hasRootCauseMessage_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasRootCauseMessage("message");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasRootCauseMessage(getInfo(assertions), getActual(assertions), "message");
+  }
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCauseMessage_with_String_format_syntax_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCauseMessage_with_String_format_syntax_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ThrowableAssert hasRootCauseMessageWithStringFormat")
+public class ThrowableAssert_hasRootCauseMessage_with_String_format_syntax_Test extends ThrowableAssertBaseTest {
+  @Override
+  protected ThrowableAssert invoke_api_method() {
+    return assertions.hasRootCauseMessage("%s %s", "expected", "message");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // check that we end calling assertHasRootCauseMessage with the resolved String.
+    verify(throwables).assertHasRootCauseMessage(getInfo(assertions), getActual(assertions), "expected message");
+  }
+
+  @Test
+  public void should_throw_if_String_format_syntax_is_not_met() {
+    assertThatIllegalArgumentException().isThrownBy(() -> assertions.hasRootCauseMessage("%s %s", "message"));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
@@ -13,11 +13,14 @@
 package org.assertj.core.error;
 
 import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCauseWithMessage;
 
 /**
  * Tests for
@@ -25,9 +28,16 @@ import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
  *
  * @author Jack Gough
  */
+@DisplayName("ShouldHaveRootCause create")
 public class ShouldHaveRootCause_create_Test {
 
   private static final TestDescription DESCRIPTION = new TestDescription("TEST");
+
+  @Test
+  public void should_fail_if_expected_message_is_null() {
+    assertThatIllegalArgumentException().isThrownBy(() -> shouldHaveRootCauseWithMessage(null, null))
+      .withMessage("expected root cause message should not be null");
+  }
 
   @Test
   public void should_create_error_message_for_expected_without_actual() {
@@ -100,5 +110,37 @@ public class ShouldHaveRootCause_create_Test {
                                         + "  <\"java.lang.RuntimeException\">%n"
                                         + "and message was:%n"
                                         + "  <\"wibble\">."));
+  }
+
+  @Test
+  public void should_create_error_message_for_null_root_cause() {
+    // GIVEN
+    String expectedMessage = "wobble";
+
+    // WHEN
+    String actual = shouldHaveRootCauseWithMessage(null, expectedMessage).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n" +
+                                        "Expecting a root cause with message:%n" +
+                                        "  <\"wobble\">%n" +
+                                        "but actual had no root cause."));
+  }
+
+  @Test
+  public void should_create_error_message_for_actual_message_unequal_to_expected() {
+    // GIVEN
+    Throwable actualCause = new RuntimeException("wibble");
+    String expectedMessage = "wobble";
+
+    // WHEN
+    String actual = shouldHaveRootCauseWithMessage(actualCause, expectedMessage).create(DESCRIPTION);
+
+    // THEN
+    assertThat(actual).isEqualTo(format("[TEST] %n" +
+                                        "Expecting a root cause with message:%n" +
+                                        "  <\"wobble\">%n" +
+                                        "but message was:%n" +
+                                        "  <\"wibble\">."));
   }
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseMessage_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseMessage_Test.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCauseWithMessage;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+@DisplayName("Throwables assertHasRootCauseMessage")
+public class Throwables_assertHasRootCauseMessage_Test extends ThrowablesBaseTest {
+
+  private static final AssertionInfo INFO = someInfo();
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> throwables.assertHasRootCauseMessage(INFO, null, "message"));
+    // THEN
+    assertThat(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  public void should_fail_if_root_cause_is_null() {
+    // GIVEN
+    Throwable error = new RuntimeException();
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> throwables.assertHasRootCauseMessage(INFO, error, "message"));
+    // THEN
+    assertThat(assertionError).hasMessage(shouldHaveRootCauseWithMessage(null,"message").create());
+  }
+
+  @Test
+  public void should_fail_if_root_cause_has_no_message() {
+    // GIVEN
+    Throwable root = new RuntimeException();
+    Throwable error = new RuntimeException(root);
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> throwables.assertHasRootCauseMessage(INFO, error, "message"));
+    // THEN
+    assertThat(assertionError).hasMessage(shouldHaveRootCauseWithMessage(root, "message").create());
+  }
+
+  @Test
+  public void should_fail_if_root_cause_message_is_different() {
+    // GIVEN
+    Throwable root = new RuntimeException("fail");
+    Throwable error = new RuntimeException(root);
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> throwables.assertHasRootCauseMessage(INFO, error, "message"));
+    // THEN
+    assertThat(assertionError).hasMessage(shouldHaveRootCauseWithMessage(root, "message").create());
+  }
+
+  @Test
+  public void should_pass_if_throwable_has_root_cause_with_message_equal_to_expected() {
+    // GIVEN
+    Throwable error = new RuntimeException(new RuntimeException("expected message"));
+    // THEN
+    throwables.assertHasRootCauseMessage(INFO, error, "expected message");
+  }
+
+  @Test
+  public void should_pass_if_actual_root_cause_has_no_message_and_expected_message_is_null() {
+    // GIVEN
+    Throwable error = new RuntimeException(new RuntimeException());
+    // THEN
+    throwables.assertHasRootCauseMessage(INFO, error, null);
+  }
+}


### PR DESCRIPTION
**NOTE**: I can add all methods similar to `haveMessage...` such as `hasMessageContaining`, `hasStartingWith` if maintainers will find it reasonable.

#### Check List:
* Fixes - no open issue
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
