### PR TITLE
Implemented isPackagePrivate into AbstractClassAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -273,8 +273,8 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * assertThat(MyClass.class).isPackagePrivate();
    *
    * // these assertions fail:
-   * assertThat(String.class).isProtected();
-   * assertThat(Math.class).isProtected();</code></pre>
+   * assertThat(String.class).isPackagePrivate();
+   * assertThat(Math.class).isPackagePrivate();</code></pre>
    *
    * @return {@code this} assertions object
    * @throws AssertionError if {@code actual} is {@code null}.

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -267,7 +267,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * Verifies that the actual {@code Class} is package-private (has no modifier).
    * <p>
    * Example:
-   * <pre><code class='java'> public MyClass { }
+   * <pre><code class='java'> class MyClass { }
    *
    * // this assertion succeeds:
    * assertThat(MyClass.class).isPackagePrivate();

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -278,9 +278,9 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @return {@code this} assertions object
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} is not protected.
+   * @throws AssertionError if the actual {@code Class} is not package private.
    *
-   * @since 2.7.0 / 3.7.0
+   * @since 3.15.0
    */
   public SELF isPackagePrivate() {
     classes.assertIsPackagePrivate(info, actual);

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -278,7 +278,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @return {@code this} assertions object
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} is not package private.
+   * @throws AssertionError if the actual {@code Class} is not package-private.
    *
    * @since 3.15.0
    */

--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -264,6 +264,30 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
+   * Verifies that the actual {@code Class} is package-private (has no modifier).
+   * <p>
+   * Example:
+   * <pre><code class='java'> public MyClass { }
+   *
+   * // this assertion succeeds:
+   * assertThat(MyClass.class).isPackagePrivate();
+   *
+   * // these assertions fail:
+   * assertThat(String.class).isProtected();
+   * assertThat(Math.class).isProtected();</code></pre>
+   *
+   * @return {@code this} assertions object
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} is not protected.
+   *
+   * @since 2.7.0 / 3.7.0
+   */
+  public SELF isPackagePrivate() {
+    classes.assertIsPackagePrivate(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code Class} has the given {@code Annotation}s.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -65,4 +65,13 @@ public class ClassModifierShouldBe extends BasicErrorMessageFactory {
     return new ClassModifierShouldBe(actual, true, Modifier.toString(Modifier.PROTECTED));
   }
 
+  /**
+   * Creates a new {@link ClassModifierShouldBe}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBePackagePrivate(Class<?> actual) {
+    return new ClassModifierShouldBe(actual, true, "Package-Private");
+  }
 }

--- a/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
+++ b/src/main/java/org/assertj/core/error/ClassModifierShouldBe.java
@@ -72,6 +72,6 @@ public class ClassModifierShouldBe extends BasicErrorMessageFactory {
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBePackagePrivate(Class<?> actual) {
-    return new ClassModifierShouldBe(actual, true, "Package-Private");
+    return new ClassModifierShouldBe(actual, true, "package-private");
   }
 }

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -217,9 +217,8 @@ public class Classes {
    */
   public void assertIsPackagePrivate(AssertionInfo info, Class<?> actual) {
     assertNotNull(info, actual);
-    if ((Modifier.isPublic(actual.getModifiers())
-      || Modifier.isProtected(actual.getModifiers())
-      || Modifier.isPrivate(actual.getModifiers()))) {
+    final int modifiers = actual.getModifiers();
+    if (Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || Modifier.isPrivate(modifiers)) {
       throw failures.failure(info, shouldBePackagePrivate(actual));
     }
   }

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal;
 
 import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBeFinal;
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBePackagePrivate;
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBeProtected;
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBePublic;
 import static org.assertj.core.error.ClassModifierShouldBe.shouldNotBeFinal;
@@ -203,6 +204,23 @@ public class Classes {
     assertNotNull(info, actual);
     if (!Modifier.isProtected(actual.getModifiers())) {
       throw failures.failure(info, shouldBeProtected(actual));
+    }
+  }
+
+  /**
+   * Verifies that the actual {@code Class} is package-private.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the "actual" {@code Class}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} is not protected.
+   */
+  public void assertIsPackagePrivate(AssertionInfo info, Class<?> actual) {
+    assertNotNull(info, actual);
+    if ((Modifier.isPublic(actual.getModifiers())
+      || Modifier.isProtected(actual.getModifiers())
+      || Modifier.isPrivate(actual.getModifiers()))) {
+      throw failures.failure(info, shouldBePackagePrivate(actual));
     }
   }
 

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_isPackagePrivate_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_isPackagePrivate_Test.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link ClassAssert#isPackagePrivate()} ()} ()}</code>.
+ */
+public class ClassAssert_isPackagePrivate_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.isPackagePrivate();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertIsPackagePrivate(getInfo(assertions), getActual(assertions));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPackagePrivate_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPackagePrivate_Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.error.ClassModifierShouldBe.shouldBePackagePrivate;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("Classes assertIsPackagePrivate")
+class Classes_assertIsPackagePrivate_Test extends ClassesBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> classes.assertIsPackagePrivate(someInfo(), null))
+                                                   .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_pass_if_actual_is_a_package_private_class() {
+    classes.assertIsPackagePrivate(someInfo(), PackagePrivateClass.class);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_a_package_private_class() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> classes.assertIsPackagePrivate(someInfo(), Object.class))
+                                                   .withMessage(shouldBePackagePrivate(Object.class).create());
+  }
+}
+
+class PackagePrivateClass {
+
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPackagePrivate_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertIsPackagePrivate_Test.java
@@ -16,9 +16,10 @@ import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ClassModifierShouldBe.shouldBePackagePrivate;
-import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 @DisplayName("Classes assertIsPackagePrivate")
@@ -26,19 +27,30 @@ class Classes_assertIsPackagePrivate_Test extends ClassesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> classes.assertIsPackagePrivate(someInfo(), null))
-                                                   .withMessage(actualIsNull());
+    //GIVEN
+    Class clazz = null;
+    //WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(clazz).isPackagePrivate());
+    //THEN
+    then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
   public void should_pass_if_actual_is_a_package_private_class() {
-    classes.assertIsPackagePrivate(someInfo(), PackagePrivateClass.class);
+    //GIVEN
+    Class clazz = PackagePrivateClass.class;
+    //THEN
+    then(clazz).isPackagePrivate();
   }
 
   @Test
   public void should_fail_if_actual_is_not_a_package_private_class() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> classes.assertIsPackagePrivate(someInfo(), Object.class))
-                                                   .withMessage(shouldBePackagePrivate(Object.class).create());
+    //GIVEN
+    Class clazz = Object.class;
+    //WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(clazz).isPackagePrivate());
+    //THEN
+    then(assertionError).hasMessage(shouldBePackagePrivate(Object.class).create());
   }
 }
 


### PR DESCRIPTION
Implemented `isPackagePrivate()` as described in #1700.

#### Check List:
* Fixes #1700 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


