### PR TITLE
Revise module declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,7 @@ Copyright ${inceptionYear}-${currentYear} the original author or authors.
                   <configuration>
                     <release>9</release>
                     <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
                       <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
                     </compileSourceRoots>
                     <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -36,19 +36,23 @@ module org.assertj.core {
   exports org.assertj.core.util.introspection;
   exports org.assertj.core.util.xml;
 
-  requires java.instrument;
+
+  requires static java.sql; // import java.sql.Timestamp; in Assertions.java for Javadoc-only
+  // requires static java.instrument;
   // required when printThreadDump is true
   requires static java.management;
   // used for pretty print XML
   requires static java.xml;
   // these lines are commented to avoid this compilation warning
   // Required filename-based automodules detected. Please don't publish this project to a public artifact repository!
-  // requires static jsr305;
-  // requires static hamcrest.core;
-  // requires static junit;
+  requires static jsr305;
+  requires static junit; // "junit" is the stable module name of JUnit 4 (4.13+)
   requires static org.junit.jupiter.api;
   // To throw AssertionFailedError which is IDE friendly
   requires static org.opentest4j;
+
+  requires static net.bytebuddy;
+  requires static org.hamcrest;
 
   // Services loaded by org.assertj.core.configuration.ConfigurationProvider
   uses org.assertj.core.configuration.Configuration;


### PR DESCRIPTION
Relates to #1656 -- here are the changes that made AssertJ Core compile with Java 9+, including the module descriptor.

- Added the "base" source root `/src/main/java` to the compilation set of the `java9+` profile.
- Encountered a lot of "invisible package" errors...
- ...and added a bunch of `requires ...;` statements to fix those. Left some comments in the `module-info.java` file.

Open ends:
- [ ] Delete/ignore all Java-9+ compiled classes, except for `module-info.class`
- [x] `java.instrument` is a special snow flake, it's not required directly to compile AssertJ Core, but ByteBuddy seems to need it. @raphw ... any new input here? (removed in 116798b15518f16597e8754b83c06cd3b89ebe24)
- [x] Module `java.sql` is only(?) needed due to a link reference in the javadoc of `Assertions.java` (not needed since 5c136d6268a6e0c375c6d6ae266c6a6e2b2b0c6d)
- [x] Module name `junit` is file named based -- JUnit 4.13 will fix this, though. (fixed in b0385fcf6459bb1a5ddb1c2783dc7dc6c054df30)
- [x] Module name `jsr305` is file name based -- don't see a fix in the near future, do you? (not needed since 24176f5450b8e3624a819fdc594f709a378ca09f)

TODO:
- [ ] Provide integration test that uses module `org.assertj.core` on the module path.
- [ ] Run `jdeps --check ...`, similar to https://github.com/junit-team/junit5/issues/1939