### PR TITLE
Support nested maps and fields within map entry values using .extracting()

### DIFF
--- a/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
+++ b/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
@@ -17,6 +17,8 @@ import static org.assertj.core.util.Preconditions.checkArgument;
 
 import org.assertj.core.util.VisibleForTesting;
 
+import java.util.Map;
+
 public class PropertyOrFieldSupport {
   private static final String SEPARATOR = ".";
   private PropertySupport propertySupport;
@@ -54,11 +56,18 @@ public class PropertyOrFieldSupport {
       // extract next sub-property/field value until reaching the last sub-property/field
       return getValueOf(nextNameFrom(propertyOrFieldName), propertyOrFieldValue);
     }
+
     return getSimpleValue(propertyOrFieldName, input);
   }
 
   public Object getSimpleValue(String propertyOrFieldName, Object input) {
-    // first try to get given property values from objects, then try fields
+    // first check if input object is a map
+    if (input instanceof Map) {
+      Map<?, ?> map = (Map<?, ?>) input;
+      return map.get(propertyOrFieldName);
+    }
+
+    // then try to get given property values from objects, then try fields
     try {
       return propertySupport.propertyValueOf(propertyOrFieldName, Object.class, input);
     } catch (IntrospectionError propertyIntrospectionError) {

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_Test.java
@@ -38,6 +38,7 @@ public class ObjectAssert_extracting_Test {
   @BeforeEach
   public void setup() {
     luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+    luke.setAttribute("side", "light");
   }
 
   @Test
@@ -56,6 +57,13 @@ public class ObjectAssert_extracting_Test {
     assertThat(luke).extracting("name.first", "name.last")
                     .hasSize(2)
                     .containsExactly("Luke", "Skywalker");
+  }
+
+  @Test
+  public void should_allow_assertion_on_mixed_properties_or_fields_with_nested_map_values() {
+    assertThat(luke).extracting("id", "name.last", "attributes.side").containsExactly(
+      2L, "Skywalker", "light"
+    );
   }
 
   @Test

--- a/src/test/java/org/assertj/core/test/Employee.java
+++ b/src/test/java/org/assertj/core/test/Employee.java
@@ -12,6 +12,9 @@
  */
 package org.assertj.core.test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static java.lang.String.format;
 
 /**
@@ -31,6 +34,8 @@ public class Employee {
   // keep private to test we are able to read private field without property
   @SuppressWarnings("unused")
   private String city = "New York";
+  private Map<String, String> attributes;
+  private Map<String, Employee> relations;
 
   public Employee() {}
 
@@ -38,6 +43,8 @@ public class Employee {
     this.id = id;
     setName(name);
     setAge(age);
+    this.attributes = new HashMap<>();
+    this.relations = new HashMap<>();
   }
 
   public Name getName() {
@@ -54,6 +61,14 @@ public class Employee {
 
   public void setAge(int age) {
     this.age = age;
+  }
+
+  public void setAttribute(String attribute, String attributeValue) {
+    this.attributes.put(attribute, attributeValue);
+  }
+
+  public void setRelation(String relation, Employee other) {
+    this.relations.put(relation, other);
   }
   
   // pure property not backed by a field

--- a/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
@@ -27,12 +27,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class PropertyOrFieldSupport_getValueOf_Test {
-  private static final Employee yoda = new Employee(1L, new Name("Yoda"), 800);
+
   private PropertyOrFieldSupport propertyOrFieldSupport;
+  private Employee yoda;
 
   @BeforeEach
   public void setup() {
     propertyOrFieldSupport = PropertyOrFieldSupport.EXTRACTION;
+    yoda = new Employee(1L, new Name("Yoda"), 800);
+    yoda.setRelation("padawan", new Employee(3L, new Name("Luke", "Skywalker"), 24));
   }
 
   @Test
@@ -93,6 +96,21 @@ public class PropertyOrFieldSupport_getValueOf_Test {
     luke.surname = new Name("Young", "Padawan");
     Object value = propertyOrFieldSupport.getValueOf("me.field.me.field.me.field.surname.name", darth);
     assertThat(value).isEqualTo("Young Padawan");
+  }
+
+  @Test
+  public void should_extract_value_from_nested_map() {
+    Employee darth = new Employee(1L, new Name("Darth", "Vader"), 100);
+    darth.setAttribute("side", "dark");
+
+    Object value = propertyOrFieldSupport.getValueOf("attributes.side", darth);
+    assertThat(value).isEqualTo("dark");
+  }
+
+  @Test
+  public void should_extract_nested_property_field_within_nested_map() {
+    Object value = propertyOrFieldSupport.getValueOf("relations.padawan.name.first", yoda);
+    assertThat(value).isEqualTo("Luke");
   }
 
   @Test


### PR DESCRIPTION
* Fixes issue with extracting() with nested maps. (No tracker issue, to my knowledge)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA

Consider the following:
```
public class Employee {
   private Map<String, Employee> relations = new HashMap<>();
}
```

```
assertThat(employee).extracting("relations.padawan.name.first").isEqualTo(..)
```
This will break, since the current implementation only considers Maps as the first element in a nested property path. This pull request allows for getting a nested map entry value and for reaching further into nested properties of a nested map entry value.


Potential blocker for this PR could be the fact that the logic used by the extractor after the first element in the dot notated chain is located in PropertyOrFieldSupport, which may or may not be intended to deal with maps.