### PR TITLE
Add element(int, InstanceOfAssertFactory) to AbstractIterableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2536,9 +2536,47 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * @return the assertion on the given element
    * @throws AssertionError if the given index is out of bound.
    * @since 2.5.0 / 3.5.0
+   * @see #element(int, InstanceOfAssertFactory)
    */
   @CheckReturnValue
   public ELEMENT_ASSERT element(int index) {
+    return internalElement(index);
+  }
+
+  /**
+   * Navigate and allow to perform assertions on the chosen element of the {@link Iterable} under test.
+   * <p>
+   * The {@code assertFactory} parameter allows to specify an {@link InstanceOfAssertFactory}, which is used to get the
+   * assertions narrowed to the factory type.
+   * <p>
+   * Example: use of {@code String} assertions after {@code element(index, as(InstanceOfAssertFactories.STRING)}
+   * <pre><code class='java'> Iterable&lt;String&gt; hobbits = newArrayList("frodo", "sam", "pippin");
+   *
+   * // assertion succeeds
+   * assertThat(hobbits).element(1, as(InstanceOfAssertFactories.STRING))
+   *                    .startsWith("sa")
+   *                    .endsWith("am");
+   * // assertion fails
+   * assertThat(hobbits).element(1, as(InstanceOfAssertFactories.STRING))
+   *                    .startsWith("fro");
+   * // assertion fails because of wrong factory type
+   * assertThat(hobbits).element(1, as(InstanceOfAssertFactories.INTEGER))
+   *                    .isZero();</code></pre>
+   *
+   * @param <ASSERT>      the type of the resulting {@code Assert}
+   * @param index         the element's index
+   * @param assertFactory the factory which verifies the type and creates the new {@code Assert}
+   * @return a new narrowed {@link Assert} instance for assertions chaining on the element at the given index
+   * @throws AssertionError if the given index is out of bound.
+   * @throws NullPointerException if the given factory is {@code null}
+   * @since 3.14.0
+   */
+  @CheckReturnValue
+  public <ASSERT extends AbstractAssert<?, ?>> ASSERT element(int index, InstanceOfAssertFactory<?, ASSERT> assertFactory) {
+    return internalElement(index).asInstanceOf(assertFactory);
+  }
+
+  private ELEMENT_ASSERT internalElement(int index) {
     isNotEmpty();
     assertThat(index).describedAs(navigationDescription("check index validity"))
                      .isBetween(0, IterableUtil.sizeOf(actual) - 1);

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2434,12 +2434,49 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * assertThat(hobbits, StringAssert.class).last()
    *                                        .startsWith("fro");</code></pre>
    *
-   * @return the assertion on the first element
+   * @return the assertion on the last element
    * @throws AssertionError if the actual {@link Iterable} is empty.
    * @since 2.5.0 / 3.5.0
+   * @see #last(InstanceOfAssertFactory)
    */
   @CheckReturnValue
   public ELEMENT_ASSERT last() {
+    return internalLast();
+  }
+
+  /**
+   * Navigate and allow to perform assertions on the last element of the {@link Iterable} under test.
+   * <p>
+   * The {@code assertFactory} parameter allows to specify an {@link InstanceOfAssertFactory}, which is used to get the
+   * assertions narrowed to the factory type.
+   * <p>
+   * Example: use of {@code String} assertions after {@code last(as(InstanceOfAssertFactories.STRING)}
+   * <pre><code class='java'> Iterable&lt;String&gt; hobbits = newArrayList("frodo", "sam", "pippin");
+   *
+   * // assertion succeeds
+   * assertThat(hobbits).last(as(InstanceOfAssertFactories.STRING))
+   *                    .startsWith("pip")
+   *                    .endsWith("pin");
+   * // assertion fails
+   * assertThat(hobbits).last(as(InstanceOfAssertFactories.STRING))
+   *                    .startsWith("fro");
+   * // assertion fails because of wrong factory type
+   * assertThat(hobbits).last(as(InstanceOfAssertFactories.INTEGER))
+   *                    .isZero();</code></pre>
+   *
+   * @param <ASSERT>      the type of the resulting {@code Assert}
+   * @param assertFactory the factory which verifies the type and creates the new {@code Assert}
+   * @return a new narrowed {@link Assert} instance for assertions chaining on the last element
+   * @throws AssertionError if the actual {@link Iterable} is empty.
+   * @throws NullPointerException if the given factory is {@code null}
+   * @since 3.14.0
+   */
+  @CheckReturnValue
+  public <ASSERT extends AbstractAssert<?, ?>> ASSERT last(InstanceOfAssertFactory<?, ASSERT> assertFactory) {
+    return internalLast().asInstanceOf(assertFactory);
+  }
+
+  private ELEMENT_ASSERT internalLast() {
     isNotEmpty();
     return toAssert(lastElement(), navigationDescription("check last element"));
   }

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1998,6 +1998,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @see AbstractOptionalAssert#get(InstanceOfAssertFactory)
    * @see AbstractIterableAssert#first(InstanceOfAssertFactory)
    * @see AbstractIterableAssert#last(InstanceOfAssertFactory)
+   * @see AbstractIterableAssert#element(int, InstanceOfAssertFactory)
    */
   public static <T, ASSERT extends AbstractAssert<?, ?>> InstanceOfAssertFactory<T, ASSERT> as(InstanceOfAssertFactory<T, ASSERT> assertFactory) {
     return assertFactory;

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1997,6 +1997,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @see AbstractMapAssert#extractingByKey(Object, InstanceOfAssertFactory)
    * @see AbstractOptionalAssert#get(InstanceOfAssertFactory)
    * @see AbstractIterableAssert#first(InstanceOfAssertFactory)
+   * @see AbstractIterableAssert#last(InstanceOfAssertFactory)
    */
   public static <T, ASSERT extends AbstractAssert<?, ?>> InstanceOfAssertFactory<T, ASSERT> as(InstanceOfAssertFactory<T, ASSERT> assertFactory) {
     return assertFactory;

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -749,6 +749,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     softly.then(emptyList()).last();
     // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
     softly.then(emptyList()).last(as(STRING));
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.then(emptyList()).element(1);
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.then(emptyList()).element(1, as(STRING));
     // nested proxied call to throwAssertionError when checking that is optional is present
     softly.then(Optional.empty()).contains("Foo");
     // nested proxied call to isNotNull
@@ -756,7 +760,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     // nested proxied call to isCompleted
     softly.then(new CompletableFuture<String>()).isCompletedWithValue("done");
     // it must be caught by softly.assertAll()
-    assertThat(softly.errorsCollected()).hasSize(7);
+    assertThat(softly.errorsCollected()).hasSize(9);
   }
 
   // bug #447

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -745,6 +745,10 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     softly.then(emptyList()).first();
     // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
     softly.then(emptyList()).first(as(STRING));
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.then(emptyList()).last();
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.then(emptyList()).last(as(STRING));
     // nested proxied call to throwAssertionError when checking that is optional is present
     softly.then(Optional.empty()).contains("Foo");
     // nested proxied call to isNotNull
@@ -752,7 +756,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     // nested proxied call to isCompleted
     softly.then(new CompletableFuture<String>()).isCompletedWithValue("done");
     // it must be caught by softly.assertAll()
-    assertThat(softly.errorsCollected()).hasSize(5);
+    assertThat(softly.errorsCollected()).hasSize(7);
   }
 
   // bug #447

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1027,6 +1027,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .element(0)
           .isNull();
     softly.assertThat(names)
+          .as("element(0) as Name")
+          .overridingErrorMessage("error message")
+          .element(0, as(type(Name.class)))
+          .isNull();
+    softly.assertThat(names)
           .as("last element")
           .overridingErrorMessage("error message")
           .last()
@@ -1038,15 +1043,16 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .isNull();
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(8);
+    assertThat(errorsCollected).hasSize(9);
     assertThat(errorsCollected.get(0)).hasMessage("[size isGreaterThan(10)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[size isGreaterThan(22)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[should not be empty] error message 2");
     assertThat(errorsCollected.get(3)).hasMessage("[first element] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[first element as Name] error message");
     assertThat(errorsCollected.get(5)).hasMessage("[element(0)] error message");
-    assertThat(errorsCollected.get(6)).hasMessage("[last element] error message");
-    assertThat(errorsCollected.get(7)).hasMessage("[last element as Name] error message");
+    assertThat(errorsCollected.get(6)).hasMessage("[element(0) as Name] error message");
+    assertThat(errorsCollected.get(7)).hasMessage("[last element] error message");
+    assertThat(errorsCollected.get(8)).hasMessage("[last element as Name] error message");
   }
 
   @Test
@@ -1084,6 +1090,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .element(0)
           .isNull();
     softly.assertThat(names)
+          .as("element(0) as Name")
+          .overridingErrorMessage("error message")
+          .element(0, as(type(Name.class)))
+          .isNull();
+    softly.assertThat(names)
           .as("last element")
           .overridingErrorMessage("error message")
           .last()
@@ -1095,15 +1106,16 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .isNull();
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(8);
+    assertThat(errorsCollected).hasSize(9);
     assertThat(errorsCollected.get(0)).hasMessage("[size isGreaterThan(10)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[size isGreaterThan(22)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[shoud not be empty] error message 2");
     assertThat(errorsCollected.get(3)).hasMessage("[first element] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[first element as Name] error message");
     assertThat(errorsCollected.get(5)).hasMessage("[element(0)] error message");
-    assertThat(errorsCollected.get(6)).hasMessage("[last element] error message");
-    assertThat(errorsCollected.get(7)).hasMessage("[last element as Name] error message");
+    assertThat(errorsCollected.get(6)).hasMessage("[element(0) as Name] error message");
+    assertThat(errorsCollected.get(7)).hasMessage("[last element] error message");
+    assertThat(errorsCollected.get(8)).hasMessage("[last element as Name] error message");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -856,6 +856,10 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(emptyList()).first();
     // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
     softly.assertThat(emptyList()).first(as(STRING));
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.assertThat(emptyList()).last();
+    // the nested proxied call to isNotEmpty() throw an Assertion error that must be propagated to the caller.
+    softly.assertThat(emptyList()).last(as(STRING));
     // nested proxied call to throwAssertionError when checking that is optional is present
     softly.assertThat(Optional.empty()).contains("Foo");
     // nested proxied call to isNotNull
@@ -863,7 +867,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // nested proxied call to isCompleted
     softly.assertThat(new CompletableFuture<String>()).isCompletedWithValue("done");
     // it must be caught by softly.assertAll()
-    assertThat(softly.errorsCollected()).hasSize(5);
+    assertThat(softly.errorsCollected()).hasSize(7);
   }
 
   @Test
@@ -1004,7 +1008,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .size()
           .isGreaterThan(22)
           .returnToIterable()
-          .as("shoud not be empty") // TODO returnToIterable() does not yet propagate assertion info
+          .as("should not be empty") // TODO returnToIterable() does not yet propagate assertion info
           .overridingErrorMessage("error message 2")
           .isEmpty();
     softly.assertThat(names)
@@ -1027,16 +1031,22 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .overridingErrorMessage("error message")
           .last()
           .isNull();
+    softly.assertThat(names)
+          .as("last element as Name")
+          .overridingErrorMessage("error message")
+          .last(as(type(Name.class)))
+          .isNull();
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(7);
+    assertThat(errorsCollected).hasSize(8);
     assertThat(errorsCollected.get(0)).hasMessage("[size isGreaterThan(10)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[size isGreaterThan(22)] error message");
-    assertThat(errorsCollected.get(2)).hasMessage("[shoud not be empty] error message 2");
+    assertThat(errorsCollected.get(2)).hasMessage("[should not be empty] error message 2");
     assertThat(errorsCollected.get(3)).hasMessage("[first element] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[first element as Name] error message");
     assertThat(errorsCollected.get(5)).hasMessage("[element(0)] error message");
     assertThat(errorsCollected.get(6)).hasMessage("[last element] error message");
+    assertThat(errorsCollected.get(7)).hasMessage("[last element as Name] error message");
   }
 
   @Test
@@ -1078,9 +1088,14 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .overridingErrorMessage("error message")
           .last()
           .isNull();
+    softly.assertThat(names)
+          .as("last element as Name")
+          .overridingErrorMessage("error message")
+          .last(as(type(Name.class)))
+          .isNull();
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(7);
+    assertThat(errorsCollected).hasSize(8);
     assertThat(errorsCollected.get(0)).hasMessage("[size isGreaterThan(10)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[size isGreaterThan(22)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[shoud not be empty] error message 2");
@@ -1088,6 +1103,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(4)).hasMessage("[first element as Name] error message");
     assertThat(errorsCollected.get(5)).hasMessage("[element(0)] error message");
     assertThat(errorsCollected.get(6)).hasMessage("[last element] error message");
+    assertThat(errorsCollected.get(7)).hasMessage("[last element as Name] error message");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_involving_iterable_navigation_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_involving_iterable_navigation_Test.java
@@ -63,6 +63,7 @@ class Assumptions_assumeThat_involving_iterable_navigation_Test {
       assumeThat(jedis).first().isEqualTo(yoda);
       assumeThat(jedis).first(as(type(Jedi.class))).isEqualTo(yoda);
       assumeThat(jedis).last().isEqualTo(luke);
+      assumeThat(jedis).last(as(type(Jedi.class))).isEqualTo(luke);
       assumeThat(jedis).element(1).isEqualTo(luke);
     }).doesNotThrowAnyException();
   }
@@ -91,6 +92,13 @@ class Assumptions_assumeThat_involving_iterable_navigation_Test {
   @Test
   void should_ignore_test_when_assumption_after_navigating_to_last_fails() {
     assertThatExceptionOfType(AssumptionViolatedException.class).isThrownBy(() -> assumeThat(jedis).last()
+                                                                                                   .as("check last element")
+                                                                                                   .isEqualTo(yoda));
+  }
+
+  @Test
+  void should_ignore_test_when_assumption_after_navigating_to_last_with_InstanceOfAssertFactory_fails() {
+    assertThatExceptionOfType(AssumptionViolatedException.class).isThrownBy(() -> assumeThat(jedis).last(as(type(Jedi.class)))
                                                                                                    .as("check last element")
                                                                                                    .isEqualTo(yoda));
   }

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_involving_iterable_navigation_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_involving_iterable_navigation_Test.java
@@ -65,6 +65,7 @@ class Assumptions_assumeThat_involving_iterable_navigation_Test {
       assumeThat(jedis).last().isEqualTo(luke);
       assumeThat(jedis).last(as(type(Jedi.class))).isEqualTo(luke);
       assumeThat(jedis).element(1).isEqualTo(luke);
+      assumeThat(jedis).element(1, as(type(Jedi.class))).isEqualTo(luke);
     }).doesNotThrowAnyException();
   }
 
@@ -106,6 +107,14 @@ class Assumptions_assumeThat_involving_iterable_navigation_Test {
   @Test
   void should_ignore_test_when_assumption_after_navigating_to_element_fails() {
     assertThatExceptionOfType(AssumptionViolatedException.class).isThrownBy(() -> assumeThat(jedis).element(1)
+                                                                                                   .as("check element at index 1")
+                                                                                                   .isEqualTo(yoda));
+  }
+
+  @Test
+  void should_ignore_test_when_assumption_after_navigating_to_element_with_InstanceOfAssertFactory_fails() {
+    assertThatExceptionOfType(AssumptionViolatedException.class).isThrownBy(() -> assumeThat(jedis).element(1,
+                                                                                                            as(type(Jedi.class)))
                                                                                                    .as("check element at index 1")
                                                                                                    .isEqualTo(yoda));
   }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_element_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_element_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsEmpty;
+
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.IterableAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.StringAssert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link IterableAssert#element(int)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("IterableAssert element(int)")
+class IterableAssert_element_Test {
+
+  private final Iterable<String> iterable = asList("Homer", "Marge", "Lisa", "Bart", "Maggie");
+
+  @Test
+  void should_fail_if_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> iterable = emptyList();
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).element(1));
+    // THEN
+    then(assertionError).hasMessage(actualIsEmpty());
+  }
+
+  @Test
+  void should_pass_allowing_object_assertions_if_iterable_contains_at_least_one_element() {
+    // WHEN
+    ObjectAssert<String> result = assertThat(iterable).element(1);
+    // THEN
+    result.isEqualTo("Marge");
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_assertion_was_created_with_assert_class() {
+    // GIVEN
+    Class<StringAssert> assertClass = StringAssert.class;
+    // WHEN
+    StringAssert result = assertThat(iterable, assertClass).element(1);
+    // THEN
+    result.startsWith("Mar");
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_assertion_was_created_with_assert_factory() {
+    // GIVEN
+    AssertFactory<String, StringAssert> assertFactory = StringAssert::new;
+    // WHEN
+    StringAssert result = assertThat(iterable, assertFactory).element(1);
+    // THEN
+    result.startsWith("Mar");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_element_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_element_with_InstanceOfAssertFactory_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsEmpty;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.IterableAssert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link IterableAssert#element(int, InstanceOfAssertFactory)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("IterableAssert element(int, InstanceOfAssertFactory)")
+class IterableAssert_element_with_InstanceOfAssertFactory_Test {
+
+  private final Iterable<Object> iterable = asList(0.0, "string", 42);
+
+  @Test
+  void should_fail_if_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> iterable = emptyList();
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).element(1, STRING));
+    // THEN
+    then(assertionError).hasMessage(actualIsEmpty());
+  }
+
+  @Test
+  void should_fail_throwing_npe_if_assert_factory_is_null() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(iterable).element(1, null));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_element_is_an_instance_of_the_factory_type() {
+    // WHEN
+    AbstractStringAssert<?> result = assertThat(iterable).element(1, STRING);
+    // THEN
+    result.startsWith("str");
+  }
+
+  @Test
+  void should_fail_if_last_element_is_not_an_instance_of_the_factory_type() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).element(1, INTEGER));
+    // THEN
+    then(assertionError).hasMessageContainingAll("Expecting:", "to be an instance of:", "but was instance of:");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_last_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_last_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsEmpty;
+
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.IterableAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.StringAssert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link IterableAssert#last()}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("IterableAssert last")
+class IterableAssert_last_Test {
+
+  private final Iterable<String> iterable = asList("Homer", "Marge", "Lisa", "Bart", "Maggie");
+
+  @Test
+  void should_fail_if_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> iterable = emptyList();
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).last());
+    // THEN
+    then(assertionError).hasMessage(actualIsEmpty());
+  }
+
+  @Test
+  void should_pass_allowing_object_assertions_if_iterable_contains_at_least_one_element() {
+    // WHEN
+    ObjectAssert<String> result = assertThat(iterable).last();
+    // THEN
+    result.isEqualTo("Maggie");
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_assertion_was_created_with_assert_class() {
+    // GIVEN
+    Class<StringAssert> assertClass = StringAssert.class;
+    // WHEN
+    StringAssert result = assertThat(iterable, assertClass).last();
+    // THEN
+    result.startsWith("Mag");
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_assertion_was_created_with_assert_factory() {
+    // GIVEN
+    AssertFactory<String, StringAssert> assertFactory = StringAssert::new;
+    // WHEN
+    StringAssert result = assertThat(iterable, assertFactory).last();
+    // THEN
+    result.startsWith("Mag");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_last_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_last_with_InstanceOfAssertFactory_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsEmpty;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.IterableAssert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link IterableAssert#last(InstanceOfAssertFactory)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("IterableAssert last(InstanceOfAssertFactory)")
+class IterableAssert_last_with_InstanceOfAssertFactory_Test {
+
+  private final Iterable<Object> iterable = asList(0.0, 42, "string");
+
+  @Test
+  void should_fail_if_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> iterable = emptyList();
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).last(STRING));
+    // THEN
+    then(assertionError).hasMessage(actualIsEmpty());
+  }
+
+  @Test
+  void should_fail_throwing_npe_if_assert_factory_is_null() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(iterable).last(null));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());
+  }
+
+  @Test
+  void should_pass_allowing_type_narrowed_assertions_if_last_element_is_an_instance_of_the_factory_type() {
+    // WHEN
+    AbstractStringAssert<?> result = assertThat(iterable).last(STRING);
+    // THEN
+    result.startsWith("str");
+  }
+
+  @Test
+  void should_fail_if_last_element_is_not_an_instance_of_the_factory_type() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(iterable).last(INTEGER));
+    // THEN
+    then(assertionError).hasMessageContainingAll("Expecting:", "to be an instance of:", "but was instance of:");
+  }
+
+}


### PR DESCRIPTION
**NOTE: this PR is currently rebased onto #1647 to (hopefully) prevent merge conflicts, so the latter should be checked first!**

#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


