### PR TITLE
improve .hasToString() reporting

### DIFF
--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -414,8 +414,9 @@ public class Objects {
 
   public void assertHasToString(AssertionInfo info, Object actual, String expectedToString) {
     assertNotNull(info, actual);
-    if (!actual.toString().equals(expectedToString))
-      throw failures.failure(info, shouldHaveToString(actual, expectedToString));
+    String actualString = actual.toString();
+    if (!actualString.equals(expectedToString))
+      throw failures.failure(info, shouldHaveToString(actualString, expectedToString), actualString, expectedToString);
   }
 
   /**

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertHasToString_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertHasToString_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.error.ShouldHaveToString.shouldHaveToString;
 import static org.assertj.core.test.TestData.someInfo;
@@ -26,6 +27,7 @@ import org.assertj.core.internal.ObjectsBaseTest;
 import org.assertj.core.test.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 public class Objects_assertHasToString_Test extends ObjectsBaseTest {
 
@@ -57,7 +59,9 @@ public class Objects_assertHasToString_Test extends ObjectsBaseTest {
       objects.assertHasToString(info, actual, "bar");
       failBecauseExpectedAssertionErrorWasNotThrown();
     } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveToString(actual, "bar"));
+      verify(failures).failure(info, shouldHaveToString("foo", "bar"), "foo", "bar");
+      assertThat(err).isExactlyInstanceOf(AssertionFailedError.class);
+      assertThat(err).hasMessageContainingAll("\"foo\"", "\"bar\"");
     }
   }
 }


### PR DESCRIPTION
* Throw full AssertionFailedErrors instead of plain AssertionErrors.
* Unify formatting:

Before `actual` was formatted as an object, without surrounding quotes,
while the expected string was formatted as string without surrounding quotes,
which is confusing.

```
java.lang.AssertionError:
Expecting actual's toString() to return:
  <"a">
but was:
  <x>
```

By formatting the failure message based on `acutal.toString()` directly the
errormessage is consistent:

```
java.lang.AssertionError:
Expecting actual's toString() to return:
  <"a">
but was:
  <"x">
```

#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


