### PR TITLE
Add additional stacktrace information for throwable assertions

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
@@ -12,6 +12,9 @@
  */
 package org.assertj.core.error;
 
+import static org.assertj.core.util.Strings.escapePercent;
+import static org.assertj.core.util.Throwables.getStackTrace;
+
 import java.util.Set;
 
 import org.assertj.core.internal.ComparisonStrategy;
@@ -37,6 +40,36 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldContain(CharSequence actual, CharSequence sequence) {
     return new ShouldContainCharSequence("%nExpecting:%n <%s>%nto contain:%n <%s> %s", actual, sequence,
                                    StandardComparisonStrategy.instance());
+  }
+
+  public static ErrorMessageFactory shouldContain(Throwable actual, CharSequence sequence) {
+    String format = "%n" +
+                    "Expecting:%n" +
+                    "  <%s>%n" +
+                    "to contain:%n" +
+                    "  <%s>%n" +
+                    "but did not.%n" +
+                    "%n" +
+                    "Throwable that failed the check:%n" +
+                    "%n" + escapePercent(getStackTrace(actual)); // to avoid AssertJ default String formatting
+
+    return new ShouldContainCharSequence(format, actual.getMessage(), sequence, StandardComparisonStrategy.instance());
+  }
+
+  public static ErrorMessageFactory shouldContain(Throwable actual, CharSequence[] sequence,
+                                                  Set<? extends CharSequence> notFound) {
+    String format = "%n" +
+                    "Expecting:%n" +
+                    "  <%s>%n" +
+                    "to contain:%n" +
+                    "  <%s>%n" +
+                    "but could not find:%n" +
+                    "  <%s>%n" +
+                    "%n" +
+                    "Throwable that failed the check:%n" +
+                    "%n" + escapePercent(getStackTrace(actual)); // to avoid AssertJ default String formatting
+
+    return new ShouldContainCharSequence(format, actual.getMessage(), sequence, notFound, StandardComparisonStrategy.instance());
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
@@ -44,7 +44,7 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldContain(Throwable actual, CharSequence sequence) {
     String format = "%n" +
-                    "Expecting:%n" +
+                    "Expecting throwable message:%n" +
                     "  <%s>%n" +
                     "to contain:%n" +
                     "  <%s>%n" +
@@ -59,7 +59,7 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldContain(Throwable actual, CharSequence[] sequence,
                                                   Set<? extends CharSequence> notFound) {
     String format = "%n" +
-                    "Expecting:%n" +
+                    "Expecting throwable message:%n" +
                     "  <%s>%n" +
                     "to contain:%n" +
                     "  <%s>%n" +

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -191,7 +191,7 @@ public class Throwables {
   public void assertHasMessageContaining(AssertionInfo info, Throwable actual, String description) {
     assertNotNull(info, actual);
     if (actual.getMessage() != null && actual.getMessage().contains(description)) return;
-    throw failures.failure(info, shouldContain(actual.getMessage(), description));
+    throw failures.failure(info, shouldContain(actual, description));
   }
 
   /**
@@ -211,9 +211,9 @@ public class Throwables {
                                                .collect(toCollection(LinkedHashSet::new));
     if (notFound.isEmpty()) return;
     if (notFound.size() == 1 && values.length == 1) {
-      throw failures.failure(info, shouldContain(actualMessage, values[0]), actualMessage, values[0]);
+      throw failures.failure(info, shouldContain(actual, values[0]), actual, values[0]);
     }
-    throw failures.failure(info, shouldContain(actualMessage, values, notFound), actualMessage, values);
+    throw failures.failure(info, shouldContain(actual, values, notFound), actual, values);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -119,7 +119,7 @@ class Assertions_assertThat_with_Throwable_Test {
     // GIVEN
     ThrowingCallable code = () -> assertThatThrownBy(raisingException("boom")).hasMessageContaining("%s", "bam");
     // THEN
-    assertThatAssertionErrorIsThrownBy(code).withMessageContainingAll("Expecting:",
+    assertThatAssertionErrorIsThrownBy(code).withMessageContainingAll("Expecting throwable message:",
                                                                       "<\"boom\">",
                                                                       "to contain",
                                                                       "<\"bam\">");

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Throwable_Test.java
@@ -27,22 +27,22 @@ import java.io.IOException;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
-public class Assertions_assertThat_with_Throwable_Test {
+class Assertions_assertThat_with_Throwable_Test {
 
   @Test
-  public void should_build_ThrowableAssert_with_runtime_exception_thrown() {
+  void should_build_ThrowableAssert_with_runtime_exception_thrown() {
     assertThatThrownBy(codeThrowing(new IllegalArgumentException("boom"))).isInstanceOf(IllegalArgumentException.class)
                                                                           .hasMessage("boom");
   }
 
   @Test
-  public void should_build_ThrowableAssert_with_throwable_thrown() {
+  void should_build_ThrowableAssert_with_throwable_thrown() {
     assertThatThrownBy(codeThrowing(new Throwable("boom"))).isInstanceOf(Throwable.class)
                                                            .hasMessage("boom");
   }
 
   @Test
-  public void should_be_able_to_pass_a_description_to_assertThatThrownBy() {
+  void should_be_able_to_pass_a_description_to_assertThatThrownBy() {
     // GIVEN a failing assertion with a description
     ThrowingCallable code = () -> assertThatThrownBy(raisingException("boom"), "Test %s", "code").hasMessage("bam");
     // WHEN
@@ -52,13 +52,13 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void should_fail_if_no_throwable_was_thrown() {
+  void should_fail_if_no_throwable_was_thrown() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatThrownBy(() -> {}).hasMessage("boom ?"))
                                                    .withMessage(format("%nExpecting code to raise a throwable."));
   }
 
   @Test
-  public void can_capture_exception_and_then_assert_following_AAA_or_BDD_style() {
+  void can_capture_exception_and_then_assert_following_AAA_or_BDD_style() {
     // when
     Exception exception = new Exception("boom!!");
     Throwable boom = catchThrowable(codeThrowing(exception));
@@ -67,7 +67,7 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void catchThrowable_returns_null_when_no_exception_thrown() {
+  void catchThrowable_returns_null_when_no_exception_thrown() {
     // when
     Throwable boom = catchThrowable(() -> {});
     // then
@@ -75,7 +75,7 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void catchThrowableOfType_should_fail_with_a_message_containing_the_original_stack_trace_when_the_wrong_Throwable_type_was_thrown() {
+  void catchThrowableOfType_should_fail_with_a_message_containing_the_original_stack_trace_when_the_wrong_Throwable_type_was_thrown() {
     // GIVEN
     final Exception exception = new Exception("boom!!");
     ThrowingCallable codeThrowingException = codeThrowing(exception);
@@ -88,7 +88,7 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void catchThrowableOfType_should_succeed_and_return_actual_instance_with_correct_class() {
+  void catchThrowableOfType_should_succeed_and_return_actual_instance_with_correct_class() {
     // GIVEN
     final Exception expected = new RuntimeException("boom!!");
     // WHEN
@@ -98,13 +98,13 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void catchThrowableOfType_should_succeed_and_return_null_if_no_exception_thrown() {
+  void catchThrowableOfType_should_succeed_and_return_null_if_no_exception_thrown() {
     IOException actual = catchThrowableOfType(() -> {}, IOException.class);
     assertThat(actual).isNull();
   }
 
   @Test
-  public void should_fail_with_good_message_when_assertion_is_failing() {
+  void should_fail_with_good_message_when_assertion_is_failing() {
     // GIVEN
     ThrowingCallable code = () -> assertThatThrownBy(raisingException("boom")).hasMessage("bam");
     // THEN
@@ -115,7 +115,7 @@ public class Assertions_assertThat_with_Throwable_Test {
   }
 
   @Test
-  public void should_fail_with_good_message_when_vararg_has_message_containing_assertion_is_failing() {
+  void should_fail_with_good_message_when_vararg_has_message_containing_assertion_is_failing() {
     // GIVEN
     ThrowingCallable code = () -> assertThatThrownBy(raisingException("boom")).hasMessageContaining("%s", "bam");
     // THEN

--- a/src/test/java/org/assertj/core/error/ShouldContainThrowable_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainThrowable_create_Test.java
@@ -12,7 +12,8 @@
  */
 package org.assertj.core.error;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainCharSequence.*;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Throwables.getStackTrace;
 import static org.mockito.internal.util.collections.Sets.newSet;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link ShouldContainCharSequence#shouldContain(Throwable, CharSequence[], Set)})}</code> and
- *  <code>{@link ShouldContainCharSequence#shouldContain(Throwable, CharSequence)})}</code>.
+ * <code>{@link ShouldContainCharSequence#shouldContain(Throwable, CharSequence)})}</code>.
  *
  * @author Benoit Dupont
  */
@@ -36,19 +37,19 @@ class ShouldContainThrowable_create_Test {
     // GIVEN
     RuntimeException actual = new RuntimeException("You know nothing %");
     // WHEN
-    String errorMessage = ShouldContainCharSequence.shouldContain(actual, "You know nothing % Jon Snow")
-                                                   .create(new TestDescription("TEST"));
+    String errorMessage = shouldContain(actual, "You know nothing % Jon Snow")
+      .create(new TestDescription("TEST"));
     // THEN
-    assertThat(errorMessage).isEqualTo("[TEST] %n" +
-                                       "Expecting:%n" +
-                                       "  <\"You know nothing %%\">%n" +
-                                       "to contain:%n" +
-                                       "  <\"You know nothing %% Jon Snow\">%n" +
-                                       "but did not.%n" +
-                                       "%n" +
-                                       "Throwable that failed the check:%n" +
-                                       "%n%s",
-                                       getStackTrace(actual));
+    then(errorMessage).isEqualTo("[TEST] %n" +
+        "Expecting throwable message:%n" +
+        "  <\"You know nothing %%\">%n" +
+        "to contain:%n" +
+        "  <\"You know nothing %% Jon Snow\">%n" +
+        "but did not.%n" +
+        "%n" +
+        "Throwable that failed the check:%n" +
+        "%n%s",
+      getStackTrace(actual));
   }
 
   @Test
@@ -56,20 +57,20 @@ class ShouldContainThrowable_create_Test {
     // GIVEN
     RuntimeException actual = new RuntimeException("You know nothing");
     // WHEN
-    String errorMessage = ShouldContainCharSequence.shouldContain(actual, array("You", "know", "nothing", "Jon", "Snow"),
-                                                                  newSet("Jon", "Snow"))
-                                                   .create(new TestDescription("TEST"));
+    String errorMessage = shouldContain(actual, array("You", "know", "nothing", "Jon", "Snow"),
+      newSet("Jon", "Snow"))
+      .create(new TestDescription("TEST"));
     // THEN
-    assertThat(errorMessage).isEqualTo("[TEST] %n" +
-                                       "Expecting:%n" +
-                                       "  <\"You know nothing\">%n" +
-                                       "to contain:%n" +
-                                       "  <[\"You\", \"know\", \"nothing\", \"Jon\", \"Snow\"]>%n" +
-                                       "but could not find:%n" +
-                                       "  <[\"Jon\", \"Snow\"]>%n" +
-                                       "%n" +
-                                       "Throwable that failed the check:%n" +
-                                       "%n%s",
-                                       getStackTrace(actual));
+    then(errorMessage).isEqualTo("[TEST] %n" +
+        "Expecting throwable message:%n" +
+        "  <\"You know nothing\">%n" +
+        "to contain:%n" +
+        "  <[\"You\", \"know\", \"nothing\", \"Jon\", \"Snow\"]>%n" +
+        "but could not find:%n" +
+        "  <[\"Jon\", \"Snow\"]>%n" +
+        "%n" +
+        "Throwable that failed the check:%n" +
+        "%n%s",
+      getStackTrace(actual));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainThrowable_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainThrowable_create_Test.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Throwables.getStackTrace;
+import static org.mockito.internal.util.collections.Sets.newSet;
+
+import java.util.Set;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ShouldContainCharSequence#shouldContain(Throwable, CharSequence[], Set)})}</code> and
+ *  <code>{@link ShouldContainCharSequence#shouldContain(Throwable, CharSequence)})}</code>.
+ *
+ * @author Benoit Dupont
+ */
+@DisplayName("ShouldContainThrowable create")
+class ShouldContainThrowable_create_Test {
+  @Test
+  void should_create_error_message_with_escaping_percent() {
+    // GIVEN
+    RuntimeException actual = new RuntimeException("You know nothing %");
+    // WHEN
+    String errorMessage = ShouldContainCharSequence.shouldContain(actual, "You know nothing % Jon Snow")
+                                                   .create(new TestDescription("TEST"));
+    // THEN
+    assertThat(errorMessage).isEqualTo("[TEST] %n" +
+                                       "Expecting:%n" +
+                                       "  <\"You know nothing %%\">%n" +
+                                       "to contain:%n" +
+                                       "  <\"You know nothing %% Jon Snow\">%n" +
+                                       "but did not.%n" +
+                                       "%n" +
+                                       "Throwable that failed the check:%n" +
+                                       "%n%s",
+                                       getStackTrace(actual));
+  }
+
+  @Test
+  void should_create_error_message_with_several_values_not_found() {
+    // GIVEN
+    RuntimeException actual = new RuntimeException("You know nothing");
+    // WHEN
+    String errorMessage = ShouldContainCharSequence.shouldContain(actual, array("You", "know", "nothing", "Jon", "Snow"),
+                                                                  newSet("Jon", "Snow"))
+                                                   .create(new TestDescription("TEST"));
+    // THEN
+    assertThat(errorMessage).isEqualTo("[TEST] %n" +
+                                       "Expecting:%n" +
+                                       "  <\"You know nothing\">%n" +
+                                       "to contain:%n" +
+                                       "  <[\"You\", \"know\", \"nothing\", \"Jon\", \"Snow\"]>%n" +
+                                       "but could not find:%n" +
+                                       "  <[\"Jon\", \"Snow\"]>%n" +
+                                       "%n" +
+                                       "Throwable that failed the check:%n" +
+                                       "%n%s",
+                                       getStackTrace(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
@@ -63,7 +63,7 @@ public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBas
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageContainingAll(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content), actual.getMessage(), content);
+    verify(failures).failure(INFO, shouldContain(actual, content), actual, content);
   }
 
   @Test
@@ -73,8 +73,8 @@ public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBas
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageContainingAll(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content, Collections.singleton("catchable")),
-                             actual.getMessage(), content);
+    verify(failures).failure(INFO, shouldContain(actual, content, Collections.singleton("catchable")),
+                             actual, content);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
@@ -34,22 +34,22 @@ import org.junit.jupiter.api.Test;
  *
  * @author Phillip Webb
  */
-public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBaseTest {
+class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBaseTest {
 
   private static final AssertionInfo INFO = someInfo();
 
   @Test
-  public void should_pass_if_actual_has_message_containing_the_expected_string() {
+  void should_pass_if_actual_has_message_containing_the_expected_string() {
     throwables.assertHasMessageContainingAll(someInfo(), actual, "able");
   }
 
   @Test
-  public void should_pass_if_actual_has_message_containing_all_the_expected_strings() {
+  void should_pass_if_actual_has_message_containing_all_the_expected_strings() {
     throwables.assertHasMessageContainingAll(someInfo(), actual, "able", "message");
   }
 
   @Test
-  public void should_fail_if_actual_is_null() {
+  void should_fail_if_actual_is_null() {
     // GIVEN
     ThrowingCallable code = () -> throwables.assertHasMessageContainingAll(INFO, null, "Throwable");
     // THEN
@@ -57,7 +57,7 @@ public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBas
   }
 
   @Test
-  public void should_fail_if_actual_has_message_not_containing_all_the_expected_strings() {
+  void should_fail_if_actual_has_message_not_containing_all_the_expected_strings() {
     // GIVEN
     String content = "expected description part";
     // WHEN
@@ -67,7 +67,7 @@ public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBas
   }
 
   @Test
-  public void should_fail_if_actual_has_message_not_containing_some_of_the_expected_strings() {
+  void should_fail_if_actual_has_message_not_containing_some_of_the_expected_strings() {
     // GIVEN
     String[] content = { "catchable", "message" };
     // WHEN
@@ -78,7 +78,7 @@ public class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBas
   }
 
   @Test
-  public void should_throw_error_if_expected_strings_are_null() {
+  void should_throw_error_if_expected_strings_are_null() {
     assertThatNullPointerException().isThrownBy(() -> throwables.assertHasMessageContainingAll(INFO, actual, (String) null))
                                     .withMessage(charSequenceToLookForIsNull());
   }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
@@ -31,23 +31,23 @@ import org.junit.jupiter.api.Test;
  * @author Joel Costigliola
  * @author Phillip Webb
  */
-public class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTest {
+class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTest {
 
   private static final AssertionInfo INFO = someInfo();
 
   @Test
-  public void should_pass_if_actual_has_message_containing_with_expected_description() {
+  void should_pass_if_actual_has_message_containing_with_expected_description() {
     throwables.assertHasMessageContaining(someInfo(), actual, "able");
   }
 
   @Test
-  public void should_fail_if_actual_is_null() {
+  void should_fail_if_actual_is_null() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> throwables.assertHasMessageContaining(someInfo(), null, "Throwable"))
                                                    .withMessage(actualIsNull());
   }
 
   @Test
-  public void should_fail_if_actual_has_message_not_containing_with_expected_description() {
+  void should_fail_if_actual_has_message_not_containing_with_expected_description() {
     // GIVEN
     String content = "expected description part";
     // WHEN

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
@@ -53,7 +53,7 @@ public class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTe
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageContaining(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldContain(actual.getMessage(), content));
+    verify(failures).failure(INFO, shouldContain(actual, content));
   }
 
 }


### PR DESCRIPTION
Show the stack trace for the Throwable under test when assertions for Throwable hasMessageContaining and hasMessageContainingAll fails

#### Check List:
* Fixes #1355
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA


