### PR TITLE
Fix tests that fail on Windows

### DIFF
--- a/src/test/java/org/assertj/core/error/ShouldBeEmpty_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEmpty_create_Test.java
@@ -46,10 +46,12 @@ class ShouldBeEmpty_create_Test {
   @Test
   void should_create_error_message_for_File() {
     // GIVEN
-    ErrorMessageFactory factory = shouldBeEmpty(new File("/te%st.txt"));
+	File f = new File("/te%st.txt");
+    ErrorMessageFactory factory = shouldBeEmpty(f);
     // WHEN
     String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(format("[Test] %nExpecting file </te%%st.txt> to be empty"));
+    String expected = f.getAbsolutePath().replace("%", "%%");
+    then(message).isEqualTo(format("[Test] %nExpecting file <" + expected + "> to be empty"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotBeEmpty_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotBeEmpty_create_Test.java
@@ -46,10 +46,12 @@ class ShouldNotBeEmpty_create_Test {
   @Test
   void should_create_error_message_for_File() {
     // GIVEN
-    factory = shouldNotBeEmpty(new File("/test.txt"));
+	File f = new File("/test.txt");
+    factory = shouldNotBeEmpty(f);
     // WHEN
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo(String.format("[Test] %nExpecting file </test.txt> not to be empty"));
+    String expected = f.getAbsolutePath().replace("%", "%%");
+    then(message).isEqualTo(String.format("[Test] %nExpecting file <" + expected + "> not to be empty"));
   }
 }


### PR DESCRIPTION
These tests made assumptions about paths that don't apply when running on Windows. `new File("/test.txt")` produced `C:\test.txt` in the error message output, while the test was expecting `/test.txt`.

Updated it to call `getAbsolutePath()` to generate the correct expected value in a platform-inspecific way.