### PR TITLE
Add java.time.Duration assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -177,6 +178,18 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
   @CheckReturnValue
   public InstantAssert then(Instant actual) {
     return proxy(InstantAssert.class, Instant.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  @CheckReturnValue
+  public DurationAssert then(Duration actual) {
+    return proxy(DurationAssert.class, Duration.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractDurationAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDurationAssert.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveDays;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveHours;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMillis;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMinutes;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveNanos;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveSeconds;
+
+import java.time.Duration;
+
+import org.assertj.core.internal.Failures;
+
+/**
+ * Assertions for {@link Duration} type.
+ * @author Filip Hrisafov
+ * @since 3.15.0
+ */
+public abstract class AbstractDurationAssert<SELF extends AbstractDurationAssert<SELF>>
+  extends AbstractComparableAssert<SELF, Duration> {
+
+  /**
+   * Creates a new <code>{@link org.assertj.core.api.AbstractDurationAssert}</code>
+   * @param duration the actual value to verify
+   * @param selfType the "self type"
+   */
+  public AbstractDurationAssert(Duration duration, Class<?> selfType) {
+    super(duration, selfType);
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} is equal to {@link Duration#ZERO}.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ZERO).isZero();
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofMinutes(3)).isZero();</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} is not {@link Duration#ZERO}
+   * @since 3.15.0
+   */
+  public SELF isZero() {
+    isNotNull();
+    return isEqualTo(Duration.ZERO);
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} is negative (i.e. is less than {@link Duration#ZERO}).
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofMinutes(-15)).isNegative();
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofMinutes(10)).isNegative();</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} is not less than {@link Duration#ZERO}
+   * @since 3.15.0
+   */
+  public SELF isNegative() {
+    isNotNull();
+    return isLessThan(Duration.ZERO);
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} is positive (i.e. is greater than {@link Duration#ZERO}).
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofHours(5)).isPositive();
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofHours(-2)).isPositive();</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} is not greater than {@link Duration#ZERO}
+   * @since 3.15.0
+   */
+  public SELF isPositive() {
+    isNotNull();
+    return isGreaterThan(Duration.ZERO);
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} has the given nanos.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofNanos(145)).hasNanos(145);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofNanos(145)).hasNanos(50);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given nanos
+   * @since 3.15.0
+   */
+  public SELF hasNanos(long otherNanos) {
+    isNotNull();
+    long actualNanos = actual.toNanos();
+    if (otherNanos != actualNanos) {
+      throw Failures.instance().failure(info, shouldHaveNanos(actual, actualNanos, otherNanos), actualNanos, otherNanos);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} has the given millis.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofMillis(250)).hasMillis(250);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofMillis(250)).hasMillis(700);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given millis
+   * @since 3.15.0
+   */
+  public SELF hasMillis(long otherMillis) {
+    isNotNull();
+    long actualMillis = actual.toMillis();
+    if (otherMillis != actualMillis) {
+      throw Failures.instance().failure(info, shouldHaveMillis(actual, actualMillis, otherMillis), actualMillis, otherMillis);
+    }
+    return myself;
+  }
+  
+  /**
+   * Verifies that the actual {@code Duration} has the given seconds.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofSeconds(250)).hasSeconds(250);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofSeconds(250)).hasSeconds(700);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given seconds
+   * @since 3.15.0
+   */
+  public SELF hasSeconds(long otherSeconds) {
+    isNotNull();
+    long actualSeconds = actual.getSeconds();
+    if (otherSeconds != actualSeconds) {
+      throw Failures.instance().failure(info, shouldHaveSeconds(actual, actualSeconds, otherSeconds), actualSeconds, otherSeconds);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} has the given minutes.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofMinutes(65)).hasMinutes(65);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofMinutes(65)).hasMinutes(25);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given minutes
+   * @since 3.15.0
+   */
+  public SELF hasMinutes(long otherMinutes) {
+    isNotNull();
+    long actualMinutes = actual.toMinutes();
+    if (otherMinutes != actualMinutes) {
+      throw Failures.instance()
+                    .failure(info, shouldHaveMinutes(actual, actualMinutes, otherMinutes), actualMinutes, otherMinutes);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} has the given hours.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofHours(15)).hasHours(15);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofHours(15)).hasHours(5);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given hours
+   * @since 3.15.0
+   */
+  public SELF hasHours(long otherHours) {
+    isNotNull();
+    long actualHours = actual.toHours();
+    if (otherHours != actualHours) {
+      throw Failures.instance().failure(info, shouldHaveHours(actual, actualHours, otherHours), actualHours, otherHours);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Duration} has the given days.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(Duration.ofDays(5)).hasDays(5);
+   *
+   * // assertion will fail 
+   * assertThat(Duration.ofDays(5)).hasDays(1);</code></pre>
+   * @return this assertion object
+   * @throws AssertionError if the actual {@code Duration} is {@code null}
+   * @throws AssertionError if the actual {@code Duration} does not have the given days
+   * @since 3.15.0
+   */
+  public SELF hasDays(long otherDays) {
+    isNotNull();
+    long actualDays = actual.toDays();
+    if (otherDays != actualDays) {
+      throw Failures.instance().failure(info, shouldHaveDays(actual, actualDays, otherDays), actualDays, otherDays);
+    }
+    return myself;
+  }
+}

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -166,6 +167,17 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    */
   public InstantAssert assertThat(Instant actual) {
     return proxy(InstantAssert.class, Instant.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  public DurationAssert assertThat(Duration actual) {
+    return proxy(DurationAssert.class, Duration.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -854,6 +855,17 @@ public class Assertions implements InstanceOfAssertFactories {
    * @since 3.7.0
    */
   public static AbstractInstantAssert<?> assertThat(Instant actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link InstantAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  public static AbstractDurationAssert<?> assertThat(Duration actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -563,6 +564,17 @@ public class AssertionsForClassTypes {
    */
   public static AbstractInstantAssert<?> assertThat(Instant instant) {
     return new InstantAssert(instant);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code>.
+   *
+   * @param duration the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  public static AbstractDurationAssert<?> assertThat(Duration duration) {
+    return new DurationAssert(duration);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1054,6 +1055,17 @@ public class Assumptions {
    */
   public static AbstractInstantAssert<?> assumeThat(Instant actual) {
     return asAssumption(InstantAssert.class, Instant.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link DurationAssert} assumption.
+   *
+   * @param actual the Duration to test
+   * @return the created assumption for assertion object.
+   * @since 3.15.0
+   */
+  public static AbstractDurationAssert<?> assumeThat(Duration actual) {
+    return asAssumption(DurationAssert.class, Duration.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1200,6 +1201,17 @@ public class BDDAssertions extends Assertions {
    * @since 3.7.0
    */
   public static AbstractInstantAssert<?> then(Instant actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  public static AbstractDurationAssert<?> then(Duration actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -2368,6 +2369,17 @@ public final class BDDAssumptions {
    * @since 3.14.0
    */
   public static AbstractInstantAssert<?> given(Instant actual) {
+    return assumeThat(actual);
+  }
+
+  /**
+   * Creates a new assumption's instance for a {@link Instant} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  public static AbstractDurationAssert<?> given(Duration actual) {
     return assumeThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/DurationAssert.java
+++ b/src/main/java/org/assertj/core/api/DurationAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.Duration;
+
+/**
+ * Assertion methods for {@link Duration}
+ *
+ * @author Filip Hrisafov
+ * @since 3.15.0
+ */
+public class DurationAssert extends AbstractDurationAssert<DurationAssert> {
+  /**
+   * Creates a new <code>{@link DurationAssert}</code>
+   * @param duration the actual value to verify
+   */
+  public DurationAssert(Duration duration) {
+    super(duration, DurationAssert.class);
+  }
+}

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -446,11 +446,12 @@ public interface InstanceOfAssertFactories {
                                                                                                      Assertions::assertThat);
 
   /**
-   * {@link InstanceOfAssertFactory} for an {@link Duration}.
+   * {@link InstanceOfAssertFactory} for a {@link Duration}.
+   *
    * @since 3.15.0
    */
   InstanceOfAssertFactory<Duration, AbstractDurationAssert<?>> DURATION = new InstanceOfAssertFactory<>(Duration.class,
-                                                                                                     Assertions::assertThat);
+                                                                                                        Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicBoolean}.

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -442,6 +443,13 @@ public interface InstanceOfAssertFactories {
    * {@link InstanceOfAssertFactory} for an {@link Instant}.
    */
   InstanceOfAssertFactory<Instant, AbstractInstantAssert<?>> INSTANT = new InstanceOfAssertFactory<>(Instant.class,
+                                                                                                     Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for an {@link Duration}.
+   * @since 3.15.0
+   */
+  InstanceOfAssertFactory<Duration, AbstractDurationAssert<?>> DURATION = new InstanceOfAssertFactory<>(Duration.class,
                                                                                                      Assertions::assertThat);
 
   /**

--- a/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
+++ b/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -129,6 +130,7 @@ public class ProxifyMethodChangingTheObjectUnderTest {
     if (currentAssert instanceof DoubleAssert) return Double.class;
     if (currentAssert instanceof DoubleArrayAssert) return double[].class;
     if (currentAssert instanceof DoublePredicateAssert) return DoublePredicate.class;
+    if (currentAssert instanceof DurationAssert) return Duration.class;
     if (currentAssert instanceof FileAssert) return File.class;
     if (currentAssert instanceof FloatAssert) return Float.class;
     if (currentAssert instanceof FloatArrayAssert) return float[].class;

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -24,6 +24,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -2201,6 +2202,17 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @since 3.7.0
    */
   default AbstractInstantAssert<?> assertThat(final Instant actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.15.0
+   */
+  default AbstractDurationAssert<?> assertThat(final Duration actual) {
     return Assertions.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -879,6 +880,17 @@ public interface WithAssumptions {
    */
   default AbstractInstantAssert<?> assumeThat(final Instant instant) {
     return Assumptions.assumeThat(instant);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link DurationAssert}</code> assumption.
+   *
+   * @param duration the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.15.0
+   */
+  default AbstractDurationAssert<?> assumeThat(final Duration duration) {
+    return Assumptions.assumeThat(duration);
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/ShouldHaveDuration.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDuration.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.time.Duration;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class ShouldHaveDuration extends BasicErrorMessageFactory {
+
+  private static final String EXPECTED_PREFIX = "%n"
+                                                + "Expecting Duration:%n"
+                                                + " <%s>%n"
+                                                + "to have %s ";
+
+  public static ShouldHaveDuration shouldHaveNanos(Duration actual, long actualNanos, long expectedNanos) {
+    String metric;
+    if (expectedNanos == 1 || expectedNanos == -1) {
+      metric = "nano";
+    } else {
+      metric = "nanos";
+    }
+    return new ShouldHaveDuration(actual, actualNanos, expectedNanos, metric);
+  }
+
+  public static ShouldHaveDuration shouldHaveMillis(Duration actual, long actualMillis, long expectedMillis) {
+    String metric;
+    if (expectedMillis == 1 || expectedMillis == -1) {
+      metric = "milli";
+    } else {
+      metric = "millis";
+    }
+    return new ShouldHaveDuration(actual, actualMillis, expectedMillis, metric);
+  }
+
+  public static ShouldHaveDuration shouldHaveSeconds(Duration actual, long actualSeconds, long expectedSeconds) {
+    String metric;
+    if (expectedSeconds == 1 || expectedSeconds == -1) {
+      metric = "second";
+    } else {
+      metric = "seconds";
+    }
+    return new ShouldHaveDuration(actual, actualSeconds, expectedSeconds, metric);
+  }
+
+  public static ShouldHaveDuration shouldHaveMinutes(Duration actual, long actualMinutes, long expectedMinutes) {
+    String metric;
+    if (expectedMinutes == 1 || expectedMinutes == -1) {
+      metric = "minute";
+    } else {
+      metric = "minutes";
+    }
+    return new ShouldHaveDuration(actual, actualMinutes, expectedMinutes, metric);
+  }
+
+  public static ShouldHaveDuration shouldHaveHours(Duration actual, long actualHours, long expectedHours) {
+    String metric;
+    if (expectedHours == 1 || expectedHours == -1) {
+      metric = "hour";
+    } else {
+      metric = "hours";
+    }
+    return new ShouldHaveDuration(actual, actualHours, expectedHours, metric);
+  }
+
+  public static ShouldHaveDuration shouldHaveDays(Duration actual, long actualDays, long expectedDays) {
+    String metric;
+    if (expectedDays == 1 || expectedDays == -1) {
+      metric = "day";
+    } else {
+      metric = "days";
+    }
+    return new ShouldHaveDuration(actual, actualDays, expectedDays, metric);
+  }
+
+  private ShouldHaveDuration(Duration actual, long actualSpecific, long expectedSpecific, String metric) {
+    super(EXPECTED_PREFIX + metric + " but had %s", actual, expectedSpecific, actualSpecific);
+  }
+}

--- a/src/test/java/org/assertj/core/api/DurationBaseAssertTest.java
+++ b/src/test/java/org/assertj/core/api/DurationBaseAssertTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.Duration;
+
+import org.assertj.core.internal.Comparables;
+
+/**
+ * @author Filip Hrisafov
+ */
+public abstract class DurationBaseAssertTest extends ComparableAssertBaseTest<DurationAssert, Duration> {
+
+  @Override
+  protected Comparables getComparables(DurationAssert someAssertions) {
+    return someAssertions.comparables;
+  }
+}

--- a/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_PREDICATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_STREAM;
+import static org.assertj.core.api.InstanceOfAssertFactories.DURATION;
 import static org.assertj.core.api.InstanceOfAssertFactories.FILE;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT_ARRAY;
@@ -117,6 +118,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -660,6 +662,16 @@ class InstanceOfAssertFactoriesTest {
     AbstractInstantAssert<?> result = assertThat(value).asInstanceOf(INSTANT);
     // THEN
     result.isBeforeOrEqualTo(Instant.now());
+  }
+
+  @Test
+  void duration_factory_should_allow_duration_assertions() {
+    // GIVEN
+    Object value = Duration.ofHours(10);
+    // WHEN
+    AbstractDurationAssert<?> result = assertThat(value).asInstanceOf(DURATION);
+    // THEN
+    result.isPositive();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -46,6 +46,7 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.time.Duration;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
@@ -315,12 +316,13 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
       softly.assertThat((LongPredicate) s -> s == 1).accepts(2);
       softly.assertThat((DoublePredicate) s -> s == 1).accepts(2);
       softly.assertThat(URI.create("http://assertj.org:80").toURL()).hasNoPort();
+      softly.assertThat(Duration.ofHours(10)).hasHours(5);
 
       softly.assertAll();
       fail("Should not reach here");
     } catch (MultipleFailuresError e) {
       List<String> errors = e.getFailures().stream().map(Object::toString).collect(toList());
-      assertThat(errors).hasSize(53);
+      assertThat(errors).hasSize(54);
       assertThat(errors.get(0)).contains(format("%nExpecting:%n <0>%nto be equal to:%n <1>%nbut was not."));
       assertThat(errors.get(1)).contains(format("%nExpecting:%n <false>%nto be equal to:%n <true>%nbut was not."));
       assertThat(errors.get(2)).contains(format("%nExpecting:%n <false>%nto be equal to:%n <true>%nbut was not."));
@@ -418,6 +420,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                                  + "  <http://assertj.org:80>%n"
                                                  + "not to have a port but had:%n"
                                                  + "  <80>"));
+      assertThat(errors.get(53)).contains(format("%nExpecting Duration:%n"
+                                                 + " <PT10H>%n"
+                                                 + "to have 5L hours but had 10L"));
     }
   }
 

--- a/src/test/java/org/assertj/core/api/SoftAssertions_combined_with_asInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertions_combined_with_asInstanceOf_Test.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_PREDICATE;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE_STREAM;
+import static org.assertj.core.api.InstanceOfAssertFactories.DURATION;
 import static org.assertj.core.api.InstanceOfAssertFactories.FILE;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT;
 import static org.assertj.core.api.InstanceOfAssertFactories.FLOAT_ARRAY;
@@ -91,6 +92,7 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -206,6 +208,7 @@ public class SoftAssertions_combined_with_asInstanceOf_Test extends BaseAssertio
                      Arguments.of(future, FUTURE),
                      Arguments.of(new ByteArrayInputStream("stream".getBytes()), INPUT_STREAM),
                      Arguments.of(Instant.now(), INSTANT),
+                     Arguments.of(Duration.ofMinutes(65), DURATION),
                      Arguments.of(new int[0], INT_ARRAY),
                      Arguments.of((IntPredicate) i -> i == 0, INT_PREDICATE),
                      Arguments.of(IntStream.empty(), INT_STREAM),

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasDays_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasDays_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveDays;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasDays")
+class DurationAssert_hasDays_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_days() {
+    assertThat(Duration.ofDays(4L)).hasDays(4L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasDays(5L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_days() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofDays(10L)).hasDays(15L))
+      .withMessage(shouldHaveDays(Duration.ofDays(10L), 10L, 15L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasDays_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasDays_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasDays_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_days() {
-    assertThat(Duration.ofDays(4L)).hasDays(4L);
+    // GIVEN
+    Duration duration = Duration.ofDays(4L);
+    //WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    //THEN
+    assertThat(duration).hasDays(4L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasDays(5L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasDays(5L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_days() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofDays(10L)).hasDays(15L))
-      .withMessage(shouldHaveDays(Duration.ofDays(10L), 10L, 15L).create());
+    // GIVEN
+    Duration duration = Duration.ofDays(10L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasDays(15L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveDays(duration, 10L, 15L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasHours_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasHours_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasHours_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_hours() {
-    assertThat(Duration.ofHours(4L)).hasHours(4L);
+    // GIVEN
+    Duration duration = Duration.ofHours(4L);
+    // WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    // THEN
+    durationAssert.hasHours(4L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasHours(5L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasHours(5L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_hours() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofHours(10L)).hasHours(15L))
-      .withMessage(shouldHaveHours(Duration.ofHours(10L), 10L, 15L).create());
+    // GIVEN
+    Duration duration = Duration.ofHours(10L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasHours(15L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveHours(duration, 10L, 15L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasHours_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasHours_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveHours;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasHours")
+class DurationAssert_hasHours_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_hours() {
+    assertThat(Duration.ofHours(4L)).hasHours(4L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasHours(5L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_hours() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofHours(10L)).hasHours(15L))
+      .withMessage(shouldHaveHours(Duration.ofHours(10L), 10L, 15L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMillis_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMillis_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMillis;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasMillis")
+class DurationAssert_hasMillis_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_millis() {
+    assertThat(Duration.ofMillis(32893L)).hasMillis(32893L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasMillis(190L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_millis() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofMillis(5866L)).hasMillis(758L))
+      .withMessage(shouldHaveMillis(Duration.ofMillis(5866L), 5866L, 758L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMillis_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMillis_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasMillis_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_millis() {
-    assertThat(Duration.ofMillis(32893L)).hasMillis(32893L);
+    // GIVEN
+    Duration duration = Duration.ofMillis(32893L);
+    // WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    // THEN
+    durationAssert.hasMillis(32893L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasMillis(190L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasMillis(190L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_millis() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofMillis(5866L)).hasMillis(758L))
-      .withMessage(shouldHaveMillis(Duration.ofMillis(5866L), 5866L, 758L).create());
+    // GIVEN
+    Duration duration = Duration.ofMillis(5866L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasMillis(758L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveMillis(duration, 5866L, 758L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMinutes_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMinutes;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasMinutes")
+class DurationAssert_hasMinutes_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_minutes() {
+    assertThat(Duration.ofMinutes(18L)).hasMinutes(18L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasMinutes(20L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_minutes() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofMinutes(35L)).hasMinutes(10L))
+      .withMessage(shouldHaveMinutes(Duration.ofMinutes(35L), 35L, 10L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasMinutes_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasMinutes_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_minutes() {
-    assertThat(Duration.ofMinutes(18L)).hasMinutes(18L);
+    // GIVEN
+    Duration duration = Duration.ofMinutes(18L);
+    // WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    // THEN
+    durationAssert.hasMinutes(18L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasMinutes(20L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasMinutes(20L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_minutes() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofMinutes(35L)).hasMinutes(10L))
-      .withMessage(shouldHaveMinutes(Duration.ofMinutes(35L), 35L, 10L).create());
+    // GIVEN
+    Duration duration = Duration.ofMinutes(35L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasMinutes(10L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveMinutes(duration, 35L, 10L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasNanos_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasNanos_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasNanos_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_nanos() {
-    assertThat(Duration.ofNanos(145692L)).hasNanos(145692L);
+    // GIVEN
+    Duration duration = Duration.ofNanos(145692L);
+    // WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    // THEN
+    durationAssert.hasNanos(145692L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasNanos(190L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasNanos(190L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_nanos() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofNanos(1892L)).hasNanos(190L))
-      .withMessage(shouldHaveNanos(Duration.ofNanos(1892L), 1892L, 190L).create());
+    // GIVEN
+    Duration duration = Duration.ofNanos(1892L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasNanos(190L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveNanos(duration, 1892L, 190L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasNanos_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasNanos_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveNanos;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasNanos")
+class DurationAssert_hasNanos_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_nanos() {
+    assertThat(Duration.ofNanos(145692L)).hasNanos(145692L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasNanos(190L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_nanos() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofNanos(1892L)).hasNanos(190L))
+      .withMessage(shouldHaveNanos(Duration.ofNanos(1892L), 1892L, 190L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasSeconds_Test.java
@@ -19,7 +19,9 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 
+import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.BaseTest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,18 +33,33 @@ class DurationAssert_hasSeconds_Test extends BaseTest {
 
   @Test
   void should_pass_if_duration_has_matching_seconds() {
-    assertThat(Duration.ofSeconds(120L)).hasSeconds(120L);
+    // GIVEN
+    Duration duration = Duration.ofSeconds(120L);
+    // WHEN
+    AbstractDurationAssert<?> durationAssert = assertThat(duration);
+    // THEN
+    durationAssert.hasSeconds(120L);
   }
 
   @Test
   void should_fail_when_duration_is_null() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasSeconds(190L)).withMessage(actualIsNull());
+    // GIVEN
+    Duration duration = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasSeconds(190L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_duration_does_not_have_matching_seconds() {
-    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofSeconds(120L)).hasSeconds(758L))
-      .withMessage(shouldHaveSeconds(Duration.ofSeconds(120L), 120L, 758L).create());
+    // GIVEN
+    Duration duration = Duration.ofSeconds(120L);
+    // WHEN
+    ThrowingCallable code = () -> assertThat(duration).hasSeconds(758L);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code)
+      .withMessage(shouldHaveSeconds(duration, 120L, 758L).create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_hasSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_hasSeconds_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveSeconds;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Duration;
+
+import org.assertj.core.api.BaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert hasSeconds")
+class DurationAssert_hasSeconds_Test extends BaseTest {
+
+  @Test
+  void should_pass_if_duration_has_matching_seconds() {
+    assertThat(Duration.ofSeconds(120L)).hasSeconds(120L);
+  }
+
+  @Test
+  void should_fail_when_duration_is_null() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat((Duration) null).hasSeconds(190L)).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_duration_does_not_have_matching_seconds() {
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(Duration.ofSeconds(120L)).hasSeconds(758L))
+      .withMessage(shouldHaveSeconds(Duration.ofSeconds(120L), 120L, 758L).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_isNegative_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_isNegative_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.assertj.core.api.DurationAssert;
+import org.assertj.core.api.DurationBaseAssertTest;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert isNegative")
+class DurationAssert_isNegative_Test extends DurationBaseAssertTest {
+
+  @Override
+  protected DurationAssert create_assertions() {
+    return new DurationAssert(Duration.ofHours(-1));
+  }
+
+  @Override
+  protected DurationAssert invoke_api_method() {
+    return assertions.isNegative();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotNull(getInfo(assertions), Duration.ofHours(-1));
+    verify(comparables).assertLessThan(getInfo(assertions), Duration.ofHours(-1), Duration.ZERO);
+  }
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_isPositive_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_isPositive_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.assertj.core.api.DurationAssert;
+import org.assertj.core.api.DurationBaseAssertTest;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert isPositive")
+class DurationAssert_isPositive_Test extends DurationBaseAssertTest {
+
+  @Override
+  protected DurationAssert create_assertions() {
+    return new DurationAssert(Duration.ofMinutes(10));
+  }
+
+  @Override
+  protected DurationAssert invoke_api_method() {
+    return assertions.isPositive();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotNull(getInfo(assertions), Duration.ofMinutes(10));
+    verify(comparables).assertGreaterThan(getInfo(assertions), Duration.ofMinutes(10), Duration.ZERO);
+  }
+}

--- a/src/test/java/org/assertj/core/api/duration/DurationAssert_isZero_Test.java
+++ b/src/test/java/org/assertj/core/api/duration/DurationAssert_isZero_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.duration;
+
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.assertj.core.api.DurationAssert;
+import org.assertj.core.api.DurationBaseAssertTest;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * @author Filip Hrisafov
+ */
+@DisplayName("DurationAssert isZero")
+class DurationAssert_isZero_Test extends DurationBaseAssertTest {
+
+  @Override
+  protected DurationAssert create_assertions() {
+    return new DurationAssert(Duration.ofHours(1));
+  }
+
+  @Override
+  protected DurationAssert invoke_api_method() {
+    return assertions.isZero();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotNull(getInfo(assertions), Duration.ofHours(1));
+    verify(objects).assertEqual(getInfo(assertions), Duration.ofHours(1), Duration.ZERO);
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveDuration_create_test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveDuration_create_test.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveDays;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveHours;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMillis;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveMinutes;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveNanos;
+import static org.assertj.core.error.ShouldHaveDuration.shouldHaveSeconds;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+class ShouldHaveDuration_create_test {
+
+  @Test
+  void should_create_error_message_for_nanos() {
+    Duration duration = Duration.ofNanos(1893);
+    String errorMessage = shouldHaveNanos(duration, 1893, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have 190L nanos but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_nano() {
+    Duration duration = Duration.ofNanos(1893);
+    String errorMessage = shouldHaveNanos(duration, 1893, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have 1L nano but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_nano() {
+    Duration duration = Duration.ofNanos(1893);
+    String errorMessage = shouldHaveNanos(duration, 1893, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have -1L nano but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_millis() {
+    Duration duration = Duration.ofMillis(1893);
+    String errorMessage = shouldHaveMillis(duration, 1893, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have 190L millis but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_milli() {
+    Duration duration = Duration.ofMillis(1893);
+    String errorMessage = shouldHaveMillis(duration, 1893, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have 1L milli but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_milli() {
+    Duration duration = Duration.ofMillis(1893);
+    String errorMessage = shouldHaveMillis(duration, 1893, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have -1L milli but had 1893L"));
+  }
+
+  @Test
+  void should_create_error_message_for_seconds() {
+    Duration duration = Duration.ofSeconds(120);
+    String errorMessage = shouldHaveSeconds(duration, 120, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have 190L seconds but had 120L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_second() {
+    Duration duration = Duration.ofSeconds(120);
+    String errorMessage = shouldHaveSeconds(duration, 120, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have 1L second but had 120L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_second() {
+    Duration duration = Duration.ofSeconds(120);
+    String errorMessage = shouldHaveSeconds(duration, 120, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have -1L second but had 120L"));
+  }
+  
+  @Test
+  void should_create_error_message_for_minutes() {
+    Duration duration = Duration.ofMinutes(65);
+    String errorMessage = shouldHaveMinutes(duration, 65, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have 190L minutes but had 65L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_minute() {
+    Duration duration = Duration.ofMinutes(65);
+    String errorMessage = shouldHaveMinutes(duration, 65, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have 1L minute but had 65L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_minute() {
+    Duration duration = Duration.ofMinutes(65);
+    String errorMessage = shouldHaveMinutes(duration, 65, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have -1L minute but had 65L"));
+  }
+
+  @Test
+  void should_create_error_message_for_hours() {
+    Duration duration = Duration.ofMinutes(125);
+    String errorMessage = shouldHaveHours(duration, 2, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have 190L hours but had 2L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_hour() {
+    Duration duration = Duration.ofMinutes(125);
+    String errorMessage = shouldHaveHours(duration, 2, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have 1L hour but had 2L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_hour() {
+    Duration duration = Duration.ofMinutes(125);
+    String errorMessage = shouldHaveHours(duration, 2, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have -1L hour but had 2L"));
+  }
+  
+  @Test
+  void should_create_error_message_for_days() {
+    Duration duration = Duration.ofHours(50);
+    String errorMessage = shouldHaveDays(duration, 2, 190).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have 190L days but had 2L"));
+  }
+
+  @Test
+  void should_create_error_message_for_1_day() {
+    Duration duration = Duration.ofHours(50);
+    String errorMessage = shouldHaveDays(duration, 2, 1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have 1L day but had 2L"));
+  }
+
+  @Test
+  void should_create_error_message_for_negative_1_day() {
+    Duration duration = Duration.ofHours(50);
+    String errorMessage = shouldHaveDays(duration, 2, -1).create();
+    assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have -1L day but had 2L"));
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveDuration_create_test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveDuration_create_test.java
@@ -32,127 +32,209 @@ class ShouldHaveDuration_create_test {
 
   @Test
   void should_create_error_message_for_nanos() {
+    // GIVEN
     Duration duration = Duration.ofNanos(1893);
-    String errorMessage = shouldHaveNanos(duration, 1893, 190).create();
+    long actualNanos = 1893;
+    long expectedNanos = 190;
+    // WHEN
+    String errorMessage = shouldHaveNanos(duration, actualNanos, expectedNanos).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have 190L nanos but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_1_nano() {
+    // GIVEN
     Duration duration = Duration.ofNanos(1893);
-    String errorMessage = shouldHaveNanos(duration, 1893, 1).create();
+    long actualNanos = 1893;
+    long expectedNanos = 1;
+    // WHEN
+    String errorMessage = shouldHaveNanos(duration, actualNanos, expectedNanos).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have 1L nano but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_nano() {
+    // GIVEN
     Duration duration = Duration.ofNanos(1893);
-    String errorMessage = shouldHaveNanos(duration, 1893, -1).create();
+    long actualNanos = 1893;
+    long expectedNanos = -1;
+    // WHEN
+    String errorMessage = shouldHaveNanos(duration, actualNanos, expectedNanos).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT0.000001893S>%nto have -1L nano but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_millis() {
+    // GIVEN
     Duration duration = Duration.ofMillis(1893);
-    String errorMessage = shouldHaveMillis(duration, 1893, 190).create();
+    long actualMillis = 1893;
+    long expectedMillis = 190;
+    // WHEN
+    String errorMessage = shouldHaveMillis(duration, actualMillis, expectedMillis).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have 190L millis but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_1_milli() {
+    // GIVEN
     Duration duration = Duration.ofMillis(1893);
-    String errorMessage = shouldHaveMillis(duration, 1893, 1).create();
+    long actualMillis = 1893;
+    long expectedMillis = 1;
+    // WHEN
+    String errorMessage = shouldHaveMillis(duration, actualMillis, expectedMillis).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have 1L milli but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_milli() {
+    // GIVEN
     Duration duration = Duration.ofMillis(1893);
-    String errorMessage = shouldHaveMillis(duration, 1893, -1).create();
+    long actualMillis = 1893;
+    long expectedMillis = -1;
+    // WHEN
+    String errorMessage = shouldHaveMillis(duration, actualMillis, expectedMillis).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1.893S>%nto have -1L milli but had 1893L"));
   }
 
   @Test
   void should_create_error_message_for_seconds() {
+    // GIVEN
     Duration duration = Duration.ofSeconds(120);
-    String errorMessage = shouldHaveSeconds(duration, 120, 190).create();
+    long actualSeconds = 120;
+    long expectedSeconds = 190;
+    // WHEN
+    String errorMessage = shouldHaveSeconds(duration, actualSeconds, expectedSeconds).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have 190L seconds but had 120L"));
   }
 
   @Test
   void should_create_error_message_for_1_second() {
+    // GIVEN
     Duration duration = Duration.ofSeconds(120);
-    String errorMessage = shouldHaveSeconds(duration, 120, 1).create();
+    long actualSeconds = 120;
+    long expectedSeconds = 1;
+    // WHEN
+    String errorMessage = shouldHaveSeconds(duration, actualSeconds, expectedSeconds).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have 1L second but had 120L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_second() {
+    // GIVEN
     Duration duration = Duration.ofSeconds(120);
-    String errorMessage = shouldHaveSeconds(duration, 120, -1).create();
+    long actualSeconds = 120;
+    long expectedSeconds = -1;
+    // WHEN
+    String errorMessage = shouldHaveSeconds(duration, actualSeconds, expectedSeconds).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2M>%nto have -1L second but had 120L"));
   }
   
   @Test
   void should_create_error_message_for_minutes() {
+    // GIVEN
     Duration duration = Duration.ofMinutes(65);
-    String errorMessage = shouldHaveMinutes(duration, 65, 190).create();
+    long actualMinutes = 65;
+    long expectedMinutes = 190;
+    // WHEN
+    String errorMessage = shouldHaveMinutes(duration, actualMinutes, expectedMinutes).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have 190L minutes but had 65L"));
   }
 
   @Test
   void should_create_error_message_for_1_minute() {
     Duration duration = Duration.ofMinutes(65);
-    String errorMessage = shouldHaveMinutes(duration, 65, 1).create();
+    long actualMinutes = 65;
+    long expectedMinutes = 1;
+    // WHEN
+    String errorMessage = shouldHaveMinutes(duration, actualMinutes, expectedMinutes).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have 1L minute but had 65L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_minute() {
     Duration duration = Duration.ofMinutes(65);
-    String errorMessage = shouldHaveMinutes(duration, 65, -1).create();
+    long actualMinutes = 65;
+    long expectedMinutes = -1;
+    // WHEN
+    String errorMessage = shouldHaveMinutes(duration, actualMinutes, expectedMinutes).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT1H5M>%nto have -1L minute but had 65L"));
   }
 
   @Test
   void should_create_error_message_for_hours() {
     Duration duration = Duration.ofMinutes(125);
-    String errorMessage = shouldHaveHours(duration, 2, 190).create();
+    long actualHours = 2;
+    long expectedHours = 190;
+    // WHEN
+    String errorMessage = shouldHaveHours(duration, actualHours, expectedHours).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have 190L hours but had 2L"));
   }
 
   @Test
   void should_create_error_message_for_1_hour() {
     Duration duration = Duration.ofMinutes(125);
-    String errorMessage = shouldHaveHours(duration, 2, 1).create();
+    long actualHours = 2;
+    long expectedHours = 1;
+    // WHEN
+    String errorMessage = shouldHaveHours(duration, actualHours, expectedHours).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have 1L hour but had 2L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_hour() {
     Duration duration = Duration.ofMinutes(125);
-    String errorMessage = shouldHaveHours(duration, 2, -1).create();
+    long actualHours = 2;
+    long expectedHours = -1;
+    // WHEN
+    String errorMessage = shouldHaveHours(duration, actualHours, expectedHours).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT2H5M>%nto have -1L hour but had 2L"));
   }
   
   @Test
   void should_create_error_message_for_days() {
     Duration duration = Duration.ofHours(50);
-    String errorMessage = shouldHaveDays(duration, 2, 190).create();
+    long actualDays = 2;
+    long expectedDays = 190;
+    // WHEN
+    String errorMessage = shouldHaveDays(duration, actualDays, expectedDays).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have 190L days but had 2L"));
   }
 
   @Test
   void should_create_error_message_for_1_day() {
     Duration duration = Duration.ofHours(50);
-    String errorMessage = shouldHaveDays(duration, 2, 1).create();
+    long actualDays = 2;
+    long expectedDays = 1;
+    // WHEN
+    String errorMessage = shouldHaveDays(duration, actualDays, expectedDays).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have 1L day but had 2L"));
   }
 
   @Test
   void should_create_error_message_for_negative_1_day() {
     Duration duration = Duration.ofHours(50);
-    String errorMessage = shouldHaveDays(duration, 2, -1).create();
+    long actualDays = 2;
+    long expectedDays = -1;
+    // WHEN
+    String errorMessage = shouldHaveDays(duration, actualDays, expectedDays).create();
+    // THEN
     assertThat(errorMessage).isEqualTo(format("%nExpecting Duration:%n <PT50H>%nto have -1L day but had 2L"));
   }
 


### PR DESCRIPTION
Added assertions:

* isZero()
* isNegative()
* isPositive()
* hasDays(long)
* hasHours(long)
* hasMinutes(long)
* hasSeconds(long)
* hasMillis(long)
* hasNanos(long)

#### Check List:
* Fixes #1650 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES