### PR TITLE
Fix #1654: Make conversion script work on Windows

### DIFF
--- a/src/main/scripts/convert-junit-assertions-to-assertj.sh
+++ b/src/main/scripts/convert-junit-assertions-to-assertj.sh
@@ -38,7 +38,7 @@ FILES_PATTERN=${1:-*Test.java}
 # what file do we want to convert ?
 MATCHED_FILES=$(find . -name "$FILES_PATTERN")
 
-function replace-in-all-files() {
+function replace() {
   for file in ${MATCHED_FILES}; do
     sed "${SED_OPTIONS[@]}" "$1" "$file"
   done
@@ -48,56 +48,56 @@ echo ''
 echo "Converting JUnit assertions to AssertJ assertions in files matching pattern : $FILES_PATTERN"
 echo ''
 echo ' 1 - Replacing : assertEquals(0, myList.size()) ................. by : assertThat(myList).isEmpty()'
-replace-in-all-files 's/assertEquals(\(\".*\"\),[[:blank:]]*0,[[:blank:]]*\(.*\).size())/assertThat(\2).as(\1).isEmpty()/g'
-replace-in-all-files 's/assertEquals([[:blank:]]*0,[[:blank:]]*\(.*\).size())/assertThat(\1).isEmpty()/g'
+replace 's/assertEquals(\(\".*\"\),[[:blank:]]*0,[[:blank:]]*\(.*\).size())/assertThat(\2).as(\1).isEmpty()/g'
+replace 's/assertEquals([[:blank:]]*0,[[:blank:]]*\(.*\).size())/assertThat(\1).isEmpty()/g'
 
 echo ' 2 - Replacing : assertEquals(expectedSize, myList.size()) ...... by : assertThat(myList).hasSize(expectedSize)'
-replace-in-all-files 's/assertEquals(\(\".*\"\),[[:blank:]]*\([[:digit:]]*\),[[:blank:]]*\(.*\).size())/assertThat(\3).as(\1).hasSize(\2)/g'
-replace-in-all-files 's/assertEquals([[:blank:]]*\([[:digit:]]*\),[[:blank:]]*\(.*\).size())/assertThat(\2).hasSize(\1)/g'
+replace 's/assertEquals(\(\".*\"\),[[:blank:]]*\([[:digit:]]*\),[[:blank:]]*\(.*\).size())/assertThat(\3).as(\1).hasSize(\2)/g'
+replace 's/assertEquals([[:blank:]]*\([[:digit:]]*\),[[:blank:]]*\(.*\).size())/assertThat(\2).hasSize(\1)/g'
 
 echo ' 3 - Replacing : assertEquals(expectedDouble, actual, delta) .... by : assertThat(actual).isCloseTo(expectedDouble, within(delta))'
-replace-in-all-files 's/assertEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isCloseTo(\2, within(\4))/g'
+replace 's/assertEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isCloseTo(\2, within(\4))/g'
 # must be done before assertEquals("description", expected, actual) -> assertThat(actual).as("description").isEqualTo(expected)
 # will only replace triplets without double quote to avoid matching : assertEquals("description", expected, actual)
-replace-in-all-files 's/assertEquals([[:blank:]]*\([^"]*\),[[:blank:]]*\([^"]*\),[[:blank:]]*\([^"]*\))/assertThat(\2).isCloseTo(\1, within(\3))/g'
+replace 's/assertEquals([[:blank:]]*\([^"]*\),[[:blank:]]*\([^"]*\),[[:blank:]]*\([^"]*\))/assertThat(\2).isCloseTo(\1, within(\3))/g'
 
 echo ' 4 - Replacing : assertEquals(expected, actual) ................. by : assertThat(actual).isEqualTo(expected)'
-replace-in-all-files 's/assertEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isEqualTo(\2)/g'
-replace-in-all-files 's/assertEquals([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isEqualTo(\1)/g'
+replace 's/assertEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isEqualTo(\2)/g'
+replace 's/assertEquals([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isEqualTo(\1)/g'
 
 echo ' 5 - Replacing : assertArrayEquals(expectedArray, actual) ....... by : assertThat(actual).isEqualTo(expectedArray)'
-replace-in-all-files 's/assertArrayEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isEqualTo(\2)/g'
-replace-in-all-files 's/assertArrayEquals([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isEqualTo(\1)/g'
+replace 's/assertArrayEquals(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isEqualTo(\2)/g'
+replace 's/assertArrayEquals([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isEqualTo(\1)/g'
 
 echo ' 6 - Replacing : assertNull(actual) ............................. by : assertThat(actual).isNull()'
-replace-in-all-files 's/assertNull(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isNull()/g'
-replace-in-all-files 's/assertNull([[:blank:]]*\(.*\))/assertThat(\1).isNull()/g'
+replace 's/assertNull(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isNull()/g'
+replace 's/assertNull([[:blank:]]*\(.*\))/assertThat(\1).isNull()/g'
 
 echo ' 7 - Replacing : assertNotNull(actual) .......................... by : assertThat(actual).isNotNull()'
-replace-in-all-files 's/assertNotNull(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isNotNull()/g'
-replace-in-all-files 's/assertNotNull([[:blank:]]*\(.*\))/assertThat(\1).isNotNull()/g'
+replace 's/assertNotNull(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isNotNull()/g'
+replace 's/assertNotNull([[:blank:]]*\(.*\))/assertThat(\1).isNotNull()/g'
 
 echo ' 8 - Replacing : assertTrue(logicalCondition) ................... by : assertThat(logicalCondition).isTrue()'
-replace-in-all-files 's/assertTrue(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isTrue()/g'
-replace-in-all-files 's/assertTrue([[:blank:]]*\(.*\))/assertThat(\1).isTrue()/g'
+replace 's/assertTrue(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isTrue()/g'
+replace 's/assertTrue([[:blank:]]*\(.*\))/assertThat(\1).isTrue()/g'
 
 echo ' 9 - Replacing : assertFalse(logicalCondition) .................. by : assertThat(logicalCondition).isFalse()'
-replace-in-all-files 's/assertFalse(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isFalse()/g'
-replace-in-all-files 's/assertFalse([[:blank:]]*\(.*\))/assertThat(\1).isFalse()/g'
+replace 's/assertFalse(\(\".*\"\),[[:blank:]]*\(.*\))/assertThat(\2).as(\1).isFalse()/g'
+replace 's/assertFalse([[:blank:]]*\(.*\))/assertThat(\1).isFalse()/g'
 
 echo '10 - Replacing : assertSame(expected, actual) ................... by : assertThat(actual).isSameAs(expected)'
-replace-in-all-files 's/assertSame(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isSameAs(\2)/g'
-replace-in-all-files 's/assertSame([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isSameAs(\1)/g'
+replace 's/assertSame(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isSameAs(\2)/g'
+replace 's/assertSame([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isSameAs(\1)/g'
 
 echo '11 - Replacing : assertNotSame(expected, actual) ................ by : assertThat(actual).isNotSameAs(expected)'
-replace-in-all-files 's/assertNotSame(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isNotSameAs(\2)/g'
-replace-in-all-files 's/assertNotSame([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isNotSameAs(\1)/g'
+replace 's/assertNotSame(\(\".*\"\),[[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\3).as(\1).isNotSameAs(\2)/g'
+replace 's/assertNotSame([[:blank:]]*\(.*\),[[:blank:]]*\(.*\))/assertThat(\2).isNotSameAs(\1)/g'
 
 echo ''
 echo '12 - Replacing JUnit static imports by AssertJ ones, at this point you will probably need to :'
 echo '12 --- optimize imports with your IDE to remove unused imports'
 echo '12 --- add "import static org.assertj.core.api.Assertions.within;" if you were using JUnit number assertions with deltas'
-replace-in-all-files 's/import static org.junit.Assert.assertEquals;/import static org.assertj.core.api.Assertions.assertThat;/g'
-replace-in-all-files 's/import static org.junit.Assert.fail;/import static org.assertj.core.api.Assertions.fail;/g'
-replace-in-all-files 's/import static org.junit.Assert.\*;/import static org.assertj.core.api.Assertions.*;/g'
+replace 's/import static org.junit.Assert.assertEquals;/import static org.assertj.core.api.Assertions.assertThat;/g'
+replace 's/import static org.junit.Assert.fail;/import static org.assertj.core.api.Assertions.fail;/g'
+replace 's/import static org.junit.Assert.\*;/import static org.assertj.core.api.Assertions.*;/g'
 echo ''


### PR DESCRIPTION
When executing the conversion script on Windows (in the bash shell of Git for Windows) it stops with an error:
`./convert-junit-assertions-to-assertj.sh: line 45: `replace-in-all-files': not a valid identifier`

Shortening the function name to not contain hyphen characters fixes the problem.

* Fixes #1654
* Unit tests : NA
* Javadoc with a code example (on API only) : NA


