### PR TITLE
get rid of not needed extra arguments (String.format)

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldHaveSizeGreaterThan.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSizeGreaterThan.java
@@ -40,7 +40,7 @@ public class ShouldHaveSizeGreaterThan extends BasicErrorMessageFactory {
     super(format("%n" +
                  "Expecting size of:%n" +
                  "  <%%s>%n" +
-                 "to be greater than %s but was %s", expectedSize, actualSize, "%s"),
+                 "to be greater than %s but was %s", expectedSize, actualSize),
           actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSizeGreaterThanOrEqualTo.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSizeGreaterThanOrEqualTo.java
@@ -40,7 +40,7 @@ public class ShouldHaveSizeGreaterThanOrEqualTo extends BasicErrorMessageFactory
     super(format("%n" +
                  "Expecting size of:%n" +
                  "  <%%s>%n" +
-                 "to be greater than or equal to %s but was %s", expectedSize, actualSize, "%s"),
+                 "to be greater than or equal to %s but was %s", expectedSize, actualSize),
           actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSizeLessThan.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSizeLessThan.java
@@ -40,7 +40,7 @@ public class ShouldHaveSizeLessThan extends BasicErrorMessageFactory {
     super(format("%n" +
                  "Expecting size of:%n" +
                  "  <%%s>%n" +
-                 "to be less than %s but was %s", expectedSize, actualSize, "%s"),
+                 "to be less than %s but was %s", expectedSize, actualSize),
           actual);
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveSizeGreaterThanOrEqualTo_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSizeGreaterThanOrEqualTo_create_Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Sandra Parsick
  * @author Georg Berky
  */
-public class ShouldHaveSizeGreaterThanOrEqualTo_create_Test {
+class ShouldHaveSizeGreaterThanOrEqualTo_create_Test {
 
   private ErrorMessageFactory factory;
 

--- a/src/test/java/org/assertj/core/error/ShouldHaveSizeGreaterThan_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSizeGreaterThan_create_Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Sandra Parsick
  * @author Georg Berky
  */
-public class ShouldHaveSizeGreaterThan_create_Test {
+class ShouldHaveSizeGreaterThan_create_Test {
 
   private ErrorMessageFactory factory;
 

--- a/src/test/java/org/assertj/core/error/ShouldHaveSizeLessThanOrEqualTo_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSizeLessThanOrEqualTo_create_Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Sandra Parsick
  * @author Georg Berky
  */
-public class ShouldHaveSizeLessThanOrEqualTo_create_Test {
+class ShouldHaveSizeLessThanOrEqualTo_create_Test {
 
   private ErrorMessageFactory factory;
 

--- a/src/test/java/org/assertj/core/error/ShouldHaveSizeLessThan_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSizeLessThan_create_Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Sandra Parsick
  * @author Georg Berky
  */
-public class ShouldHaveSizeLessThan_create_Test {
+class ShouldHaveSizeLessThan_create_Test {
 
   private ErrorMessageFactory factory;
 


### PR DESCRIPTION
I've enabled errorprone locally and found the following violation:

`[FormatString] extra format arguments: used 2, provided 3`


