### PR TITLE
Tests to reproduce #1715

### DIFF
--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isGreaterThanOrEqualTo_double_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isGreaterThanOrEqualTo_double_Test.java
@@ -14,7 +14,9 @@ package org.assertj.core.api.double_;
 
 import org.assertj.core.api.DoubleAssert;
 import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 
@@ -33,5 +35,14 @@ public class DoubleAssert_isGreaterThanOrEqualTo_double_Test extends DoubleAsser
   @Override
   protected void verify_internal_effects() {
     verify(doubles).assertGreaterThanOrEqualTo(getInfo(assertions), getActual(assertions), 6d);
+  }
+
+  @Test
+  public void should_pass_with_double_negativeZero() {
+    // GIVEN
+    final double positiveZero = 0D;
+    final double negativeZero = -0D;
+    // THEN
+    assertThat(negativeZero).isGreaterThanOrEqualTo(positiveZero);
   }
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isGreaterThan_double_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isGreaterThan_double_Test.java
@@ -14,7 +14,10 @@ package org.assertj.core.api.double_;
 
 import org.assertj.core.api.DoubleAssert;
 import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 
@@ -33,5 +36,21 @@ public class DoubleAssert_isGreaterThan_double_Test extends DoubleAssertBaseTest
   @Override
   protected void verify_internal_effects() {
     verify(doubles).assertGreaterThan(getInfo(assertions), getActual(assertions), 6d);
+  }
+
+  @Test
+  public void should_fail_with_double_negativeZero() {
+    // GIVEN
+    final double positiveZero = 0D;
+    final double negativeZero = -0D;
+    // WHEN
+    try {
+      assertThat(positiveZero).isGreaterThan(negativeZero);
+    } catch (AssertionError e) {
+      // THEN
+      assertThat(e).hasMessage(format("%nExpecting:%n <0.0f>%nto be greater than:%n <-0.0f> "));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isGreaterThanOrEqualTo_float_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isGreaterThanOrEqualTo_float_Test.java
@@ -14,7 +14,9 @@ package org.assertj.core.api.float_;
 
 import org.assertj.core.api.FloatAssert;
 import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 
@@ -34,4 +36,14 @@ public class FloatAssert_isGreaterThanOrEqualTo_float_Test extends FloatAssertBa
   protected void verify_internal_effects() {
     verify(floats).assertGreaterThanOrEqualTo(getInfo(assertions), getActual(assertions), 6f);
   }
+
+  @Test
+  public void should_pass_with_float_negativeZero() {
+    // GIVEN
+    final float positiveZero = 0f;
+    final float negativeZero = -0f;
+    // THEN
+    assertThat(negativeZero).isGreaterThanOrEqualTo(positiveZero);
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isGreaterThan_float_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isGreaterThan_float_Test.java
@@ -14,7 +14,10 @@ package org.assertj.core.api.float_;
 
 import org.assertj.core.api.FloatAssert;
 import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 
@@ -33,5 +36,21 @@ public class FloatAssert_isGreaterThan_float_Test extends FloatAssertBaseTest {
   @Override
   protected void verify_internal_effects() {
     verify(floats).assertGreaterThan(getInfo(assertions), getActual(assertions), 6f);
+  }
+
+  @Test
+  public void should_fail_with_float_negativeZero() {
+    // GIVEN
+    final float positiveZero = 0f;
+    final float negativeZero = -0f;
+    // WHEN
+    try {
+      assertThat(positiveZero).isGreaterThan(negativeZero);
+    } catch (AssertionError e) {
+      // THEN
+      assertThat(e).hasMessage(format("%nExpecting:%n <0.0f>%nto be greater than:%n <-0.0f> "));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 }


### PR DESCRIPTION
Floating point comparisons consider positive zero greater than negative
zero.

Note this PR only provides failing unit tests, it does not fix the bug.

#### Check List:
* Fixes #???
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


