### PR TITLE
Reduce visibility of getParameters()

### DIFF
--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -97,8 +97,7 @@ public class Uris {
     if (!areEqual(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
   }
 
-  @VisibleForTesting
-  public static Map<String, List<String>> getParameters(String query) {
+  static Map<String, List<String>> getParameters(String query) {
     Map<String, List<String>> parameters = new LinkedHashMap<>();
 
     if (query != null && !query.isEmpty()) {

--- a/src/test/java/org/assertj/core/internal/UrisBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/UrisBaseTest.java
@@ -15,6 +15,9 @@ package org.assertj.core.internal;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.mockito.Mockito.spy;
 
+import java.util.List;
+import java.util.Map;
+
 import org.assertj.core.api.AssertionInfo;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -29,12 +32,16 @@ public abstract class UrisBaseTest {
   protected Uris uris;
   protected AssertionInfo info;
 
-
   @BeforeEach
-  public void setUp() {
-	failures = spy(new Failures());
-	uris = new Uris();
-	uris.failures = failures;
-	info = someInfo();
+  void setUp() {
+    failures = spy(new Failures());
+    uris = new Uris();
+    uris.failures = failures;
+    info = someInfo();
   }
+
+  protected static Map<String, List<String>> getParameters(String query) {
+    return Uris.getParameters(query);
+  }
+
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_getParameters_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_getParameters_Test.java
@@ -12,28 +12,28 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.internal.UrisBaseTest;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.internal.Uris.getParameters;
-
-public class Uris_getParameters_Test {
+class Uris_getParameters_Test extends UrisBaseTest {
 
   @Test
-  public void should_return_empty_for_empty_query() {
+  void should_return_empty_for_empty_query() {
     assertThat(getParameters("")).isEmpty();
   }
 
   @Test
-  public void should_return_empty_for_null_query() {
+  void should_return_empty_for_null_query() {
     assertThat(getParameters(null)).isEmpty();
   }
 
   @Test
-  public void should_accept_parameter_with_no_value() {
+  void should_accept_parameter_with_no_value() {
     Map<String, List<String>> parameters = getParameters("foo");
 
     assertThat(parameters).containsKey("foo");
@@ -42,7 +42,7 @@ public class Uris_getParameters_Test {
   }
 
   @Test
-  public void should_accept_parameter_with_value() {
+  void should_accept_parameter_with_value() {
     Map<String, List<String>> parameters = getParameters("foo=bar");
 
     assertThat(parameters).containsKey("foo");
@@ -50,17 +50,17 @@ public class Uris_getParameters_Test {
   }
 
   @Test
-  public void should_decode_name() {
+  void should_decode_name() {
     assertThat(getParameters("foo%3Dbar=baz")).containsKey("foo=bar");
   }
 
   @Test
-  public void should_decode_value() {
+  void should_decode_value() {
     assertThat(getParameters("foo=bar%3Dbaz").get("foo")).contains("bar=baz");
   }
 
   @Test
-  public void should_accept_duplicate_names() {
+  void should_accept_duplicate_names() {
     Map<String, List<String>> parameters = getParameters("foo&foo=bar");
 
     assertThat(parameters).containsKey("foo");
@@ -68,7 +68,7 @@ public class Uris_getParameters_Test {
   }
 
   @Test
-  public void should_accept_duplicate_values() {
+  void should_accept_duplicate_values() {
     Map<String, List<String>> parameters = getParameters("foo=bar&foo=bar");
 
     assertThat(parameters).containsKey("foo");


### PR DESCRIPTION
The method was public only to allow access from tests. This refactoring
still allows the access but without having it public.