### PR TITLE
Remove failBecauseExpectedAssertionErrorWasNotThrown()

### DIFF
--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_DoubleStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_DoubleStream_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
@@ -103,13 +103,10 @@ public class Assertions_assertThat_with_DoubleStream_Test {
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
     assertThat(intStream).isNotExactlyInstanceOf(DoubleStream.class);
-    try {
-      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
-    } catch (AssertionError e) {
-      // ok
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_IntStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_IntStream_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
@@ -103,13 +103,10 @@ public class Assertions_assertThat_with_IntStream_Test {
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
     assertThat(intStream).isNotExactlyInstanceOf(IntStream.class);
-    try {
-      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
-    } catch (AssertionError e) {
-      // ok
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.api;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -108,13 +108,10 @@ public class Assertions_assertThat_with_Iterator_Test {
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_iterator() {
     assertThat(stringIterator).isNotExactlyInstanceOf(Iterator.class);
-    try {
-      assertThat(stringIterator).isNotExactlyInstanceOf(StringIterator.class);
-    } catch (AssertionError e) {
-      // ok
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat(stringIterator).isNotExactlyInstanceOf(StringIterator.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_LongStream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_LongStream_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
@@ -103,13 +103,10 @@ public class Assertions_assertThat_with_LongStream_Test {
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
     assertThat(intStream).isNotExactlyInstanceOf(LongStream.class);
-    try {
-      assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass());
-    } catch (AssertionError e) {
-      // ok
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat(intStream).isNotExactlyInstanceOf(intStream.getClass()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Stream_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Stream_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -96,13 +96,10 @@ public class Assertions_assertThat_with_Stream_Test {
   @Test
   public void isNotExactlyInstanceOf_should_check_the_original_stream() {
     assertThat(stringStream).isNotExactlyInstanceOf(Stream.class);
-    try {
-      assertThat(stringStream).isNotExactlyInstanceOf(StringStream.class);
-    } catch (AssertionError e) {
-      // ok
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat(stringStream).isNotExactlyInstanceOf(StringStream.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/BaseTest.java
+++ b/src/test/java/org/assertj/core/api/BaseTest.java
@@ -19,9 +19,4 @@ package org.assertj.core.api;
  * A simple base class for test.
  */
 public class BaseTest {
-
-  public void failBecauseExpectedAssertionErrorWasNotThrown() {
-    Assertions.fail("Assertion error expected");
-  }
-
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingFieldByFieldElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingFieldByFieldElementComparator_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.atomic.referencearray;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -157,43 +158,45 @@ public class AtomicReferenceArrayAssert_usingFieldByFieldElementComparator_Test
 
   @Test
   public void failed_isEqualTo_assertion_using_field_by_field_element_comparator() {
+    // GIVEN
     Foo[] array1 = array(new Foo("id", 1));
     Foo[] array2 = array(new Foo("id", 2));
-    try {
-      assertThat(array1).usingFieldByFieldElementComparator().isEqualTo(array2);
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("%nExpecting:%n"
-                                      + " <[Foo(id=id, bar=1)]>%n"
-                                      + "to be equal to:%n"
-                                      + " <[Foo(id=id, bar=2)]>%n"
-                                      + "when comparing elements using field/property by field/property comparator on all fields/properties%n"
-                                      + "Comparators used:%n"
-                                      + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "but was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(array1).usingFieldByFieldElementComparator().isEqualTo(array2));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n"
+                          + " <[Foo(id=id, bar=1)]>%n"
+                          + "to be equal to:%n"
+                          + " <[Foo(id=id, bar=2)]>%n"
+                          + "when comparing elements using field/property by field/property comparator on all fields/properties%n"
+                          + "Comparators used:%n"
+                          + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "but was not."));
   }
 
   @Test
   public void failed_isIn_assertion_using_field_by_field_element_comparator() {
+    // GIVEN
     AtomicReferenceArray<Foo> array1 = atomicArrayOf(new Foo("id", 1));
     Foo[] array2 = array(new Foo("id", 2));
-    try {
-      assertThat(array1).usingFieldByFieldElementComparator().isIn(array2, array2);
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("%nExpecting:%n"
-                                      + " <[Foo(id=id, bar=1)]>%n"
-                                      + "to be in:%n"
-                                      + " <[[Foo(id=id, bar=2)], [Foo(id=id, bar=2)]]>%n"
-                                      + "when comparing elements using field/property by field/property comparator on all fields/properties%n"
-                                      + "Comparators used:%n"
-                                      + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(array1).usingFieldByFieldElementComparator().isIn(array2, array2));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n"
+                          + " <[Foo(id=id, bar=1)]>%n"
+                          + "to be in:%n"
+                          + " <[[Foo(id=id, bar=2)], [Foo(id=id, bar=2)]]>%n"
+                          + "when comparing elements using field/property by field/property comparator on all fields/properties%n"
+                          + "Comparators used:%n"
+                          + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingRecursiveFieldByFieldElementComparator_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingRecursiveFieldByFieldElementComparator_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.atomic.referencearray;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 
 import java.util.Comparator;
@@ -65,43 +66,45 @@ public class AtomicReferenceArrayAssert_usingRecursiveFieldByFieldElementCompara
 
   @Test
   public void failed_isEqualTo_assertion_using_recursive_field_by_field_element_comparator() {
+    // GIVEN
     AtomicReferenceArray<Foo> array1 = atomicArrayOf(new Foo("id", new Bar(1)));
     Foo[] array2 = { new Foo("id", new Bar(2)) };
-    try {
-      assertThat(array1).usingRecursiveFieldByFieldElementComparator().isEqualTo(array2);
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("%nExpecting:%n"
-                                      + " <[Foo(id=id, bar=Bar(id=1))]>%n"
-                                      + "to be equal to:%n"
-                                      + " <[Foo(id=id, bar=Bar(id=2))]>%n"
-                                      + "when comparing elements using recursive field/property by field/property comparator on all fields/properties%n"
-                                      + "Comparators used:%n"
-                                      + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "but was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(array1).usingRecursiveFieldByFieldElementComparator().isEqualTo(array2));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n"
+                          + " <[Foo(id=id, bar=Bar(id=1))]>%n"
+                          + "to be equal to:%n"
+                          + " <[Foo(id=id, bar=Bar(id=2))]>%n"
+                          + "when comparing elements using recursive field/property by field/property comparator on all fields/properties%n"
+                          + "Comparators used:%n"
+                          + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "but was not."));
   }
 
   @Test
   public void failed_isIn_assertion_using_recursive_field_by_field_element_comparator() {
+    // GIVEN
     AtomicReferenceArray<Foo> array1 = atomicArrayOf(new Foo("id", new Bar(1)));
     Foo[] array2 = { new Foo("id", new Bar(2)) };
-    try {
-      assertThat(array1).usingRecursiveFieldByFieldElementComparator().isIn(new Object[] { array2 });
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("%nExpecting:%n"
-                                      + " <[Foo(id=id, bar=Bar(id=1))]>%n"
-                                      + "to be in:%n"
-                                      + " <[[Foo(id=id, bar=Bar(id=2))]]>%n"
-                                      + "when comparing elements using recursive field/property by field/property comparator on all fields/properties%n"
-                                      + "Comparators used:%n"
-                                      + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
-                                      + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(array1).usingRecursiveFieldByFieldElementComparator().isIn(new Object[] { array2 }));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n"
+                          + " <[Foo(id=id, bar=Bar(id=1))]>%n"
+                          + "to be in:%n"
+                          + " <[[Foo(id=id, bar=Bar(id=2))]]>%n"
+                          + "when comparing elements using recursive field/property by field/property comparator on all fields/properties%n"
+                          + "Comparators used:%n"
+                          + "- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}%n"
+                          + "- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
@@ -15,9 +15,9 @@ package org.assertj.core.api.date;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.registerCustomDateFormat;
 import static org.assertj.core.api.Assertions.useDefaultDateFormatsOnly;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.DateUtil.parseDatetime;
 import static org.assertj.core.util.DateUtil.parseDatetimeWithMs;
 
@@ -158,24 +158,25 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
 
   @Test
   public void use_custom_date_formats_set_from_Assertions_entry_point() {
+    // GIVEN
     final Date date = DateUtil.parse("2003-04-26");
 
     registerCustomDateFormat("yyyy/MM/dd'T'HH:mm:ss");
 
-    try {
-      // fail : the registered format does not match the given date
-      assertThat(date).isEqualTo("2003/04/26");
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
-                                      "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss,%n" +
-                                      "    yyyy-MM-dd]"));
-    }
+    // WHEN
+    // fail : the registered format does not match the given date
+    Throwable error = catchThrowable(() -> assertThat(date).isEqualTo("2003/04/26"));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
+                          "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss,%n" +
+                          "    yyyy-MM-dd]"));
 
     // register the expected custom formats, they are used in the order they have been registered.
     registerCustomDateFormat("yyyy/MM/dd");
@@ -193,23 +194,24 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
 
   @Test
   public void use_custom_date_formats_first_then_defaults_to_parse_a_date() {
+    // GIVEN
     // using default formats should work
     final Date date = DateUtil.parse("2003-04-26");
     assertThat(date).isEqualTo("2003-04-26");
 
-    try {
-      // date with a custom format : failure since the default formats don't match.
-      assertThat(date).isEqualTo("2003/04/26");
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
-                                      "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss,%n" +
-                                      "    yyyy-MM-dd]"));
-    }
+    // WHEN
+    // date with a custom format : failure since the default formats don't match.
+    Throwable error = catchThrowable(() -> assertThat(date).isEqualTo("2003/04/26"));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
+                          "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss,%n" +
+                          "    yyyy-MM-dd]"));
 
     // registering a custom date format to make the assertion pass
     registerCustomDateFormat("yyyy/MM/dd");
@@ -218,21 +220,20 @@ public class DateAssert_with_string_based_date_representation_Test extends DateA
     assertThat(date).isEqualTo("2003-04-26");
     assertThat(date).isEqualTo("2003-04-26T00:00:00");
 
-    try {
-      // but if not format at all matches, it fails.
-      assertThat(date).isEqualTo("2003 04 26");
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n" +
-                                      "   [yyyy/MM/dd,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
-                                      "    yyyy-MM-dd'T'HH:mm:ss,%n" +
-                                      "    yyyy-MM-dd]"));
+    // WHEN
+    // but if not format at all matches, it fails.
+    error = catchThrowable(() -> assertThat(date).isEqualTo("2003 04 26"));
 
-    }
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n" +
+                          "   [yyyy/MM/dd,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
+                          "    yyyy-MM-dd'T'HH:mm:ss,%n" +
+                          "    yyyy-MM-dd]"));
 
     // register a new custom format should work
     registerCustomDateFormat("yyyy MM dd");

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotZero_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotZero_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.double_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.DoubleAssert;
@@ -44,45 +45,37 @@ public class DoubleAssert_isNotZero_Test extends DoubleAssertBaseTest {
   public void should_fail_with_primitive_negative_zero() {
     // GIVEN
     final double negativeZero = -0.0;
-    try {
-      // WHEN
-      assertThat(negativeZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <-0.0>%nnot to be equal to:%n <0.0>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(negativeZero).isNotZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <-0.0>%nnot to be equal to:%n <0.0>%n"));
   }
 
   @Test
   public void should_fail_with_primitive_positive_zero() {
     // GIVEN
     final double positiveZero = 0.0;
-    try {
-      // WHEN
-      assertThat(positiveZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <0.0>%nnot to be equal to:%n <0.0>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(positiveZero).isNotZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <0.0>%nnot to be equal to:%n <0.0>%n"));
   }
 
   @Test
   public void should_fail_with_Double_positive_zero() {
     // GIVEN
     final Double positiveZero = 0.0;
-    try {
-      // WHEN
-      assertThat(positiveZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <0.0>%nnot to be equal to:%n <0.0>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(positiveZero).isNotZero());
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <0.0>%nnot to be equal to:%n <0.0>%n"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isZero_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isZero_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.double_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.DoubleAssert;
@@ -61,30 +62,26 @@ public class DoubleAssert_isZero_Test extends DoubleAssertBaseTest {
   public void should_fail_with_non_zero() {
     // GIVEN
     final double notZero = 1.0;
-    try {
-      // WHEN
-      assertThat(notZero).isZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <1.0>%nto be equal to:%n <0.0>%nbut was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(notZero).isZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <1.0>%nto be equal to:%n <0.0>%nbut was not."));
   }
 
   @Test
   public void should_fail_with_Double_negative_zero() {
     // GIVEN
     final Double negativeZero = -0.0;
-    try {
-      // WHEN
-      assertThat(negativeZero).isZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <-0.0>%nto be equal to:%n <0.0>%nbut was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(negativeZero).isZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <-0.0>%nto be equal to:%n <0.0>%nbut was not."));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotZero_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotZero_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.float_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.FloatAssert;
@@ -50,45 +51,39 @@ public class FloatAssert_isNotZero_Test extends FloatAssertBaseTest {
   public void should_fail_with_primitive_negative_zero() {
     // GIVEN
     final float negativeZero = -0.0f;
-    try {
-      // WHEN
-      assertThat(negativeZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <-0.0f>%nnot to be equal to:%n <0.0>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(negativeZero).isNotZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <-0.0f>%nnot to be equal to:%n <0.0>%n"));
   }
 
   @Test
   public void should_fail_with_primitive_positive_zero() {
     // GIVEN
     final float positiveZero = 0.0f;
-    try {
-      // WHEN
-      assertThat(positiveZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <0.0f>%nnot to be equal to:%n <0.0>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(positiveZero).isNotZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <0.0f>%nnot to be equal to:%n <0.0>%n"));
   }
 
   @Test
   public void should_fail_with_Float_positive_zero() {
     // GIVEN
     final Float positiveZero = 0.0f;
-    try {
-      // WHEN
-      assertThat(positiveZero).isNotZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <0.0f>%nnot to be equal to:%n <0.0f>%n"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(positiveZero).isNotZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <0.0f>%nnot to be equal to:%n <0.0f>%n"));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isZero_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isZero_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.float_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.FloatAssert;
@@ -66,30 +67,26 @@ public class FloatAssert_isZero_Test extends FloatAssertBaseTest {
   public void should_fail_with_non_zero() {
     // GIVEN
     final float notZero = 1.0f;
-    try {
-      // WHEN
-      assertThat(notZero).isZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <1.0f>%nto be equal to:%n <0.0f>%nbut was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(notZero).isZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <1.0f>%nto be equal to:%n <0.0f>%nbut was not."));
   }
 
   @Test
   public void should_fail_with_Float_negative_zero() {
     // GIVEN
     final Float negativeZero = -0.0f;
-    try {
-      // WHEN
-      assertThat(negativeZero).isZero();
-    } catch (AssertionError e) {
-      // THEN
-      assertThat(e).hasMessage(format("%nExpecting:%n <-0.0f>%nto be equal to:%n <0.0f>%nbut was not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // WHEN
+    Throwable error = catchThrowable(() -> assertThat(negativeZero).isZero());
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n <-0.0f>%nto be equal to:%n <0.0f>%nbut was not."));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.AbstractZonedDateTimeAssert.NULL_DATE_TIME_PA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.ZoneId;
@@ -43,14 +44,14 @@ public class ZonedDateTimeAssert_isEqualToIgnoringHours_Test extends BaseTest {
     assertThat(utcDateTime).isEqualToIgnoringHours(ZonedDateTime.of(2013, 6, 10, 5, 0, 0, 0, cestTimeZone));
     // new DateTime(2013, 6, 11, 1, 0, cestTimeZone) = DateTime(2013, 6, 10, 23, 0, DateTimeZone.UTC)
     assertThat(utcDateTime).isEqualToIgnoringHours(ZonedDateTime.of(2013, 6, 11, 1, 0, 0, 0, cestTimeZone));
-    try {
-      // DateTime(2013, 6, 10, 0, 0, cestTimeZone) = DateTime(2013, 6, 9, 22, 0, DateTimeZone.UTC)
-      assertThat(utcDateTime).isEqualToIgnoringHours(ZonedDateTime.of(2013, 6, 10, 0, 0, 0, 0, cestTimeZone));
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage(format("%nExpecting:%n  <2013-06-10T00:00Z>%nto have same year, month and day as:%n  <2013-06-09T22:00Z>%nbut had not."));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    // DateTime(2013, 6, 10, 0, 0, cestTimeZone) = DateTime(2013, 6, 9, 22, 0, DateTimeZone.UTC)
+    Throwable error = catchThrowable(() -> assertThat(utcDateTime)
+      .isEqualToIgnoringHours(ZonedDateTime.of(2013, 6, 10, 0, 0, 0, 0, cestTimeZone)));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(format("%nExpecting:%n  <2013-06-10T00:00Z>%nto have same year, month and day as:%n  <2013-06-09T22:00Z>%nbut had not."));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_assertj_elements_stack_trace_filtering_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_assertj_elements_stack_trace_filtering_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.util.StackTraceUtils.hasStackTraceElementRelatedToAssertJ;
 
 
@@ -32,25 +32,21 @@ public class ShouldBeEqual_assertj_elements_stack_trace_filtering_Test {
   @Test
   public void fest_elements_should_be_removed_from_assertion_error_stack_trace() {
     Fail.setRemoveAssertJRelatedElementsFromStackTrace(true);
-    try {
-      assertThat("Xavi").isEqualTo("Xabi");
-    } catch (AssertionError assertionError) {
-      assertThat(hasStackTraceElementRelatedToAssertJ(assertionError)).isFalse();
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat("Xavi").isEqualTo("Xabi"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    assertThat(hasStackTraceElementRelatedToAssertJ(error)).isFalse();
   }
 
   @Test
   public void fest_elements_should_be_kept_in_assertion_error_stack_trace() {
     Fail.setRemoveAssertJRelatedElementsFromStackTrace(false);
-    try {
-      assertThat("Messi").isEqualTo("Ronaldo");
-    } catch (AssertionError assertionError) {
-      assertThat(hasStackTraceElementRelatedToAssertJ(assertionError)).isTrue();
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> assertThat("Messi").isEqualTo("Ronaldo"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    assertThat(hasStackTraceElementRelatedToAssertJ(error)).isTrue();
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/Arrays_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/Arrays_assertContains_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -82,13 +83,11 @@ public class Arrays_assertContains_Test extends BaseArraysTest {
   public void should_fail_if_actual_does_not_contain_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Leia", "Yoda", "John" };
-    try {
-      arrays.assertContains(info, failures, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("John")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, failures, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("John")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -141,13 +140,11 @@ public class Arrays_assertContains_Test extends BaseArraysTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "LeiA", "YODA", "JOhN" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, failures, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("JOhN"),
-                                                   caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, failures, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("JOhN"),
+                                                 caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/Arrays_containsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/Arrays_containsAnyOf_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -86,13 +87,11 @@ public class Arrays_containsAnyOf_Test extends BaseArraysTest {
   public void should_fail_if_actual_does_not_contain_any_of_the_given_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "John" };
-    try {
-      arrays.assertContainsAnyOf(info, failures, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAnyOf(actual, expected));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsAnyOf(info, failures, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAnyOf(actual, expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -136,12 +135,10 @@ public class Arrays_containsAnyOf_Test extends BaseArraysTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "John" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsAnyOf(info, failures, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAnyOf(actual, expected, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsAnyOf(info, failures, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAnyOf(actual, expected, caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertEqualByComparison_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -52,13 +53,11 @@ public class BigDecimals_assertEqualByComparison_Test extends BigDecimalsBaseTes
   @Test
   public void should_fail_if_big_decimals_are_not_equal_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertEqualByComparison(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertEqualByComparison(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, info.representation()));
   }
 
   @Test
@@ -75,13 +74,11 @@ public class BigDecimals_assertEqualByComparison_Test extends BigDecimalsBaseTes
   @Test
   public void should_fail_if_big_decimals_are_not_equal_by_comparison_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertEqualByComparison(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, absValueComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertEqualByComparison(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, absValueComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertEqual_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -53,13 +54,11 @@ public class BigDecimals_assertEqual_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_big_decimals_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertEqual(info, ONE_WITH_3_DECIMALS, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE_WITH_3_DECIMALS, ONE, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertEqual(info, ONE_WITH_3_DECIMALS, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE_WITH_3_DECIMALS, ONE, info.representation()));
   }
 
   @Test
@@ -76,14 +75,12 @@ public class BigDecimals_assertEqual_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_big_decimals_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithComparatorComparisonStrategy.assertEqual(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, comparatorComparisonStrategy,
+
+    Throwable error = catchThrowable(() -> numbersWithComparatorComparisonStrategy.assertEqual(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, comparatorComparisonStrategy,
           new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertGreaterThanOrEqualTo_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -61,13 +62,11 @@ public class BigDecimals_assertGreaterThanOrEqualTo_Test extends BigDecimalsBase
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThanOrEqualTo(info, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThanOrEqualTo(info, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -87,13 +86,11 @@ public class BigDecimals_assertGreaterThanOrEqualTo_Test extends BigDecimalsBase
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, ONE, TEN.negate());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN.negate(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, ONE, TEN.negate()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN.negate(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertGreaterThan_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -51,37 +52,31 @@ public class BigDecimals_assertGreaterThan_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThan(info, TEN, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(TEN, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, TEN, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(TEN, TEN));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_other_by_comparison() {
-	AssertionInfo info = someInfo();
-	try {
-	  numbers.assertGreaterThan(info, TEN, new BigDecimal("10.00"));
-	} catch (AssertionError e) {
+	  AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, TEN, new BigDecimal("10.00")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeGreater(TEN, new BigDecimal("10.00")));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
   
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThan(info, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(ONE, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(ONE, TEN));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -96,25 +91,21 @@ public class BigDecimals_assertGreaterThan_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, TEN.negate(), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(TEN.negate(), TEN, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, TEN.negate(), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(TEN.negate(), TEN, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, ONE, TEN.negate());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(ONE, TEN.negate(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, ONE, TEN.negate()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(ONE, TEN.negate(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsBetween_Test.java
@@ -13,11 +13,12 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -75,24 +76,20 @@ public class BigDecimals_assertIsBetween_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        numbers.assertIsBetween(info, ONE, new BigDecimal(2), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, new BigDecimal(2), TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsBetween(info, ONE, new BigDecimal(2), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, new BigDecimal(2), TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -85,12 +86,10 @@ public class BigDecimals_assertIsCloseToPercentage_Test extends BigDecimalsBaseT
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(10));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(10)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN.subtract(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsCloseTo_Test.java
@@ -15,15 +15,16 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.ErrorMessages.offsetIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -91,37 +92,31 @@ public class BigDecimals_assertIsCloseTo_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, ONE, TEN, within(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, ONE, TEN, within(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_with_a_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), ONE));
   }
 
   // with comparison strategy
@@ -152,25 +147,21 @@ public class BigDecimals_assertIsCloseTo_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, offset(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, offset(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, offset(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, offset(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_strictly_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -80,24 +81,20 @@ public class BigDecimals_assertIsNotCloseToPercentage_Test extends BigDecimalsBa
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(BigDecimal actual, BigDecimal other, Integer percentage) {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsNotCloseToPercentage(info, actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withinPercentage(percentage), actual.subtract(other).abs()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseToPercentage(info, actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withinPercentage(percentage), actual.subtract(other).abs()));
   }
 
   @Test
   public void should_fail_if_actual_is_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(100));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), TEN.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(100)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), TEN.subtract(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsNotCloseTo_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigdecimals;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,26 +68,22 @@ public class BigDecimals_assertIsNotCloseTo_Test extends BigDecimalsBaseTest {
   public void should_fail_if_difference_is_less_than_given_offset() {
     BigDecimal fiveDotOne = new BigDecimal("5.1");
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotOne, FIVE, within(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(fiveDotOne, FIVE, within(ONE), fiveDotOne.subtract(FIVE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotOne, FIVE, within(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(fiveDotOne, FIVE, within(ONE), fiveDotOne.subtract(FIVE)));
   }
 
   @Test
   public void should_fail_if_difference_is_less_than_given_strict_offset() {
     BigDecimal fiveDotOne = new BigDecimal("5.1");
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotOne, FIVE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(fiveDotOne, FIVE, byLessThan(ONE), fiveDotOne.subtract(FIVE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotOne, FIVE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(fiveDotOne, FIVE, byLessThan(ONE), fiveDotOne.subtract(FIVE)));
   }
 
   @ParameterizedTest
@@ -103,14 +100,12 @@ public class BigDecimals_assertIsNotCloseTo_Test extends BigDecimalsBaseTest {
                                                                  BigDecimal offsetValue) {
     AssertionInfo info = someInfo();
     Offset<BigDecimal> offset = within(offsetValue);
-    try {
-      numbers.assertIsNotCloseTo(info, actual, expected, offset);
-    } catch (AssertionError e) {
-      BigDecimal diff = actual.subtract(expected).abs();
-      verify(failures).failure(info, shouldNotBeEqual(actual, expected, offset, diff));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseTo(info, actual, expected, offset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    BigDecimal diff = actual.subtract(expected).abs();
+    verify(failures).failure(info, shouldNotBeEqual(actual, expected, offset, diff));
   }
 
   @Test
@@ -146,13 +141,11 @@ public class BigDecimals_assertIsNotCloseTo_Test extends BigDecimalsBaseTest {
   public void should_fail_if_big_decimals_are_equal_whatever_custom_comparison_strategy_is() {
     BigDecimal fiveDotZero = new BigDecimal("5.0");
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotZero, FIVE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(fiveDotZero, FIVE, byLessThan(ONE), fiveDotZero.subtract(FIVE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, fiveDotZero, FIVE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(fiveDotZero, FIVE, byLessThan(ONE), fiveDotZero.subtract(FIVE)));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertIsStrictlyBetween_Test.java
@@ -13,12 +13,13 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -63,61 +64,51 @@ public class BigDecimals_assertIsStrictlyBetween_Test extends BigDecimalsBaseTes
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        numbers.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_start_by_comparison() {
-	AssertionInfo info = someInfo();
-	try {
-	  numbers.assertIsStrictlyBetween(info, ONE, new BigDecimal("1.00"), TEN);
-	} catch (AssertionError e) {
+  	AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, new BigDecimal("1.00"), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeBetween(ONE, new BigDecimal("1.00"), TEN, false, false));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
   
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end_by_comparison() {
-	AssertionInfo info = someInfo();
-	try {
-	  numbers.assertIsStrictlyBetween(info, ONE, ZERO, new BigDecimal("1.00"));
-	} catch (AssertionError e) {
+  	AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ZERO, new BigDecimal("1.00")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeBetween(ONE, ZERO, new BigDecimal("1.00"), false, false));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
   
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        numbers.assertIsStrictlyBetween(info, ONE, new BigDecimal(2), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, new BigDecimal(2), TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, new BigDecimal(2), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, new BigDecimal(2), TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertLessThanOrEqualTo_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -59,13 +60,11 @@ public class BigDecimals_assertLessThanOrEqualTo_Test extends BigDecimalsBaseTes
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThanOrEqualTo(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(TEN, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThanOrEqualTo(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(TEN, ONE));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -85,13 +84,11 @@ public class BigDecimals_assertLessThanOrEqualTo_Test extends BigDecimalsBaseTes
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, TEN.negate(), ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(TEN.negate(), ONE, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, TEN.negate(), ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(TEN.negate(), ONE, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertLessThan_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -51,37 +52,31 @@ public class BigDecimals_assertLessThan_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThan(info, TEN, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN, TEN));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_other_by_comparison() {
-	AssertionInfo info = someInfo();
-	try {
-	  numbers.assertLessThan(info, TEN, new BigDecimal("10.00"));
-	} catch (AssertionError e) {
+  	AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, new BigDecimal("10.00")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeLess(TEN, new BigDecimal("10.00")));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
   
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThan(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN, ONE));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -96,25 +91,21 @@ public class BigDecimals_assertLessThan_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN.negate(), TEN, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN.negate(), TEN, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN.negate(), ONE, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN.negate(), ONE, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertNotEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertNotEqualByComparison_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -51,13 +52,11 @@ public class BigDecimals_assertNotEqualByComparison_Test extends BigDecimalsBase
   @Test
   public void should_fail_if_big_decimals_are_equal_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertNotEqualByComparison(info, ONE_WITH_3_DECIMALS, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertNotEqualByComparison(info, ONE_WITH_3_DECIMALS, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE));
   }
 
   @Test
@@ -74,12 +73,10 @@ public class BigDecimals_assertNotEqualByComparison_Test extends BigDecimalsBase
   @Test
   public void should_fail_if_big_decimals_are_equal_by_comparison_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertNotEqualByComparison(info, ONE_WITH_3_DECIMALS, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertNotEqualByComparison(info, ONE_WITH_3_DECIMALS, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimals_assertNotEqual_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.bigdecimals;
 
 import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -53,13 +54,11 @@ public class BigDecimals_assertNotEqual_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_big_decimals_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertNotEqual(info, ONE, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertNotEqual(info, ONE, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
   }
 
   @Test
@@ -76,12 +75,10 @@ public class BigDecimals_assertNotEqual_Test extends BigDecimalsBaseTest {
   @Test
   public void should_fail_if_big_decimals_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithComparatorComparisonStrategy.assertNotEqual(info, ONE_WITH_3_DECIMALS, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE, comparatorComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithComparatorComparisonStrategy.assertNotEqual(info, ONE_WITH_3_DECIMALS, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE_WITH_3_DECIMALS, ONE, comparatorComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertEqualByComparison_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +49,11 @@ public class BigIntegers_assertEqualByComparison_Test extends BigIntegersBaseTes
   @Test
   public void should_fail_if_big_integers_are_not_equal_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertEqualByComparison(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertEqualByComparison(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, info.representation()));
   }
 
   @Test
@@ -71,13 +70,11 @@ public class BigIntegers_assertEqualByComparison_Test extends BigIntegersBaseTes
   @Test
   public void should_fail_if_big_integers_are_not_equal_by_comparison_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertEqualByComparison(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, absValueComparisonStrategy,
-                                                   new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertEqualByComparison(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, absValueComparisonStrategy,
+                                                 new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertEqual_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +49,11 @@ public class BigIntegers_assertEqual_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_big_integers_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertEqual(info, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertEqual(info, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, info.representation()));
   }
 
   @Test
@@ -71,13 +70,11 @@ public class BigIntegers_assertEqual_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_big_integers_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithComparatorComparisonStrategy.assertEqual(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TEN, ONE, comparatorComparisonStrategy,
-                                                   new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithComparatorComparisonStrategy.assertEqual(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TEN, ONE, comparatorComparisonStrategy,
+                                                 new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertGreaterThanOrEqualTo_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -57,13 +58,11 @@ public class BigIntegers_assertGreaterThanOrEqualTo_Test extends BigIntegersBase
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThanOrEqualTo(info, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThanOrEqualTo(info, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -83,13 +82,11 @@ public class BigIntegers_assertGreaterThanOrEqualTo_Test extends BigIntegersBase
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, ONE, TEN.negate());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN.negate(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, ONE, TEN.negate()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(ONE, TEN.negate(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertGreaterThan_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,37 +48,31 @@ public class BigIntegers_assertGreaterThan_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThan(info, TEN, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(TEN, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, TEN, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(TEN, TEN));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_other_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThan(info, TEN, new BigInteger("10"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(TEN, new BigInteger("10")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, TEN, new BigInteger("10")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(TEN, new BigInteger("10")));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertGreaterThan(info, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(ONE, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertGreaterThan(info, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(ONE, TEN));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -92,25 +87,21 @@ public class BigIntegers_assertGreaterThan_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, TEN.negate(), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(TEN.negate(), TEN, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, TEN.negate(), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(TEN.negate(), TEN, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, ONE, TEN.negate());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(ONE, TEN.negate(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertGreaterThan(info, ONE, TEN.negate()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(ONE, TEN.negate(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsBetween_Test.java
@@ -15,11 +15,12 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -72,24 +73,20 @@ public class BigIntegers_assertIsBetween_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsBetween(info, ONE, new BigInteger("2"), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("2"), TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsBetween(info, ONE, new BigInteger("2"), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("2"), TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -87,12 +88,10 @@ public class BigIntegers_assertIsCloseToPercentage_Test extends BigIntegersBaseT
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(10));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(10)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN.subtract(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsCloseTo_Test.java
@@ -15,15 +15,16 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.ErrorMessages.offsetIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -82,13 +83,11 @@ public class BigIntegers_assertIsCloseTo_Test extends BigIntegersBaseTest {
                                                                                      BigInteger expected,
                                                                                      BigInteger offset) {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(someInfo(), actual, expected, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), offset));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(someInfo(), actual, expected, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), offset));
   }
 
   @Test
@@ -128,37 +127,31 @@ public class BigIntegers_assertIsCloseTo_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, ONE, TEN, within(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, ONE, TEN, within(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_with_a_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), ONE));
   }
 
   // with comparison strategy
@@ -185,25 +178,21 @@ public class BigIntegers_assertIsCloseTo_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, offset(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, offset(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, offset(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, offset(ONE), NINE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_strictly_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), NINE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -82,26 +83,22 @@ public class BigIntegers_assertIsNotCloseToPercentage_Test extends BigIntegersBa
   public void should_fail_if_difference_is_equal_to_given_percentage(BigInteger actual, BigInteger other,
                                                                      Integer percentage) {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsNotCloseToPercentage(info, actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withinPercentage(percentage),
-                                                                      actual.subtract(other).abs()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseToPercentage(info, actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withinPercentage(percentage),
+                                                                    actual.subtract(other).abs()));
   }
 
   @Test
   public void should_fail_if_actual_is_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(100));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), TEN.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(100)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), TEN.subtract(ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsNotCloseTo_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -64,25 +65,21 @@ public class BigIntegers_assertIsNotCloseTo_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_difference_is_less_than_given_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, ONE, FIVE, within(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, FIVE, within(TEN), FIVE.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, ONE, FIVE, within(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, FIVE, within(TEN), FIVE.subtract(ONE)));
   }
 
   @Test
   public void should_fail_if_difference_is_less_than_given_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, ONE, FIVE, byLessThan(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, FIVE, byLessThan(TEN), FIVE.subtract(ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, ONE, FIVE, byLessThan(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, FIVE, byLessThan(TEN), FIVE.subtract(ONE)));
   }
 
   @ParameterizedTest
@@ -99,14 +96,12 @@ public class BigIntegers_assertIsNotCloseTo_Test extends BigIntegersBaseTest {
                                                                  BigInteger offset) {
     AssertionInfo info = someInfo();
     Offset<BigInteger> bigDecimalOffset = within(offset);
-    try {
-      numbers.assertIsNotCloseTo(info, actual, expected, bigDecimalOffset);
-    } catch (AssertionError e) {
-      BigInteger diff = actual.subtract(expected).abs();
-      verify(failures).failure(info, shouldNotBeEqual(actual, expected, bigDecimalOffset, diff));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsNotCloseTo(info, actual, expected, bigDecimalOffset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    BigInteger diff = actual.subtract(expected).abs();
+    verify(failures).failure(info, shouldNotBeEqual(actual, expected, bigDecimalOffset, diff));
   }
 
   @Test
@@ -135,13 +130,11 @@ public class BigIntegers_assertIsNotCloseTo_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_difference_is_less_than_given_offset_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, FIVE, FIVE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(FIVE, FIVE, byLessThan(ONE), FIVE.subtract(FIVE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, FIVE, FIVE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(FIVE, FIVE, byLessThan(ONE), FIVE.subtract(FIVE)));
   }
 
   @Test
@@ -153,12 +146,10 @@ public class BigIntegers_assertIsNotCloseTo_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_big_integers_are_equal_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, FIVE, FIVE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(FIVE, FIVE, byLessThan(ONE), FIVE.subtract(FIVE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertIsNotCloseTo(info, FIVE, FIVE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(FIVE, FIVE, byLessThan(ONE), FIVE.subtract(FIVE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertIsStrictlyBetween_Test.java
@@ -15,12 +15,14 @@ package org.assertj.core.internal.bigintegers;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -60,61 +62,51 @@ public class BigIntegers_assertIsStrictlyBetween_Test extends BigIntegersBaseTes
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_start_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, new BigInteger("1"), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("1"), TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, new BigInteger("1"), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("1"), TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, ZERO, new BigInteger("1"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, new BigInteger("1"), false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, ZERO, new BigInteger("1")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, new BigInteger("1"), false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertIsStrictlyBetween(info, ONE, new BigInteger("2"), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("2"), TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertIsStrictlyBetween(info, ONE, new BigInteger("2"), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, new BigInteger("2"), TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertLessThanOrEqualTo_Test.java
@@ -14,10 +14,12 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -57,13 +59,11 @@ public class BigIntegers_assertLessThanOrEqualTo_Test extends BigIntegersBaseTes
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThanOrEqualTo(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(TEN, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThanOrEqualTo(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(TEN, ONE));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -83,13 +83,11 @@ public class BigIntegers_assertLessThanOrEqualTo_Test extends BigIntegersBaseTes
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, TEN.negate(), ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(TEN.negate(), ONE, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, TEN.negate(), ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(TEN.negate(), ONE, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertLessThan_Test.java
@@ -14,10 +14,12 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,37 +49,31 @@ public class BigIntegers_assertLessThan_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThan(info, TEN, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN, TEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN, TEN));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_other_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThan(info, TEN, new BigInteger("10"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN, new BigInteger("10")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, new BigInteger("10")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN, new BigInteger("10")));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertLessThan(info, TEN, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertLessThan(info, TEN, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN, ONE));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -92,25 +88,21 @@ public class BigIntegers_assertLessThan_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN.negate(), TEN, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN.negate(), TEN, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(TEN.negate(), ONE, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertLessThan(info, TEN.negate(), ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(TEN.negate(), ONE, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertNotEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertNotEqualByComparison_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,13 +48,11 @@ public class BigIntegers_assertNotEqualByComparison_Test extends BigIntegersBase
   @Test
   public void should_fail_if_big_integers_are_equal_by_comparison() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertNotEqualByComparison(info, ONE, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertNotEqualByComparison(info, ONE, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
   }
 
   @Test
@@ -70,12 +69,10 @@ public class BigIntegers_assertNotEqualByComparison_Test extends BigIntegersBase
   @Test
   public void should_fail_if_big_integers_are_equal_by_comparison_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithAbsValueComparisonStrategy.assertNotEqualByComparison(info, ONE, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithAbsValueComparisonStrategy.assertNotEqualByComparison(info, ONE, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bigintegers/BigIntegers_assertNotEqual_Test.java
@@ -14,10 +14,11 @@ package org.assertj.core.internal.bigintegers;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,13 +48,11 @@ public class BigIntegers_assertNotEqual_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_big_integers_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      numbers.assertNotEqual(info, ONE, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbers.assertNotEqual(info, ONE, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, ONE));
   }
 
   @Test
@@ -70,12 +69,10 @@ public class BigIntegers_assertNotEqual_Test extends BigIntegersBaseTest {
   @Test
   public void should_fail_if_big_integers_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      numbersWithComparatorComparisonStrategy.assertNotEqual(info, ONE, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, ONE, comparatorComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> numbersWithComparatorComparisonStrategy.assertNotEqual(info, ONE, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, ONE, comparatorComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -80,29 +81,25 @@ public class BooleanArrays_assertContainsExactlyInAnyOrder_Test extends BooleanA
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     boolean[] expected = {true, true};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected,
-          newArrayList(true), newArrayList(false), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected,
+        newArrayList(true), newArrayList(false), StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     boolean[] expected = {true};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(false),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(false),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -110,14 +107,12 @@ public class BooleanArrays_assertContainsExactlyInAnyOrder_Test extends BooleanA
     AssertionInfo info = someInfo();
     actual = arrayOf(true, false, true);
     boolean[] expected = {true, false};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(true), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(true), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -125,14 +120,12 @@ public class BooleanArrays_assertContainsExactlyInAnyOrder_Test extends BooleanA
     AssertionInfo info = someInfo();
     actual = arrayOf(true, false);
     boolean[] expected = {true, false, true};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(true), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(true), emptyList(), StandardComparisonStrategy.instance()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseT
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(false, true));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(true, false, 0));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(false, true)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(true, false, 0));
   }
 
   @Test
@@ -85,14 +84,12 @@ public class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseT
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     boolean[] expected = { true, true };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList(true), newArrayList(false)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList(true), newArrayList(false)));
   }
 
   @Test
@@ -100,14 +97,12 @@ public class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseT
     AssertionInfo info = someInfo();
     boolean[] actual = { true, true };
     boolean[] expected = { true };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList(true)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList(true)));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class BooleanArrays_assertContainsOnlyOnce_Test extends BooleanArraysBase
     AssertionInfo info = someInfo();
     actual = arrayOf(true, true, false, false);
     boolean[] expected = { true, false };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(), newLinkedHashSet(true, false)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(), newLinkedHashSet(true, false)));
   }
 
   @Test
@@ -95,14 +94,12 @@ public class BooleanArrays_assertContainsOnlyOnce_Test extends BooleanArraysBase
     AssertionInfo info = someInfo();
     actual = arrayOf(true);
     boolean[] expected = { true, false };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
           shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(false), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -88,12 +89,10 @@ public class BooleanArrays_assertContainsOnly_Test extends BooleanArraysBaseTest
     AssertionInfo info = someInfo();
     actual = arrayOf(true);
     boolean[] expected = { false };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(false), newArrayList(true)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(false), newArrayList(true)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.BooleanArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -74,13 +75,11 @@ public class BooleanArrays_assertContainsSequence_Test extends BooleanArraysBase
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, true, true, false, false, false };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
@@ -94,13 +93,11 @@ public class BooleanArrays_assertContainsSequence_Test extends BooleanArraysBase
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, true };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, boolean[] sequence) {

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContains_at_Index_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.booleanarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsEmpty;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -73,13 +74,11 @@ public class BooleanArrays_assertContains_at_Index_Test extends BooleanArraysBas
     AssertionInfo info = someInfo();
     boolean value = true;
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -79,12 +80,10 @@ public class BooleanArrays_assertDoesNotContain_Test extends BooleanArraysBaseTe
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     boolean[] expected = arrayOf(true);
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(true)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(true)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -73,12 +74,10 @@ public class BooleanArrays_assertDoesNotContain_at_Index_Test extends BooleanArr
     AssertionInfo info = someInfo();
     boolean value = true;
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.BooleanArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -57,12 +58,10 @@ public class BooleanArrays_assertDoesNotHaveDuplicates_Test extends BooleanArray
   public void should_fail_if_actual_contains_duplicates() {
     actual = arrayOf(true, true, false);
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(true)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(true)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class BooleanArrays_assertEmpty_Test extends BooleanArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     boolean[] actual = { true, false };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -73,39 +74,33 @@ public class BooleanArrays_assertEndsWith_Test extends BooleanArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, false, false, true, true, false };
-    try {
-      arrays.assertEndsWith(someInfo(), actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(someInfo(), actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, false };
-    try {
-      arrays.assertEndsWith(someInfo(), actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(someInfo(), actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { false, false };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, boolean[] sequence) {

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class BooleanArrays_assertIsSortedAccordingToComparator_Test extends Bool
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new boolean[] { true, true, false, true };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, booleanDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, booleanDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, booleanDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, booleanDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSorted;
 import static org.assertj.core.test.BooleanArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -68,13 +69,11 @@ public class BooleanArrays_assertIsSorted_Test extends BooleanArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(false, true, false);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.BooleanArrays.*;
+import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +47,11 @@ public class BooleanArrays_assertNotEmpty_Test extends BooleanArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class BooleanArrays_assertNullOrEmpty_Test extends BooleanArraysBaseTest 
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     boolean[] actual = { true, false };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertStartsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.booleanarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.BooleanArrays.arrayOf;
 import static org.assertj.core.test.BooleanArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,39 +64,33 @@ public class BooleanArrays_assertStartsWith_Test extends BooleanArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, false, false, true, true, false };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { false, true };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     boolean[] sequence = { true, true };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, boolean[] sequence) {

--- a/src/test/java/org/assertj/core/internal/booleans/Booleans_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleans/Booleans_assertEqual_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.booleans;
 
 import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -51,12 +52,10 @@ public class Booleans_assertEqual_Test extends BooleansBaseTest {
   public void should_fail_if_booleans_are_not_equal() {
     AssertionInfo info = someInfo();
     boolean expected = false;
-    try {
-      booleans.assertEqual(info, TRUE, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TRUE, expected, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> booleans.assertEqual(info, TRUE, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TRUE, expected, info.representation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/booleans/Booleans_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/booleans/Booleans_assertNotEqual_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.booleans;
 
 import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -50,12 +51,10 @@ public class Booleans_assertNotEqual_Test extends BooleansBaseTest {
   @Test
   public void should_fail_if_bytes_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      booleans.assertNotEqual(info, TRUE, true);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(TRUE, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> booleans.assertNotEqual(info, TRUE, true));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(TRUE, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -79,29 +80,25 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     byte[] expected = {6, 8, 20};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected,
-          newArrayList((byte) 20), newArrayList((byte) 10), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected,
+        newArrayList((byte) 20), newArrayList((byte) 10), StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     byte[] expected = {6, 8};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 10),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 10),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -109,15 +106,13 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 8);
     byte[] expected = {6, 8};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 8),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 8),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -125,14 +120,12 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8);
     byte[] expected = {6, 8, 8};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 8), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 8), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -173,27 +166,23 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly_in_any_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = {6, -8, 20};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 20),
-          newArrayList((byte) 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 20),
+        newArrayList((byte) 10), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = {6, 8};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 10), absValueComparisonStrategy));
   }
 
   @Test
@@ -201,14 +190,12 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 8);
     byte[] expected = {6, 8};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((byte) 8), absValueComparisonStrategy));
   }
 
   @Test
@@ -216,14 +203,12 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_Test extends ByteArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8);
     byte[] expected = {6, 8, 8};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 8), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 8), emptyList(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -79,57 +80,49 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_T
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 20),
-          newArrayList((byte) 20), newArrayList((byte) 10), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 20),
+        newArrayList((byte) 20), newArrayList((byte) 10), StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 10),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 10),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_duplicates_and_expected_does_not() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 8);
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 8),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 8),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_expected_contains_duplicates_and_actual_does_not() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8);
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 8), newArrayList((byte) 8), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 8), newArrayList((byte) 8), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -169,54 +162,46 @@ public class ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_T
   public void should_fail_if_actual_does_not_contain_given_values_exactly_in_any_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = {6, -8, 20};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 20),
-          newArrayList((byte) 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((byte) 20),
+        newArrayList((byte) 10), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 10), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_duplicates_and_expected_does_not_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 8);
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8), emptyList(), newArrayList((byte) 8), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_expected_contains_duplicates_and_actual_does_not_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8);
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 8), newArrayList((byte) 8), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, IntArrays.arrayOf(6, 8, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, arrayOf(6, 8, 8), newArrayList((byte) 8), emptyList(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
   }
 
   @Test
@@ -84,28 +83,24 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 20), newArrayList((byte) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 20), newArrayList((byte) 10)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 10, 10 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 10), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 10), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { -6, 10, 8 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -153,30 +146,26 @@ public class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 20), newArrayList((byte) 10),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 20), newArrayList((byte) 10),
+                                                        absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 10, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 10), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 10), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -50,13 +51,11 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, IntArrays.arrayOf(6, 10, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, IntArrays.arrayOf(6, 10, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
   }
 
   @Test
@@ -85,28 +84,24 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     byte[] expected = arrayOf(6, 8, 20);
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 20), newArrayList((byte) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 20), newArrayList((byte) 10)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     byte[] expected = arrayOf(6, 8, 10, 10);
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 10), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 10), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
   @Test
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, IntArrays.arrayOf(-6, 10, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, IntArrays.arrayOf(-6, 10, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -153,30 +146,26 @@ public class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extend
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = arrayOf(6, -8, 20);
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 20), newArrayList((byte) 10),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 20), newArrayList((byte) 10),
+                                                        absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = arrayOf(6, 8, 10, 10);
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((byte) 10), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((byte) 10), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     byte[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8)));
   }
 
   @Test
@@ -94,14 +93,12 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet()));
   }
 
   @Test
@@ -119,16 +116,14 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     byte[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -156,15 +151,13 @@ public class ByteArrays_assertContainsOnlyOnce_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((byte) 20), newLinkedHashSet(),
+            absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -49,14 +50,12 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
   public void should_fail_if_actual_contains_given_values_only_more_than_once() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8)));
   }
 
   @Test
@@ -91,14 +90,12 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, 8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, arrayOf(6, 8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, 8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, arrayOf(6, 8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet()));
   }
 
   @Test
@@ -115,16 +112,14 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
   public void should_fail_if_actual_contains_given_values_only_more_than_once_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet((byte) 6, (byte) -8),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -151,15 +146,13 @@ public class ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test exten
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 20), newLinkedHashSet(),
+            absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -86,14 +87,12 @@ public class ByteArrays_assertContainsOnly_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList((byte) 20), newArrayList((byte) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList((byte) 20), newArrayList((byte) 10)));
   }
 
   @Test
@@ -140,14 +139,12 @@ public class ByteArrays_assertContainsOnly_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList((byte) 20), newArrayList((byte) 10),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList((byte) 20), newArrayList((byte) 10),
+                                               absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsOnly_with_Integer_Arguments_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -83,14 +84,12 @@ public class ByteArrays_assertContainsOnly_with_Integer_Arguments_Test extends B
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsOnly(info, actual, IntArrays.arrayOf(6, 8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, arrayOf(6, 8, 20), newArrayList((byte) 20), newArrayList((byte) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, IntArrays.arrayOf(6, 8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, arrayOf(6, 8, 20), newArrayList((byte) 20), newArrayList((byte) 10)));
   }
 
   @Test
@@ -138,14 +137,12 @@ public class ByteArrays_assertContainsOnly_with_Integer_Arguments_Test extends B
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, arrayOf(6, -8, 20), newArrayList((byte) 20), newArrayList((byte) 10),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, arrayOf(6, -8, 20), newArrayList((byte) 20), newArrayList((byte) 10),
+                                               absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class ByteArrays_assertContainsSequence_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class ByteArrays_assertContainsSequence_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsSequence_with_Integer_Arguments_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -67,37 +68,31 @@ public class ByteArrays_assertContainsSequence_with_Integer_Arguments_Test exten
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 8, 10, 12, 20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 8, 10, 12, 20, 22)));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20)));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20, 22)));
   }
 
   @Test
@@ -134,37 +129,31 @@ public class ByteArrays_assertContainsSequence_with_Integer_Arguments_Test exten
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, IntArrays.arrayOf(6, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, arrayOf(6, 20, 22), absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.bytearrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 
@@ -71,14 +72,12 @@ public class ByteArrays_assertContains_at_Index_Test extends ByteArraysBaseTest 
     AssertionInfo info = someInfo();
     byte value = 6;
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      byte found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    byte found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found));
   }
 
   @Test
@@ -121,14 +120,12 @@ public class ByteArrays_assertContains_at_Index_Test extends ByteArraysBaseTest 
     AssertionInfo info = someInfo();
     byte value = 6;
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      byte found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    byte found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_with_Integer_Argument_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_at_Index_with_Integer_Argument_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.bytearrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 
@@ -67,14 +68,12 @@ public class ByteArrays_assertContains_at_Index_with_Integer_Argument_Test exten
   public void should_fail_if_actual_does_not_contain_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, 6, index);
-    } catch (AssertionError e) {
-      byte found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, (byte) 6, index, found));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    byte found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, (byte) 6, index, found));
   }
 
   @Test
@@ -115,14 +114,12 @@ public class ByteArrays_assertContains_at_Index_with_Integer_Argument_Test exten
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, 6, index);
-    } catch (AssertionError e) {
-      byte found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, (byte) 6 , index, found, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    byte found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, (byte) 6 , index, found, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContains_with_Integer_Arguments_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -86,13 +87,11 @@ public class ByteArrays_assertContains_with_Integer_Arguments_Test extends ByteA
   public void should_fail_if_actual_does_not_contain_values() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 9 };
-    try {
-      arrays.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet((byte) 9)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet((byte) 9)));
   }
 
   @Test
@@ -143,13 +142,11 @@ public class ByteArrays_assertContains_with_Integer_Arguments_Test extends ByteA
   @Test
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, IntArrays.arrayOf(6, -8, 9));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, ByteArrays.arrayOf(6, -8, 9), newLinkedHashSet((byte) 9),
-                                                   absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, IntArrays.arrayOf(6, -8, 9)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, ByteArrays.arrayOf(6, -8, 9), newLinkedHashSet((byte) 9),
+                                                 absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -72,13 +73,11 @@ public class ByteArrays_assertDoesNotContain_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((byte) 6, (byte) 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((byte) 6, (byte) 8)));
   }
 
   @Test
@@ -117,12 +116,10 @@ public class ByteArrays_assertDoesNotContain_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,13 +71,11 @@ public class ByteArrays_assertDoesNotContain_at_Index_Test extends ByteArraysBas
     AssertionInfo info = someInfo();
     byte value = 6;
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
   }
 
   @Test
@@ -114,12 +113,10 @@ public class ByteArrays_assertDoesNotContain_at_Index_Test extends ByteArraysBas
     AssertionInfo info = someInfo();
     byte value = 6;
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -66,13 +67,11 @@ public class ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, (byte) 6, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, (byte) 6, index));
   }
 
   @Test
@@ -108,12 +107,10 @@ public class ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, (byte) 6, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, (byte) 6, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -69,13 +70,11 @@ public class ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test extends
   @Test
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertDoesNotContain(info, actual, IntArrays.arrayOf(6, 8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, arrayOf(6, 8, 20), newLinkedHashSet((byte) 6, (byte) 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, IntArrays.arrayOf(6, 8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, arrayOf(6, 8, 20), newLinkedHashSet((byte) 6, (byte) 8)));
   }
 
   @Test
@@ -113,12 +112,10 @@ public class ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test extends
   @Test
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, IntArrays.arrayOf(6, -8, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, IntArrays.arrayOf(6, -8, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, arrayOf(6, -8, 20), newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -62,13 +63,11 @@ public class ByteArrays_assertDoesNotHaveDuplicates_Test extends ByteArraysBaseT
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 6, 8);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((byte) 6, (byte) 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((byte) 6, (byte) 8)));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class ByteArrays_assertDoesNotHaveDuplicates_Test extends ByteArraysBaseT
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 6, -8);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((byte) 6, (byte) -8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class ByteArrays_assertEmpty_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     byte[] actual = { 6, 8 };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,39 +71,33 @@ public class ByteArrays_assertEndsWith_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class ByteArrays_assertEndsWith_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertEndsWith_with_Integer_Arguments_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -66,37 +67,31 @@ public class ByteArrays_assertEndsWith_with_Integer_Arguments_Test extends ByteA
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertEndsWith(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 8, 10, 12, 20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 8, 10, 12, 20, 22)));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertEndsWith(info, actual, IntArrays.arrayOf(20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, IntArrays.arrayOf(20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(20, 22)));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertEndsWith(info, actual, IntArrays.arrayOf(6, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, IntArrays.arrayOf(6, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 20, 22)));
   }
 
   @Test
@@ -131,37 +126,31 @@ public class ByteArrays_assertEndsWith_with_Integer_Arguments_Test extends ByteA
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(20, 22), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(6, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, IntArrays.arrayOf(6, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, arrayOf(6, 20, 22), absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class ByteArrays_assertIsSortedAccordingToComparator_Test extends ByteArr
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new byte[] { 3, 2, 1, 9 };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, byteDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, byteDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, byteDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, byteDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,13 +66,11 @@ public class ByteArrays_assertIsSorted_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -100,14 +99,12 @@ public class ByteArrays_assertIsSorted_Test extends ByteArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertNotEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class ByteArrays_assertNotEmpty_Test extends ByteArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.ByteArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class ByteArrays_assertNullOrEmpty_Test extends ByteArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     byte[] actual = { 6, 8 };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class ByteArrays_assertStartsWith_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 8, 10 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -135,39 +130,33 @@ public class ByteArrays_assertStartsWith_Test extends ByteArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { -8, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     byte[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_with_Integer_Arguments_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertStartsWith_with_Integer_Arguments_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.bytearrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ByteArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -67,37 +68,31 @@ public class ByteArrays_assertStartsWith_with_Integer_Arguments_Test extends Byt
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertStartsWith(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 8, 10, 12, 20, 22)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, IntArrays.arrayOf(6, 8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 8, 10, 12, 20, 22)));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertStartsWith(info, actual, IntArrays.arrayOf(8, 10));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(8, 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, IntArrays.arrayOf(8, 10)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(8, 10)));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertStartsWith(info, actual, IntArrays.arrayOf(6, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 20)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, IntArrays.arrayOf(6, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 20)));
   }
 
   @Test
@@ -132,37 +127,31 @@ public class ByteArrays_assertStartsWith_with_Integer_Arguments_Test extends Byt
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(6, -8, 10, 12, 20, 22)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, -8, 10, 12, 20, 22), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(-8, 10));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(-8, 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(-8, 10)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(-8, 10), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(6, 20));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 20), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, IntArrays.arrayOf(6, 20)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, arrayOf(6, 20), absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -50,13 +51,11 @@ public class Bytes_assertEqual_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_bytes_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertEqual(info, (byte) 6, (byte) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual((byte) 6, (byte) 8, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertEqual(info, (byte) 6, (byte) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual((byte) 6, (byte) 8, info.representation()));
   }
 
   @Test
@@ -73,13 +72,11 @@ public class Bytes_assertEqual_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_bytes_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertEqual(info, (byte) 6, (byte) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual((byte) 6, (byte) 8, absValueComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertEqual(info, (byte) 6, (byte) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual((byte) 6, (byte) 8, absValueComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Bytes_assertGreaterThanOrEqualTo_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertGreaterThanOrEqualTo(info, (byte) 6, (byte) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual((byte) 6, (byte) 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertGreaterThanOrEqualTo(info, (byte) 6, (byte) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual((byte) 6, (byte) 8));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Bytes_assertGreaterThanOrEqualTo_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, (byte) 6, (byte) -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual((byte) 6, (byte) -8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, (byte) 6, (byte) -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual((byte) 6, (byte) -8, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -48,25 +49,20 @@ public class Bytes_assertGreaterThan_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
-    try {
-      bytes.assertGreaterThan(someInfo(), (byte) 6, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldBeGreater((byte) 6, (byte) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> bytes.assertGreaterThan(someInfo(), (byte) 6, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldBeGreater((byte) 6, (byte) 6));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertGreaterThan(info, (byte) 6, (byte) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((byte) 6, (byte) 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertGreaterThan(info, (byte) 6, (byte) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((byte) 6, (byte) 8));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -80,25 +76,20 @@ public class Bytes_assertGreaterThan_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
-    try {
-      bytesWithAbsValueComparisonStrategy.assertGreaterThan(someInfo(), (byte) -6, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldBeGreater((byte) -6, (byte) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertGreaterThan(someInfo(), (byte) -6, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldBeGreater((byte) -6, (byte) 6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertGreaterThan(info, (byte) -6, (byte) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((byte) -6, (byte) 8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertGreaterThan(info, (byte) -6, (byte) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((byte) -6, (byte) 8, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsBetween_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -74,24 +75,20 @@ public class Bytes_assertIsBetween_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        bytes.assertIsBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseToPercentage_Test.java
@@ -12,14 +12,16 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -84,12 +86,10 @@ public class Bytes_assertIsCloseToPercentage_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), (TEN - ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), (TEN - ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.bytes;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,13 +68,11 @@ public class Bytes_assertIsCloseTo_Test extends BytesBaseTest {
   })
   public void should_fail_if_actual_is_too_close_to_the_other_value(byte actual, byte other, byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -85,13 +84,11 @@ public class Bytes_assertIsCloseTo_Test extends BytesBaseTest {
   public void should_fail_if_actual_is_too_close_to_the_other_value_with_strict_offset(byte actual, byte other,
                                                                                        byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(info, actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(info, actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -102,13 +99,11 @@ public class Bytes_assertIsCloseTo_Test extends BytesBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(byte actual, byte other, byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (byte) abs(actual - other)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseToPercentage_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.bytes;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -81,25 +82,21 @@ public class Bytes_assertIsNotCloseToPercentage_Test extends BytesBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(Byte actual, Byte other, Byte percentage) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
                                                                       abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), (TEN - ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100), (TEN - ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.bytes;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,13 +68,11 @@ public class Bytes_assertIsNotCloseTo_Test extends BytesBaseTest {
   })
   public void should_fail_if_actual_is_too_close_to_the_other_value(byte actual, byte other, byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -85,13 +84,11 @@ public class Bytes_assertIsNotCloseTo_Test extends BytesBaseTest {
   public void should_fail_if_actual_is_too_close_to_the_other_value_with_strict_offset(byte actual, byte other,
                                                                                        byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(info, actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(info, actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (byte) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -102,13 +99,11 @@ public class Bytes_assertIsNotCloseTo_Test extends BytesBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(byte actual, byte other, byte offset) {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (byte) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (byte) abs(actual - other)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsStrictlyBetween_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,37 +66,31 @@ public class Bytes_assertIsStrictlyBetween_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        bytes.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        bytes.assertIsStrictlyBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertIsStrictlyBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Bytes_assertLessThanOrEqualTo_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertLessThanOrEqualTo(info, (byte) 8, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual((byte) 8, (byte) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertLessThanOrEqualTo(info, (byte) 8, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual((byte) 8, (byte) 6));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Bytes_assertLessThanOrEqualTo_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, (byte) -8, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual((byte) -8, (byte) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, (byte) -8, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual((byte) -8, (byte) 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Bytes_assertLessThan_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertLessThan(info, (byte) 6, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((byte) 6, (byte) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertLessThan(info, (byte) 6, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((byte) 6, (byte) 6));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertLessThan(info, (byte) 8, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((byte) 8, (byte) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertLessThan(info, (byte) 8, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((byte) 8, (byte) 6));
   }
 
   @Test
@@ -84,24 +81,20 @@ public class Bytes_assertLessThan_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertLessThan(info, (byte) 6, (byte) -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((byte) 6, (byte) -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertLessThan(info, (byte) 6, (byte) -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((byte) 6, (byte) -6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertLessThan(info, (byte) -8, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((byte) -8, (byte) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertLessThan(info, (byte) -8, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((byte) -8, (byte) 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.bytes;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Bytes_assertNotEqual_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_bytes_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      bytes.assertNotEqual(info, (byte) 6, (byte) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual((byte) 6, (byte) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytes.assertNotEqual(info, (byte) 6, (byte) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual((byte) 6, (byte) 6));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Bytes_assertNotEqual_Test extends BytesBaseTest {
   @Test
   public void should_fail_if_bytes_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      bytesWithAbsValueComparisonStrategy.assertNotEqual(info, (byte) 6, (byte) -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual((byte) 6, (byte) -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> bytesWithAbsValueComparisonStrategy.assertNotEqual(info, (byte) 6, (byte) -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual((byte) 6, (byte) -6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -50,13 +51,11 @@ public class Characters_assertEqual_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_characters_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertEqual(info, 'b', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual('b', 'a', info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertEqual(info, 'b', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual('b', 'a', info.representation()));
   }
 
   @Test
@@ -73,13 +72,11 @@ public class Characters_assertEqual_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_characters_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertEqual(info, 'b', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual('b', 'a', caseInsensitiveComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertEqual(info, 'b', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual('b', 'a', caseInsensitiveComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Characters_assertGreaterThanOrEqualTo_Test extends CharactersBaseTe
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertGreaterThanOrEqualTo(info, 'a', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual('a', 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertGreaterThanOrEqualTo(info, 'a', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual('a', 'b'));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Characters_assertGreaterThanOrEqualTo_Test extends CharactersBaseTe
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThanOrEqualTo(info, 'a', 'B');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual('a', 'B', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThanOrEqualTo(info, 'a', 'B'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual('a', 'B', caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Characters_assertGreaterThan_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo someInfo = someInfo();
-    try {
-      characters.assertGreaterThan(someInfo, 'b', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo, shouldBeGreater('b', 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertGreaterThan(someInfo, 'b', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo, shouldBeGreater('b', 'b'));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertGreaterThan(info, 'a', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater('a', 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertGreaterThan(info, 'a', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater('a', 'b'));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -82,25 +79,21 @@ public class Characters_assertGreaterThan_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo someInfo = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThan(someInfo, 'B', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo, shouldBeGreater('B', 'b', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThan(someInfo, 'B', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo, shouldBeGreater('B', 'b', caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThan(info, 'A', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater('A', 'b', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertGreaterThan(info, 'A', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater('A', 'b', caseInsensitiveComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Characters_assertLessThanOrEqualTo_Test extends CharactersBaseTest 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertLessThanOrEqualTo(info, 'b', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual('b', 'a'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertLessThanOrEqualTo(info, 'b', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual('b', 'a'));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Characters_assertLessThanOrEqualTo_Test extends CharactersBaseTest 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertLessThanOrEqualTo(info, 'B', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual('B', 'a', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertLessThanOrEqualTo(info, 'B', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual('B', 'a', caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Characters_assertLessThan_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertLessThan(info, 'b', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess('b', 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertLessThan(info, 'b', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess('b', 'b'));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertLessThan(info, 'b', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess('b', 'a'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertLessThan(info, 'b', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess('b', 'a'));
   }
 
   @Test
@@ -84,24 +81,20 @@ public class Characters_assertLessThan_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertLessThan(info, 'b', 'B');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess('b', 'B', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertLessThan(info, 'b', 'B'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess('b', 'B', caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertLessThan(info, 'B', 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess('B', 'a', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertLessThan(info, 'B', 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess('B', 'a', caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertLowerCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertLowerCase_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLowerCase.shouldBeLowerCase;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Characters_assertLowerCase_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_lowercase() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertLowerCase(info, 'A');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLowerCase('A'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertLowerCase(info, 'A'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLowerCase('A'));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Characters_assertLowerCase_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_lowercase_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertLowerCase(info, 'A');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLowerCase('A'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertLowerCase(info, 'A'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLowerCase('A'));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Characters_assertNotEqual_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_characters_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertNotEqual(info, 'b', 'b');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual('b', 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertNotEqual(info, 'b', 'b'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual('b', 'b'));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Characters_assertNotEqual_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_characters_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertNotEqual(info, 'b', 'B');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual('b', 'B', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertNotEqual(info, 'b', 'B'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual('b', 'B', caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/characters/Characters_assertUpperCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/characters/Characters_assertUpperCase_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.characters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeUpperCase.shouldBeUpperCase;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Characters_assertUpperCase_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_uppercase() {
     AssertionInfo info = someInfo();
-    try {
-      characters.assertUpperCase(info, 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeUpperCase('a'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> characters.assertUpperCase(info, 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeUpperCase('a'));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Characters_assertUpperCase_Test extends CharactersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_uppercase_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      charactersWithCaseInsensitiveComparisonStrategy.assertUpperCase(info, 'a');
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeUpperCase('a'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> charactersWithCaseInsensitiveComparisonStrategy.assertUpperCase(info, 'a'));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeUpperCase('a'));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -78,29 +79,25 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     char[] expected = {'a', 'b', 'e'};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList('e'), newArrayList('c'),
-          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList('e'), newArrayList('c'),
+        StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     char[] expected = {'a', 'b'};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('c'),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('c'),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -108,15 +105,13 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b', 'b');
     char[] expected = {'a', 'b'};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('b'),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('b'),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -124,14 +119,12 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b');
     char[] expected = {'a', 'b', 'b'};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList('b'), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList('b'), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -172,28 +165,24 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = {'a', 'B', 'e'};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList('e'), newArrayList('c'),
-          caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList('e'), newArrayList('c'),
+        caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = {'a', 'b'};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('c'), caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('c'), caseInsensitiveComparisonStrategy));
   }
 
   @Test
@@ -201,14 +190,12 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b', 'b');
     char[] expected = {'a', 'b'};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('b'), caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList('b'), caseInsensitiveComparisonStrategy));
   }
 
   @Test
@@ -216,14 +203,12 @@ public class CharArrays_assertContainsExactlyInAnyOrder_Test extends CharArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b');
     char[] expected = {'a', 'b', 'b'};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList('b'), emptyList(), caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList('b'), emptyList(), caseInsensitiveComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf('a', 'c', 'b'));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf('a', 'c', 'b')));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1));
   }
 
   @Test
@@ -84,28 +83,24 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'e' };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList('e'), newArrayList('c')));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList('e'), newArrayList('c')));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'c', 'c' };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList('c'), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList('c'), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'A', 'c', 'b' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1, caseInsensitiveComparisonStrategy));
   }
 
   @Test
@@ -155,30 +148,26 @@ public class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'B', 'e' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList('e'), newArrayList('c'),
-                                                          caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList('e'), newArrayList('c'),
+                                                        caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'C', 'c' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList('c'), newArrayList(),
-                                                          caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList('c'), newArrayList(),
+                                                        caseInsensitiveComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b', 'b', 'a', 'c', 'd');
     char[] expected = { 'a', 'b', 'e' };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('e'), newLinkedHashSet('a', 'b')));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('e'), newLinkedHashSet('a', 'b')));
   }
 
   @Test
@@ -94,14 +93,12 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'd' };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('d'), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('d'), newLinkedHashSet()));
   }
 
   @Test
@@ -119,16 +116,14 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'B', 'b', 'A', 'c', 'd');
     char[] expected = { 'a', 'B', 'e' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('e'), newLinkedHashSet('a', 'B'),
-              caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('e'), newLinkedHashSet('a', 'B'),
+            caseInsensitiveComparisonStrategy));
   }
 
   @Test
@@ -157,15 +152,13 @@ public class CharArrays_assertContainsOnlyOnce_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'A', 'b', 'D' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('D'), newLinkedHashSet(),
-              caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet('D'), newLinkedHashSet(),
+            caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -86,13 +87,11 @@ public class CharArrays_assertContainsOnly_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'd' };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList('d'), newArrayList('c')));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList('d'), newArrayList('c')));
   }
 
   @Test
@@ -139,13 +138,11 @@ public class CharArrays_assertContainsOnly_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'A', 'b', 'd' };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList('d'), newArrayList('c'),
-                                                 caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList('d'), newArrayList('c'),
+                                               caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.CharArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class CharArrays_assertContainsSequence_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'a', 'b', 'c', 12, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     char[] sequence = { 6, 20 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     char[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class CharArrays_assertContainsSequence_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'A', 'b', 'c', 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.chararrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 
@@ -70,13 +71,11 @@ public class CharArrays_assertContains_at_Index_Test extends CharArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, 'a', index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, 'a', index, 'b'));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, 'a', index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, 'a', index, 'b'));
   }
 
   @Test
@@ -117,13 +116,11 @@ public class CharArrays_assertContains_at_Index_Test extends CharArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, 'a', index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, 'a', index, 'b', caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, 'a', index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, 'a', index, 'b', caseInsensitiveComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -72,13 +73,11 @@ public class CharArrays_assertDoesNotContain_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     char[] expected = { 'a', 'b', 'd' };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet('a', 'b')));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet('a', 'b')));
   }
 
   @Test
@@ -117,12 +116,10 @@ public class CharArrays_assertDoesNotContain_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] expected = { 'A', 'b', 'd' };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet('A', 'b'), caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet('A', 'b'), caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,13 +70,11 @@ public class CharArrays_assertDoesNotContain_at_Index_Test extends CharArraysBas
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 'a', index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 'a', index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, 'a', index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 'a', index));
   }
 
   @Test
@@ -112,12 +111,10 @@ public class CharArrays_assertDoesNotContain_at_Index_Test extends CharArraysBas
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 'A', index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 'A', index, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 'A', index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 'A', index, caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.CharArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -62,13 +63,11 @@ public class CharArrays_assertDoesNotHaveDuplicates_Test extends CharArraysBaseT
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'b', 'a', 'b');
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet('a', 'b')));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet('a', 'b')));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class CharArrays_assertDoesNotHaveDuplicates_Test extends CharArraysBaseT
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf('A', 'b', 'A', 'b');
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet('A', 'b'), caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet('A', 'b'), caseInsensitiveComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class CharArrays_assertEmpty_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     char[] actual = { 'a', 'b' };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,39 +71,33 @@ public class CharArrays_assertEndsWith_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'a', 'b', 'c', 'd', 'e', 'f' };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'x', 'y', 'z' };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'b', 'y', 'z' };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class CharArrays_assertEndsWith_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'A', 'b', 'c', 'd', 'e', 'f' };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'x', 'y', 'z' };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'b', 'y', 'z' };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class CharArrays_assertIsSortedAccordingToComparator_Test extends CharArr
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new char[] { 'c', 'b', 'a', 'z' };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, charDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, charDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, charDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, charDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.CharArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,13 +66,11 @@ public class CharArrays_assertIsSorted_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf('a', 'c', 'b');
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -99,14 +98,12 @@ public class CharArrays_assertIsSorted_Test extends CharArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf('A', 'c', 'b');
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.CharArrays.*;
+import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -44,13 +46,11 @@ public class CharArrays_assertNotEmpty_Test extends CharArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.CharArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class CharArrays_assertNullOrEmpty_Test extends CharArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     char[] actual = { 'a' };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.chararrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.CharArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class CharArrays_assertStartsWith_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'a', 'b', 'c', 'd', 'e', 'f' };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'b', 'c' };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'a', 'x' };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -137,39 +132,33 @@ public class CharArrays_assertStartsWith_Test extends CharArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'A', 'b', 'c', 'd', 'e', 'f' };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'b', 'c' };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     char[] sequence = { 'A', 'x' };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertEqualByComparison_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -64,13 +64,11 @@ public class Comparables_assertEqualByComparison_Test extends ComparablesBaseTes
   @Test
   public void should_fail_if_objects_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertEqualByComparison(info, "Luke", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertEqualByComparison(info, "Luke", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -96,13 +94,11 @@ public class Comparables_assertEqualByComparison_Test extends ComparablesBaseTes
   @Test
   public void should_fail_if_objects_are_not_equal_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertEqualByComparison(info, "Luke", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertEqualByComparison(info, "Luke", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -57,13 +58,11 @@ public class Comparables_assertGreaterThanOrEqualTo_Test extends ComparablesBase
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertGreaterThanOrEqualTo(info, 6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6, 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertGreaterThanOrEqualTo(info, 6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6, 8));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -83,13 +82,11 @@ public class Comparables_assertGreaterThanOrEqualTo_Test extends ComparablesBase
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertGreaterThanOrEqualTo(info, 6, -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6, -8, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertGreaterThanOrEqualTo(info, 6, -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6, -8, customComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Comparables_assertGreaterThan_Test extends ComparablesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertGreaterThan(info, "Yoda", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater("Yoda", "Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertGreaterThan(info, "Yoda", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater("Yoda", "Yoda"));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertGreaterThan(info, 6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6, 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertGreaterThan(info, 6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6, 8));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -82,25 +79,21 @@ public class Comparables_assertGreaterThan_Test extends ComparablesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertGreaterThan(info, 7, -7);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(7, -7, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertGreaterThan(info, 7, -7));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(7, -7, customComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertGreaterThan(info, -6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6, 8, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertGreaterThan(info, -6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6, 8, customComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -57,13 +58,11 @@ public class Comparables_assertLessThanOrEqualTo_Test extends ComparablesBaseTes
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertLessThanOrEqualTo(info, 8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(8, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertLessThanOrEqualTo(info, 8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(8, 6));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -83,13 +82,11 @@ public class Comparables_assertLessThanOrEqualTo_Test extends ComparablesBaseTes
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertLessThanOrEqualTo(info, -8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(-8, 6, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertLessThanOrEqualTo(info, -8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(-8, 6, customComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Comparables_assertLessThan_Test extends ComparablesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertLessThan(info, "Yoda", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess("Yoda", "Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertLessThan(info, "Yoda", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess("Yoda", "Yoda"));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertLessThan(info, 8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertLessThan(info, 8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8, 6));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -82,25 +79,21 @@ public class Comparables_assertLessThan_Test extends ComparablesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertLessThan(info, -7, 7);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(-7, 7, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertLessThan(info, -7, 7));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(-7, 7, customComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertLessThan(info, 8, -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8, -6, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertLessThan(info, 8, -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8, -6, customComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_assertNotEqualByComparison_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_assertNotEqualByComparison_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.comparables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -61,13 +62,11 @@ public class Comparables_assertNotEqualByComparison_Test extends ComparablesBase
   @Test
   public void should_fail_if_objects_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      comparables.assertNotEqualByComparison(info, "Yoda", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual("Yoda", "Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparables.assertNotEqualByComparison(info, "Yoda", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual("Yoda", "Yoda"));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -91,12 +90,10 @@ public class Comparables_assertNotEqualByComparison_Test extends ComparablesBase
   @Test
   public void should_fail_if_objects_are_equal_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertNotEqualByComparison(info, new Person("Yoda"), new Person("Yoda"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(new Person("Yoda"), new Person("Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertNotEqualByComparison(info, new Person("Yoda"), new Person("Yoda")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(new Person("Yoda"), new Person("Yoda")));
   }
 }

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_isBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_isBetween_Test.java
@@ -17,9 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ComparablesBaseTest;
+import org.assertj.core.test.Person;
 import org.junit.jupiter.api.Test;
 
 public class Comparables_isBetween_Test extends ComparablesBaseTest {
@@ -104,25 +105,21 @@ public class Comparables_isBetween_Test extends ComparablesBaseTest {
   @Test
   public void fails_if_actual_is_is_greater_than_end_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), -12, 8, 10, true, true);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(-12, 8, 10, true, true, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), -12, 8, 10, true, true));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(-12, 8, 10, true, true, customComparisonStrategy));
   }
 
   @Test
   public void fails_if_actual_is_is_less_than_start_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), 6, -8, 10, true, true);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(6, -8, 10, true, true, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), 6, -8, 10, true, true));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(6, -8, 10, true, true, customComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/comparables/Comparables_isStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/comparables/Comparables_isStrictlyBetween_Test.java
@@ -17,9 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -106,25 +106,21 @@ public class Comparables_isStrictlyBetween_Test extends ComparablesBaseTest {
   @Test
   public void fails_if_actual_is_is_greater_than_end_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), -12, 8, 10, false, false);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(-12, 8, 10, false, false, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), -12, 8, 10, false, false));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(-12, 8, 10, false, false, customComparisonStrategy));
   }
 
   @Test
   public void fails_if_actual_is_is_less_than_start_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), 6, -8, 10, false, false);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(6, -8, 10, false, false, customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> comparablesWithCustomComparisonStrategy.assertIsBetween(someInfo(), 6, -8, 10, false, false));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(6, -8, 10, false, false, customComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/conditions/Conditions_assertDoesNotHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/conditions/Conditions_assertDoesNotHave_Test.java
@@ -12,7 +12,9 @@
  */
 package org.assertj.core.internal.conditions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHave.shouldNotHave;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -50,12 +52,10 @@ public class Conditions_assertDoesNotHave_Test extends ConditionsBaseTest {
   public void should_fail_if_Condition_is_met() {
     condition.shouldMatch(true);
     AssertionInfo info = someInfo();
-    try {
-      conditions.assertDoesNotHave(info, actual, condition);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHave(actual, condition));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> conditions.assertDoesNotHave(info, actual, condition));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHave(actual, condition));
   }
 }

--- a/src/test/java/org/assertj/core/internal/conditions/Conditions_assertDoesNotHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/conditions/Conditions_assertDoesNotHave_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHave.shouldNotHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;

--- a/src/test/java/org/assertj/core/internal/conditions/Conditions_assertHas_Test.java
+++ b/src/test/java/org/assertj/core/internal/conditions/Conditions_assertHas_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.conditions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHave.shouldHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -49,12 +50,10 @@ public class Conditions_assertHas_Test extends ConditionsBaseTest {
   public void should_fail_if_Condition_is_not_met() {
     condition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      conditions.assertHas(info, actual, condition);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHave(actual, condition));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> conditions.assertHas(info, actual, condition));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHave(actual, condition));
   }
 }

--- a/src/test/java/org/assertj/core/internal/conditions/Conditions_assertIsNot_Test.java
+++ b/src/test/java/org/assertj/core/internal/conditions/Conditions_assertIsNot_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.conditions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBe.shouldNotBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -50,12 +51,10 @@ public class Conditions_assertIsNot_Test extends ConditionsBaseTest {
   public void should_fail_if_Condition_is_met() {
     condition.shouldMatch(true);
     AssertionInfo info = someInfo();
-    try {
-      conditions.assertIsNot(info, actual, condition);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBe(actual, condition));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> conditions.assertIsNot(info, actual, condition));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBe(actual, condition));
   }
 }

--- a/src/test/java/org/assertj/core/internal/conditions/Conditions_assertIs_Test.java
+++ b/src/test/java/org/assertj/core/internal/conditions/Conditions_assertIs_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.conditions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBe.shouldBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -50,12 +51,10 @@ public class Conditions_assertIs_Test extends ConditionsBaseTest {
   public void should_fail_if_Condition_is_not_met() {
     condition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      conditions.assertIs(info, actual, condition);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBe(actual, condition));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> conditions.assertIs(info, actual, condition));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBe(actual, condition));
   }
 }

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasDayOfMonth_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasDayOfMonth_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -40,13 +41,11 @@ public class Dates_assertHasDayOfMonth_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_day_of_month() {
     AssertionInfo info = someInfo();
     int day_of_month = 5;
-    try {
-      dates.assertHasDayOfMonth(info, actual, day_of_month);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "day of month", day_of_month));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasDayOfMonth(info, actual, day_of_month));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "day of month", day_of_month));
   }
 
   @Test
@@ -64,13 +63,11 @@ public class Dates_assertHasDayOfMonth_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_day_of_month_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int day_of_month = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasDayOfMonth(info, actual, day_of_month);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "day of month", day_of_month));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasDayOfMonth(info, actual, day_of_month));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "day of month", day_of_month));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasDayOfWeek_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasDayOfWeek_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.dates;
 
 import static java.util.Calendar.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -41,13 +42,11 @@ public class Dates_assertHasDayOfWeek_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_day_of_week() {
     AssertionInfo info = someInfo();
     int day_of_week = SUNDAY;
-    try {
-      dates.assertHasDayOfWeek(info, actual, day_of_week);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "day of week", day_of_week));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasDayOfWeek(info, actual, day_of_week));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "day of week", day_of_week));
   }
 
   @Test
@@ -65,13 +64,11 @@ public class Dates_assertHasDayOfWeek_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_day_of_week_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int day_of_week = SUNDAY;
-    try {
-      datesWithCustomComparisonStrategy.assertHasDayOfWeek(info, actual, day_of_week);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "day of week", day_of_week));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasDayOfWeek(info, actual, day_of_week));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "day of week", day_of_week));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasHourOfDay_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasHourOfDay_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class Dates_assertHasHourOfDay_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_hour_of_day() {
     AssertionInfo info = someInfo();
     int hour_of_day = 5;
-    try {
-      dates.assertHasHourOfDay(info, actual, hour_of_day);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "hour", hour_of_day));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasHourOfDay(info, actual, hour_of_day));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "hour", hour_of_day));
   }
 
   @Test
@@ -69,13 +68,11 @@ public class Dates_assertHasHourOfDay_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_hour_of_day_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int hour_of_day = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasHourOfDay(info, actual, hour_of_day);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "hour", hour_of_day));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasHourOfDay(info, actual, hour_of_day));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "hour", hour_of_day));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMillisecond_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMillisecond_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class Dates_assertHasMillisecond_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_millisecond() {
     AssertionInfo info = someInfo();
     int millisecond = 5;
-    try {
-      dates.assertHasMillisecond(info, actual, millisecond);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "millisecond", millisecond));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasMillisecond(info, actual, millisecond));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "millisecond", millisecond));
   }
 
   @Test
@@ -69,13 +68,11 @@ public class Dates_assertHasMillisecond_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_millisecond_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int millisecond = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasMillisecond(info, actual, millisecond);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "millisecond", millisecond));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasMillisecond(info, actual, millisecond));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "millisecond", millisecond));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMinute_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMinute_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class Dates_assertHasMinute_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_minute() {
     AssertionInfo info = someInfo();
     int minute = 5;
-    try {
-      dates.assertHasMinute(info, actual, minute);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "minute", minute));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasMinute(info, actual, minute));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "minute", minute));
   }
 
   @Test
@@ -69,13 +68,11 @@ public class Dates_assertHasMinute_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_minute_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int minute = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasMinute(info, actual, minute);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "minute", minute));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasMinute(info, actual, minute));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "minute", minute));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMonth_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasMonth_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -40,13 +41,11 @@ public class Dates_assertHasMonth_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_month() {
     AssertionInfo info = someInfo();
     int month = 5;
-    try {
-      dates.assertHasMonth(info, actual, month);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "month", month));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasMonth(info, actual, month));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "month", month));
   }
 
   @Test
@@ -64,13 +63,11 @@ public class Dates_assertHasMonth_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_month_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int month = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasMonth(info, actual, month);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "month", month));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasMonth(info, actual, month));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "month", month));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasSecond_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasSecond_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class Dates_assertHasSecond_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_second() {
     AssertionInfo info = someInfo();
     int second = 5;
-    try {
-      dates.assertHasSecond(info, actual, second);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "second", second));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasSecond(info, actual, second));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "second", second));
   }
 
   @Test
@@ -69,13 +68,11 @@ public class Dates_assertHasSecond_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_second_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int second = 5;
-    try {
-      datesWithCustomComparisonStrategy.assertHasSecond(info, actual, second);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "second", second));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasSecond(info, actual, second));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "second", second));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasTime_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasTime_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveTime.shouldHaveTime;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -56,12 +57,10 @@ public class Dates_assertHasTime_Test extends DatesBaseTest {
   @Test()
   public void should_fail_if_actual_has_not_same_time() {
     AssertionInfo info = someInfo();
-    try {
-      dates.assertHasTime(someInfo(), actual, 24L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveTime(actual, 24L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasTime(someInfo(), actual, 24L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveTime(actual, 24L));
   }
 }

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertHasYear_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertHasYear_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -40,13 +41,11 @@ public class Dates_assertHasYear_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_year() {
     AssertionInfo info = someInfo();
     int year = 2010;
-    try {
-      dates.assertHasYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "year", year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertHasYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "year", year));
   }
 
   @Test
@@ -64,13 +63,11 @@ public class Dates_assertHasYear_Test extends DatesBaseTest {
   public void should_fail_if_actual_has_not_given_year_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int year = 2010;
-    try {
-      datesWithCustomComparisonStrategy.assertHasYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveDateField(actual, "year", year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertHasYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveDateField(actual, "year", year));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfterOrEqualTo_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -41,13 +42,11 @@ public class Dates_assertIsAfterOrEqualTo_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_after_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2022-01-01");
-    try {
-      dates.assertIsAfterOrEqualTo(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAfterOrEqualTo(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsAfterOrEqualTo(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAfterOrEqualTo(actual, other));
   }
 
   @Test
@@ -76,13 +75,11 @@ public class Dates_assertIsAfterOrEqualTo_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_after_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2022-01-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsAfterOrEqualTo(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsAfterOrEqualTo(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfterYear_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfterYear_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeAfterYear.shouldBeAfterYear;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -35,29 +36,25 @@ public class Dates_assertIsAfterYear_Test extends DatesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_strictly_after_given_year() {
-	AssertionInfo info = someInfo();
-	int year = 2020;
-	try {
-	  dates.assertIsAfterYear(info, actual, year);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    int year = 2020;
+
+    Throwable error = catchThrowable(() -> dates.assertIsAfterYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeAfterYear(actual, year));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
   public void should_fail_if_actual_year_is_equals_to_given_year() {
-	AssertionInfo info = someInfo();
-	parseDate("2011-01-01");
-	int year = 2011;
-	try {
-	  dates.assertIsAfterYear(info, actual, year);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    parseDate("2011-01-01");
+    int year = 2011;
+
+    Throwable error = catchThrowable(() -> dates.assertIsAfterYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeAfterYear(actual, year));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
@@ -73,29 +70,25 @@ public class Dates_assertIsAfterYear_Test extends DatesBaseTest {
 
   @Test
   public void should_fail_if_actual_is_not_strictly_after_given_year_whatever_custom_comparison_strategy_is() {
-	AssertionInfo info = someInfo();
-	int year = 2020;
-	try {
-	  datesWithCustomComparisonStrategy.assertIsAfterYear(info, actual, year);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    int year = 2020;
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsAfterYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeAfterYear(actual, year));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
   public void should_fail_if_actual_year_is_equals_to_given_year_whatever_custom_comparison_strategy_is() {
-	AssertionInfo info = someInfo();
-	parseDate("2011-01-01");
-	int year = 2011;
-	try {
-	  datesWithCustomComparisonStrategy.assertIsAfterYear(info, actual, year);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    parseDate("2011-01-01");
+    int year = 2011;
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsAfterYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldBeAfterYear(actual, year));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfter_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsAfter_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -45,26 +46,22 @@ public class Dates_assertIsAfter_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_after_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2022-01-01");
-    try {
-      dates.assertIsAfter(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAfter(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsAfter(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAfter(actual, other));
   }
 
   @Test
   public void should_fail_if_actual_is_equals_to_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-15");
-    try {
-      dates.assertIsAfter(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAfter(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsAfter(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAfter(actual, other));
   }
 
   @Test
@@ -88,26 +85,22 @@ public class Dates_assertIsAfter_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_after_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2022-01-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsAfter(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAfter(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsAfter(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAfter(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_equals_to_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-31");
-    try {
-      datesWithCustomComparisonStrategy.assertIsAfter(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAfter(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsAfter(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAfter(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBeforeOrEqualTo_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -41,13 +42,11 @@ public class Dates_assertIsBeforeOrEqualTo_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      dates.assertIsBeforeOrEqualTo(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBeforeOrEqualTo(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBeforeOrEqualTo(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBeforeOrEqualTo(actual, other));
   }
 
   @Test
@@ -76,13 +75,11 @@ public class Dates_assertIsBeforeOrEqualTo_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsBeforeOrEqualTo(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBeforeOrEqualTo(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBeforeYear_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBeforeYear_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBeforeYear.shouldBeBeforeYear;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -38,13 +39,11 @@ public class Dates_assertIsBeforeYear_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_year() {
     AssertionInfo info = someInfo();
     int year = 2010;
-    try {
-      dates.assertIsBeforeYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBeforeYear(actual, year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBeforeYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBeforeYear(actual, year));
   }
 
   @Test
@@ -52,13 +51,11 @@ public class Dates_assertIsBeforeYear_Test extends DatesBaseTest {
     AssertionInfo info = someInfo();
     parseDate("2011-01-01");
     int year = 2011;
-    try {
-      dates.assertIsBeforeYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBeforeYear(actual, year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBeforeYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBeforeYear(actual, year));
   }
 
   @Test
@@ -76,13 +73,11 @@ public class Dates_assertIsBeforeYear_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_year_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     int year = 2010;
-    try {
-      datesWithCustomComparisonStrategy.assertIsBeforeYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBeforeYear(actual, year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBeforeYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBeforeYear(actual, year));
   }
 
   @Test
@@ -90,13 +85,11 @@ public class Dates_assertIsBeforeYear_Test extends DatesBaseTest {
     AssertionInfo info = someInfo();
     parseDate("2011-01-01");
     int year = 2011;
-    try {
-      datesWithCustomComparisonStrategy.assertIsBeforeYear(info, actual, year);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBeforeYear(actual, year));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBeforeYear(info, actual, year));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBeforeYear(actual, year));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBefore_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBefore_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -40,26 +41,22 @@ public class Dates_assertIsBefore_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      dates.assertIsBefore(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBefore(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBefore(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBefore(actual, other));
   }
 
   @Test
   public void should_fail_if_actual_is_equals_to_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-01");
-    try {
-      dates.assertIsBefore(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBefore(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBefore(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBefore(actual, other));
   }
 
   @Test
@@ -83,26 +80,22 @@ public class Dates_assertIsBefore_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_strictly_before_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsBefore(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBefore(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBefore(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBefore(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_equals_to_given_date_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-31");
-    try {
-      datesWithCustomComparisonStrategy.assertIsBefore(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBefore(actual, other, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBefore(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBefore(actual, other, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsBetween_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.internal.ErrorMessages.endDateToCompareActualWithIsNull;
 import static org.assertj.core.internal.ErrorMessages.startDateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -50,13 +51,11 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = true;
-    try {
-      dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -67,13 +66,11 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = false;
     boolean inclusiveEnd = true;
-    try {
-      dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -84,13 +81,11 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = false;
-    try {
-      dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -151,14 +146,12 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = true;
-    try {
-      datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test
@@ -169,14 +162,12 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-10-30");
     boolean inclusiveStart = false;
     boolean inclusiveEnd = true;
-    try {
-      datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test
@@ -187,14 +178,12 @@ public class Dates_assertIsBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30"); // = 2011-09-01 according to comparison strategy
     boolean inclusiveStart = true;
     boolean inclusiveEnd = false;
-    try {
-      datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsCloseTo_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeCloseTo.shouldBeCloseTo;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Dates_assertIsCloseTo_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_to_given_date_by_less_than_given_delta() {
     AssertionInfo info = someInfo();
-    try {
-      dates.assertIsCloseTo(info, actual, other, delta);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeCloseTo(actual, other, delta, 101));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsCloseTo(info, actual, other, delta));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeCloseTo(actual, other, delta, 101));
   }
 
   @Test
@@ -81,13 +80,11 @@ public class Dates_assertIsCloseTo_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_to_given_date_by_less_than_given_delta_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      datesWithCustomComparisonStrategy.assertIsCloseTo(info, actual, other, delta);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeCloseTo(actual, other, delta, 101));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsCloseTo(info, actual, other, delta));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeCloseTo(actual, other, delta, 101));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsEqualWithPrecision_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsEqualWithPrecision_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualWithTimePrecision.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.util.Calendar;
@@ -81,52 +82,44 @@ public class Dates_assertIsEqualWithPrecision_Test extends DatesBaseTest {
   public void should_fail_if_ms_fields_differ() {
     AssertionInfo info = someInfo();
     Date other = parseDatetimeWithMs("2011-09-27T12:23:35.998");
-    try {
-      dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MICROSECONDS);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MICROSECONDS));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MICROSECONDS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MICROSECONDS));
   }
 
   @Test
   public void should_fail_if_second_fields_differ() {
     AssertionInfo info = someInfo();
     Date other = parseDatetimeWithMs("2011-09-27T12:23:36.999");
-    try {
-      dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MILLISECONDS);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MILLISECONDS));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MILLISECONDS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void should_fail_if_minute_fields_differ() {
     AssertionInfo info = someInfo();
     Date other = parseDatetimeWithMs("2011-09-27T12:24:35.999");
-    try {
-      dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.SECONDS);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.SECONDS));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.SECONDS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.SECONDS));
   }
 
   @Test
   public void should_fail_if_hour_fields_differ() {
     AssertionInfo info = someInfo();
     Date other = parseDatetimeWithMs("2011-09-27T13:23:35.999");
-    try {
-      dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MINUTES);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MINUTES));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.MINUTES));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.MINUTES));
   }
 
   @Test
@@ -142,26 +135,22 @@ public class Dates_assertIsEqualWithPrecision_Test extends DatesBaseTest {
     calendar2.set(Calendar.HOUR_OF_DAY, 6);
     Date date1 = calendar1.getTime();
     Date date2 = calendar2.getTime();
-    try {
-      dates.assertIsEqualWithPrecision(info, date1, date2, TimeUnit.MINUTES);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(date1, date2, TimeUnit.MINUTES));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, date1, date2, TimeUnit.MINUTES));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(date1, date2, TimeUnit.MINUTES));
   }
 
   @Test
   public void should_fail_if_day_not_equal() {
     AssertionInfo info = someInfo();
     Date other = parseDatetimeWithMs("2011-09-28T12:23:35.999");
-    try {
-      dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.HOURS);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.HOURS));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsEqualWithPrecision(info, actual, other, TimeUnit.HOURS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, other, TimeUnit.HOURS));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameDayAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameDayAs_Test.java
@@ -12,16 +12,18 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameDay.shouldBeInSameDay;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Dates;
@@ -40,13 +42,11 @@ public class Dates_assertIsInSameDayAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_day_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-02");
-    try {
-      dates.assertIsInSameDayAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameDay(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameDayAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameDay(actual, other));
   }
 
   @Test
@@ -70,13 +70,11 @@ public class Dates_assertIsInSameDayAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_day_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-01-02");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameDayAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameDay(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameDayAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameDay(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameHourAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameHourAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameHour.shouldBeInSameHour;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -45,13 +46,11 @@ public class Dates_assertIsInSameHourAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_hour_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T04:01:02");
-    try {
-      dates.assertIsInSameHourAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameHour(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameHourAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameHour(actual, other));
   }
 
   @Test
@@ -75,13 +74,11 @@ public class Dates_assertIsInSameHourAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_hour_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T04:01:02");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameHourAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameHour(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameHourAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameHour(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameHourWindowAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameHourWindowAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameHourWindow.shouldBeInSameHourWindow;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -51,26 +52,22 @@ public class Dates_assertIsInSameHourWindowAs_Test extends DatesBaseTest {
   public void should_fail_if_time_difference_is_exactly_one_hour() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T04:01:02");
-    try {
-      dates.assertIsInSameHourWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameHourWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_same_hour_window_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T04:01:03");
-    try {
-      dates.assertIsInSameHourWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameHourWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
   }
 
   @Test
@@ -89,13 +86,11 @@ public class Dates_assertIsInSameHourWindowAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_hour_window_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T04:01:03");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameHourWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameHourWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameHourWindow(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMinuteAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMinuteAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameMinute.shouldBeInSameMinute;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -45,13 +46,11 @@ public class Dates_assertIsInSameMinuteAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_minute_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:14:02");
-    try {
-      dates.assertIsInSameMinuteAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMinute(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameMinuteAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMinute(actual, other));
   }
 
   @Test
@@ -75,13 +74,11 @@ public class Dates_assertIsInSameMinuteAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_minute_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:14:02");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameMinuteAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMinute(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameMinuteAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMinute(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMinuteWindowAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMinuteWindowAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameMinuteWindow.shouldBeInSameMinuteWindow;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -51,26 +52,22 @@ public class Dates_assertIsInSameMinuteWindowAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_exactly_one_minute_away_from_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:16:00");
-    try {
-      dates.assertIsInSameMinuteWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameMinuteWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_same_minute_window_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:16:01");
-    try {
-      dates.assertIsInSameMinuteWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameMinuteWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
   }
 
   @Test
@@ -90,13 +87,11 @@ public class Dates_assertIsInSameMinuteWindowAs_Test extends DatesBaseTest {
     () {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:13:59");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameMinuteWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameMinuteWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMinuteWindow(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMonthAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameMonthAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameMonth.shouldBeInSameMonth;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -40,13 +41,11 @@ public class Dates_assertIsInSameMonthAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_month_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-02-01");
-    try {
-      dates.assertIsInSameMonthAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMonth(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameMonthAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMonth(actual, other));
   }
 
   @Test
@@ -70,13 +69,11 @@ public class Dates_assertIsInSameMonthAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_month_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2011-02-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameMonthAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameMonth(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameMonthAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameMonth(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameSecondAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameSecondAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameSecond.shouldBeInSameSecond;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -45,13 +46,11 @@ public class Dates_assertIsInSameSecondAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_second_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:15:02");
-    try {
-      dates.assertIsInSameSecondAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameSecond(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameSecondAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameSecond(actual, other));
   }
 
   @Test
@@ -77,13 +76,11 @@ public class Dates_assertIsInSameSecondAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_second_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:15:02");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameSecondAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameSecond(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameSecondAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameSecond(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameSecondWindowAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameSecondWindowAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameSecondWindow.shouldBeInSameSecondWindow;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -53,26 +54,22 @@ public class Dates_assertIsInSameSecondWindowAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_second_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:15:02");
-    try {
-      dates.assertIsInSameSecondWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameSecondWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
   }
 
   @Test
   public void should_fail_if_actual_if_dates_time_difference_is_exactly_one_second() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:15:06");
-    try {
-      dates.assertIsInSameSecondWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameSecondWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
   }
 
   @Test
@@ -91,13 +88,11 @@ public class Dates_assertIsInSameSecondWindowAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_second_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDatetime("2011-01-01T03:15:02");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameSecondWindowAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameSecondWindowAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameSecondWindow(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameYearAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInSameYearAs_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInSameYear.shouldBeInSameYear;
 import static org.assertj.core.internal.ErrorMessages.dateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -40,13 +41,11 @@ public class Dates_assertIsInSameYearAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_year_as_given_date() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      dates.assertIsInSameYearAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameYear(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInSameYearAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameYear(actual, other));
   }
 
   @Test
@@ -70,13 +69,11 @@ public class Dates_assertIsInSameYearAs_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_not_in_same_year_as_given_date_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Date other = parseDate("2000-01-01");
-    try {
-      datesWithCustomComparisonStrategy.assertIsInSameYearAs(info, actual, other);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInSameYear(actual, other));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInSameYearAs(info, actual, other));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInSameYear(actual, other));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInTheFuture_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInTheFuture_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.DateUtil.monthOf;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -41,26 +42,22 @@ public class Dates_assertIsInTheFuture_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_the_future() {
     AssertionInfo info = someInfo();
-    try {
-      dates.assertIsInTheFuture(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInTheFuture(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInTheFuture(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInTheFuture(actual));
   }
 
   @Test
   public void should_fail_if_actual_is_today() {
     AssertionInfo info = someInfo();
-    try {
-      actual = new Date();
-      dates.assertIsInTheFuture(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInTheFuture(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = new Date();
+
+    Throwable error = catchThrowable(() -> dates.assertIsInTheFuture(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInTheFuture(actual));
   }
 
   @Test
@@ -78,34 +75,30 @@ public class Dates_assertIsInTheFuture_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_the_future_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      datesWithCustomComparisonStrategy.assertIsInTheFuture(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInTheFuture(actual, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInTheFuture(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInTheFuture(actual, yearAndMonthComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_today_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      // we want actual to be different from today but still in the same month so that it is = today according to our
-      // comparison strategy (that compares only month and year)
-      // => if we are at the end of the month we subtract one day instead of adding one
-      Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.DAY_OF_MONTH, 1);
-      Date tomorrow = cal.getTime();
-      cal.add(Calendar.DAY_OF_MONTH, -2);
-      Date yesterday = cal.getTime();
-      actual = monthOf(tomorrow) == monthOf(new Date()) ? tomorrow : yesterday;
-      datesWithCustomComparisonStrategy.assertIsInTheFuture(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInTheFuture(actual, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    // we want actual to be different from today but still in the same month so that it is = today according to our
+    // comparison strategy (that compares only month and year)
+    // => if we are at the end of the month we subtract one day instead of adding one
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DAY_OF_MONTH, 1);
+    Date tomorrow = cal.getTime();
+    cal.add(Calendar.DAY_OF_MONTH, -2);
+    Date yesterday = cal.getTime();
+    actual = monthOf(tomorrow) == monthOf(new Date()) ? tomorrow : yesterday;
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInTheFuture(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInTheFuture(actual, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInThePast_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInThePast_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.DateUtil.monthOf;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -41,16 +42,14 @@ public class Dates_assertIsInThePast_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_the_past() {
     AssertionInfo info = someInfo();
-    try {
-      // init actual so that it is in the future compared to the instant when we call dates.assertIsInThePast
-      long oneSecond = 1000;
-      actual = new Date(System.currentTimeMillis() + oneSecond);
-      dates.assertIsInThePast(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInThePast(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    // init actual so that it is in the future compared to the instant when we call dates.assertIsInThePast
+    long oneSecond = 1000;
+    actual = new Date(System.currentTimeMillis() + oneSecond);
+
+    Throwable error = catchThrowable(() -> dates.assertIsInThePast(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInThePast(actual));
   }
 
   @Test
@@ -68,35 +67,31 @@ public class Dates_assertIsInThePast_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_the_past_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      // set actual to a date in the future according to our comparison strategy (that compares only month and year)
-      actual = parseDate("2111-01-01");
-      datesWithCustomComparisonStrategy.assertIsInThePast(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInThePast(actual, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    // set actual to a date in the future according to our comparison strategy (that compares only month and year)
+    actual = parseDate("2111-01-01");
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInThePast(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInThePast(actual, yearAndMonthComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_today_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      // we want actual to "now" according to our comparison strategy (that compares only month and year)
-      // => if we are at the end of the month we subtract one day instead of adding one
-      Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.DAY_OF_MONTH, 1);
-      Date tomorrow = cal.getTime();
-      cal.add(Calendar.DAY_OF_MONTH, -2);
-      Date yesterday = cal.getTime();
-      actual = monthOf(tomorrow) == monthOf(new Date()) ? tomorrow : yesterday;
-      datesWithCustomComparisonStrategy.assertIsInThePast(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeInThePast(actual, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    // we want actual to "now" according to our comparison strategy (that compares only month and year)
+    // => if we are at the end of the month we subtract one day instead of adding one
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DAY_OF_MONTH, 1);
+    Date tomorrow = cal.getTime();
+    cal.add(Calendar.DAY_OF_MONTH, -2);
+    Date yesterday = cal.getTime();
+    actual = monthOf(tomorrow) == monthOf(new Date()) ? tomorrow : yesterday;
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsInThePast(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInThePast(actual, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsNotBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsNotBetween_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeBetween.shouldNotBeBetween;
 import static org.assertj.core.internal.ErrorMessages.endDateToCompareActualWithIsNull;
 import static org.assertj.core.internal.ErrorMessages.startDateToCompareActualWithIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -49,13 +50,11 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = true;
-    try {
-      dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -66,13 +65,11 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = false;
-    try {
-      dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -83,13 +80,11 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = false;
     boolean inclusiveEnd = true;
-    try {
-      dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> dates.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd));
   }
 
   @Test
@@ -150,14 +145,12 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = true;
-    try {
-      datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test
@@ -168,14 +161,12 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-10-01");
     boolean inclusiveStart = true;
     boolean inclusiveEnd = false;
-    try {
-      datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test
@@ -186,14 +177,12 @@ public class Dates_assertIsNotBetween_Test extends DatesBaseTest {
     Date end = parseDate("2011-09-30"); // = 2011-09-15 according to comparison strategy
     boolean inclusiveStart = false;
     boolean inclusiveEnd = true;
-    try {
-      datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsNotBetween(info, actual, start, end, inclusiveStart, inclusiveEnd));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotBeBetween(actual, start, end, inclusiveStart, inclusiveEnd, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsToday_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsToday_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.dates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeToday.shouldBeToday;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.DateUtil.*;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -40,14 +41,12 @@ public class Dates_assertIsToday_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_today() {
     AssertionInfo info = someInfo();
-    try {
-      actual = parseDate("2111-01-01");
-      dates.assertIsToday(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeToday(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = parseDate("2111-01-01");
+
+    Throwable error = catchThrowable(() -> dates.assertIsToday(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeToday(actual));
   }
 
   @Test
@@ -64,14 +63,12 @@ public class Dates_assertIsToday_Test extends DatesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_today_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      actual = parseDate("2111-01-01");
-      datesWithCustomComparisonStrategy.assertIsToday(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeToday(actual, yearAndMonthComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = parseDate("2111-01-01");
+
+    Throwable error = catchThrowable(() -> datesWithCustomComparisonStrategy.assertIsToday(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeToday(actual, yearAndMonthComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,13 +48,11 @@ public class Doubles_assertEqual_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_doubles_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertEqual(info, 6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6d, 8d, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertEqual(info, 6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6d, 8d, info.representation()));
   }
 
   @Test
@@ -70,13 +69,11 @@ public class Doubles_assertEqual_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_doubles_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertEqual(info, 6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6d, 8d, absValueComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertEqual(info, 6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6d, 8d, absValueComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Doubles_assertGreaterThanOrEqualTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertGreaterThanOrEqualTo(info, 6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6d, 8d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertGreaterThanOrEqualTo(info, 6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6d, 8d));
   }
 
   @Test
@@ -80,12 +79,10 @@ public class Doubles_assertGreaterThanOrEqualTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, -6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(-6d, 8d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, -6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(-6d, 8d, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,25 +48,21 @@ public class Doubles_assertGreaterThan_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertGreaterThan(info, 6d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6d, 6d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertGreaterThan(info, 6d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6d, 6d));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertGreaterThan(info, 6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6d, 8d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertGreaterThan(info, 6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6d, 8d));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -80,25 +77,21 @@ public class Doubles_assertGreaterThan_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertGreaterThan(info, -6d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6d, 6d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertGreaterThan(info, -6d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6d, 6d, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertGreaterThan(info, -6d, 8d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6d, 8d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertGreaterThan(info, -6d, 8d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6d, 8d, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsBetween_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -72,24 +73,20 @@ public class Doubles_assertIsBetween_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        doubles.assertIsBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -87,14 +88,12 @@ public class Doubles_assertIsCloseToPercentage_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
-                                                                   TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                 TEN - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsCloseTo_Test.java
@@ -15,15 +15,16 @@ package org.assertj.core.internal.doubles;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.ErrorMessages.offsetIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -94,37 +95,31 @@ public class Doubles_assertIsCloseTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsCloseTo(info, ONE, TEN, within(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsCloseTo(info, ONE, TEN, within(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), TEN - ONE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_with_a_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), TEN - ONE));
   }
 
   @Test
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), TWO - ONE));
   }
 
   @Test
@@ -180,25 +175,21 @@ public class Doubles_assertIsCloseTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Double(6d), new Double(8d), offset(1d));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6d, 8d, offset(1d), 2d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Double(6d), new Double(8d), offset(1d)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6d, 8d, offset(1d), 2d));
   }
 
   @Test
   public void should_fail_if_actual_is_not_strictly_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Double(6d), new Double(8d), byLessThan(1d));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6d, 8d, byLessThan(1d), 2d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Double(6d), new Double(8d), byLessThan(1d)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6d, 8d, byLessThan(1d), 2d));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseToPercentage_Test.java
@@ -16,14 +16,15 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -84,27 +85,23 @@ public class Doubles_assertIsNotCloseToPercentage_Test extends DoublesBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(Double actual, Double other, Double percentage) {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
-                                                                      abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+                                                                    abs(actual - other)));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
-        TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
+      TEN - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsNotCloseTo_Test.java
@@ -16,13 +16,14 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -102,37 +103,31 @@ public class Doubles_assertIsNotCloseTo_Test extends DoublesBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(Double actual, Double other, Double offset) {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
   }
   
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsNotCloseTo(info, ONE, TWO, within(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, within(TEN), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsNotCloseTo(info, ONE, TWO, within(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, within(TEN), TWO - ONE));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value_with_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsNotCloseTo(info, ONE, TWO, byLessThan(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, byLessThan(TEN), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsNotCloseTo(info, ONE, TWO, byLessThan(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, byLessThan(TEN), TWO - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsStrictlyBetween_Test.java
@@ -12,12 +12,14 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,37 +65,31 @@ public class Doubles_assertIsStrictlyBetween_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        doubles.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        doubles.assertIsStrictlyBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertIsStrictlyBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Doubles_assertLessThanOrEqualTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertLessThanOrEqualTo(info, 8d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(8d, 6d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertLessThanOrEqualTo(info, 8d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(8d, 6d));
   }
 
   @Test
@@ -80,12 +79,10 @@ public class Doubles_assertLessThanOrEqualTo_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(-8d, 6d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(-8d, 6d, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,25 +48,21 @@ public class Doubles_assertLessThan_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertLessThan(info, 6d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6d, 6d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertLessThan(info, 6d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6d, 6d));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertLessThan(info, 8d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8d, 6d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertLessThan(info, 8d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8d, 6d));
   }
 
   @Test
@@ -82,24 +79,20 @@ public class Doubles_assertLessThan_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertLessThan(info, 6d, -6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6d, -6d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertLessThan(info, 6d, -6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6d, -6d, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertLessThan(info, -8d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(-8d, 6d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertLessThan(info, -8d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(-8d, 6d, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.doubles;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,13 +48,11 @@ public class Doubles_assertNotEqual_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_doubles_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      doubles.assertNotEqual(info, 6d, 6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6d, 6d));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doubles.assertNotEqual(info, 6d, 6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6d, 6d));
   }
 
   @Test
@@ -70,12 +69,10 @@ public class Doubles_assertNotEqual_Test extends DoublesBaseTest {
   @Test
   public void should_fail_if_doubles_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      doublesWithAbsValueComparisonStrategy.assertNotEqual(info, 6d, -6d);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6d, -6d, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> doublesWithAbsValueComparisonStrategy.assertNotEqual(info, 6d, -6d));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6d, -6d, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -47,13 +48,11 @@ public class Files_assertCanRead_Test extends FilesBaseTest {
   public void should_fail_if_can_not_read() {
     when(actual.canRead()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertCanRead(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeReadable(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertCanRead(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeReadable(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertCanWrite_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertCanWrite_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeWritable.shouldBeWritable;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -47,13 +48,11 @@ public class Files_assertCanWrite_Test extends FilesBaseTest {
   public void should_fail_if_can_not_write() {
     when(actual.canWrite()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertCanWrite(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeWritable(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertCanWrite(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeWritable(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertDoesNotExist_Test extends FilesBaseTest {
   public void should_fail_if_actual_exists() {
     when(actual.exists()).thenReturn(true);
     AssertionInfo info = someInfo();
-    try {
-      files.assertDoesNotExist(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotExist(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertDoesNotExist(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotExist(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertExists_Test extends FilesBaseTest {
   public void should_fail_if_actual_does_not_exist() {
     when(actual.exists()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertExists(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldExist(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertExists(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldExist(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,13 +68,11 @@ public class Files_assertHasBinaryContent_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_file() {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
-    try {
-      files.assertHasBinaryContent(info, notAFile, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFile(notAFile));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasBinaryContent(info, notAFile, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeFile(notAFile));
   }
 
   @Test
@@ -98,12 +97,10 @@ public class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     BinaryDiffResult diff = new BinaryDiffResult(15, (byte) 0xCA, (byte) 0xFE);
     when(binaryDiff.diff(actual, expected)).thenReturn(diff);
     AssertionInfo info = someInfo();
-    try {
-      files.assertHasBinaryContent(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveBinaryContent(actual, diff));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasBinaryContent(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveBinaryContent(actual, diff));
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,13 +74,11 @@ public class Files_assertHasContent_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_file() {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
-    try {
-      files.assertHasContent(info, notAFile, expected, charset);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFile(notAFile));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasContent(info, notAFile, expected, charset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeFile(notAFile));
   }
 
   @Test
@@ -103,12 +102,10 @@ public class Files_assertHasContent_Test extends FilesBaseTest {
     List<Delta<String>> diffs = Lists.newArrayList(delta);
     when(diff.diff(actual, expected, charset)).thenReturn(diffs);
     AssertionInfo info = someInfo();
-    try {
-      files.assertHasContent(info, actual, expected, charset);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveContent(actual, charset, diffs));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasContent(info, actual, expected, charset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveContent(actual, charset, diffs));
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasExtension_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasExtension_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveExtension.shouldHaveExtension;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,13 +55,11 @@ public class Files_assertHasExtension_Test extends FilesBaseTest {
   public void should_throw_error_if_actual_is_not_a_file() {
     AssertionInfo info = someInfo();
     when(actual.isFile()).thenReturn(false);
-    try {
-      files.assertHasExtension(info, actual, expectedExtension);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFile(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasExtension(info, actual, expectedExtension));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeFile(actual));
   }
 
   @Test
@@ -68,13 +67,11 @@ public class Files_assertHasExtension_Test extends FilesBaseTest {
     AssertionInfo info = someInfo();
     when(actual.isFile()).thenReturn(true);
     when(actual.getName()).thenReturn("file.png");
-    try {
-      files.assertHasExtension(info, actual, expectedExtension);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveExtension(actual, "png", expectedExtension));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasExtension(info, actual, expectedExtension));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveExtension(actual, "png", expectedExtension));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasName_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasName_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,13 +53,11 @@ public class Files_assertHasName_Test extends FilesBaseTest {
   public void should_throw_error_if_actual_does_not_have_the_expected_name() {
     AssertionInfo info = someInfo();
     when(actual.getName()).thenReturn("not.expected.name");
-    try {
-      files.assertHasName(info, actual, expectedName);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveName(actual, expectedName));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasName(info, actual, expectedName));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveName(actual, expectedName));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasNoParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasNoParent_Test.java
@@ -18,10 +18,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertHasNoParent_Test extends FilesBaseTest {
   public void should_fail_if_actual_has_parent() {
     AssertionInfo info = someInfo();
     when(actual.getParentFile()).thenReturn(mock(File.class));
-    try {
-      files.assertHasNoParent(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParent(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasNoParent(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParent(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
@@ -20,11 +20,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -58,26 +59,22 @@ public class Files_assertHasParent_Test extends FilesBaseTest {
   public void should_fail_if_actual_has_no_parent() {
     AssertionInfo info = someInfo();
     File withoutParent = new File("without-parent");
-    try {
-      files.assertHasParent(info, withoutParent, expectedParent);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParent(withoutParent, expectedParent));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasParent(info, withoutParent, expectedParent));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParent(withoutParent, expectedParent));
   }
 
   @Test
   public void should_fail_if_actual_does_not_have_the_expected_parent() {
     AssertionInfo info = someInfo();
     File expectedParent = new File("./expected-parent");
-    try {
-      files.assertHasParent(info, actual, expectedParent);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParent(actual, expectedParent));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertHasParent(info, actual, expectedParent));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParent(actual, expectedParent));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsAbsolute_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsAbsolute_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertIsAbsolute_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_absolute_path() {
     when(actual.isAbsolute()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertIsAbsolute(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAbsolutePath(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertIsAbsolute(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAbsolutePath(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectory_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectory_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertIsDirectory_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_directory() {
     when(actual.isDirectory()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertIsDirectory(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeDirectory(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertIsDirectory(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeDirectory(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsFile_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsFile_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertIsFile_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_file() {
     when(actual.isFile()).thenReturn(false);
     AssertionInfo info = someInfo();
-    try {
-      files.assertIsFile(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFile(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertIsFile(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeFile(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.files;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeRelativePath.shouldBeRelativePath;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -46,13 +47,11 @@ public class Files_assertIsRelative_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_relative_path() {
     when(actual.isAbsolute()).thenReturn(true);
     AssertionInfo info = someInfo();
-    try {
-      files.assertIsRelative(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeRelativePath(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertIsRelative(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeRelativePath(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -15,13 +15,14 @@ package org.assertj.core.internal.files;
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.Files.readAllBytes;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,13 +87,11 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
   public void should_fail_if_actual_is_not_file() {
     AssertionInfo info = someInfo();
     File notAFile = new File("xyz");
-    try {
-      files.assertSameContentAs(info, notAFile, defaultCharset(), expected, defaultCharset());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeFile(notAFile));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertSameContentAs(info, notAFile, defaultCharset(), expected, defaultCharset()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeFile(notAFile));
   }
 
   @Test
@@ -120,13 +119,11 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
     when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(diffs);
     when(binaryDiff.diff(actual, readAllBytes(expected.toPath()))).thenReturn(new BinaryDiffResult(1, -1, -1));
     AssertionInfo info = someInfo();
-    try {
-      files.assertSameContentAs(info, actual, defaultCharset(), expected, defaultCharset());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveSameContent(actual, expected, diffs));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> files.assertSameContentAs(info, actual, defaultCharset(), expected, defaultCharset()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveSameContent(actual, expected, diffs));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -78,29 +79,25 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     float[] expected = {6f, 8f, 20f};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20f), newArrayList(10f),
-          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20f), newArrayList(10f),
+        StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     float[] expected = {6f, 8f};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10f),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10f),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -108,15 +105,13 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1f, 2f, 3f);
     float[] expected = {1f, 2f};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3f),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3f),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -124,14 +119,12 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1f, 2f);
     float[] expected = {1f, 2f, 3f};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3f), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3f), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -172,29 +165,25 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = {6f, -8f, 20f};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20f), newArrayList(10f),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20f), newArrayList(10f),
+            absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = {6f, -8f};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10f), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10f), absValueComparisonStrategy));
   }
 
   @Test
@@ -202,15 +191,13 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1f, 2f, 3f);
     float[] expected = {1f, 2f};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3f),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3f),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -218,13 +205,11 @@ public class FloatArrays_assertContainsExactlyInAnyOrder_Test extends FloatArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1f, 2f);
     float[] expected = {1f, 2f, 3f};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3f), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3f), emptyList(), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6f, 10f, 8f));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6f, 10f, 8f)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1));
   }
 
   @Test
@@ -84,28 +83,24 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, 8f, 20f };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(20f), newArrayList(10f)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(20f), newArrayList(10f)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, 8f, 10f, 10f };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10f), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10f), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { -6f, 10f, 8f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -153,29 +146,25 @@ public class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, -8f, 20f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(20f), newArrayList(10f),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(20f), newArrayList(10f),
+                                                        absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, -8f, -10f, 10f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10f), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10f), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     float[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
-                                                            newLinkedHashSet((float) 6, (float) -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
+                                                          newLinkedHashSet((float) 6, (float) -8)));
   }
 
   @Test
@@ -93,15 +92,13 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     float[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
-                                                      newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
+                                                    newLinkedHashSet()));
   }
 
   @Test
@@ -119,17 +116,15 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     float[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-                               info,
-                               shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
-                                                      newLinkedHashSet((float) 6, (float) -8),
-                                                      absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+                             info,
+                             shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
+                                                    newLinkedHashSet((float) 6, (float) -8),
+                                                    absValueComparisonStrategy));
   }
 
   @Test
@@ -160,16 +155,14 @@ public class FloatArrays_assertContainsOnlyOnce_Test extends FloatArraysBaseTest
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-                               info,
-                               shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
-                                                      newLinkedHashSet(),
-                                                      absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+                             info,
+                             shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((float) 20),
+                                                    newLinkedHashSet(),
+                                                    absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -85,13 +86,11 @@ public class FloatArrays_assertContainsOnly_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, 8f, 20f };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20f), newArrayList(10f)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20f), newArrayList(10f)));
   }
 
   @Test
@@ -138,13 +137,11 @@ public class FloatArrays_assertContainsOnly_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, -8f, 20f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20f), newArrayList(10f),
-                                                       absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20f), newArrayList(10f),
+                                                     absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.FloatArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -68,39 +69,33 @@ public class FloatArrays_assertContainsSequence_Test extends FloatArraysBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 8f, 10f, 12f, 20f, 22f };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f, 22f };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
@@ -136,39 +131,33 @@ public class FloatArrays_assertContainsSequence_Test extends FloatArraysBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, -8f, 10f, 12f, 20f, 22f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f, 22f };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.floatarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 import static org.mockito.Mockito.verify;
@@ -69,13 +70,11 @@ public class FloatArrays_assertContains_at_Index_Test extends FloatArraysBaseTes
     float value = 6f;
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8f));
   }
 
   @Test
@@ -117,13 +116,11 @@ public class FloatArrays_assertContains_at_Index_Test extends FloatArraysBaseTes
     float value = 6f;
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8f, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -71,13 +72,11 @@ public class FloatArrays_assertDoesNotContain_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, 8f, 20f };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6f, 8f)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6f, 8f)));
   }
 
   @Test
@@ -116,13 +115,11 @@ public class FloatArrays_assertDoesNotContain_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] expected = { 6f, -8f, 20f };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6f, -8f),
-                                                      absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6f, -8f),
+                                                    absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -68,13 +69,11 @@ public class FloatArrays_assertDoesNotContain_at_Index_Test extends FloatArraysB
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 6f, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6f, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, 6f, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6f, index));
   }
 
   @Test
@@ -111,12 +110,10 @@ public class FloatArrays_assertDoesNotContain_at_Index_Test extends FloatArraysB
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6f, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6f, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6f, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6f, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.FloatArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -60,13 +61,11 @@ public class FloatArrays_assertDoesNotHaveDuplicates_Test extends FloatArraysBas
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6f, 8f, 6f, 8f);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6f, 8f)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6f, 8f)));
   }
 
   @Test
@@ -89,13 +88,11 @@ public class FloatArrays_assertDoesNotHaveDuplicates_Test extends FloatArraysBas
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6f, -8f, 6f, -8f);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldNotHaveDuplicates(actual, newLinkedHashSet(6f, -8f), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldNotHaveDuplicates(actual, newLinkedHashSet(6f, -8f), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -44,13 +45,11 @@ public class FloatArrays_assertEmpty_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     float[] actual = { 6f, 8f };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.FloatArrays.arrayOf;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,39 +70,33 @@ public class FloatArrays_assertEndsWith_Test extends FloatArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 8f, 10f, 12f, 20f, 22f };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     float[] sequence = { 20f, 22f };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f, 22f };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -136,39 +131,33 @@ public class FloatArrays_assertEndsWith_Test extends FloatArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, -8f, 10f, 12f, 20f, 22f };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 20f, 22f };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f, 22f };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -75,14 +76,12 @@ public class FloatArrays_assertIsSortedAccordingToComparator_Test extends FloatA
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new float[] { 3.0f, 2.0f, 1.0f, 9.0f };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, floatDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldBeSortedAccordingToGivenComparator(2, actual, floatDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, floatDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldBeSortedAccordingToGivenComparator(2, actual, floatDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.FloatArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -63,13 +64,11 @@ public class FloatArrays_assertIsSorted_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1.0f, 3.0f, 2.0f);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -98,14 +97,12 @@ public class FloatArrays_assertIsSorted_Test extends FloatArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1.0f, 3.0f, 2.0f);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(1, actual,
-                                                                              comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(1, actual,
+                                                                            comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.FloatArrays.*;
+import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -43,13 +45,11 @@ public class FloatArrays_assertNotEmpty_Test extends FloatArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.FloatArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 import static org.mockito.Mockito.verify;
 
@@ -36,13 +37,11 @@ public class FloatArrays_assertNullOrEmpty_Test extends FloatArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     float[] actual = { 6f, 8f };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.floatarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.FloatArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -66,41 +67,35 @@ public class FloatArrays_assertStartsWith_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual() {
+    AssertionInfo info = someInfo();
     float[] sequence = { 6f, 8f, 10f, 12f, 20f, 22f };
-    try {
-      AssertionInfo info = someInfo();
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     float[] sequence = { 8f, 10f };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -133,41 +128,35 @@ public class FloatArrays_assertStartsWith_Test extends FloatArraysBaseTest {
 
   @Test
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
+    AssertionInfo info = someInfo();
     float[] sequence = { 6f, -8f, 10f, 12f, 20f, 22f };
-    try {
-      AssertionInfo info = someInfo();
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { -8f, 10f };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     float[] sequence = { 6f, 20f };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +49,11 @@ public class Floats_assertEqual_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_floats_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertEqual(info, 6f, 8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6f, 8f, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertEqual(info, 6f, 8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6f, 8f, info.representation()));
   }
 
   @Test
@@ -71,13 +70,11 @@ public class Floats_assertEqual_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_floats_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertEqual(info, 6f, -8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6f, -8f, absValueComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertEqual(info, 6f, -8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6f, -8f, absValueComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Floats_assertGreaterThanOrEqualTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertGreaterThanOrEqualTo(info, 6f, 8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6f, 8f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertGreaterThanOrEqualTo(info, 6f, 8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6f, 8f));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Floats_assertGreaterThanOrEqualTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6f, -8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6f, -8f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6f, -8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6f, -8f, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,25 +48,21 @@ public class Floats_assertGreaterThan_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertGreaterThan(info, 6f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6f, 6f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertGreaterThan(info, 6f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6f, 6f));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertGreaterThan(info, 6f, 8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6f, 8f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertGreaterThan(info, 6f, 8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6f, 8f));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -80,25 +77,21 @@ public class Floats_assertGreaterThan_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6f, 6f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6f, 6f, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6f, 8f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6f, 8f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6f, 8f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6f, 8f, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsBetween_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -71,24 +72,20 @@ public class Floats_assertIsBetween_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseToPercentage_Test.java
@@ -15,14 +15,15 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -87,13 +88,11 @@ public class Floats_assertIsCloseToPercentage_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), TEN - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsCloseTo_Test.java
@@ -15,15 +15,16 @@ package org.assertj.core.internal.floats;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.data.Offset.offset;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.internal.ErrorMessages.offsetIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -94,37 +95,31 @@ public class Floats_assertIsCloseTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsCloseTo(info, ONE, TEN, within(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsCloseTo(info, ONE, TEN, within(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, within(ONE), TEN - ONE));
   }
 
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_with_a_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsCloseTo(info, ONE, TEN, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(ONE, TEN, byLessThan(ONE), TEN - ONE));
   }
 
   @Test
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsCloseTo(info, TWO, ONE, byLessThan(ONE)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(TWO, ONE, byLessThan(ONE), TWO - ONE));
   }
 
   @Test
@@ -180,25 +175,21 @@ public class Floats_assertIsCloseTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Float(6f), new Float(8f), offset(1f));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6f, 8f, offset(1f), 2f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Float(6f), new Float(8f), offset(1f)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6f, 8f, offset(1f), 2f));
   }
 
   @Test
   public void should_fail_if_actual_is_not_strictly_close_enough_to_expected_value_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Float(6f), new Float(8f), byLessThan(1f));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6f, 8f, byLessThan(1f), 2f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertIsCloseTo(info, new Float(6f), new Float(8f), byLessThan(1f)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6f, 8f, byLessThan(1f), 2f));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseToPercentage_Test.java
@@ -16,14 +16,15 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -83,27 +84,23 @@ public class Floats_assertIsNotCloseToPercentage_Test extends FloatsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(Float actual, Float other, Float percentage) {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
-                                                                      abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+                                                                    abs(actual - other)));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
-                                                                      TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
+                                                                    TEN - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsNotCloseTo_Test.java
@@ -16,13 +16,14 @@ import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -102,37 +103,31 @@ public class Floats_assertIsNotCloseTo_Test extends FloatsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(Float actual, Float other, Float offset) {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
   }
   
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsNotCloseTo(info, ONE, TWO, within(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, within(TEN), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsNotCloseTo(info, ONE, TWO, within(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, within(TEN), TWO - ONE));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value_with_strict_offset() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsNotCloseTo(info, ONE, TWO, byLessThan(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, byLessThan(TEN), TWO - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsNotCloseTo(info, ONE, TWO, byLessThan(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(ONE, TWO, byLessThan(TEN), TWO - ONE));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsStrictlyBetween_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,37 +64,31 @@ public class Floats_assertIsStrictlyBetween_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        floats.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        floats.assertIsStrictlyBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertIsStrictlyBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Floats_assertLessThanOrEqualTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertLessThanOrEqualTo(info, 8f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(8f, 6f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertLessThanOrEqualTo(info, 8f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(8f, 6f));
   }
 
   @Test
@@ -80,12 +79,10 @@ public class Floats_assertLessThanOrEqualTo_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(-8f, 6f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(-8f, 6f, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,25 +48,21 @@ public class Floats_assertLessThan_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertLessThan(info, 6f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6f, 6f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertLessThan(info, 6f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6f, 6f));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertLessThan(info, 8f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8f, 6f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertLessThan(info, 8f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8f, 6f));
   }
 
   @Test
@@ -82,24 +79,20 @@ public class Floats_assertLessThan_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertLessThan(info, 6f, -6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6f, -6f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertLessThan(info, 6f, -6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6f, -6f, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertLessThan(info, -8f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(-8f, 6f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertLessThan(info, -8f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(-8f, 6f, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.floats;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -47,13 +48,11 @@ public class Floats_assertNotEqual_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_floats_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      floats.assertNotEqual(info, 6f, 6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6f, 6f));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floats.assertNotEqual(info, 6f, 6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6f, 6f));
   }
 
   @Test
@@ -70,12 +69,10 @@ public class Floats_assertNotEqual_Test extends FloatsBaseTest {
   @Test
   public void should_fail_if_floats_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      floatsWithAbsValueComparisonStrategy.assertNotEqual(info, 6f, -6f);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6f, -6f, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> floatsWithAbsValueComparisonStrategy.assertNotEqual(info, 6f, -6f));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6f, -6f, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.inputstreams;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
@@ -77,12 +78,10 @@ public class InputStreams_assertSameContentAs_Test extends InputStreamsBaseTest 
     List<Delta<String>> diffs = newArrayList((Delta<String>) mock(Delta.class));
     when(diff.diff(actual, expected)).thenReturn(diffs);
     AssertionInfo info = someInfo();
-    try {
-      inputStreams.assertSameContentAs(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveSameContent(actual, expected, diffs));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> inputStreams.assertSameContentAs(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveSameContent(actual, expected, diffs));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -84,29 +85,25 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     int[] expected = {6, 8, 20};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20), newArrayList(10),
-          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20), newArrayList(10),
+        StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     int[] expected = {6, 8};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -114,15 +111,13 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2, 3);
     int[] expected = {1, 2};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -130,14 +125,12 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2);
     int[] expected = {1, 2, 3};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -178,29 +171,25 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = {6, -8, 20};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20), newArrayList(10),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20), newArrayList(10),
+            absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = {6, 8};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10), absValueComparisonStrategy));
   }
 
   @Test
@@ -208,15 +197,13 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2, 3);
     int[] expected = {1, 2};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -224,14 +211,12 @@ public class IntArrays_assertContainsExactlyInAnyOrder_Test extends IntArraysBas
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2);
     int[] expected = {1, 2, 3};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3), emptyList(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -55,13 +56,11 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1));
   }
 
   @Test
@@ -90,28 +89,24 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(20), newArrayList(10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(20), newArrayList(10)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 10, 10 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -127,13 +122,11 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { -6, 10, 8 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -159,30 +152,26 @@ public class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList(20), newArrayList(10),
-                                                    absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList(20), newArrayList(10),
+                                                  absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 10, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     int[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(6, -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(6, -8)));
   }
 
   @Test
@@ -93,14 +92,12 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet()));
   }
 
   @Test
@@ -118,16 +115,14 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     int[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(6, -8),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(6, -8),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -158,15 +153,13 @@ public class IntArrays_assertContainsOnlyOnce_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20), newLinkedHashSet(),
+            absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -86,13 +87,11 @@ public class IntArrays_assertContainsOnly_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20), newArrayList(10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20), newArrayList(10)));
   }
 
   @Test
@@ -139,14 +138,12 @@ public class IntArrays_assertContainsOnly_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList(20), newArrayList(10),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList(20), newArrayList(10),
+                                               absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.IntArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class IntArrays_assertContainsSequence_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class IntArrays_assertContainsSequence_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.intarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 
@@ -70,13 +71,11 @@ public class IntArrays_assertContains_at_Index_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, 6, index, 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, 6, index, 8));
   }
 
   @Test
@@ -117,13 +116,11 @@ public class IntArrays_assertContains_at_Index_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, 6, index, 8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, 6, index, 8, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -72,13 +73,11 @@ public class IntArrays_assertDoesNotContain_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6, 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6, 8)));
   }
 
   @Test
@@ -117,12 +116,10 @@ public class IntArrays_assertDoesNotContain_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6, -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6, -8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,13 +70,11 @@ public class IntArrays_assertDoesNotContain_at_Index_Test extends IntArraysBaseT
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6, index));
   }
 
   @Test
@@ -111,12 +110,10 @@ public class IntArrays_assertDoesNotContain_at_Index_Test extends IntArraysBaseT
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.IntArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -62,13 +63,11 @@ public class IntArrays_assertDoesNotHaveDuplicates_Test extends IntArraysBaseTes
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 6, 8);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6, 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6, 8)));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class IntArrays_assertDoesNotHaveDuplicates_Test extends IntArraysBaseTes
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 6, 8);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6, 8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6, 8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class IntArrays_assertEmpty_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     int[] actual = { 6, 8 };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.IntArrays.arrayOf;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,39 +71,33 @@ public class IntArrays_assertEndsWith_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     int[] sequence = { 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -138,39 +133,33 @@ public class IntArrays_assertEndsWith_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class IntArrays_assertIsSortedAccordingToComparator_Test extends IntArray
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new int[] { 3, 2, 1, 9 };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, intDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, intDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, intDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, intDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.IntArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,13 +66,11 @@ public class IntArrays_assertIsSorted_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -100,14 +99,12 @@ public class IntArrays_assertIsSorted_Test extends IntArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.IntArrays.*;
+import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +47,11 @@ public class IntArrays_assertNotEmpty_Test extends IntArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.IntArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class IntArrays_assertNullOrEmpty_Test extends IntArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     int[] actual = { 6, 8 };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.intarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.IntArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class IntArrays_assertStartsWith_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     int[] sequence = { 8, 10 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, int[] sequence) {
@@ -141,39 +136,33 @@ public class IntArrays_assertStartsWith_Test extends IntArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { -8, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     int[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Integers_assertEqual_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_integers_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertEqual(info, 6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6, 8, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertEqual(info, 6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6, 8, info.representation()));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Integers_assertEqual_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_integers_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertEqual(info, 6, -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6, -8, absValueComparisonStrategy, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertEqual(info, 6, -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6, -8, absValueComparisonStrategy, info.representation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Integers_assertGreaterThanOrEqualTo_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertGreaterThanOrEqualTo(info, 6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6, 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertGreaterThanOrEqualTo(info, 6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6, 8));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Integers_assertGreaterThanOrEqualTo_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6, -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6, -8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6, -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6, -8, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -48,25 +49,21 @@ public class Integers_assertGreaterThan_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertGreaterThan(info, 6, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6, 6, StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertGreaterThan(info, 6, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6, 6, StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertGreaterThan(info, 6, 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6, 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertGreaterThan(info, 6, 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6, 8));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -81,25 +78,21 @@ public class Integers_assertGreaterThan_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertGreaterThan(info, 6, -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6, -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertGreaterThan(info, 6, -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6, -6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertGreaterThan(info, -6, -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6, -8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertGreaterThan(info, -6, -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6, -8, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsBetween_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -72,24 +73,20 @@ public class Integers_assertIsBetween_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseToPercentage_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -84,13 +85,11 @@ public class Integers_assertIsCloseToPercentage_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
-                                                                   (TEN - ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                 (TEN - ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.integers;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,13 +70,11 @@ public class Integers_assertIsCloseTo_Test extends IntegersBaseTest {
   })
   public void should_fail_if_actual_is_not_close_enough_to_expected(int actual, int expected, int offset) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsCloseTo(info, actual, expected, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsCloseTo(info, actual, expected, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), abs(actual - expected)));
   }
 
   @ParameterizedTest
@@ -88,13 +87,11 @@ public class Integers_assertIsCloseTo_Test extends IntegersBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset(int actual, int expected, int offset) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsCloseTo(info, actual, expected, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsCloseTo(info, actual, expected, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), abs(actual - expected)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseToPercentage_Test.java
@@ -19,14 +19,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -82,26 +83,22 @@ public class Integers_assertIsNotCloseToPercentage_Test extends IntegersBaseTest
   public void should_fail_if_difference_is_equal_to_given_percentage(Integer actual, Integer other,
                                                                      Integer percentage) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
-                                                                      abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+                                                                    abs(actual - other)));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
-        TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
+      TEN - ONE));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsNotCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.integers;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,13 +68,11 @@ public class Integers_assertIsNotCloseTo_Test extends IntegersBaseTest {
   })
   public void should_fail_if_actual_is_too_close_to_the_other_value(int actual, int other, int offset) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -85,13 +84,11 @@ public class Integers_assertIsNotCloseTo_Test extends IntegersBaseTest {
   public void should_fail_if_actual_is_too_close_to_the_other_value_with_strict_offset(int actual, int other,
                                                                                        int offset) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsNotCloseTo(info, actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsNotCloseTo(info, actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -102,13 +99,11 @@ public class Integers_assertIsNotCloseTo_Test extends IntegersBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(int actual, int other, int offset) {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertIsStrictlyBetween_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,37 +66,31 @@ public class Integers_assertIsStrictlyBetween_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        integers.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        integers.assertIsStrictlyBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertIsStrictlyBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Integers_assertLessThanOrEqualTo_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertLessThanOrEqualTo(info, 8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(8, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertLessThanOrEqualTo(info, 8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(8, 6));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Integers_assertLessThanOrEqualTo_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(-8, 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(-8, 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -48,25 +49,21 @@ public class Integers_assertLessThan_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertLessThan(info, 6, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertLessThan(info, 6, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6, 6));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertLessThan(info, 8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertLessThan(info, 8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8, 6));
   }
 
   @Test
@@ -83,24 +80,20 @@ public class Integers_assertLessThan_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertLessThan(info, 6, -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6, -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertLessThan(info, 6, -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6, -6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertLessThan(info, -8, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(-8, 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertLessThan(info, -8, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(-8, 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/integers/Integers_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/integers/Integers_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.integers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Integers_assertNotEqual_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_integers_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      integers.assertNotEqual(info, 6, 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6, 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integers.assertNotEqual(info, 6, 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6, 6));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Integers_assertNotEqual_Test extends IntegersBaseTest {
   @Test
   public void should_fail_if_integers_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      integersWithAbsValueComparisonStrategy.assertNotEqual(info, 6, -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6, -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> integersWithAbsValueComparisonStrategy.assertNotEqual(info, 6, -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6, -6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllMatch_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllMatch_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -45,40 +46,33 @@ public class Iterables_assertAllMatch_Test extends IterablesBaseTest {
   public void should_fail_if_predicate_is_not_met() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<? super String> predicate = s -> s.startsWith("L");
-    try {
-      iterables.assertAllMatch(info, actual, predicate, PredicateDescription.GIVEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldMatch(actual, "Yoda", PredicateDescription.GIVEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertAllMatch(info, actual, predicate, PredicateDescription.GIVEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldMatch(actual, "Yoda", PredicateDescription.GIVEN));
   }
 
   @Test
   public void should_fail_with_custom_description_if_predicate_is_not_met() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<? super String> predicate = s -> s.startsWith("L");
-    try {
-      iterables.assertAllMatch(info, actual, predicate, new PredicateDescription("custom"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldMatch(actual, "Yoda", new PredicateDescription("custom")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertAllMatch(info, actual, predicate, new PredicateDescription("custom")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldMatch(actual, "Yoda", new PredicateDescription("custom")));
   }
 
   @Test
   public void should_report_all_items_that_do_not_match() {
     List<String> actual = newArrayList("123", "1234", "12345");
 
-    try {
-      iterables.assertAllMatch(someInfo(), actual, s -> s.length() <= 3, PredicateDescription.GIVEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               elementsShouldMatch(actual, newArrayList("1234", "12345"), PredicateDescription.GIVEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> iterables.assertAllMatch(someInfo(), actual, s -> s.length() <= 3, PredicateDescription.GIVEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             elementsShouldMatch(actual, newArrayList("1234", "12345"), PredicateDescription.GIVEN));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnyMatch_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnyMatch_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.AnyElementShouldMatch.anyElementShouldMatch;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -40,26 +41,22 @@ public class Iterables_assertAnyMatch_Test extends IterablesBaseTest {
   public void should_fail_if_predicate_is_not_met_by_any_elements() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<String> startsWithM = s -> s.startsWith("M");
-    try {
-      iterables.assertAnyMatch(info, actual, startsWithM, PredicateDescription.GIVEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, anyElementShouldMatch(actual, PredicateDescription.GIVEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertAnyMatch(info, actual, startsWithM, PredicateDescription.GIVEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, anyElementShouldMatch(actual, PredicateDescription.GIVEN));
   }
 
   @Test
   public void should_fail_with_custom_description_if_predicate_is_met_by_no_element() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<String> startsWithM = s -> s.startsWith("M");
-    try {
-      iterables.assertAnyMatch(info, actual, startsWithM, new PredicateDescription("custom"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, anyElementShouldMatch(actual, new PredicateDescription("custom")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertAnyMatch(info, actual, startsWithM, new PredicateDescription("custom")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, anyElementShouldMatch(actual, new PredicateDescription("custom")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnySatisfy_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnySatisfy_Test.java
@@ -15,10 +15,10 @@ package org.assertj.core.internal.iterables;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfyAny;
 import static org.assertj.core.error.ElementsShouldSatisfy.unsatisfiedRequirement;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
@@ -78,48 +78,43 @@ public class Iterables_assertAnySatisfy_Test extends IterablesBaseTest {
 
   @Test
   public void should_fail_if_no_elements_satisfy_the_assertions_requirements() {
-    try {
-      iterables.<String> assertAnySatisfy(someInfo(), actual, s -> {
-        assertThat(s).hasSize(4);
-        assertThat(s).contains("W");
-      });
-    } catch (AssertionError e) {
-      List<ElementsShouldSatisfy.UnsatisfiedRequirement> errors = list(unsatisfiedRequirement("Luke", format("%n" +
-                                                                                                             "Expecting:%n" +
-                                                                                                             " <\"Luke\">%n" +
-                                                                                                             "to contain:%n" +
-                                                                                                             " <\"W\"> ")),
-                                                                       unsatisfiedRequirement("Leia", format("%n" +
-                                                                                                             "Expecting:%n" +
-                                                                                                             " <\"Leia\">%n" +
-                                                                                                             "to contain:%n" +
-                                                                                                             " <\"W\"> ")),
-                                                                       unsatisfiedRequirement("Yoda", format("%n" +
-                                                                                                             "Expecting:%n" +
-                                                                                                             " <\"Yoda\">%n" +
-                                                                                                             "to contain:%n" +
-                                                                                                             " <\"W\"> ")),
-                                                                       unsatisfiedRequirement("Obiwan", format("%n" +
-                                                                                                               "Expected size:<4> but was:<6> in:%n"
-                                                                                                               +
-                                                                                                               "<\"Obiwan\">")));
+    Throwable error = catchThrowable(() -> iterables.<String> assertAnySatisfy(someInfo(), actual, s -> {
+      assertThat(s).hasSize(4);
+      assertThat(s).contains("W");
+    }));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    List<ElementsShouldSatisfy.UnsatisfiedRequirement> errors = list(unsatisfiedRequirement("Luke", format("%n" +
+                                                                                                           "Expecting:%n" +
+                                                                                                           " <\"Luke\">%n" +
+                                                                                                           "to contain:%n" +
+                                                                                                           " <\"W\"> ")),
+                                                                     unsatisfiedRequirement("Leia", format("%n" +
+                                                                                                           "Expecting:%n" +
+                                                                                                           " <\"Leia\">%n" +
+                                                                                                           "to contain:%n" +
+                                                                                                           " <\"W\"> ")),
+                                                                     unsatisfiedRequirement("Yoda", format("%n" +
+                                                                                                           "Expecting:%n" +
+                                                                                                           " <\"Yoda\">%n" +
+                                                                                                           "to contain:%n" +
+                                                                                                           " <\"W\"> ")),
+                                                                     unsatisfiedRequirement("Obiwan", format("%n" +
+                                                                                                             "Expected size:<4> but was:<6> in:%n"
+                                                                                                             +
+                                                                                                             "<\"Obiwan\">")));
       verify(failures).failure(info, elementsShouldSatisfyAny(actual, errors, someInfo()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   @Test
   public void should_fail_if_the_iterable_under_test_is_empty_whatever_the_assertions_requirements_are() {
     actual.clear();
-    try {
-      iterables.<String> assertAnySatisfy(someInfo(), actual, $ -> assertThat(true).isTrue());
-    } catch (AssertionError e) {
-      List<ElementsShouldSatisfy.UnsatisfiedRequirement> errors = emptyList();
-      verify(failures).failure(info, elementsShouldSatisfyAny(actual, errors, someInfo()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.<String> assertAnySatisfy(someInfo(), actual, $ -> assertThat(true).isTrue()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    List<ElementsShouldSatisfy.UnsatisfiedRequirement> errors = emptyList();
+    verify(failures).failure(info, elementsShouldSatisfyAny(actual, errors, someInfo()));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreAtLeast_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreAtLeast_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeAtLeast.elementsShouldBeAtLeast;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class Iterables_assertAreAtLeast_Test extends IterablesWithConditionsBase
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Solo", "Leia");
-      iterables.assertAreAtLeast(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeAtLeast(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertAreAtLeast(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeAtLeast(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreAtMost_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreAtMost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeAtMost.elementsShouldBeAtMost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -61,15 +62,13 @@ public class Iterables_assertAreAtMost_Test extends IterablesWithConditionsBaseT
   public void should_fail_if_condition_is_not_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Obiwan");
-      iterables.assertAreAtMost(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeAtMost(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> iterables.assertAreAtMost(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeAtMost(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreExactly_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeExactly.elementsShouldBeExactly;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -55,30 +56,26 @@ public class Iterables_assertAreExactly_Test extends IterablesWithConditionsBase
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Solo", "Leia");
-      iterables.assertAreExactly(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertAreExactly(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
   }
 
   @Test
   public void should_fail_if_condition_is_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Obiwan");
-      iterables.assertAreExactly(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> iterables.assertAreExactly(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreNot_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAreNot_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldNotBe.elementsShouldNotBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -54,15 +55,13 @@ public class Iterables_assertAreNot_Test extends IterablesWithConditionsBaseTest
   public void should_fail_if_condition_is_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Solo", "Leia", "Yoda");
-      iterables.assertAreNot(someInfo(), actual, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldNotBe(actual, newArrayList("Yoda"), jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Solo", "Leia", "Yoda");
+
+    Throwable error = catchThrowable(() -> iterables.assertAreNot(someInfo(), actual, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldNotBe(actual, newArrayList("Yoda"), jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAre_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAre_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -54,15 +55,13 @@ public class Iterables_assertAre_Test extends IterablesWithConditionsBaseTest {
   public void should_fail_if_condition_is_not_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Leia");
-      iterables.assertAre(someInfo(), actual, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBe(actual, newArrayList("Leia"), jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertAre(someInfo(), actual, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBe(actual, newArrayList("Leia"), jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAll_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAll_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -71,13 +72,11 @@ public class Iterables_assertContainsAll_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_values() {
     AssertionInfo info = someInfo();
     List<String> expected = newArrayList("Han", "Luke");
-    try {
-      iterables.assertContainsAll(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsAll(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -114,13 +113,11 @@ public class Iterables_assertContainsAll_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     List<String> expected = newArrayList("Han", "LUKE");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsAll(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsAll(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han"), comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.Name.name;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -105,13 +106,11 @@ public class Iterables_assertContainsAnyOf_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_any_of_the_given_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "John" };
-    try {
-      iterables.assertContainsAnyOf(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAnyOf(actual, expected));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsAnyOf(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAnyOf(actual, expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -155,13 +154,11 @@ public class Iterables_assertContainsAnyOf_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "John" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsAnyOf(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAnyOf(actual, expected, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsAnyOf(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAnyOf(actual, expected, comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactlyInAnyOrder_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -78,14 +79,12 @@ public class Iterables_assertContainsExactlyInAnyOrder_Test extends IterablesBas
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterables.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -100,29 +99,24 @@ public class Iterables_assertContainsExactlyInAnyOrder_Test extends IterablesBas
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
     Object[] expected = { "Luke", "Leia" };
-    try {
-      iterables.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
-  }
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), StandardComparisonStrategy.instance())); }
 
   @Test
   public void should_fail_if_expected_contains_duplicates_and_actual_does_not() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia");
     Object[] expected = { "Luke", "Leia", "Luke"};
-    try {
-      iterables.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -139,14 +133,12 @@ public class Iterables_assertContainsExactlyInAnyOrder_Test extends IterablesBas
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"),
-          newArrayList("Leia"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"),
+        newArrayList("Leia"), comparisonStrategy));
   }
 
   @Test
@@ -161,13 +153,11 @@ public class Iterables_assertContainsExactlyInAnyOrder_Test extends IterablesBas
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
     Object[] expected = { "LUKE", "Leia" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -80,28 +81,24 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterables.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      List<String> notFound = newArrayList("Han");
-      List<String> notExpected = newArrayList("Leia");
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected), notFound, notExpected));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    List<String> notFound = newArrayList("Han");
+    List<String> notExpected = newArrayList("Leia");
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected), notFound, notExpected));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Leia", "Yoda" };
-    try {
-      iterables.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
   }
 
   @Test
@@ -109,14 +106,12 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
     Object[] expected = { "Luke", "Leia" };
-    try {
-      iterables.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(), newArrayList("Luke")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(), newArrayList("Luke")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -133,28 +128,24 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList("Han"), newArrayList("Leia"),
-                                                          comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList("Han"), newArrayList("Leia"),
+                                                        comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Leia", "Yoda" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, comparisonStrategy));
   }
 
   @Test
@@ -162,15 +153,13 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
     Object[] expected = { "LUKE", "Leia" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(), newArrayList("Luke"),
-                                                          comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(), newArrayList("Luke"),
+                                                        comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsNull_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -65,13 +66,11 @@ public class Iterables_assertContainsNull_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_null() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda");
-    try {
-      iterables.assertContainsNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainNull(actual));
   }
 
   @Test
@@ -101,12 +100,10 @@ public class Iterables_assertContainsNull_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_null_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainNull(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyNulls_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyNulls_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnlyNulls.shouldContainOnlyNulls;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -58,13 +59,11 @@ public class Iterables_assertContainsOnlyNulls_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      iterables.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual));
   }
 
   @Test
@@ -72,13 +71,11 @@ public class Iterables_assertContainsOnlyNulls_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual = newArrayList(null, null, "person");
     List<String> nonNulls = newArrayList("person");
-    try {
-      iterables.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
   }
 
   @Test
@@ -86,12 +83,10 @@ public class Iterables_assertContainsOnlyNulls_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual = newArrayList("person", "person2");
     List<String> nonNulls = newArrayList("person", "person2");
-    try {
-      iterables.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -70,14 +71,12 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual.addAll(newArrayList("Luke", "Luke", null, null));
     Object[] expected = { "Luke", "Luke", "Yoda", "Han", null };
-    try {
-      iterables.assertContainsOnlyOnce(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet("Luke", null)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyOnce(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet("Luke", null)));
   }
 
   @Test
@@ -85,14 +84,12 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual.addAll(newArrayList("Luke", "Luke"));
     Object[] expected = { null };
-    try {
-      iterables.assertContainsOnlyOnce(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(array((String) null)), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyOnce(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(array((String) null)), newLinkedHashSet()));
   }
 
   @Test
@@ -127,14 +124,12 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_once() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterables.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -158,15 +153,12 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual.addAll(newArrayList("Luke", "Luke"));
     Object[] expected = array("luke", "YOda", "LeIA");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(), newLinkedHashSet("luke"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
 
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(), newLinkedHashSet("luke"), comparisonStrategy));
   }
 
   @Test
@@ -174,29 +166,25 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
     AssertionInfo info = someInfo();
     actual.addAll(newArrayList("LUKE"));
     Object[] expected = array("LUke", "LUke", "lukE", "YOda", "Leia", "Han");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet("LUke", "lukE"),
-              comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet("LUke", "lukE"),
+            comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet(), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet(), comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -95,42 +96,36 @@ public class Iterables_assertContainsOnly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_all_given_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterables.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia")));
   }
 
   @Test
   public void should_fail_if_actual_contains_additional_elements() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda" };
-    try {
-      iterables.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList(), newArrayList("Leia")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList(), newArrayList("Leia")));
   }
 
   @Test
   public void should_fail_if_actual_contains_a_subset_of_expected_elements() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Obiwan", "Leia" };
-    try {
-      iterables.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList("Obiwan"), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList("Obiwan"), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -167,14 +162,12 @@ public class Iterables_assertContainsOnly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia"),
-                                                       comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia"),
+                                                     comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -77,39 +78,33 @@ public class Iterables_assertContainsSequence_Test extends IterablesBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterables.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterables.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_but_not_whole_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia", "Han" };
-    try {
-      iterables.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -146,26 +141,22 @@ public class Iterables_assertContainsSequence_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_but_not_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, comparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -75,39 +76,33 @@ public class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest 
   public void should_fail_if_subsequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterables.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_subsequence() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Han", "C-3PO" };
-    try {
-      iterables.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_subsequence_but_not_whole_subsequence() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Luke", "Leia", "Han" };
-    try {
-      iterables.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   private void verifyFailureThrownWhenSubsequenceNotFound(AssertionInfo info, Object[] subsequence) {
@@ -151,26 +146,22 @@ public class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest 
   public void should_fail_if_actual_does_not_contain_whole_subsequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Han", "C-3PO" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_subsequence_but_not_whole_subsequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Luke", "Leia", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -93,13 +94,11 @@ public class Iterables_assertContains_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "Luke" };
-    try {
-      iterables.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("Han")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertContains(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("Han")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -136,13 +135,11 @@ public class Iterables_assertContains_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Han", "Luke" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("Han"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContains(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet("Han"), comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoNotHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoNotHave_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldNotHave.elementsShouldNotHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -54,15 +55,13 @@ public class Iterables_assertDoNotHave_Test extends IterablesWithConditionsBaseT
   public void should_fail_if_condition_is_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Solo", "Leia", "Yoda");
-      iterables.assertDoNotHave(someInfo(), actual, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Solo", "Leia", "Yoda");
+
+    Throwable error = catchThrowable(() -> iterables.assertDoNotHave(someInfo(), actual, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainAnyElementsOf_Test.java
@@ -13,9 +13,11 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsNull;
@@ -77,13 +79,11 @@ public class Iterables_assertDoesNotContainAnyElementsOf_Test extends IterablesB
   public void should_fail_if_actual_contains_one_element_of_given_iterable() {
     AssertionInfo info = someInfo();
     List<String> list = newArrayList("Vador", "Yoda", "Han");
-    try {
-      iterables.assertDoesNotContainAnyElementsOf(info, actual, list);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, list.toArray(), newLinkedHashSet("Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainAnyElementsOf(info, actual, list));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, list.toArray(), newLinkedHashSet("Yoda")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -106,14 +106,12 @@ public class Iterables_assertDoesNotContainAnyElementsOf_Test extends IterablesB
   public void should_fail_if_actual_contains_one_element_of_given_iterable_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     List<String> expected = newArrayList("LuKe", "YODA", "Han");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainAnyElementsOf(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotContain(actual, expected.toArray(), newLinkedHashSet("LuKe", "YODA"), comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainAnyElementsOf(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotContain(actual, expected.toArray(), newLinkedHashSet("LuKe", "YODA"), comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainAnyElementsOf_Test.java
@@ -22,7 +22,6 @@ import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainNull_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -59,13 +60,11 @@ public class Iterables_assertDoesNotContainNull_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_null() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda", null);
-    try {
-      iterables.assertDoesNotContainNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainNull(actual));
   }
 
   @Test
@@ -89,12 +88,10 @@ public class Iterables_assertDoesNotContainNull_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_null_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda", null);
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainNull(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainSequence_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainSequence.shouldNotContainSequence;
 import static org.assertj.core.internal.ErrorMessages.emptySequence;
 import static org.assertj.core.internal.ErrorMessages.nullSequence;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -92,26 +93,22 @@ public class Iterables_assertDoesNotContainSequence_Test extends IterablesBaseTe
   public void should_fail_if_actual_contains_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia" };
-    try {
-      iterables.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence, 1);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence, 1);
   }
 
   @Test
   public void should_fail_if_actual_and_sequence_are_equal() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan" };
-    try {
-      iterables.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence, 0);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence, 0);
   }
 
   @Test
@@ -119,13 +116,11 @@ public class Iterables_assertDoesNotContainSequence_Test extends IterablesBaseTe
     AssertionInfo info = someInfo();
     actual = newArrayList("Yoda", "Luke", "Yoda", "Obi-Wan");
     Object[] sequence = { "Yoda", "Obi-Wan" };
-    try {
-      iterables.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence, 2);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence, 2);
   }
 
   @Test
@@ -133,13 +128,11 @@ public class Iterables_assertDoesNotContainSequence_Test extends IterablesBaseTe
     AssertionInfo info = someInfo();
     actual = newArrayList("a", "-", "b", "-", "c");
     Object[] sequence = { "a", "-", "b", "-", "c" };
-    try {
-      iterables.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence, 0);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence, 0);
   }
   
   // ------------------------------------------------------------------------------------------------------------------
@@ -164,26 +157,22 @@ public class Iterables_assertDoesNotContainSequence_Test extends IterablesBaseTe
   public void should_fail_if_actual_contains_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LUKe", "leia" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1, comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_and_sequence_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "YODA", "luke", "lEIA", "Obi-wan" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0, comparisonStrategy));
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence, int index) {

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContainSubsequence_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainSubsequence.shouldNotContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.emptySubsequence;
 import static org.assertj.core.internal.ErrorMessages.nullSubsequence;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -139,14 +140,12 @@ public class Iterables_assertDoesNotContainSubsequence_Test extends IterablesBas
 
   private void expectFailure(Iterables iterables, Iterable<String> sequence, Object[] subsequence, int index) {
     AssertionInfo info = someInfo();
-    try {
-      iterables.assertDoesNotContainSubsequence(info, sequence, subsequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSubsequence(actual, subsequence, iterables.getComparisonStrategy(),
-                                                                 index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContainSubsequence(info, sequence, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSubsequence(actual, subsequence, iterables.getComparisonStrategy(),
+                                                               index));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotContain_Test.java
@@ -13,15 +13,16 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -79,13 +80,11 @@ public class Iterables_assertDoesNotContain_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      iterables.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("Luke", "Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("Luke", "Yoda")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -107,14 +106,12 @@ public class Iterables_assertDoesNotContain_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "LuKe", "YODA", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("LuKe", "YODA"),
-                                                      comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("LuKe", "YODA"),
+                                                    comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertDoesNotHaveDuplicates_Test.java
@@ -16,9 +16,9 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -67,13 +67,11 @@ public class Iterables_assertDoesNotHaveDuplicates_Test extends IterablesBaseTes
     AssertionInfo info = someInfo();
     Collection<String> duplicates = newLinkedHashSet("Luke", "Yoda");
     actual.addAll(duplicates);
-    try {
-      iterables.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates));
   }
 
   @Test
@@ -94,14 +92,11 @@ public class Iterables_assertDoesNotHaveDuplicates_Test extends IterablesBaseTes
     // duplicates is commented, because mockito is not smart enough to compare arrays contents 
     // Collection<String[]> duplicates = newLinkedHashSet();
     // duplicates.add(array("Luke", "Yoda"));
-    try {
-      iterables.assertDoesNotHaveDuplicates(someInfo(), actual);
-    } catch (AssertionError e) {
-      // can't use verify since mockito not smart enough to compare arrays contents
-      // verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> iterables.assertDoesNotHaveDuplicates(someInfo(), actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    // can't use verify since mockito not smart enough to compare arrays contents
+    // verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -118,13 +113,11 @@ public class Iterables_assertDoesNotHaveDuplicates_Test extends IterablesBaseTes
     AssertionInfo info = someInfo();
     Collection<String> duplicates = newLinkedHashSet("LUKE", "yoda");
     actual.addAll(duplicates);
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, duplicates, comparisonStrategy));
   }
   
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEmpty_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -52,13 +53,11 @@ public class Iterables_assertEmpty_Test extends IterablesBaseTest {
   public void should_fail_if_actual_has_elements() {
     AssertionInfo info = someInfo();
     Collection<String> actual = newArrayList("Yoda");
-    try {
-      iterables.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test
@@ -76,12 +75,10 @@ public class Iterables_assertEmpty_Test extends IterablesBaseTest {
   public void should_fail_if_actual_has_elements_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Collection<String> actual = newArrayList("Yoda");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWithFirstAndRest_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWithFirstAndRest_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -55,39 +56,33 @@ public class Iterables_assertEndsWithFirstAndRest_Test extends IterablesBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterables.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterables.assertEndsWith(info, actual, "Obi-Wan", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Obi-Wan", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, "Obi-Wan", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Obi-Wan", sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      iterables.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object first, Object[] sequence) {
@@ -108,42 +103,36 @@ public class Iterables_assertEndsWithFirstAndRest_Test extends IterablesBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LUKE", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
-                                                   comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
+                                                 comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
-                                                   comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
+                                                 comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Luke", sequence),
-                                                   comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Luke", sequence),
+                                                 comparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertEndsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -74,52 +75,44 @@ public class Iterables_assertEndsWith_Test extends IterablesBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterables.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterables.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_but_not_whole_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      iterables.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_sequence_is_smaller_than_end_of_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia" };
-    try {
-      iterables.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -154,26 +147,22 @@ public class Iterables_assertEndsWith_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_but_not_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveAtLeast_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveAtLeast_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveAtLeast.elementsShouldHaveAtLeast;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class Iterables_assertHaveAtLeast_Test extends IterablesWithConditionsBas
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Solo", "Leia");
-      iterables.assertHaveAtLeast(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveAtLeast(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertHaveAtLeast(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveAtLeast(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveAtMost_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveAtMost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveAtMost.elementsShouldHaveAtMost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class Iterables_assertHaveAtMost_Test extends IterablesWithConditionsBase
   public void should_fail_if_condition_is_not_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Obiwan");
-      iterables.assertHaveAtMost(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveAtMost(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> iterables.assertHaveAtMost(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveAtMost(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveExactly_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveExactly.elementsShouldHaveExactly;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -70,15 +69,13 @@ public class Iterables_assertHaveExactly_Test extends IterablesWithConditionsBas
   public void should_fail_if_condition_is_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Obiwan");
-      iterables.assertHaveExactly(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> iterables.assertHaveExactly(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHaveExactly_Test.java
@@ -12,7 +12,9 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveExactly.elementsShouldHaveExactly;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -55,15 +57,13 @@ public class Iterables_assertHaveExactly_Test extends IterablesWithConditionsBas
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Solo", "Leia");
-      iterables.assertHaveExactly(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertHaveExactly(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertHave_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHave.elementsShouldHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -53,15 +54,13 @@ public class Iterables_assertHave_Test extends IterablesWithConditionsBaseTest {
   public void should_fail_if_condition_is_not_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = newArrayList("Yoda", "Luke", "Leia");
-      iterables.assertHave(someInfo(), actual, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = newArrayList("Yoda", "Luke", "Leia");
+
+    Throwable error = catchThrowable(() -> iterables.assertHave(someInfo(), actual, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertIsSubsetOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertIsSubsetOf_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSubsetOf.shouldBeSubsetOf;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -100,13 +101,11 @@ public class Iterables_assertIsSubsetOf_Test extends IterablesBaseTest {
     actual = newArrayList("Yoda");
     List<String> values = newArrayList("C-3PO", "Leila");
     List<String> extra = newArrayList("Yoda");
-    try {
-      iterables.assertIsSubsetOf(info, actual, values);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertIsSubsetOf(info, actual, values));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -137,13 +136,11 @@ public class Iterables_assertIsSubsetOf_Test extends IterablesBaseTest {
     actual = newArrayList("Yoda", "Luke");
     List<String> values = newArrayList("yoda", "C-3PO");
     List<String> extra = newArrayList("Luke");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(info, actual, values);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(info, actual, values));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra, comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneMatch_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNoneMatch_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.NoElementsShouldMatch.noElementsShouldMatch;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -48,26 +49,22 @@ public class Iterables_assertNoneMatch_Test extends IterablesBaseTest {
   public void should_fail_if_predicate_is_met() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<? super String> predicate = s -> s.startsWith("L");
-    try {
-      iterables.assertNoneMatch(info, actual, predicate, PredicateDescription.GIVEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, noElementsShouldMatch(actual, "Luke", PredicateDescription.GIVEN));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertNoneMatch(info, actual, predicate, PredicateDescription.GIVEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, noElementsShouldMatch(actual, "Luke", PredicateDescription.GIVEN));
   }
 
   @Test
   public void should_fail_with_custom_description_if_predicate_is_not_met() {
     List<String> actual = newArrayList("Luke", "Leia", "Yoda");
     Predicate<? super String> predicate = s -> s.startsWith("L");
-    try {
-      iterables.assertNoneMatch(info, actual, predicate, new PredicateDescription("custom"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, noElementsShouldMatch(actual, "Luke", new PredicateDescription("custom")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertNoneMatch(info, actual, predicate, new PredicateDescription("custom")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, noElementsShouldMatch(actual, "Luke", new PredicateDescription("custom")));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNotEmpty_Test.java
@@ -13,10 +13,11 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -51,13 +52,11 @@ public class Iterables_assertNotEmpty_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      iterables.assertNotEmpty(info, emptyList());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertNotEmpty(info, emptyList()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test
@@ -74,12 +73,10 @@ public class Iterables_assertNotEmpty_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_is_empty_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertNotEmpty(info, emptyList());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertNotEmpty(info, emptyList()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertNullOrEmpty_Test.java
@@ -13,9 +13,10 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -49,13 +50,11 @@ public class Iterables_assertNullOrEmpty_Test extends IterablesBaseTest {
   public void should_fail_if_actual_has_elements() {
     AssertionInfo info = someInfo();
     Collection<String> actual = newArrayList("Yoda");
-    try {
-      iterables.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Iterables_assertNullOrEmpty_Test extends IterablesBaseTest {
   public void should_fail_if_actual_has_elements_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     Collection<String> actual = newArrayList("Yoda");
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -75,39 +76,33 @@ public class Iterables_assertStartsWith_Test extends IterablesBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      iterables.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterables.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      iterables.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterables.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -165,26 +160,22 @@ public class Iterables_assertStartsWith_Test extends IterablesBaseTest {
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "YODA", "luke", "Leia", "Obi-Wan", "Han" };
-    try {
-      iterablesWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, comparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/List_assertIs_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/List_assertIs_Test.java
@@ -14,13 +14,14 @@ package org.assertj.core.internal.lists;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldBeAtIndex.shouldBeAtIndex;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsEmpty;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -91,13 +92,11 @@ public class List_assertIs_Test extends ListsBaseTest {
     condition.shouldMatch(false);
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      lists.assertIs(info, actual, condition, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeAtIndex(actual, condition, index, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIs(info, actual, condition, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeAtIndex(actual, condition, index, "Luke"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertContains_Test.java
@@ -14,12 +14,13 @@ package org.assertj.core.internal.lists;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -75,13 +76,11 @@ public class Lists_assertContains_Test extends ListsBaseTest {
   public void should_fail_if_actual_does_not_contain_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      lists.assertContains(info, actual, "Han", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertContains(info, actual, "Han", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke"));
   }
 
   @Test
@@ -100,13 +99,11 @@ public class Lists_assertContains_Test extends ListsBaseTest {
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      listsWithCaseInsensitiveComparisonStrategy.assertContains(info, actual, "Han", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke", comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> listsWithCaseInsensitiveComparisonStrategy.assertContains(info, actual, "Han", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke", comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertDoesNotContain_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.lists;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -74,13 +75,11 @@ public class Lists_assertDoesNotContain_Test extends ListsBaseTest {
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      lists.assertDoesNotContain(info, actual, "Yoda", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, "Yoda", index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertDoesNotContain(info, actual, "Yoda", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, "Yoda", index));
   }
 
   @Test
@@ -92,12 +91,10 @@ public class Lists_assertDoesNotContain_Test extends ListsBaseTest {
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      listsWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(info, actual, "YODA", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, "YODA", index, comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> listsWithCaseInsensitiveComparisonStrategy.assertDoesNotContain(info, actual, "YODA", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, "YODA", index, comparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertHas_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertHas_Test.java
@@ -14,13 +14,14 @@ package org.assertj.core.internal.lists;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldHaveAtIndex.shouldHaveAtIndex;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsEmpty;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -93,13 +94,11 @@ public class Lists_assertHas_Test extends ListsBaseTest {
     condition.shouldMatch(false);
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      lists.assertHas(info, actual, condition, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAtIndex(actual, condition, index, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertHas(info, actual, condition, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAtIndex(actual, condition, index, "Luke"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSortedAccordingToComparator_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.lists;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -80,13 +81,11 @@ public class Lists_assertIsSortedAccordingToComparator_Test extends ListsBaseTes
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     List<String> actual = newArrayList("Yoda", "Vador", "Leia", "Leia", "Luke");
-    try {
-      lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(3, actual, stringDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(3, actual, stringDescendingOrderComparator));
   }
 
   @Test
@@ -96,28 +95,24 @@ public class Lists_assertIsSortedAccordingToComparator_Test extends ListsBaseTes
     actual.add("bar");
     actual.add(new Integer(5));
     actual.add("foo");
-    try {
-      lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldHaveComparableElementsAccordingToGivenComparator(actual, stringDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldHaveComparableElementsAccordingToGivenComparator(actual, stringDescendingOrderComparator));
   }
 
   @Test
   public void should_fail_if_actual_has_one_element_only_not_comparable_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     List<Object> actual = newArrayList(new Object());
-    try {
-      lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldHaveComparableElementsAccordingToGivenComparator(actual, stringDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldHaveComparableElementsAccordingToGivenComparator(actual, stringDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/lists/Lists_assertIsSorted_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.lists;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -70,52 +71,44 @@ public class Lists_assertIsSorted_Test extends ListsBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda", "Leia");
-    try {
-      lists.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Yoda", "Leia");
-    try {
-      listsWithCaseInsensitiveComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparisonStrategy.getComparator()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> listsWithCaseInsensitiveComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparisonStrategy.getComparator()));
   }
 
   @Test
   public void should_fail_if_actual_has_only_one_non_comparable_element() {
     AssertionInfo info = someInfo();
     List<Object> actual = newArrayList(new Object());
-    try {
-      lists.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
   @Test
   public void should_fail_if_actual_has_some_non_comparable_elements() {
     AssertionInfo info = someInfo();
     List<Object> actual = newArrayList("bar", new Object(), "foo");
-    try {
-      lists.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
   @Test
@@ -125,13 +118,11 @@ public class Lists_assertIsSorted_Test extends ListsBaseTest {
     actual.add("bar");
     actual.add(new Integer(5));
     actual.add("foo");
-    try {
-      lists.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> lists.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -78,28 +79,24 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     long[] expected = {6L, 8L, 20L};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20L), newArrayList(10L),
-          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20L), newArrayList(10L),
+        StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     long[] expected = {6L, 8L};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10L), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10L), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -107,15 +104,13 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 2L, 3L);
     long[] expected = {1L, 2L};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3L),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3L),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -123,14 +118,12 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 2L);
     long[] expected = {1L, 2L, 3L};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3L), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3L), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -171,29 +164,25 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = {6L, -8L, 20L};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20L), newArrayList(10L),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(20L), newArrayList(10L),
+            absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = {6L, 8L};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10L), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(10L), absValueComparisonStrategy));
   }
 
   @Test
@@ -201,15 +190,13 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 2L, 3L);
     long[] expected = {1L, 2L};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3L),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList(3L),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -217,14 +204,12 @@ public class LongArrays_assertContainsExactlyInAnyOrder_Test extends LongArraysB
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 2L);
     long[] expected = {1L, 2L, 3L};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3L), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList(3L), emptyList(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6L, 10L, 8L));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6L, 10L, 8L)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1));
   }
 
   @Test
@@ -84,28 +83,24 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, 8L, 20L };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(20L), newArrayList(10L)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(20L), newArrayList(10L)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, 8L, 10L, 10L };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10L), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10L), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { -6L, 10L, 8L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -153,30 +146,26 @@ public class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, -8L, 20L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(20L), newArrayList(10L),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(20L), newArrayList(10L),
+                                                        absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, 8L, 10L, 10L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(10L), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(10L), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,12 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     long[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20L), newLinkedHashSet(6L, -8L)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(20L), newLinkedHashSet(6L, -8L)));
   }
 
   @Test
@@ -93,14 +92,12 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     long[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet()));
   }
 
   @Test
@@ -118,16 +115,14 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     long[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet((long) 6, (long) -8),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet((long) 6, (long) -8),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -158,15 +153,13 @@ public class LongArrays_assertContainsOnlyOnce_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((long) 20), newLinkedHashSet(),
+            absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -86,13 +87,11 @@ public class LongArrays_assertContainsOnly_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, 8L, 20L };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20L), newArrayList(10L)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList(20L), newArrayList(10L)));
   }
 
   @Test
@@ -139,14 +138,12 @@ public class LongArrays_assertContainsOnly_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, -8L, 20L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList(20L), newArrayList(10L),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList(20L), newArrayList(10L),
+                                               absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.LongArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class LongArrays_assertContainsSequence_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 8L, 10L, 12L, 20L, 22L };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L, 22L };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, long[] sequence) {
@@ -142,39 +137,33 @@ public class LongArrays_assertContainsSequence_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, -8L, 10L, 12L, 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContains_at_Index_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.longarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsEmpty;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -73,13 +74,11 @@ public class LongArrays_assertContains_at_Index_Test extends LongArraysBaseTest 
     AssertionInfo info = someInfo();
     long value = 6;
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8L));
   }
 
   @Test
@@ -121,13 +120,11 @@ public class LongArrays_assertContains_at_Index_Test extends LongArraysBaseTest 
     AssertionInfo info = someInfo();
     long value = 6;
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, 8L, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -72,13 +73,11 @@ public class LongArrays_assertDoesNotContain_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, 8L, 20L };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6L, 8L)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6L, 8L)));
   }
 
   @Test
@@ -117,12 +116,10 @@ public class LongArrays_assertDoesNotContain_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] expected = { 6L, -8L, 20L };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6L, -8L), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(6L, -8L), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,13 +70,11 @@ public class LongArrays_assertDoesNotContain_at_Index_Test extends LongArraysBas
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, 6L, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6L, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, 6L, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6L, index));
   }
 
   @Test
@@ -112,12 +111,10 @@ public class LongArrays_assertDoesNotContain_at_Index_Test extends LongArraysBas
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6L, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, 6L, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, 6L, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, 6L, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.LongArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -62,13 +63,11 @@ public class LongArrays_assertDoesNotHaveDuplicates_Test extends LongArraysBaseT
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6L, 8L, 6L, 8L);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6L, 8L)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6L, 8L)));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class LongArrays_assertDoesNotHaveDuplicates_Test extends LongArraysBaseT
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6L, -8L, 6L, -8L);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6L, -8L), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet(6L, -8L), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class LongArrays_assertEmpty_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     long[] actual = { 6L, 8L };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.LongArrays.arrayOf;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,39 +71,33 @@ public class LongArrays_assertEndsWith_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 8L, 10L, 12L, 20L, 22L };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     long[] sequence = { 20L, 22L };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L, 22L };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -137,39 +132,33 @@ public class LongArrays_assertEndsWith_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, -8L, 10L, 12L, 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class LongArrays_assertIsSortedAccordingToComparator_Test extends LongArr
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new long[] { 3L, 2L, 1L, 9L };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, longDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, longDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, longDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, longDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertIsSorted_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSorted;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.LongArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -66,13 +67,11 @@ public class LongArrays_assertIsSorted_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 3L, 2L);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -100,14 +99,12 @@ public class LongArrays_assertIsSorted_Test extends LongArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1L, 3L, 2L);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.LongArrays.*;
+import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +47,11 @@ public class LongArrays_assertNotEmpty_Test extends LongArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.LongArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class LongArrays_assertNullOrEmpty_Test extends LongArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     long[] actual = { 6L, 8L };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.longarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.LongArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class LongArrays_assertStartsWith_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 8L, 10L, 12L, 20L, 22L };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     long[] sequence = { 8L, 10L };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -137,39 +132,33 @@ public class LongArrays_assertStartsWith_Test extends LongArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, -8L, 10L, 12L, 20L, 22L };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { -8L, 10L };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     long[] sequence = { 6L, 20L };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -48,13 +49,11 @@ public class Longs_assertEqual_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_longs_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertEqual(info, 6L, 8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6L, 8L, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertEqual(info, 6L, 8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6L, 8L, info.representation()));
   }
 
   @Test
@@ -71,12 +70,10 @@ public class Longs_assertEqual_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_longs_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertEqual(info, 6L, 8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(6L, 8L, absValueComparisonStrategy, new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertEqual(info, 6L, 8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(6L, 8L, absValueComparisonStrategy, new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Longs_assertGreaterThanOrEqualTo_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertGreaterThanOrEqualTo(info, 6L, 8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6L, 8L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertGreaterThanOrEqualTo(info, 6L, 8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6L, 8L));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Longs_assertGreaterThanOrEqualTo_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6L, -8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual(6L, -8L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, 6L, -8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual(6L, -8L, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Longs_assertGreaterThan_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertGreaterThan(info, 6L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6L, 6L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertGreaterThan(info, 6L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6L, 6L));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertGreaterThan(info, 6L, 8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6L, 8L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertGreaterThan(info, 6L, 8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6L, 8L));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -82,25 +79,21 @@ public class Longs_assertGreaterThan_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(-6L, 6L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertGreaterThan(info, -6L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(-6L, 6L, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertGreaterThan(info, 6L, -8L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater(6L, -8L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertGreaterThan(info, 6L, -8L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater(6L, -8L, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseToPercentage_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -83,14 +84,12 @@ public class Longs_assertIsCloseToPercentage_Test extends LongsBaseTest {
 
     @Test
     public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
-        AssertionInfo info = someInfo();
-        try {
-            longs.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-        } catch (AssertionError e) {
-            verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
-                                                                         (TEN - ONE)));
-            return;
-        }
-        failBecauseExpectedAssertionErrorWasNotThrown();
+      AssertionInfo info = someInfo();
+
+      Throwable error = catchThrowable(() -> longs.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+      assertThat(error).isInstanceOf(AssertionError.class);
+      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(TEN),
+                                                                   (TEN - ONE)));
     }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.longs;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -68,13 +69,11 @@ public class Longs_assertIsCloseTo_Test extends LongsBaseTest {
   })
   public void should_fail_if_actual_is_not_close_enough_to_expected(long actual, long expected, long offset) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsCloseTo(info, actual, expected, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsCloseTo(info, actual, expected, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), abs(actual - expected)));
   }
 
   @ParameterizedTest
@@ -87,13 +86,11 @@ public class Longs_assertIsCloseTo_Test extends LongsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset(long actual, long expected, long offset) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsCloseTo(info, actual, expected, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsCloseTo(info, actual, expected, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), abs(actual - expected)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseToPercentage_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.longs;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -81,26 +82,22 @@ public class Longs_assertIsNotCloseToPercentage_Test extends LongsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(Long actual, Long other, Long percentage) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
-                                                                      abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+                                                                    abs(actual - other)));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
-                                                                      TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
+                                                                    TEN - ONE));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsNotCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.longs;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,13 +68,11 @@ public class Longs_assertIsNotCloseTo_Test extends LongsBaseTest {
   })
   public void should_fail_if_actual_is_too_close_to_the_other_value(long actual, long other, long offset) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -85,13 +84,11 @@ public class Longs_assertIsNotCloseTo_Test extends LongsBaseTest {
   public void should_fail_if_actual_is_too_close_to_the_other_value_with_strict_offset(long actual, long other,
                                                                                        long offset) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsNotCloseTo(info, actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsNotCloseTo(info, actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -102,13 +99,11 @@ public class Longs_assertIsNotCloseTo_Test extends LongsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(long actual, long other, long offset) {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), abs(actual - other)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Longs_assertLessThanOrEqualTo_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertLessThanOrEqualTo(info, 8L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(8L, 6L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertLessThanOrEqualTo(info, 8L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(8L, 6L));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Longs_assertLessThanOrEqualTo_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual(-8L, 6L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, -8L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual(-8L, 6L, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Longs_assertLessThan_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertLessThan(info, 6L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6L, 6L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertLessThan(info, 6L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6L, 6L));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertLessThan(info, 8L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(8L, 6L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertLessThan(info, 8L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(8L, 6L));
   }
 
   @Test
@@ -84,24 +81,20 @@ public class Longs_assertLessThan_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertLessThan(info, 6L, -6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(6L, -6L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertLessThan(info, 6L, -6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(6L, -6L, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertLessThan(info, -8L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess(-8L, 6L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertLessThan(info, -8L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess(-8L, 6L, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.longs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Longs_assertNotEqual_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_longs_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      longs.assertNotEqual(info, 6L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(6L, 6L));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longs.assertNotEqual(info, 6L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(6L, 6L));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Longs_assertNotEqual_Test extends LongsBaseTest {
   @Test
   public void should_fail_if_longs_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      longsWithAbsValueComparisonStrategy.assertNotEqual(info, -6L, 6L);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(-6L, 6L, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> longsWithAbsValueComparisonStrategy.assertNotEqual(info, -6L, 6L));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(-6L, 6L, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsAnyOf_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
 import static org.assertj.core.internal.ErrorMessages.entryToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -85,12 +86,10 @@ public class Maps_assertContainsAnyOf_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_any_of_the_given_entries() {
     AssertionInfo info = someInfo();
     MapEntry<String, String>[] expected = array(entry("name", "Vador"), entry("job", "Jedi"));
-    try {
-      maps.assertContainsAnyOf(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAnyOf(actual, expected));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsAnyOf(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAnyOf(actual, expected));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -66,12 +67,10 @@ public class Maps_assertContainsKey_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_key() {
     AssertionInfo info = someInfo();
     String key = "power";
-    try {
-      maps.assertContainsKeys(info, actual, key);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsKeys(info, actual, key));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -65,13 +66,11 @@ public class Maps_assertContainsKeys_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_key() {
     AssertionInfo info = someInfo();
     String key = "power";
-    try {
-      maps.assertContainsKeys(info, actual, key);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsKeys(info, actual, key));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
 
   @Test
@@ -79,12 +78,10 @@ public class Maps_assertContainsKeys_Test extends MapsBaseTest {
     AssertionInfo info = someInfo();
     String key1 = "power";
     String key2 = "rangers";
-    try {
-      maps.assertContainsKeys(info, actual, key1, key2);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key1, key2)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsKeys(info, actual, key1, key2));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key1, key2)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValue_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValue_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -67,12 +68,10 @@ public class Maps_assertContainsValue_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_value() {
     AssertionInfo info = someInfo();
     String value = "veryOld";
-    try {
-      maps.assertContainsValue(info, actual, value);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainValue(actual, value));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsValue(info, actual, value));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainValue(actual, value));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainValues.shouldContainValues;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -79,12 +80,10 @@ public class Maps_assertContainsValues_Test extends MapsBaseTest {
     AssertionInfo info = someInfo();
     String value = "veryOld";
     String value2 = "veryOld2";
-    try {
-      maps.assertContainsValues(info, actual, value, value2);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainValues(actual, newLinkedHashSet(value, value2)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContainsValues(info, actual, value, value2));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainValues(actual, newLinkedHashSet(value, value2)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
 import static org.assertj.core.internal.ErrorMessages.entryToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -95,12 +96,10 @@ public class Maps_assertContains_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_entries() {
     AssertionInfo info = someInfo();
     MapEntry<String, String>[] expected = array(entry("name", "Yoda"), entry("job", "Jedi"));
-    try {
-      maps.assertContains(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet(entry("job", "Jedi"))));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertContains(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected, newLinkedHashSet(entry("job", "Jedi"))));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKey_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKey_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldNotContainKey.shouldNotContainKey;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -65,12 +66,10 @@ public class Maps_assertDoesNotContainKey_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_key() {
     AssertionInfo info = someInfo();
     String key = "name";
-    try {
-      maps.assertDoesNotContainKey(info, actual, key);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainKey(actual, key));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertDoesNotContainKey(info, actual, key));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainKey(actual, key));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -59,13 +60,11 @@ public class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
   public void should_fail_if_actual_contains_key() {
     AssertionInfo info = someInfo();
     String key = "name";
-    try {
-      maps.assertDoesNotContainKeys(info, actual, key);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, key));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key)));
   }
 
   @Test
@@ -73,12 +72,10 @@ public class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
     AssertionInfo info = someInfo();
     String key1 = "name";
     String key2 = "color";
-    try {
-      maps.assertDoesNotContainKeys(info, actual, key1, key2);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key1, key2)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, key1, key2));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key1, key2)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainValue_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainValue_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -65,12 +66,10 @@ public class Maps_assertDoesNotContainValue_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_value() {
     AssertionInfo info = someInfo();
     String value = "Yoda";
-    try {
-      maps.assertDoesNotContainValue(info, actual, value);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainValue(actual, value));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertDoesNotContainValue(info, actual, value));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainValue(actual, value));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContain_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -72,12 +73,10 @@ public class Maps_assertDoesNotContain_Test extends MapsBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     MapEntry<String, String>[] expected = array(entry("name", "Yoda"), entry("job", "Jedi"));
-    try {
-      maps.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(entry("name", "Yoda"))));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet(entry("name", "Yoda"))));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertEmpty_Test.java
@@ -13,12 +13,13 @@
 package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -55,12 +56,10 @@ public class Maps_assertEmpty_Test extends MapsBaseTest {
   public void should_fail_if_actual_has_elements() {
     AssertionInfo info = someInfo();
     Map<?, ?> actual = mapOf(entry("name", "Yoda"));
-    try {
-      maps.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfyingCondition_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfyingCondition_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.condition.Not.not;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -79,39 +80,33 @@ public class Maps_assertHasEntrySatisfyingCondition_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contain_key() {
     AssertionInfo info = someInfo();
     String key = "id";
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, isDigits);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, isDigits));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
 
   @Test
   public void should_fail_if_actual_contains_key_with_value_not_matching_condition() {
     AssertionInfo info = someInfo();
     String key = "name";
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, isDigits);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), isDigits));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, isDigits));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), isDigits));
   }
 
   @Test
   public void should_fail_if_actual_contains_null_key_with_value_not_matching_condition() {
     AssertionInfo info = someInfo();
     String key = null;
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, nonNull);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), nonNull));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, nonNull));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), nonNull));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfyingConsumer_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfyingConsumer_Test.java
@@ -14,12 +14,12 @@ package org.assertj.core.internal.maps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.error.ShouldContainPattern.shouldContainPattern;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -70,13 +70,11 @@ public class Maps_assertHasEntrySatisfyingConsumer_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contains_key() {
     AssertionInfo info = someInfo();
     String key = "id";
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, s -> assertThat(s).containsPattern(IS_DIGITS));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, s -> assertThat(s).containsPattern(IS_DIGITS)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_entry_condition_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_entry_condition_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -64,13 +65,11 @@ public class Maps_assertHasEntrySatisfying_with_entry_condition_Test extends Map
   @Test
   public void should_fail_if_actual_does_not_contain_any_entry_matching_the_given_condition() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasEntrySatisfying(info, actual, blackColorCondition);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, blackColorCondition));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, blackColorCondition));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainEntry(actual, blackColorCondition));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_condition_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_condition_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.condition.Not.not;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -79,39 +80,33 @@ public class Maps_assertHasEntrySatisfying_with_key_and_condition_Test extends M
   public void should_fail_if_actual_does_not_contain_key() {
     AssertionInfo info = someInfo();
     String key = "id";
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, isDigits);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, isDigits));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
 
   @Test
   public void should_fail_if_actual_contains_key_with_value_not_matching_condition() {
     AssertionInfo info = someInfo();
     String key = "name";
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, isDigits);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), isDigits));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, isDigits));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), isDigits));
   }
 
   @Test
   public void should_fail_if_actual_contains_null_key_with_value_not_matching_condition() {
     AssertionInfo info = someInfo();
     String key = null;
-    try {
-      maps.assertHasEntrySatisfying(info, actual, key, nonNull);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), nonNull));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfying(info, actual, key, nonNull));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldBe(actual, actual.get(key), nonNull));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainEntry.shouldContainEntry;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -84,37 +85,31 @@ public class Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test ex
   @Test
   public void should_fail_if_actual_does_not_contain_any_entry_matching_the_given_key_condition() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isGreen);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, isAge, isGreen));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isGreen));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainEntry(actual, isAge, isGreen));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_any_entry_matching_the_given_value_condition() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasEntrySatisfyingConditions(info, actual, isColor, isBlack);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, isColor, isBlack));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfyingConditions(info, actual, isColor, isBlack));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainEntry(actual, isColor, isBlack));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_any_entry_matching_both_given_key_and_value_conditions() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isBlack);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainEntry(actual, isAge, isBlack));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasEntrySatisfyingConditions(info, actual, isAge, isBlack));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainEntry(actual, isAge, isBlack));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasKeySatisfying_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasKeySatisfying_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -62,13 +63,11 @@ public class Maps_assertHasKeySatisfying_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contain_any_key_matching_the_given_condition() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasKeySatisfying(info, actual, isAge);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainKey(actual, isAge));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasKeySatisfying(info, actual, isAge));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainKey(actual, isAge));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertHasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertHasValueSatisfying_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.maps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,13 +64,11 @@ public class Maps_assertHasValueSatisfying_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contain_value_matching_condition() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertHasValueSatisfying(info, actual, isBlack);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainValue(actual, isBlack));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertHasValueSatisfying(info, actual, isBlack));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainValue(actual, isBlack));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertNotEmpty_Test.java
@@ -13,12 +13,13 @@
 package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -55,13 +56,11 @@ public class Maps_assertNotEmpty_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      maps.assertNotEmpty(info, emptyMap());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertNotEmpty(info, emptyMap()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertNullOrEmpty_Test.java
@@ -14,11 +14,12 @@ package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -43,13 +44,11 @@ public class Maps_assertNullOrEmpty_Test extends MapsBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     Map<?, ?> actual = mapOf(entry("name", "Yoda"));
-    try {
-      maps.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> maps.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreAtLeast_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreAtLeast_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeAtLeast.elementsShouldBeAtLeast;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class ObjectArrays_assertAreAtLeast_Test extends ObjectArraysWithConditio
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Solo", "Leia");
-      arrays.assertAreAtLeast(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeAtLeast(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertAreAtLeast(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeAtLeast(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreAtMost_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreAtMost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeAtMost.elementsShouldBeAtMost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class ObjectArrays_assertAreAtMost_Test extends ObjectArraysWithCondition
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Obiwan");
-      arrays.assertAreAtMost(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeAtMost(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> arrays.assertAreAtMost(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeAtMost(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
@@ -12,7 +12,9 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeExactly.elementsShouldBeExactly;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
@@ -55,30 +57,26 @@ public class ObjectArrays_assertAreExactly_Test extends ObjectArraysWithConditio
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Solo", "Leia");
-      arrays.assertAreExactly(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertAreExactly(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
   }
 
   @Test
   public void should_fail_if_condition_is_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Obiwan");
-      arrays.assertAreExactly(someInfo(), actual, 2, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> arrays.assertAreExactly(someInfo(), actual, 2, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBeExactly(actual, 2, jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBeExactly.elementsShouldBeExactly;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreNot_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAreNot_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldNotBe.elementsShouldNotBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -55,15 +56,13 @@ public class ObjectArrays_assertAreNot_Test extends ObjectArraysWithConditionBas
   public void should_fail_if_condition_is_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Solo", "Leia", "Yoda");
-      arrays.assertAreNot(someInfo(), actual, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldNotBe(actual, newArrayList("Yoda"), jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Solo", "Leia", "Yoda");
+
+    Throwable error = catchThrowable(() -> arrays.assertAreNot(someInfo(), actual, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldNotBe(actual, newArrayList("Yoda"), jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAre_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertAre_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -55,15 +56,13 @@ public class ObjectArrays_assertAre_Test extends ObjectArraysWithConditionBaseTe
   public void should_fail_if_Condition_is_not_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Leia");
-      arrays.assertAre(someInfo(), actual, jedi);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jedi);
-      verify(failures).failure(info, elementsShouldBe(actual, newArrayList("Leia"), jedi));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertAre(someInfo(), actual, jedi));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jedi);
+    verify(failures).failure(info, elementsShouldBe(actual, newArrayList("Leia"), jedi));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsAll_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsAll_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -73,13 +74,11 @@ public class ObjectArrays_assertContainsAll_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_all_iterable_values() {
     AssertionInfo info = someInfo();
     List<String> expected = newArrayList("Han", "Luke");
-    try {
-      arrays.assertContainsAll(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsAll(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContain(actual, expected.toArray(), newLinkedHashSet("Han")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -129,13 +128,11 @@ public class ObjectArrays_assertContainsAll_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     List<String> expected = newArrayList("Han", "LUKE");
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsAll(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContain(actual, expected.toArray(), newLinkedHashSet("Han"), caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsAll(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContain(actual, expected.toArray(), newLinkedHashSet("Han"), caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
@@ -79,13 +80,11 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
   public void should_fail_if_actual_does_not_contain_given_values_exactly_in_any_order() {
     AssertionInfo info = someInfo();
     Object[] expected = {"Luke", "Yoda", "Han"};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -93,14 +92,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia", "Luke");
     Object[] expected = {"Luke", "Leia"};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -108,14 +105,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia");
     Object[] expected = {"Luke", "Leia", "Luke"};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -132,14 +127,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
   public void should_fail_if_actual_does_not_contain_given_values_exactly_in_any_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = {"Luke", "Yoda", "Han"};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"),
-          caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Han"), newArrayList("Leia"),
+        caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
@@ -147,14 +140,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia", "Luke");
     Object[] expected = {"Luke", "Leia"};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList("Luke"), caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
@@ -162,14 +153,12 @@ public class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArr
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia");
     Object[] expected = {"Luke", "Leia", "Luke"};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList("Luke"), emptyList(), caseInsensitiveStringComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -86,27 +87,23 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList("Han"), newArrayList("Leia")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList("Han"), newArrayList("Leia")));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_in_different_order() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Leia", "Yoda" };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
   }
 
   @Test
@@ -114,15 +111,13 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia", "Luke");
     Object[] expected = { "Luke", "Leia" };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList(), newArrayList("Luke"),
-                                                          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList(), newArrayList("Luke"),
+                                                        StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -136,17 +131,15 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
     }
     expected[actual.length] = "extra";
     AssertionInfo info = someInfo();
+
     // WHEN
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      // THEN
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList("extra"), newArrayList(),
-                                                          StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    // THEN
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList("extra"), newArrayList(),
+                                                        StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -163,28 +156,24 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList("Han"), newArrayList("Leia"),
-                                                    caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList("Han"), newArrayList("Leia"),
+                                                  caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Leia", "Yoda" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
@@ -192,15 +181,13 @@ public class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTes
     AssertionInfo info = someInfo();
     actual = array("Luke", "Leia", "Luke");
     Object[] expected = { "Luke", "Leia" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList("Luke"),
-                                                    caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList("Luke"),
+                                                  caseInsensitiveStringComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsNull_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -67,13 +68,11 @@ public class ObjectArrays_assertContainsNull_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_null() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda");
-    try {
-      arrays.assertContainsNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainNull(actual));
   }
 
   @Test
@@ -103,12 +102,10 @@ public class ObjectArrays_assertContainsNull_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_null_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda");
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainNull(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyNulls_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyNulls_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnlyNulls.shouldContainOnlyNulls;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -58,13 +59,11 @@ public class ObjectArrays_assertContainsOnlyNulls_Test extends ObjectArraysBaseT
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual));
   }
 
   @Test
@@ -72,13 +71,11 @@ public class ObjectArrays_assertContainsOnlyNulls_Test extends ObjectArraysBaseT
     AssertionInfo info = someInfo();
     actual = array(null, null, "person");
     List<String> nonNulls = newArrayList("person");
-    try {
-      arrays.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
   }
 
   @Test
@@ -86,12 +83,10 @@ public class ObjectArrays_assertContainsOnlyNulls_Test extends ObjectArraysBaseT
     AssertionInfo info = someInfo();
     actual = array("person", "person2");
     List<String> nonNulls = newArrayList("person", "person2");
-    try {
-      arrays.assertContainsOnlyNulls(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyNulls(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnlyNulls(actual, nonNulls));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -61,14 +62,12 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda", "Han", "Luke", "Yoda", "Han", "Yoda", "Luke");
     String[] expected = { "Luke", "Yoda", "Leia" };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Leia"), newLinkedHashSet("Luke", "Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Leia"), newLinkedHashSet("Luke", "Yoda")));
   }
 
   @Test
@@ -103,14 +102,12 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
   public void should_fail_if_actual_does_not_contain_all_given_values() {
     AssertionInfo info = someInfo();
     String[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Han"), newLinkedHashSet()));
   }
 
   @Test
@@ -128,16 +125,14 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
     AssertionInfo info = someInfo();
     actual = array("Luke", "yODA", "Han", "luke", "yoda", "Han", "YodA");
     String[] expected = { "Luke", "yOda", "Leia" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Leia"), newLinkedHashSet("Luke", "yOda"),
-              caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("Leia"), newLinkedHashSet("Luke", "yOda"),
+            caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
@@ -169,15 +164,13 @@ public class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTe
   public void should_fail_if_actual_does_not_contain_all_given_values_only_once_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     String[] expected = { "Luke", "yoda", "han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("han"), newLinkedHashSet(),
-              caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet("han"), newLinkedHashSet(),
+            caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -86,13 +87,11 @@ public class ObjectArrays_assertContainsOnly_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia")));
   }
 
   @Test
@@ -141,14 +140,12 @@ public class ObjectArrays_assertContainsOnly_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "LUKE", "YOda", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia"),
-                                                 caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList("Han"), newArrayList("Leia"),
+                                               caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -88,39 +89,33 @@ public class ObjectArrays_assertContainsSequence_Test extends ObjectArraysBaseTe
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -150,39 +145,33 @@ public class ObjectArrays_assertContainsSequence_Test extends ObjectArraysBaseTe
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LUKE", "LeiA", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LeiA", "Obi-Wan", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -84,39 +85,33 @@ public class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBas
   public void should_fail_if_subsequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arrays.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_subsequence() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Han", "C-3PO" };
-    try {
-      arrays.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_subsequence() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arrays.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
   }
 
   private void verifyFailureThrownWhenSubsequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -146,42 +141,36 @@ public class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBas
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] subsequence = { "LUKE", "LeiA", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainSubsequence(actual, subsequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainSubsequence(actual, subsequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_subsequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainSubsequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainSubsequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_subsequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LeiA", "Obi-Wan", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainSubsequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainSubsequence(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.objectarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.*;
 
@@ -76,13 +77,11 @@ public class ObjectArrays_assertContains_at_Index_Test extends ObjectArraysBaseT
   public void should_fail_if_actual_does_not_contain_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, "Han", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, "Han", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke"));
   }
 
   @Test
@@ -111,13 +110,11 @@ public class ObjectArrays_assertContains_at_Index_Test extends ObjectArraysBaseT
   public void should_fail_if_actual_does_not_contain_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, "Han", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke", caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, "Han", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainAtIndex(actual, "Han", index, "Luke", caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoNotHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoNotHave_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldNotHave.elementsShouldNotHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -54,15 +55,13 @@ public class ObjectArrays_assertDoNotHave_Test extends ObjectArraysWithCondition
   public void should_fail_if_condition_is_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Darth Vader", "Leia", "Yoda");
-      arrays.assertDoNotHave(someInfo(), actual, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Darth Vader", "Leia", "Yoda");
+
+    Throwable error = catchThrowable(() -> arrays.assertDoNotHave(someInfo(), actual, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainAnyElementsOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainAnyElementsOf_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.iterableValuesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -66,15 +67,13 @@ public class ObjectArrays_assertDoesNotContainAnyElementsOf_Test extends ObjectA
 
   @Test
   public void should_fail_if_actual_contains_one_element_of_given_iterable() {
-	AssertionInfo info = someInfo();
-	List<String> list = newArrayList("Vador", "Yoda", "Han");
-	try {
-	  arrays.assertDoesNotContainAnyElementsOf(info, actual, list);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    List<String> list = newArrayList("Vador", "Yoda", "Han");
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainAnyElementsOf(info, actual, list));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldNotContain(actual, list.toArray(), newLinkedHashSet("Yoda")));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -94,15 +93,13 @@ public class ObjectArrays_assertDoesNotContainAnyElementsOf_Test extends ObjectA
 
   @Test
   public void should_fail_if_actual_contains_one_element_of_given_iterable_according_to_custom_comparison_strategy() {
-	AssertionInfo info = someInfo();
-	List<String> expected = newArrayList("LuKe", "YODA", "Han");
-	try {
-	  arraysWithCustomComparisonStrategy.assertDoesNotContainAnyElementsOf(info, actual, expected);
-	} catch (AssertionError e) {
+    AssertionInfo info = someInfo();
+    List<String> expected = newArrayList("LuKe", "YODA", "Han");
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainAnyElementsOf(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
 	  verify(failures).failure(info, shouldNotContain(actual, expected.toArray(), newLinkedHashSet("LuKe", "YODA"),
 		                                              caseInsensitiveStringComparisonStrategy));
-	  return;
-	}
-	failBecauseExpectedAssertionErrorWasNotThrown();
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainNull_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -63,13 +64,11 @@ public class ObjectArrays_assertDoesNotContainNull_Test extends ObjectArraysBase
   public void should_fail_if_actual_contains_null() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda", null);
-    try {
-      arrays.assertDoesNotContainNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainNull(actual));
   }
 
   @Test
@@ -93,12 +92,10 @@ public class ObjectArrays_assertDoesNotContainNull_Test extends ObjectArraysBase
   public void should_fail_if_actual_contains_null_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda", null);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContainNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainNull(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainNull(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
@@ -17,13 +17,14 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainSequence.shouldNotContainSequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -44,26 +45,22 @@ public class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArrays
   public void should_fail_if_actual_contains_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = array("Luke", "Leia");
-    try {
-      arrays.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1));
   }
 
   @Test
   public void should_fail_if_actual_and_sequence_are_equal() {
     AssertionInfo info = someInfo();
     Object[] sequence = array("Yoda", "Luke", "Leia", "Obi-Wan");
-    try {
-      arrays.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0));
   }
 
   @Test
@@ -72,13 +69,11 @@ public class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArrays
     actual = array("Yoda", "Luke", "Leia", "Yoda", "Luke", "Obi-Wan");
     // note that actual starts with {"Yoda", "Luke"} a partial sequence of {"Yoda", "Luke", "Obi-Wan"}
     Object[] sequence = array("Yoda", "Luke", "Obi-Wan");
-    try {
-      arrays.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 3));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 3));
   }
 
   @Test
@@ -160,27 +155,23 @@ public class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArrays
   public void should_fail_if_actual_contains_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = array("LUKE", "LeiA");
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1,
-                                                              caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 1,
+                                                            caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_and_sequence_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = array("YOda", "LUKE", "LeiA", "Obi-WAn");
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0,
-                                                              caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContainSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSequence(actual, sequence, 0,
+                                                            caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
@@ -17,13 +17,14 @@ import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContainSubsequence.shouldNotContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -42,13 +43,11 @@ public class ObjectArrays_assertDoesNotContainSubsequence_Test extends ObjectArr
 
   private void expectFailure(ObjectArrays arrays, Object[] actual, Object[] subsequence, int index) {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertDoesNotContainSubsequence(info, actual, subsequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainSubsequence(actual, subsequence, arrays.getComparisonStrategy(), index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContainSubsequence(info, actual, subsequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainSubsequence(actual, subsequence, arrays.getComparisonStrategy(), index));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -72,13 +73,11 @@ public class ObjectArrays_assertDoesNotContain_Test extends ObjectArraysBaseTest
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     Object[] expected = { "Luke", "Yoda", "Han" };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("Luke", "Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet("Luke", "Yoda")));
   }
 
   @Test
@@ -103,13 +102,11 @@ public class ObjectArrays_assertDoesNotContain_Test extends ObjectArraysBaseTest
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] expected = { "LUKE", "Yoda", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotContain(actual, expected, newLinkedHashSet("LUKE", "Yoda"), caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotContain(actual, expected, newLinkedHashSet("LUKE", "Yoda"), caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -75,13 +76,11 @@ public class ObjectArrays_assertDoesNotContain_at_Index_Test extends ObjectArray
   public void should_fail_if_actual_contains_value_at_index() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, "Yoda", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, "Yoda", index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, "Yoda", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, "Yoda", index));
   }
 
   @Test
@@ -112,12 +111,10 @@ public class ObjectArrays_assertDoesNotContain_at_Index_Test extends ObjectArray
   public void should_fail_if_actual_contains_value_at_index_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, "YOda", index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, "YOda", index, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, "YOda", index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, "YOda", index, caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
@@ -62,13 +63,11 @@ public class ObjectArrays_assertDoesNotHaveDuplicates_Test extends ObjectArraysB
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda", "Luke", "Yoda");
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet("Luke", "Yoda")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet("Luke", "Yoda")));
   }
 
   @Test
@@ -91,13 +90,11 @@ public class ObjectArrays_assertDoesNotHaveDuplicates_Test extends ObjectArraysB
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = array("LUKE", "Yoda", "Luke", "Yoda");
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldNotHaveDuplicates(actual, newLinkedHashSet("Luke", "Yoda"), caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldNotHaveDuplicates(actual, newLinkedHashSet("Luke", "Yoda"), caseInsensitiveStringComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -46,13 +47,11 @@ public class ObjectArrays_assertEmpty_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     Character[] actual = { 'a', 'b' };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWithFirstAndRest_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWithFirstAndRest_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -52,39 +53,33 @@ public class ObjectArrays_assertEndsWithFirstAndRest_Test extends ObjectArraysBa
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arrays.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arrays.assertEndsWith(info, actual, "Obi-Wan", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Obi-Wan", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, "Obi-Wan", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Obi-Wan", sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arrays.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, "Luke", sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object first, Object[] sequence) {
@@ -105,42 +100,36 @@ public class ObjectArrays_assertEndsWithFirstAndRest_Test extends ObjectArraysBa
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LUKE", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
-                                                   caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
+                                                 caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
-                                                   caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Yoda", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Yoda", sequence),
+                                                 caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Luke", sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, prepend("Luke", sequence),
-                                                   caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, "Luke", sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, prepend("Luke", sequence),
+                                                 caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
@@ -70,39 +71,33 @@ public class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, Object[] sequence) {
@@ -128,39 +123,33 @@ public class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "LUKE", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveAtLeast_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveAtLeast_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveAtLeast.elementsShouldHaveAtLeast;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
@@ -61,15 +62,13 @@ public class ObjectArrays_assertHaveAtLeast_Test extends ObjectArraysWithConditi
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Solo", "Leia");
-      arrays.assertHaveAtLeast(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveAtLeast(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertHaveAtLeast(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveAtLeast(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveAtMost_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveAtMost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveAtMost.elementsShouldHaveAtMost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
@@ -62,15 +63,13 @@ public class ObjectArrays_assertHaveAtMost_Test extends ObjectArraysWithConditio
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Obiwan");
-      arrays.assertHaveAtMost(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveAtMost(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> arrays.assertHaveAtMost(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveAtMost(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveExactly_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHaveExactly.elementsShouldHaveExactly;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
@@ -55,30 +56,26 @@ public class ObjectArrays_assertHaveExactly_Test extends ObjectArraysWithConditi
   public void should_fail_if_condition_is_not_met_enough() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Solo", "Leia");
-      arrays.assertHaveExactly(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Solo", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertHaveExactly(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
   }
 
   @Test
   public void should_fail_if_condition_is_met_much() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Obiwan");
-      arrays.assertHaveExactly(someInfo(), actual, 2, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Obiwan");
+
+    Throwable error = catchThrowable(() -> arrays.assertHaveExactly(someInfo(), actual, 2, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHaveExactly(actual, 2, jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveNot_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHaveNot_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldNotHave.elementsShouldNotHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -53,14 +54,12 @@ public class ObjectArrays_assertHaveNot_Test extends ObjectArraysWithConditionBa
   public void should_fail_if_condition_is_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Solo", "Leia", "Yoda");
-      arrays.assertDoNotHave(someInfo(), actual, jediPower);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Solo", "Leia", "Yoda");
+
+    Throwable error = catchThrowable(() -> arrays.assertDoNotHave(someInfo(), actual, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsShouldNotHave(actual, newArrayList("Yoda"), jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHave_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHave_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ElementsShouldHave.elementsShouldHave;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -54,16 +55,14 @@ public class ObjectArrays_assertHave_Test extends ObjectArraysWithConditionBaseT
   public void should_fail_if_Condition_is_not_met() {
     testCondition.shouldMatch(false);
     AssertionInfo info = someInfo();
-    try {
-      actual = array("Yoda", "Luke", "Leia");
-      arrays.assertHave(someInfo(), actual, jediPower);
-    } catch (AssertionError e) {
-      verify(conditions).assertIsNotNull(jediPower);
-      verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
-      verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    actual = array("Yoda", "Luke", "Leia");
+
+    Throwable error = catchThrowable(() -> arrays.assertHave(someInfo(), actual, jediPower));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(conditions).assertIsNotNull(jediPower);
+    verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
+    verify(failures).failure(info, elementsShouldHave(actual, newArrayList("Leia"), jediPower));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -78,12 +79,10 @@ public class ObjectArrays_assertIsSortedAccordingToComparator_Test extends Objec
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = array("Yoda", "Vador", "Leia", "Leia", "Luke");
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(3, actual, stringDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, stringDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(3, actual, stringDescendingOrderComparator));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -72,52 +73,44 @@ public class ObjectArrays_assertIsSorted_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = array("Luke", "Yoda", "Leia");
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
   public void should_fail_if_actual_has_only_one_element_with_non_comparable_component_type() {
     AssertionInfo info = someInfo();
     Object[] actual = array(new Object());
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
   @Test
   public void should_fail_if_actual_has_some_elements_with_non_comparable_component_type() {
     AssertionInfo info = someInfo();
     Object[] actual = array("bar", new Object(), "foo");
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
   @Test
   public void should_fail_if_actual_has_some_not_mutually_comparable_elements() {
     AssertionInfo info = someInfo();
     Object[] actual = new Object[] { "bar", new Integer(5), "foo" };
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveMutuallyComparableElements(actual));
   }
 
   @Test
@@ -152,56 +145,48 @@ public class ObjectArrays_assertIsSorted_Test extends ObjectArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = array("LUKE", "Yoda", "Leia");
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
   @Test
   public void should_fail_if_actual_has_only_one_element_with_non_comparable_component_type_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] actual = array(new Object());
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
   }
 
   @Test
   public void should_fail_if_actual_has_some_elements_with_non_comparable_component_type_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] actual = array("bar", new Object(), "foo");
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
   }
 
   @Test
   public void should_fail_if_actual_has_some_not_mutually_comparable_elements_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] actual = new Object[] { "bar", new Integer(5), "foo" };
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSubsetOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSubsetOf_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSubsetOf.shouldBeSubsetOf;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -94,13 +95,11 @@ public class ObjectArrays_assertIsSubsetOf_Test extends ObjectArraysBaseTest {
     actual = array("Yoda");
     List<String> values = newArrayList("C-3PO", "Leila");
     List<String> extra = newArrayList("Yoda");
-    try {
-      arrays.assertIsSubsetOf(info, actual, values);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSubsetOf(info, actual, values));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -131,13 +130,11 @@ public class ObjectArrays_assertIsSubsetOf_Test extends ObjectArraysBaseTest {
     actual = array("Yoda", "Luke");
     List<String> values = newArrayList("yoda", "C-3PO");
     List<String> extra = newArrayList("Luke");
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSubsetOf(info, actual, values);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSubsetOf(info, actual, values));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra, caseInsensitiveStringComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertNotEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -46,13 +47,11 @@ public class ObjectArrays_assertNotEmpty_Test extends ObjectArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class ObjectArrays_assertNullOrEmpty_Test extends ObjectArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     Integer[] actual = new Integer[] { 5, 8 };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.objectarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -71,39 +72,33 @@ public class ObjectArrays_assertStartsWith_Test extends ObjectArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Leia", "Obi-Wan", "Han" };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -132,39 +127,33 @@ public class ObjectArrays_assertStartsWith_Test extends ObjectArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Yoda", "LUKE", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "Han", "C-3PO" };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     Object[] sequence = { "LEia", "Obi-Wan", "Han" };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, caseInsensitiveStringComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveNotSameClassAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveNotSameClassAs_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveSameClass.shouldNotHaveSameClass;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,11 +64,10 @@ public class Objects_assertDoesNotHaveNotSameClassAs_Test extends ObjectsBaseTes
   @Test
   public void should_fail_if_actual_has_same_type_as_other() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertDoesNotHaveSameClassAs(info, actual, new Person("Luke"));
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldNotHaveSameClass(actual, new Person("Luke")));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertDoesNotHaveSameClassAs(info, actual, new Person("Luke")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveSameClass(actual, new Person("Luke")));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -45,13 +46,11 @@ public class Objects_assertEqual_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_objects_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertEqual(info, "Luke", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertEqual(info, "Luke", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", info.representation()));
   }
 
   @Test
@@ -73,33 +72,25 @@ public class Objects_assertEqual_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_objects_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      objectsWithCustomComparisonStrategy.assertEqual(info, "Luke", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", customComparisonStrategy, STANDARD_REPRESENTATION));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objectsWithCustomComparisonStrategy.assertEqual(info, "Luke", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual("Luke", "Yoda", customComparisonStrategy, STANDARD_REPRESENTATION));
   }
 
   @Test
   public void should_fail_with_my_exception_if_compared_with_null() {
-    try {
-      objects.assertEqual(someInfo(), new MyObject(), null);
-    } catch (MyObject.NullEqualsException e) {
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> objects.assertEqual(someInfo(), new MyObject(), null));
+
+    assertThat(error).isInstanceOf(MyObject.NullEqualsException.class);
   }
 
   @Test
   public void should_fail_with_my_exception_if_compared_with_other_object() {
-    try {
-      objects.assertEqual(someInfo(), new MyObject(), "Yoda");
-    } catch (MyObject.DifferentClassesException e) {
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> objects.assertEqual(someInfo(), new MyObject(), "Yoda"));
+
+    assertThat(error).isInstanceOf(MyObject.DifferentClassesException.class);
   }
 
   private static class MyObject {

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertHasSameClassAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertHasSameClassAs_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveSameClass.shouldHaveSameClass;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -63,11 +64,10 @@ public class Objects_assertHasSameClassAs_Test extends ObjectsBaseTest {
   @Test
   public void should_pass_if_actual_not_has_same_type_as_other() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertHasSameClassAs(info, actual, "Yoda");
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveSameClass(actual, "Yoda"));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertHasSameClassAs(info, actual, "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveSameClass(actual, "Yoda"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertHasSameHashCodeAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertHasSameHashCodeAs_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveSameHashCode.shouldHaveSameHashCode;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -64,12 +65,11 @@ public class Objects_assertHasSameHashCodeAs_Test extends ObjectsBaseTest {
     AssertionInfo info = someInfo();
     // Jedi class hashCode is computed with the Jedi's name only
     Jedi luke = new Jedi("Luke", "green");
-    try {
-      objects.assertHasSameHashCodeAs(info, greenYoda, luke);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveSameHashCode(greenYoda, luke));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertHasSameHashCodeAs(info, greenYoda, luke));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveSameHashCode(greenYoda, luke));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
@@ -25,7 +25,6 @@ import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_TIMESTAMP;
 import static org.assertj.core.test.NeverEqualComparator.NEVER_EQUALS;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.sql.Timestamp;
@@ -165,18 +164,15 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     Person other = new Person();
     other.name = "Jack";
 
-    try {
-      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(),
-                                                              defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
-                                                                                   asList(new Difference(asList("name"),
-                                                                                                         "John",
-                                                                                                         "Jack")),
-                                                                                   CONFIGURATION_PROVIDER.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() ->
+      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
+                                                                                 asList(new Difference(asList("name"),
+                                                                                                       "John",
+                                                                                                       "Jack")),
+                                                                                 CONFIGURATION_PROVIDER.representation()));
   }
 
   @Test
@@ -191,19 +187,16 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     other.name = "John";
     other.home.address.number = 2;
 
-    try {
-      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(),
-                                                              defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
-                                                                             asList(new Difference(asList("home.address.number"),
-                                                                                                   1,
-                                                                                                   2)),
-                                                                             CONFIGURATION_PROVIDER.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() ->
+      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
+                                                                           asList(new Difference(asList("home.address.number"),
+                                                                                                 1,
+                                                                                                 2)),
+                                                                           CONFIGURATION_PROVIDER.representation()));
   }
 
   @Test
@@ -266,18 +259,15 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     other.name = "John";
     other.home.address.number = 2;
 
-    try {
-      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(),
-                                                              defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
-                                                                             asList(new Difference(asList("home.address.number"),
-                                                                                                   1, 2)),
-                                                                             CONFIGURATION_PROVIDER.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() ->
+      objects.assertIsEqualToComparingFieldByFieldRecursively(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldBeEqualByComparingFieldByFieldRecursive(actual, other,
+                                                                           asList(new Difference(asList("home.address.number"),
+                                                                                                 1, 2)),
+                                                                           CONFIGURATION_PROVIDER.representation()));
   }
 
   @Test
@@ -290,15 +280,12 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     expected.collection.add("bar");
     expected.collection.add("foo");
 
-    try {
-      assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
-    } catch (AssertionError err) {
-      assertThat(err).hasMessageContaining(format("Path to difference: <collection>%n"));
-      assertThat(err).hasMessageContaining(format("- actual  : <[\"bar\", \"foo\"] (LinkedHashSet@"));
-      assertThat(err).hasMessageContaining(format("- expected: <[\"bar\", \"foo\"] (TreeSet@"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(format("Path to difference: <collection>%n"))
+      .hasMessageContaining(format("- actual  : <[\"bar\", \"foo\"] (LinkedHashSet@"))
+      .hasMessageContaining(format("- expected: <[\"bar\", \"foo\"] (TreeSet@"));
   }
 
   @Test
@@ -311,15 +298,12 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     expected.collection.add("bar");
     expected.collection.add("foo");
 
-    try {
-      assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
-    } catch (AssertionError err) {
-      assertThat(err).hasMessageContaining(format("Path to difference: <collection>%n"));
-      assertThat(err).hasMessageContaining(format("- actual  : <[\"bar\", \"foo\"] (TreeSet@"));
-      assertThat(err).hasMessageContaining(format("- expected: <[\"bar\", \"foo\"] (LinkedHashSet@"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(format("Path to difference: <collection>%n"))
+      .hasMessageContaining(format("- actual  : <[\"bar\", \"foo\"] (TreeSet@"))
+      .hasMessageContaining(format("- expected: <[\"bar\", \"foo\"] (LinkedHashSet@"));
   }
 
   @Test
@@ -332,15 +316,12 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     expected.map.put(2L, false);
     expected.map.put(1L, true);
 
-    try {
-      assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
-    } catch (AssertionError err) {
-      assertThat(err).hasMessageContaining(format("Path to difference: <map>%n"));
-      assertThat(err).hasMessageContaining(format("- actual  : <{1L=true, 2L=false} (LinkedHashMap@"));
-      assertThat(err).hasMessageContaining(format("- expected: <{1L=true, 2L=false} (TreeMap@"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(format("Path to difference: <map>%n"))
+      .hasMessageContaining(format("- actual  : <{1L=true, 2L=false} (LinkedHashMap@"))
+      .hasMessageContaining(format("- expected: <{1L=true, 2L=false} (TreeMap@"));
   }
 
   @Test
@@ -353,15 +334,12 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     expected.map.put(2L, false);
     expected.map.put(1L, true);
 
-    try {
-      assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
-    } catch (AssertionError err) {
-      assertThat(err).hasMessageContaining(format("Path to difference: <map>%n"));
-      assertThat(err).hasMessageContaining(format("- actual  : <{1L=true, 2L=false} (TreeMap@"));
-      assertThat(err).hasMessageContaining(format("- expected: <{1L=true, 2L=false} (LinkedHashMap@"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(format("Path to difference: <map>%n"))
+      .hasMessageContaining(format("- actual  : <{1L=true, 2L=false} (TreeMap@"))
+      .hasMessageContaining(format("- expected: <{1L=true, 2L=false} (LinkedHashMap@"));
   }
 
   @Test
@@ -455,16 +433,13 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     Person other = new Person();
     other.name = "%foo";
 
-    try {
-      objects.assertIsEqualToComparingFieldByFieldRecursively(someInfo(), actual, other, noFieldComparators(),
-                                                              defaultTypeComparators());
-    } catch (AssertionError err) {
-      assertThat(err).hasMessageContaining("Path to difference: <name>")
-                     .hasMessageContaining("- expected: <\"%foo\">")
-                     .hasMessageContaining("- actual  : <\"foo\">");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() ->
+      objects.assertIsEqualToComparingFieldByFieldRecursively(someInfo(), actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessageContaining("Path to difference: <name>")
+      .hasMessageContaining("- expected: <\"%foo\">")
+      .hasMessageContaining("- actual  : <\"foo\">");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingOnlyGivenFields_Test.java
@@ -13,11 +13,12 @@
 package org.assertj.core.internal.objects;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualByComparingOnlyGivenFields.shouldBeEqualComparingOnlyGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -118,20 +119,19 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Yoda", "Blue");
-    try {
-      objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, noFieldComparators(),
-                                                      defaultTypeComparators(), "name", "lightSaberColor");
-    } catch (AssertionError err) {
-      List<Object> expected = newArrayList((Object) "Blue");
-      List<Object> rejected = newArrayList((Object) "Green");
-      verify(failures).failure(info, shouldBeEqualComparingOnlyGivenFields(actual,
-                                                                           newArrayList("lightSaberColor"),
-                                                                           rejected,
-                                                                           expected,
-                                                                           newArrayList("name", "lightSaberColor")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, noFieldComparators(),
+      defaultTypeComparators(), "name", "lightSaberColor"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+
+    List<Object> expected = newArrayList((Object) "Blue");
+    List<Object> rejected = newArrayList((Object) "Green");
+    verify(failures).failure(info, shouldBeEqualComparingOnlyGivenFields(actual,
+                                                                         newArrayList("lightSaberColor"),
+                                                                         rejected,
+                                                                         expected,
+                                                                         newArrayList("name", "lightSaberColor")));
   }
 
   @Test
@@ -139,20 +139,18 @@ public class Objects_assertIsEqualToComparingOnlyGivenFields_Test extends Object
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Luke", "Green");
-    try {
-      objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, noFieldComparators(),
-                                                      defaultTypeComparators(), "name", "lightSaberColor");
-    } catch (AssertionError err) {
-      List<Object> expected = newArrayList((Object) "Luke");
-      List<Object> rejected = newArrayList((Object) "Yoda");
-      verify(failures).failure(info, shouldBeEqualComparingOnlyGivenFields(actual,
-                                                                           newArrayList("name"),
-                                                                           rejected,
-                                                                           expected,
-                                                                           newArrayList("name", "lightSaberColor")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, noFieldComparators(),
+      defaultTypeComparators(), "name", "lightSaberColor"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    List<Object> expected = newArrayList((Object) "Luke");
+    List<Object> rejected = newArrayList((Object) "Yoda");
+    verify(failures).failure(info, shouldBeEqualComparingOnlyGivenFields(actual,
+                                                                         newArrayList("name"),
+                                                                         rejected,
+                                                                         expected,
+                                                                         newArrayList("name", "lightSaberColor")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringGivenFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringGivenFields_Test.java
@@ -14,10 +14,10 @@ package org.assertj.core.internal.objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualToIgnoringFields.shouldBeEqualToIgnoringGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -116,18 +116,16 @@ public class Objects_assertIsEqualToIgnoringGivenFields_Test extends ObjectsBase
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Yoda", "Blue");
-    try {
-      objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
-                                                 "name");
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("lightSaberColor"),
-                                                                        newArrayList((Object) "Green"),
-                                                                        newArrayList((Object) "Blue"),
-                                                                        newArrayList("name")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
+      "name"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("lightSaberColor"),
+                                                                      newArrayList((Object) "Green"),
+                                                                      newArrayList((Object) "Blue"),
+                                                                      newArrayList("name")));
   }
 
   @Test
@@ -135,17 +133,15 @@ public class Objects_assertIsEqualToIgnoringGivenFields_Test extends ObjectsBase
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Yoda", "Blue");
-    try {
-      objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("lightSaberColor"),
-                                                                        newArrayList("Green"),
-                                                                        newArrayList("Blue"),
-                                                                        new ArrayList<>()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("lightSaberColor"),
+                                                                      newArrayList("Green"),
+                                                                      newArrayList("Blue"),
+                                                                      new ArrayList<>()));
   }
 
   @Test
@@ -153,18 +149,16 @@ public class Objects_assertIsEqualToIgnoringGivenFields_Test extends ObjectsBase
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Luke", "Green");
-    try {
-      objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
-                                                 "lightSaberColor");
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("name"),
-                                                                        newArrayList("Yoda"),
-                                                                        newArrayList("Luke"),
-                                                                        newArrayList("lightSaberColor")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
+      "lightSaberColor"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("name"),
+                                                                      newArrayList("Yoda"),
+                                                                      newArrayList("Luke"),
+                                                                      newArrayList("lightSaberColor")));
   }
 
   @Test
@@ -183,19 +177,17 @@ public class Objects_assertIsEqualToIgnoringGivenFields_Test extends ObjectsBase
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", null);
     Jedi other = new Jedi("Yoda", "Green");
-    try {
-      objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
-                                                 "name");
-    } catch (AssertionError err) {
-      List<Object> expected = newArrayList((Object) "Green");
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("lightSaberColor"),
-                                                                        newArrayList((Object) null),
-                                                                        expected,
-                                                                        newArrayList("name")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringGivenFields(info, actual, other, noFieldComparators(), defaultTypeComparators(),
+      "name"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    List<Object> expected = newArrayList((Object) "Green");
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("lightSaberColor"),
+                                                                      newArrayList((Object) null),
+                                                                      expected,
+                                                                      newArrayList("name")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToIgnoringNullFields_Test.java
@@ -14,10 +14,10 @@ package org.assertj.core.internal.objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualToIgnoringFields.shouldBeEqualToIgnoringGivenFields;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -95,17 +95,15 @@ public class Objects_assertIsEqualToIgnoringNullFields_Test extends ObjectsBaseT
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", null);
     Jedi other = new Jedi("Yoda", "Green");
-    try {
-      objects.assertIsEqualToIgnoringNullFields(info, actual, other, noFieldComparators(), defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("lightSaberColor"),
-                                                                        newArrayList((Object) null),
-                                                                        newArrayList((Object) "Green"),
-                                                                        newArrayList("strangeNotReadablePrivateField")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringNullFields(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("lightSaberColor"),
+                                                                      newArrayList((Object) null),
+                                                                      newArrayList((Object) "Green"),
+                                                                      newArrayList("strangeNotReadablePrivateField")));
   }
 
   @Test
@@ -113,17 +111,15 @@ public class Objects_assertIsEqualToIgnoringNullFields_Test extends ObjectsBaseT
     AssertionInfo info = someInfo();
     Jedi actual = new Jedi("Yoda", "Green");
     Jedi other = new Jedi("Soda", "Green");
-    try {
-      objects.assertIsEqualToIgnoringNullFields(info, actual, other, noFieldComparators(), defaultTypeComparators());
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
-                                                                        newArrayList("name"),
-                                                                        newArrayList((Object) "Yoda"),
-                                                                        newArrayList((Object) "Soda"),
-                                                                        newArrayList("strangeNotReadablePrivateField")));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsEqualToIgnoringNullFields(info, actual, other, noFieldComparators(), defaultTypeComparators()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToIgnoringGivenFields(actual,
+                                                                      newArrayList("name"),
+                                                                      newArrayList((Object) "Yoda"),
+                                                                      newArrayList((Object) "Soda"),
+                                                                      newArrayList("strangeNotReadablePrivateField")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsExactlyInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsExactlyInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeExactlyInstanceOf.shouldBeExactlyInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -53,11 +54,10 @@ public class Objects_assertIsExactlyInstanceOf_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_exactly_instance_of_type() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertIsExactlyInstanceOf(info, "Yoda", Object.class);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeExactlyInstance("Yoda", Object.class));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertIsExactlyInstanceOf(info, "Yoda", Object.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeExactlyInstance("Yoda", Object.class));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsInstanceOfAny_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsInstanceOfAny_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInstanceOfAny.shouldBeInstanceOfAny;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -83,10 +84,10 @@ public class Objects_assertIsInstanceOfAny_Test extends ObjectsBaseTest {
   public void should_fail_if_actual_is_not_instance_of_any_type() {
     AssertionInfo info = someInfo();
     Class<?>[] types = { String.class, File.class };
-    try {
-      objects.assertIsInstanceOfAny(info, actual, types);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {}
+
+    Throwable error = catchThrowable(() -> objects.assertIsInstanceOfAny(info, actual, types));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldBeInstanceOfAny(actual, types));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeInstance.shouldBeInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,12 +66,10 @@ public class Objects_assertIsInstanceOf_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_instance_of_type() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertIsInstanceOf(info, actual, String.class);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeInstance(actual, String.class));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertIsInstanceOf(info, actual, String.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeInstance(actual, String.class));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotExactlyInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotExactlyInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeExactlyInstanceOf.shouldNotBeExactlyInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,11 +53,10 @@ public class Objects_assertIsNotExactlyInstanceOf_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_actual_is_exactly_instance_of_type() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertIsNotExactlyInstanceOf(info, "Yoda", String.class);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldNotBeExactlyInstance("Yoda", String.class));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertIsNotExactlyInstanceOf(info, "Yoda", String.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeExactlyInstance("Yoda", String.class));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotInstanceOfAny_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotInstanceOfAny_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeInstanceOfAny.shouldNotBeInstanceOfAny;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -83,10 +84,10 @@ public class Objects_assertIsNotInstanceOfAny_Test extends ObjectsBaseTest {
   public void should_fail_if_actual_is_instance_of_any_type() {
     AssertionInfo info = someInfo();
     Class<?>[] types = { String.class, Person.class };
-    try {
-      objects.assertIsNotInstanceOfAny(info, actual, types);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {}
+
+    Throwable error = catchThrowable(() -> objects.assertIsNotInstanceOfAny(info, actual, types));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldNotBeInstanceOfAny(actual, types));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotOfClassIn_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsNotOfClassIn_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeOfClassIn.shouldNotBeOfClassIn;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -74,12 +75,11 @@ public class Objects_assertIsNotOfClassIn_Test extends ObjectsBaseTest {
   public void should_fail_if_actual_is_of_class_in_types() {
     AssertionInfo info = someInfo();
     Class<?>[] types = new Class[] { File.class, Person.class, String.class };
-    try {
-      objects.assertIsNotOfAnyClassIn(info, actual, types);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldNotBeOfClassIn(actual, types));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertIsNotOfAnyClassIn(info, actual, types));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeOfClassIn(actual, types));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsOfClassIn_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsOfClassIn_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeOfClassIn.shouldBeOfClassIn;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -68,23 +69,21 @@ public class Objects_assertIsOfClassIn_Test extends ObjectsBaseTest {
   public void should_fail_if_actual_is_not_of_class_in_types() {
     AssertionInfo info = someInfo();
     Class<?>[] types = new Class[] { File.class, String.class };
-    try {
-      objects.assertIsOfAnyClassIn(info, actual, types);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeOfClassIn(actual, types));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertIsOfAnyClassIn(info, actual, types));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeOfClassIn(actual, types));
   }
 
   @Test
   public void should_fail_if_actual_is_not_of_class_in_empty_types() {
     AssertionInfo info = someInfo();
     Class<?>[] types = new Class[] {};
-    try {
-      objects.assertIsOfAnyClassIn(info, actual, types);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldBeOfClassIn(actual, types));
-    }
+
+    Throwable error = catchThrowable(() -> objects.assertIsOfAnyClassIn(info, actual, types));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeOfClassIn(actual, types));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertNotEqual_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -40,13 +41,11 @@ public class Objects_assertNotEqual_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_objects_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertNotEqual(info, "Yoda", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual("Yoda", "Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertNotEqual(info, "Yoda", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual("Yoda", "Yoda"));
   }
 
   @Test
@@ -57,12 +56,10 @@ public class Objects_assertNotEqual_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_objects_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      objectsWithCustomComparisonStrategy.assertNotEqual(info, "YoDA", "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual("YoDA", "Yoda", customComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objectsWithCustomComparisonStrategy.assertNotEqual(info, "YoDA", "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual("YoDA", "Yoda", customComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertNotNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertNotNull_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -41,12 +42,10 @@ public class Objects_assertNotNull_Test extends ObjectsBaseTest {
   @Test
   public void should_fail_if_object_is_null() {
     AssertionInfo info = someInfo();
-    try {
-      objects.assertNotNull(info, null);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeNull());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertNotNull(info, null));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeNull());
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertNotSame_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertNotSame_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeSame.shouldNotBeSame;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -40,12 +41,10 @@ public class Objects_assertNotSame_Test extends ObjectsBaseTest {
   public void should_fail_if_objects_are_same() {
     AssertionInfo info = someInfo();
     Object actual = new Person("Yoda");
-    try {
-      objects.assertNotSame(info, actual, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeSame(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertNotSame(info, actual, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeSame(actual));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertNull_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertNull_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -39,12 +40,10 @@ public class Objects_assertNull_Test extends ObjectsBaseTest {
   public void should_fail_if_object_is_not_null() {
     AssertionInfo info = someInfo();
     Object actual = new Object();
-    try {
-      objects.assertNull(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, null, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> objects.assertNull(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, null, info.representation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertSame_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertSame_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.objects;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSame.shouldBeSame;
 import static org.assertj.core.test.TestData.someInfo;
 
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -44,10 +45,10 @@ public class Objects_assertSame_Test extends ObjectsBaseTest {
     AssertionInfo info = someInfo();
     Object a = new Person("Yoda");
     Object e = new Person("Yoda");
-    try {
-      objects.assertSame(info, a, e);
-      failBecauseExpectedAssertionErrorWasNotThrown();
-    } catch (AssertionError err) {}
+
+    Throwable error = catchThrowable(() -> objects.assertSame(info, a, e));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldBeSame(a, e));
   }
 }

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.internal.BinaryDiffResult.noDiff;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -83,13 +84,11 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
   public void should_fail_if_actual_path_does_not_exist() {
     AssertionInfo info = someInfo();
     when(nioFilesWrapper.exists(mockPath)).thenReturn(false);
-    try {
-      paths.assertHasBinaryContent(info, mockPath, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldExist(mockPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasBinaryContent(info, mockPath, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldExist(mockPath));
   }
 
   @Test
@@ -97,13 +96,11 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     AssertionInfo info = someInfo();
     when(nioFilesWrapper.exists(mockPath)).thenReturn(true);
     when(nioFilesWrapper.isReadable(mockPath)).thenReturn(false);
-    try {
-      paths.assertHasBinaryContent(info, mockPath, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeReadable(mockPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasBinaryContent(info, mockPath, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeReadable(mockPath));
   }
 
   @Test
@@ -125,12 +122,10 @@ public class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     when(nioFilesWrapper.exists(path)).thenReturn(true);
     when(nioFilesWrapper.isReadable(path)).thenReturn(true);
     AssertionInfo info = someInfo();
-    try {
-      paths.assertHasBinaryContent(info, path, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveBinaryContent(path, binaryDiffs));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasBinaryContent(info, path, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveBinaryContent(path, binaryDiffs));
   }
 }

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.paths;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
@@ -91,13 +92,11 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
   public void should_fail_if_actual_path_does_not_exist() {
     AssertionInfo info = someInfo();
     when(nioFilesWrapper.exists(mockPath)).thenReturn(false);
-    try {
-      paths.assertHasContent(info, mockPath, expected, charset);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldExist(mockPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasContent(info, mockPath, expected, charset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldExist(mockPath));
   }
 
   @Test
@@ -105,13 +104,11 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
     AssertionInfo info = someInfo();
     when(nioFilesWrapper.exists(mockPath)).thenReturn(true);
     when(nioFilesWrapper.isReadable(mockPath)).thenReturn(false);
-    try {
-      paths.assertHasContent(info, mockPath, expected, charset);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeReadable(mockPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasContent(info, mockPath, expected, charset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeReadable(mockPath));
   }
 
   @Test
@@ -134,12 +131,10 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
     when(nioFilesWrapper.exists(path)).thenReturn(true);
     when(nioFilesWrapper.isReadable(path)).thenReturn(true);
     AssertionInfo info = someInfo();
-    try {
-      paths.assertHasContent(info, path, expected, charset);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveContent(path, charset, diffs));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> paths.assertHasContent(info, path, expected, charset));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveContent(path, charset, diffs));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -78,29 +79,25 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     short[] expected = {6, 8, 20};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 20), newArrayList((short) 10),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 20), newArrayList((short) 10),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     short[] expected = {6, 8};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 10), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 10), StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -108,15 +105,13 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2, 3);
     short[] expected = {1, 2};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 3),
-              StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 3),
+            StandardComparisonStrategy.instance()));
   }
 
   @Test
@@ -124,14 +119,12 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2);
     short[] expected = {1, 2, 3};
-    try {
-      arrays.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 3), emptyList(), StandardComparisonStrategy.instance()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 3), emptyList(), StandardComparisonStrategy.instance()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -172,28 +165,24 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = {6, -8, 20};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 20),
-          newArrayList((short) 10), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 20),
+        newArrayList((short) 10), absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = {6, 8};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 10),
-          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 10),
+        absValueComparisonStrategy));
   }
 
   @Test
@@ -201,15 +190,13 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2, 3);
     short[] expected = {1, 2};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 3),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, emptyList(), newArrayList((short) 3),
+            absValueComparisonStrategy));
   }
 
   @Test
@@ -217,14 +204,12 @@ public class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArray
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 2);
     short[] expected = {1, 2, 3};
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 3), emptyList(), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactlyInAnyOrder(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainExactlyInAnyOrder(actual, expected, newArrayList((short) 3), emptyList(), absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
@@ -12,15 +12,16 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -49,13 +50,11 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
   @Test
   public void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1));
   }
 
   @Test
@@ -84,28 +83,24 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((short) 20), newArrayList((short) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((short) 20), newArrayList((short) 10)));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 10, 10 };
-    try {
-      arrays.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((short) 10), newArrayList()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((short) 10), newArrayList()));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,13 +116,11 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
   public void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { -6, 10, 8 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1, absValueComparisonStrategy));
   }
 
   @Test
@@ -153,30 +146,26 @@ public class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest 
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((short) 20), newArrayList((short) 10),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((short) 20), newArrayList((short) 10),
+                                                        absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 10, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                          newArrayList((short) 10), newArrayList(),
-                                                          absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
+                                                        newArrayList((short) 10), newArrayList(),
+                                                        absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -51,16 +52,14 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8, 6);
     short[] expected = { 6, -8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20),
-              newLinkedHashSet((short) 6, (short) -8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20),
+            newLinkedHashSet((short) 6, (short) -8)));
   }
 
   @Test
@@ -95,14 +94,12 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20), newLinkedHashSet()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20), newLinkedHashSet()));
   }
 
   @Test
@@ -120,16 +117,14 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 10, -6, -8, 10, -8);
     short[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20),
-              newLinkedHashSet((short) 6, (short) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20),
+            newLinkedHashSet((short) 6, (short) -8), absValueComparisonStrategy));
   }
 
   @Test
@@ -160,15 +155,13 @@ public class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(
-          info,
-          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20), newLinkedHashSet(),
-              absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnlyOnce(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(
+        info,
+        shouldContainsOnlyOnce(actual, expected, newLinkedHashSet((short) 20), newLinkedHashSet(),
+            absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
@@ -86,14 +87,12 @@ public class ShortArrays_assertContainsOnly_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList((short) 20), newArrayList((short) 10)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList((short) 20), newArrayList((short) 10)));
   }
 
   @Test
@@ -140,14 +139,12 @@ public class ShortArrays_assertContainsOnly_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_does_not_contain_given_values_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info,
-                               shouldContainOnly(actual, expected, newArrayList((short) 20), newArrayList((short) 10),
-                                                 absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsOnly(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldContainOnly(actual, expected, newArrayList((short) 20), newArrayList((short) 10),
+                                               absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ShortArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class ShortArrays_assertContainsSequence_Test extends ShortArraysBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenSequenceNotFound(info, sequence);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenSequenceNotFound(info, sequence);
   }
 
   private void verifyFailureThrownWhenSequenceNotFound(AssertionInfo info, short[] sequence) {
@@ -142,39 +137,33 @@ public class ShortArrays_assertContainsSequence_Test extends ShortArraysBaseTest
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_whole_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_first_elements_of_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsSequence(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainSequence(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.shortarrays;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldContainAtIndex.shouldContainAtIndex;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.*;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.*;
 
 
@@ -71,14 +72,12 @@ public class ShortArrays_assertContains_at_Index_Test extends ShortArraysBaseTes
     AssertionInfo info = someInfo();
     short value = 6;
     Index index = atIndex(1);
-    try {
-      arrays.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      short found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    short found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found));
   }
 
   @Test
@@ -121,14 +120,12 @@ public class ShortArrays_assertContains_at_Index_Test extends ShortArraysBaseTes
     AssertionInfo info = someInfo();
     short value = 6;
     Index index = atIndex(1);
-    try {
-      arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index);
-    } catch (AssertionError e) {
-      short found = 8;
-      verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContains(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    short found = 8;
+    verify(failures).failure(info, shouldContainAtIndex(actual, value, index, found, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotContain_Test.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -72,13 +73,11 @@ public class ShortArrays_assertDoesNotContain_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, 8, 20 };
-    try {
-      arrays.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((short) 6, (short) 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((short) 6, (short) 8)));
   }
 
   @Test
@@ -117,12 +116,10 @@ public class ShortArrays_assertDoesNotContain_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_contains_given_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] expected = { 6, -8, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((short) 6, (short) -8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContain(actual, expected, newLinkedHashSet((short) 6, (short) -8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotContain_at_Index_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotContain_at_Index_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.data.Index.atIndex;
 import static org.assertj.core.error.ShouldNotContainAtIndex.shouldNotContainAtIndex;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someIndex;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -70,13 +71,11 @@ public class ShortArrays_assertDoesNotContain_at_Index_Test extends ShortArraysB
     AssertionInfo info = someInfo();
     short value = 6;
     Index index = atIndex(0);
-    try {
-      arrays.assertDoesNotContain(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotContain(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index));
   }
 
   @Test
@@ -114,12 +113,10 @@ public class ShortArrays_assertDoesNotContain_at_Index_Test extends ShortArraysB
     AssertionInfo info = someInfo();
     short value = 6;
     Index index = atIndex(0);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, value, index);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotContain(info, actual, value, index));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotContainAtIndex(actual, value, index, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertDoesNotHaveDuplicates_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.assertj.core.test.ShortArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
@@ -62,13 +63,11 @@ public class ShortArrays_assertDoesNotHaveDuplicates_Test extends ShortArraysBas
   public void should_fail_if_actual_contains_duplicates() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, 8, 6, 8);
-    try {
-      arrays.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((short) 6, (short) 8)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((short) 6, (short) 8)));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class ShortArrays_assertDoesNotHaveDuplicates_Test extends ShortArraysBas
   public void should_fail_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(6, -8, 6, 8);
-    try {
-      arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((short) 6, (short) 8), absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertDoesNotHaveDuplicates(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotHaveDuplicates(actual, newLinkedHashSet((short) 6, (short) 8), absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEmpty_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +46,11 @@ public class ShortArrays_assertEmpty_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_is_not_empty() {
     AssertionInfo info = someInfo();
     short[] actual = { 6, 8 };
-    try {
-      arrays.assertEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.test.ShortArrays.arrayOf;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -69,39 +70,33 @@ public class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence() {
     AssertionInfo info = someInfo();
     short[] sequence = { 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20, 22 };
-    try {
-      arrays.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence));
   }
 
   @Test
@@ -136,39 +131,33 @@ public class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_end_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_ends_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertEndsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldEndWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.shouldBeSortedAccordingToGivenComparator;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -77,13 +78,11 @@ public class ShortArrays_assertIsSortedAccordingToComparator_Test extends ShortA
   public void should_fail_if_actual_is_not_sorted_according_to_given_comparator() {
     AssertionInfo info = someInfo();
     actual = new short[] { 3, 2, 1, 9 };
-    try {
-      arrays.assertIsSortedAccordingToComparator(info, actual, shortDescendingOrderComparator);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, shortDescendingOrderComparator));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSortedAccordingToComparator(info, actual, shortDescendingOrderComparator));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSortedAccordingToGivenComparator(2, actual, shortDescendingOrderComparator));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertIsSorted_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSorted.*;
 import static org.assertj.core.test.ShortArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,13 +66,11 @@ public class ShortArrays_assertIsSorted_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arrays.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSorted(1, actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeSorted(1, actual));
   }
 
   @Test
@@ -100,14 +99,12 @@ public class ShortArrays_assertIsSorted_Test extends ShortArraysBaseTest {
   public void should_fail_if_actual_is_not_sorted_in_ascending_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = arrayOf(1, 3, 2);
-    try {
-      arraysWithCustomComparisonStrategy.assertIsSorted(info, actual);
-    } catch (AssertionError e) {
-      verify(failures)
-          .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures)
+        .failure(info, shouldBeSortedAccordingToGivenComparator(1, actual, comparatorForCustomComparisonStrategy()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertNotEmpty_Test.java
@@ -12,11 +12,13 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.ShortArrays.*;
+import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -45,13 +47,11 @@ public class ShortArrays_assertNotEmpty_Test extends ShortArraysBaseTest {
   @Test
   public void should_fail_if_actual_is_empty() {
     AssertionInfo info = someInfo();
-    try {
-      arrays.assertNotEmpty(info, emptyArray());
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNotEmpty(info, emptyArray()));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertNullOrEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.ShortArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 
 
 import static org.mockito.Mockito.verify;
@@ -38,13 +39,11 @@ public class ShortArrays_assertNullOrEmpty_Test extends ShortArraysBaseTest {
   public void should_fail_if_array_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
     short[] actual = { 6, 8 };
-    try {
-      arrays.assertNullOrEmpty(info, actual);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty(actual));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertNullOrEmpty(info, actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty(actual));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.shortarrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.ShortArrays.*;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -70,39 +71,33 @@ public class ShortArrays_assertStartsWith_Test extends ShortArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 8, 10, 12, 20, 22 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence() {
     AssertionInfo info = someInfo();
     short[] sequence = { 8, 10 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20 };
-    try {
-      arrays.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arrays.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence));
   }
 
   @Test
@@ -137,39 +132,33 @@ public class ShortArrays_assertStartsWith_Test extends ShortArraysBaseTest {
   public void should_fail_if_sequence_is_bigger_than_actual_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, -8, 10, 12, 20, 22 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_does_not_start_with_sequence_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { -8, 10 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_starts_with_first_elements_of_sequence_only_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     short[] sequence = { 6, 20 };
-    try {
-      arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertStartsWith(info, actual, sequence));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith(actual, sequence, absValueComparisonStrategy));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -48,13 +49,11 @@ public class Shorts_assertEqual_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_shorts_are_not_equal() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertEqual(info, (short) 6, (short) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual((short) 6, (short) 8, info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertEqual(info, (short) 6, (short) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual((short) 6, (short) 8, info.representation()));
   }
 
   @Test
@@ -71,13 +70,11 @@ public class Shorts_assertEqual_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_shorts_are_not_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertEqual(info, (short) 6, (short) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual((short) 6, (short) 8, absValueComparisonStrategy,
-          new StandardRepresentation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertEqual(info, (short) 6, (short) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual((short) 6, (short) 8, absValueComparisonStrategy,
+        new StandardRepresentation()));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertGreaterThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreaterOrEqual.shouldBeGreaterOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Shorts_assertGreaterThanOrEqualTo_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertGreaterThanOrEqualTo(info, (short) 6, (short) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual((short) 6, (short) 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertGreaterThanOrEqualTo(info, (short) 6, (short) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual((short) 6, (short) 8));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Shorts_assertGreaterThanOrEqualTo_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, (short) 6, (short) -8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreaterOrEqual((short) 6, (short) -8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertGreaterThanOrEqualTo(info, (short) 6, (short) -8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreaterOrEqual((short) 6, (short) -8, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertGreaterThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeGreater.shouldBeGreater;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Shorts_assertGreaterThan_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertGreaterThan(info, (short) 6, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((short) 6, (short) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertGreaterThan(info, (short) 6, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((short) 6, (short) 6));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertGreaterThan(info, (short) 6, (short) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((short) 6, (short) 8));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertGreaterThan(info, (short) 6, (short) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((short) 6, (short) 8));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -82,25 +79,21 @@ public class Shorts_assertGreaterThan_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertGreaterThan(info, (short) -6, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((short) -6, (short) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertGreaterThan(info, (short) -6, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((short) -6, (short) 6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_less_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertGreaterThan(info, (short) -6, (short) 8);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeGreater((short) -6, (short) 8, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertGreaterThan(info, (short) -6, (short) 8));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeGreater((short) -6, (short) 8, absValueComparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsBetween_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import static org.mockito.Mockito.verify;
@@ -72,24 +73,20 @@ public class Shorts_assertIsBetween_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, true, true));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsBetween(info, ONE, ZERO, ZERO);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsBetween(info, ONE, ZERO, ZERO));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ZERO, true, true));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseToPercentage_Test.java
@@ -12,14 +12,15 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldBeEqualWithinPercentage.shouldBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -84,12 +85,10 @@ public class Shorts_assertIsCloseToPercentage_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_close_enough_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), (short) (TEN - ONE)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsCloseToPercentage(someInfo(), ONE, TEN, withPercentage(TEN)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualWithinPercentage(ONE, TEN, withinPercentage(10), (short) (TEN - ONE)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.shorts;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldBeEqualWithinOffset.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -71,13 +72,11 @@ public class Shorts_assertIsCloseTo_Test extends ShortsBaseTest {
   })
   public void should_fail_if_actual_is_not_close_enough_to_expected(short actual, short expected, short offset) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsCloseTo(info, actual, expected, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), (short) abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsCloseTo(info, actual, expected, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, within(offset), (short) abs(actual - expected)));
   }
 
   @ParameterizedTest
@@ -91,13 +90,11 @@ public class Shorts_assertIsCloseTo_Test extends ShortsBaseTest {
   public void should_fail_if_difference_is_equal_to_the_given_strict_offset(short actual, short expected,
                                                                             short offset) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsCloseTo(info, actual, expected, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), (short) abs(actual - expected)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsCloseTo(info, actual, expected, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(actual, expected, byLessThan(offset), (short) abs(actual - expected)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseToPercentage_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseToPercentage_Test.java
@@ -13,14 +13,15 @@
 package org.assertj.core.internal.shorts;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.withinPercentage;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.assertj.core.error.ShouldNotBeEqualWithinPercentage.shouldNotBeEqualWithinPercentage;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -81,26 +82,22 @@ public class Shorts_assertIsNotCloseToPercentage_Test extends ShortsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_percentage(Short actual, Short other, Short percentage) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
-                                                                      abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsNotCloseToPercentage(someInfo(), actual, other, withPercentage(percentage)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(actual, other, withPercentage(percentage),
+                                                                    abs(actual - other)));
   }
 
   @Test
   public void should_fail_if_actual_is_too_close_to_expected_value() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
-        TEN - ONE));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsNotCloseToPercentage(someInfo(), ONE, TEN, withPercentage(ONE_HUNDRED)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqualWithinPercentage(ONE, TEN, withinPercentage(100),
+      TEN - ONE));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotCloseTo_Test.java
@@ -13,13 +13,14 @@
 package org.assertj.core.internal.shorts;
 
 import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.byLessThan;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.error.ShouldNotBeEqualWithinOffset.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -67,13 +68,11 @@ public class Shorts_assertIsNotCloseTo_Test extends ShortsBaseTest {
   })
   public void should_fail_if_actual_is_too_close_to_the_other_value(short actual, short other, short offset) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (short) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsNotCloseTo(someInfo(), actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (short) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -85,13 +84,11 @@ public class Shorts_assertIsNotCloseTo_Test extends ShortsBaseTest {
   public void should_fail_if_actual_is_too_close_to_the_other_value_with_strict_offset(short actual, short other,
                                                                                        short offset) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsNotCloseTo(info, actual, other, byLessThan(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (short) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsNotCloseTo(info, actual, other, byLessThan(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, byLessThan(offset), (short) abs(actual - other)));
   }
 
   @ParameterizedTest
@@ -102,13 +99,11 @@ public class Shorts_assertIsNotCloseTo_Test extends ShortsBaseTest {
   })
   public void should_fail_if_difference_is_equal_to_given_offset(short actual, short other, short offset) {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsNotCloseTo(someInfo(), actual, other, within(offset));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (short) abs(actual - other)));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsNotCloseTo(someInfo(), actual, other, within(offset)));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual(actual, other, within(offset), (short) abs(actual - other)));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBetween.shouldBeBetween;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -65,37 +66,31 @@ public class Shorts_assertIsStrictlyBetween_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        shorts.assertIsStrictlyBetween(info, ONE, ONE, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsStrictlyBetween(info, ONE, ONE, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ONE, TEN, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_equal_to_range_end() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertIsStrictlyBetween(info, ONE, ZERO, ONE);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsStrictlyBetween(info, ONE, ZERO, ONE));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, ZERO, ONE, false, false));
   }
 
   @Test
   public void should_fail_if_actual_is_not_in_range_start() {
     AssertionInfo info = someInfo();
-    try {
-        shorts.assertIsStrictlyBetween(info, ONE, TWO, TEN);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertIsStrictlyBetween(info, ONE, TWO, TEN));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeBetween(ONE, TWO, TEN, false, false));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertLessThanOrEqualTo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLessOrEqual.shouldBeLessOrEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -54,13 +55,11 @@ public class Shorts_assertLessThanOrEqualTo_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertLessThanOrEqualTo(info, (short) 8, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual((short) 8, (short) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertLessThanOrEqualTo(info, (short) 8, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual((short) 8, (short) 6));
   }
 
   @Test
@@ -82,12 +81,10 @@ public class Shorts_assertLessThanOrEqualTo_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, (short) -8, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLessOrEqual((short) -8, (short) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertLessThanOrEqualTo(info, (short) -8, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLessOrEqual((short) -8, (short) 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertLessThan_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,25 +50,21 @@ public class Shorts_assertLessThan_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertLessThan(info, (short) 6, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((short) 6, (short) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertLessThan(info, (short) 6, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((short) 6, (short) 6));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertLessThan(info, (short) 8, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((short) 8, (short) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertLessThan(info, (short) 8, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((short) 8, (short) 6));
   }
 
   @Test
@@ -84,24 +81,20 @@ public class Shorts_assertLessThan_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_actual_is_equal_to_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertLessThan(info, (short) 6, (short) -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((short) 6, (short) -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertLessThan(info, (short) 6, (short) -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((short) 6, (short) -6, absValueComparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_is_greater_than_other_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertLessThan(info, (short) -8, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeLess((short) -8, (short) 6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertLessThan(info, (short) -8, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeLess((short) -8, (short) 6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertNotEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertNotEqual_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.shorts;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 
@@ -49,13 +50,11 @@ public class Shorts_assertNotEqual_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_shorts_are_equal() {
     AssertionInfo info = someInfo();
-    try {
-      shorts.assertNotEqual(info, (short) 6, (short) 6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual((short) 6, (short) 6));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shorts.assertNotEqual(info, (short) 6, (short) 6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual((short) 6, (short) 6));
   }
 
   @Test
@@ -72,12 +71,10 @@ public class Shorts_assertNotEqual_Test extends ShortsBaseTest {
   @Test
   public void should_fail_if_shorts_are_equal_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      shortsWithAbsValueComparisonStrategy.assertNotEqual(info, (short) 6, (short) -6);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEqual((short) 6, (short) -6, absValueComparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> shortsWithAbsValueComparisonStrategy.assertNotEqual(info, (short) 6, (short) -6));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEqual((short) 6, (short) -6, absValueComparisonStrategy));
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualIgnoringWhitespace.shouldBeEqualIgnoringWhitespace;
 import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
@@ -42,13 +43,11 @@ public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest
   @Test
   public void should_fail_if_actual_is_null_and_expected_is_not() {
     AssertionInfo info = someInfo();
-    try {
-      strings.assertEqualsIgnoringWhitespace(info, null, "Luke");
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, null, "Luke");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertEqualsIgnoringWhitespace(info, null, "Luke"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, null, "Luke");
   }
 
   @Test
@@ -60,13 +59,11 @@ public class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest
   @Test
   public void should_fail_if_both_Strings_are_not_equal_ignoring_whitespace() {
     AssertionInfo info = someInfo();
-    try {
-      strings.assertEqualsIgnoringWhitespace(info, "Yoda", "Luke");
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, "Yoda", "Luke");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertEqualsIgnoringWhitespace(info, "Yoda", "Luke"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqualIgnoringWhitespace(info, "Yoda", "Luke");
   }
 
   @ParameterizedTest

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNewLineDifferences.shouldBeEqualIgnoringNewLineDifferences;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.internal.StringsBaseTest;
@@ -48,13 +49,11 @@ public class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBase
   public void should_fail_if_newlines_are_different_in_both_strings() {
     String actual = "Lord of the Rings\r\n\r\nis cool";
     String expected = "Lord of the Rings\nis cool";
-    try {
-      strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsXmlEqualCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsXmlEqualCase_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.xml.XmlStringPrettyFormatter.xmlPrettyFormat;
 import static org.mockito.Mockito.verify;
@@ -59,13 +60,11 @@ public class Strings_assertIsXmlEqualCase_Test extends StringsBaseTest {
     String actual = "<rss version=\"2.0\"><channel><title>Java Tutorials</title></channel></rss>";
     String expected = "<rss version=\"2.0\"><channel><title>Java Tutorials and Examples</title></channel></rss>";
     AssertionInfo info = someInfo();
-    try {
-      strings.assertXmlEqualsTo(info, actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(xmlPrettyFormat(actual), xmlPrettyFormat(expected), info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertXmlEqualsTo(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(xmlPrettyFormat(actual), xmlPrettyFormat(expected), info.representation()));
   }
 
   @Test
@@ -80,14 +79,12 @@ public class Strings_assertIsXmlEqualCase_Test extends StringsBaseTest {
     AssertionInfo info = someInfo();
     String actual = "<rss version=\"2.0\"><channel><title>Java Tutorials</title></channel></rss>";
     String expected = "<rss version=\"2.0\"><channel><title>Java Tutorials and Examples</title></channel></rss>";
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertXmlEqualsTo(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeEqual(xmlPrettyFormat(actual), xmlPrettyFormat(expected),
-          info.representation()));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertXmlEqualsTo(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqual(xmlPrettyFormat(actual), xmlPrettyFormat(expected),
+        info.representation()));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertJavaBlank_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
@@ -53,13 +54,10 @@ public class Strings_assertJavaBlank_Test extends StringsBaseTest {
   @ParameterizedTest
   @MethodSource("notBlank")
   public void should_fail_if_string_is_not_blank(String actual) {
-    try {
-      strings.assertJavaBlank(someInfo(), actual);
-    } catch (AssertionError expectedAssertionError) {
-      verifyFailureThrownWhenStringIsNotBank(someInfo(), actual);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> strings.assertJavaBlank(someInfo(), actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringIsNotBank(someInfo(), actual);
   }
 
   private void verifyFailureThrownWhenStringIsNotBank(AssertionInfo info, String actual) {

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldMatchPattern.shouldMatch;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.matchAnything;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -95,13 +96,11 @@ public class Strings_assertMatches_CharSequence_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_match_regular_expression_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertMatches(info, actual, "Luke");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldMatch(actual, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertMatches(info, actual, "Luke"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldMatch(actual, "Luke"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertMatches_Pattern_Test.java
@@ -12,13 +12,14 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldMatchPattern.shouldMatch;
 import static org.assertj.core.internal.ErrorMessages.regexPatternIsNull;
 import static org.assertj.core.test.TestData.matchAnything;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -82,13 +83,11 @@ public class Strings_assertMatches_Pattern_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_match_Pattern_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertMatches(info, actual, Pattern.compile("Luke"));
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldMatch(actual, "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertMatches(info, actual, Pattern.compile("Luke")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldMatch(actual, "Luke"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEmpty_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -59,13 +60,11 @@ public class Strings_assertNotEmpty_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_is_empty_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNotEmpty(info, "");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldNotBeEmpty());
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNotEmpty(info, ""));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldNotBeEmpty());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEqualsIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEqualsIgnoringCase_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringCase.shouldNotBeEqualIgnoringCase;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -88,51 +89,42 @@ public class Strings_assertNotEqualsIgnoringCase_Test extends StringsBaseTest {
 
   @Test
   public void should_fail_if_both_Strings_are_null_whatever_custom_comparison_strategy_is() {
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(someInfo(), null, null);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqual(someInfo(), null, null);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(someInfo(), null, null));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqual(someInfo(), null, null);
   }
 
   @Test
   public void should_fail_if_both_Strings_are_the_same_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
     String s = "Yoda";
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, s, s);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqual(info, s, s);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, s, s));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqual(info, s, s);
   }
 
   @Test
   public void should_fail_if_both_Strings_are_equal_but_not_same_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, "Yoda",
-                                                                               new String(
-                                                                                          arrayOf('Y', 'o', 'd', 'a')));
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqual(info, "Yoda", "Yoda");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, "Yoda",
+      new String(arrayOf('Y', 'o', 'd', 'a')))
+    );
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqual(info, "Yoda", "Yoda");
   }
 
   @Test
   public void should_fail_if_both_Strings_are_equal_ignoring_case_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, "Yoda", "YODA");
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreNotEqual(info, "Yoda", "YODA");
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNotEqualsIgnoringCase(info, "Yoda", "YODA"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreNotEqual(info, "Yoda", "YODA");
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEqualsIgnoringWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotEqualsIgnoringWhitespace_Test.java
@@ -12,12 +12,13 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace.shouldNotBeEqualIgnoringWhitespace;
 import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNull;
 import static org.assertj.core.test.CharArrays.arrayOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
@@ -58,13 +59,10 @@ public class Strings_assertNotEqualsIgnoringWhitespace_Test extends StringsBaseT
   @ParameterizedTest
   @MethodSource("equalIgnoringWhitespaceGenerator")
   public void should_fail_if_both_Strings_are_equal_ignoring_whitespace(String actual, String expected) {
-    try {
-      strings.assertNotEqualsIgnoringWhitespace(someInfo(), actual, expected);
-    } catch (AssertionError e) {
-      verifyFailureThrownWhenStringsAreEqualIgnoringWhitespace(someInfo(), actual, expected);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> strings.assertNotEqualsIgnoringWhitespace(someInfo(), actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringsAreEqualIgnoringWhitespace(someInfo(), actual, expected);
   }
 
   public static Stream<Arguments> equalIgnoringWhitespaceGenerator() {

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNotJavaBlank_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNotJavaBlank_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
@@ -53,13 +54,10 @@ public class Strings_assertNotJavaBlank_Test extends StringsBaseTest {
   @ParameterizedTest
   @MethodSource("blank")
   public void should_fail_if_string_is_blank(String actual) {
-    try {
-      strings.assertNotJavaBlank(someInfo(), actual);
-    } catch (AssertionError expectedAssertionError) {
-      verifyFailureThrownWhenStringIsBank(someInfo(), actual);
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    Throwable error = catchThrowable(() -> strings.assertNotJavaBlank(someInfo(), actual));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verifyFailureThrownWhenStringIsBank(someInfo(), actual);
   }
 
   private void verifyFailureThrownWhenStringIsBank(AssertionInfo info, String actual) {

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertNullOrEmpty_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -34,13 +35,11 @@ public class Strings_assertNullOrEmpty_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_null_and_is_not_empty() {
     AssertionInfo info = someInfo();
-    try {
-      strings.assertNullOrEmpty(info, "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty("Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertNullOrEmpty(info, "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty("Yoda"));
   }
 
   @Test
@@ -56,13 +55,11 @@ public class Strings_assertNullOrEmpty_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_is_not_null_and_is_not_empty_whatever_custom_comparison_strategy_is() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertNullOrEmpty(info, "Yoda");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeNullOrEmpty("Yoda"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertNullOrEmpty(info, "Yoda"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeNullOrEmpty("Yoda"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertStartsWith_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertStartsWith_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.strings;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -37,13 +38,11 @@ public class Strings_assertStartsWith_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_start_with_prefix() {
     AssertionInfo info = someInfo();
-    try {
-      strings.assertStartsWith(info, "Yoda", "Luke");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith("Yoda", "Luke"));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> strings.assertStartsWith(info, "Yoda", "Luke"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith("Yoda", "Luke"));
   }
 
   @Test
@@ -76,13 +75,11 @@ public class Strings_assertStartsWith_Test extends StringsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_start_with_prefix_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    try {
-      stringsWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, "Yoda", "Luke");
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldStartWith("Yoda", "Luke", comparisonStrategy));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> stringsWithCaseInsensitiveComparisonStrategy.assertStartsWith(info, "Yoda", "Luke"));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldStartWith("Yoda", "Luke", comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.throwables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveCauseExactlyInstance.shouldHaveCauseExactlyInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -58,38 +59,32 @@ public class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesB
   public void should_fail_if_actual_has_no_cause() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasCauseExactlyInstanceOf(info, actual, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveCauseExactlyInstance(actual, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
-  }  
+
+    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, actual, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveCauseExactlyInstance(actual, expectedCauseType));
+  }
 
   @Test
   public void should_fail_if_cause_is_not_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
 
   @Test
   public void should_fail_if_cause_is_not_exactly_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<RuntimeException> expectedCauseType = RuntimeException.class;
-    try {
-      throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.throwables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveCauseInstance.shouldHaveCauseInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -62,25 +63,21 @@ public class Throwables_assertHasCauseInstanceOf_Test extends ThrowablesBaseTest
   public void should_fail_if_actual_has_no_cause() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasCauseInstanceOf(info, actual, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveCauseInstance(actual, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasCauseInstanceOf(info, actual, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveCauseInstance(actual, expectedCauseType));
   }
 
   @Test
   public void should_fail_if_cause_is_not_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasCauseInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveCauseInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasCauseInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveCauseInstance(throwableWithCause, expectedCauseType));
   }
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseExactlyInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseExactlyInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.throwables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveRootCauseExactlyInstance.shouldHaveRootCauseExactlyInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -58,38 +59,32 @@ public class Throwables_assertHasRootCauseExactlyInstanceOf_Test extends Throwab
   public void should_fail_if_actual_has_no_cause() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasRootCauseExactlyInstanceOf(info, actual, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(actual, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasRootCauseExactlyInstanceOf(info, actual, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(actual, expectedCauseType));
   }
 
   @Test
   public void should_fail_if_root_cause_is_not_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasRootCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasRootCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
 
   @Test
   public void should_fail_if_cause_is_not_exactly_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<RuntimeException> expectedCauseType = RuntimeException.class;
-    try {
-      throwables.assertHasRootCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasRootCauseExactlyInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveRootCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasRootCauseInstanceOf_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.throwables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveRootCauseInstance.shouldHaveRootCauseInstance;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -62,25 +63,21 @@ public class Throwables_assertHasRootCauseInstanceOf_Test extends ThrowablesBase
   public void should_fail_if_actual_has_no_cause() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasRootCauseInstanceOf(info, actual, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveRootCauseInstance(actual, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasRootCauseInstanceOf(info, actual, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveRootCauseInstance(actual, expectedCauseType));
   }
 
   @Test
   public void should_fail_if_root_cause_is_not_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-    try {
-      throwables.assertHasRootCauseInstanceOf(info, throwableWithCause, expectedCauseType);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveRootCauseInstance(throwableWithCause, expectedCauseType));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasRootCauseInstanceOf(info, throwableWithCause, expectedCauseType));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveRootCauseInstance(throwableWithCause, expectedCauseType));
   }
 }

--- a/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasSuppressedException_Test.java
+++ b/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasSuppressedException_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.throwables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldHaveSuppressedException.shouldHaveSuppressedException;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -64,41 +65,35 @@ public class Throwables_assertHasSuppressedException_Test extends ThrowablesBase
   public void should_fail_if_actual_has_no_suppressed_exception_and_expected_suppressed_exception_is_not_null() {
     AssertionInfo info = someInfo();
     Throwable expectedSuppressedException = new Throwable();
-    try {
-      throwables.assertHasSuppressedException(info, actual, expectedSuppressedException);
-    } catch (AssertionError err) {
-      verify(failures).failure(info, shouldHaveSuppressedException(actual, expectedSuppressedException));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasSuppressedException(info, actual, expectedSuppressedException));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveSuppressedException(actual, expectedSuppressedException));
   }
 
   @Test
   public void should_fail_if_suppressed_exception_is_not_instance_of_expected_type() {
     AssertionInfo info = someInfo();
     Throwable expectedSuppressedException = new NullPointerException(IAE_EXCEPTION_MESSAGE);
-    try {
-      throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException);
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
   }
 
   @Test
   public void should_fail_if_suppressed_exception_has_not_the_expected_message() {
     AssertionInfo info = someInfo();
     Throwable expectedSuppressedException = new IllegalArgumentException(IAE_EXCEPTION_MESSAGE + "foo");
-    try {
-      throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException);
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
   }
 
   @Test
@@ -106,27 +101,23 @@ public class Throwables_assertHasSuppressedException_Test extends ThrowablesBase
     AssertionInfo info = someInfo();
     Throwable expectedSuppressedException = new IllegalArgumentException("error cause");
     throwableSuppressedException = new Throwable(new IllegalArgumentException());
-    try {
-      throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException);
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
   }
 
   @Test
   public void should_fail_if_suppressed_exception_has_different_type_and_message_to_expected_cause() {
     AssertionInfo info = someInfo();
     Throwable expectedSuppressedException = new NullPointerException("error cause");
-    try {
-      throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException);
-    } catch (AssertionError err) {
-      verify(failures).failure(info,
-                               shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> throwables.assertHasSuppressedException(info, throwableSuppressedException, expectedSuppressedException));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldHaveSuppressedException(throwableSuppressedException, expectedSuppressedException));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasAuthority_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasAuthority_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +49,11 @@ public class Uris_assertHasAuthority_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com:8080/pages/");
     String expectedAuthority = "example.com:8888";
-    try {
-      uris.assertHasAuthority(info, uri, expectedAuthority);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAuthority(uri, expectedAuthority));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasAuthority(info, uri, expectedAuthority));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAuthority(uri, expectedAuthority));
   }
 
   @Test
@@ -62,13 +61,11 @@ public class Uris_assertHasAuthority_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com:8080/pages/");
     String expectedAuthority = "example.org:8080";
-    try {
-      uris.assertHasAuthority(info, uri, expectedAuthority);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAuthority(uri, expectedAuthority));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasAuthority(info, uri, expectedAuthority));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAuthority(uri, expectedAuthority));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasFragment_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasFragment_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveFragment.shouldHaveFragment;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -56,13 +57,11 @@ public class Uris_assertHasFragment_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/index.html#print");
     String expectedFragment = "foo";
-    try {
-      uris.assertHasFragment(info, uri, expectedFragment);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasFragment(info, uri, expectedFragment));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
   }
 
   @Test
@@ -70,13 +69,11 @@ public class Uris_assertHasFragment_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/index.html");
     String expectedFragment = "print";
-    try {
-      uris.assertHasFragment(info, uri, expectedFragment);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasFragment(info, uri, expectedFragment));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
   }
 
   @Test
@@ -84,13 +81,11 @@ public class Uris_assertHasFragment_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/index.html#print");
     String expectedFragment = null;
-    try {
-      uris.assertHasFragment(info, uri, expectedFragment);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasFragment(info, uri, expectedFragment));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveFragment(uri, expectedFragment));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,12 +49,10 @@ public class Uris_assertHasHost_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/pages/");
     String expectedHost = "example.org";
-    try {
-      uris.assertHasHost(info, uri, expectedHost);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveHost(uri, expectedHost));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasHost(info, uri, expectedHost));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveHost(uri, expectedHost));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoParameter_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -38,14 +39,10 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
     String name = "article";
     List<String> actualValues = newArrayList((String)null);
 
-    try {
-      uris.assertHasNoParameter(info, uri, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameter(info, uri, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValues));
   }
 
   @Test
@@ -54,14 +51,10 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
     String name = "article";
     List<String> actualValue = newArrayList("10");
 
-    try {
-      uris.assertHasNoParameter(info, uri, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValue));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameter(info, uri, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValue));
   }
 
   @Test
@@ -70,14 +63,10 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
     String name = "article";
     List<String> actualValues = newArrayList(null, "10");
 
-    try {
-      uris.assertHasNoParameter(info, uri, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameter(info, uri, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(uri, name, actualValues));
   }
 
   @Test
@@ -92,14 +81,10 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
     String expectedValue = null;
     List<String> actualValues = newArrayList((String)null);
 
-    try {
-      uris.assertHasNoParameter(info, uri, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameter(info, uri, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValues));
   }
 
   @Test
@@ -129,14 +114,10 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
     String expectedValue = "10";
     List<String> actualValue = newArrayList("10");
 
-    try {
-      uris.assertHasNoParameter(info, uri, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValue));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameter(info, uri, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(uri, name, expectedValue, actualValue));
   }
 
   @Test
@@ -148,27 +129,19 @@ public class Uris_assertHasNoParameter_Test extends UrisBaseTest {
   public void should_fail_if_uri_has_some_parameters() {
     URI uri = URI.create("http://assertj.org/news?article=10&locked=false");
 
-    try {
-      uris.assertHasNoParameters(info, uri);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameters(uri, newLinkedHashSet("article", "locked")));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameters(info, uri));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameters(uri, newLinkedHashSet("article", "locked")));
   }
 
   @Test
   public void should_fail_if_uri_has_one_parameter() {
     URI uri = URI.create("http://assertj.org/news?article=10");
 
-    try {
-      uris.assertHasNoParameters(info, uri);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameters(uri, newLinkedHashSet("article")));
-      return;
-    }
+    Throwable error = catchThrowable(() -> uris.assertHasNoParameters(info, uri));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameters(uri, newLinkedHashSet("article")));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasPath_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasPath_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHavePath.shouldHavePath;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -49,13 +50,11 @@ public class Uris_assertHasPath_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/pages/");
     String expectedPath = "/news/";
-    try {
-      uris.assertHasPath(info, uri, expectedPath);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePath(uri, expectedPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasPath(info, uri, expectedPath));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePath(uri, expectedPath));
   }
 
   @Test
@@ -63,13 +62,11 @@ public class Uris_assertHasPath_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/pages/");
     String expectedPath = null;
-    try {
-      uris.assertHasPath(info, uri, expectedPath);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePath(uri, expectedPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasPath(info, uri, expectedPath));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePath(uri, expectedPath));
   }
 
   @Test
@@ -77,12 +74,10 @@ public class Uris_assertHasPath_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("mailto:java-net@java.sun.com");
     String expectedPath = "";
-    try {
-      uris.assertHasPath(info, uri, expectedPath);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePath(uri, expectedPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasPath(info, uri, expectedPath));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePath(uri, expectedPath));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasPort_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasPort_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHavePort.shouldHavePort;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -43,13 +44,11 @@ public class Uris_assertHasPort_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com:8080/pages/");
     int expectedPort = 8888;
-    try {
-      uris.assertHasPort(info, uri, expectedPort);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePort(uri, expectedPort));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasPort(info, uri, expectedPort));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePort(uri, expectedPort));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasQuery_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasQuery_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveQuery.shouldHaveQuery;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -55,13 +56,11 @@ public class Uris_assertHasQuery_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://assertj.org/news?type=beta");
     String expectedQuery = "type=final";
-    try {
-      uris.assertHasQuery(info, uri, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasQuery(info, uri, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
   }
 
   @Test
@@ -69,13 +68,11 @@ public class Uris_assertHasQuery_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://assertj.org/news");
     String expectedQuery = "type=final";
-    try {
-      uris.assertHasQuery(info, uri, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasQuery(info, uri, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
   }
 
   @Test
@@ -83,12 +80,10 @@ public class Uris_assertHasQuery_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://assertj.org/news?type=beta");
     String expectedQuery = null;
-    try {
-      uris.assertHasQuery(info, uri, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasQuery(info, uri, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(uri, expectedQuery));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasScheme_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasScheme_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveScheme.shouldHaveScheme;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -44,13 +45,11 @@ public class Uris_assertHasScheme_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://example.com/pages/");
     String expectedScheme = "ftp";
-    try {
-      uris.assertHasScheme(info, uri, expectedScheme);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveScheme(uri, expectedScheme));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasScheme(info, uri, expectedScheme));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveScheme(uri, expectedScheme));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasUserInfo_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasUserInfo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +49,11 @@ public class Uris_assertHasUserInfo_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://test:pass@assertj.org/news");
     String expectedUserInfo = "test:ok";
-    try {
-      uris.assertHasUserInfo(info, uri, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasUserInfo(info, uri, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
   }
 
   @Test
@@ -62,13 +61,11 @@ public class Uris_assertHasUserInfo_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://assertj.org/news");
     String expectedUserInfo = "test:pass";
-    try {
-      uris.assertHasUserInfo(info, uri, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasUserInfo(info, uri, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
   }
 
   @Test
@@ -76,13 +73,11 @@ public class Uris_assertHasUserInfo_Test extends UrisBaseTest {
     AssertionInfo info = someInfo();
     URI uri = URI.create("http://test:pass@assertj.org");
     String expectedUserInfo = null;
-    try {
-      uris.assertHasUserInfo(info, uri, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> uris.assertHasUserInfo(info, uri, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(uri, expectedUserInfo));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasAnchor_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasAnchor_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -50,13 +51,11 @@ public class Urls_assertHasAnchor_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/index.html#print");
     String expectedAnchor = "foo";
-    try {
-      urls.assertHasAnchor(info, url, expectedAnchor);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasAnchor(info, url, expectedAnchor));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
   }
 
   @Test
@@ -64,13 +63,11 @@ public class Urls_assertHasAnchor_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/index.html");
     String expectedAnchor = "print";
-    try {
-      urls.assertHasAnchor(info, url, expectedAnchor);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasAnchor(info, url, expectedAnchor));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
   }
 
   @Test
@@ -78,13 +75,11 @@ public class Urls_assertHasAnchor_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/index.html#print");
     String expectedAnchor = null;
-    try {
-      urls.assertHasAnchor(info, url, expectedAnchor);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasAnchor(info, url, expectedAnchor));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAnchor(url, expectedAnchor));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasAuthority_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasAuthority_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -50,13 +51,11 @@ public class Urls_assertHasAuthority_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com:8080/pages/");
     String expectedAuthority = "example.com:8888";
-    try {
-      urls.assertHasAuthority(info, url, expectedAuthority);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAuthority(url, expectedAuthority));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasAuthority(info, url, expectedAuthority));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAuthority(url, expectedAuthority));
   }
 
   @Test
@@ -65,13 +64,11 @@ public class Urls_assertHasAuthority_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com:8080/pages/");
     String expectedAuthority = "example.org:8080";
-    try {
-      urls.assertHasAuthority(info, url, expectedAuthority);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveAuthority(url, expectedAuthority));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasAuthority(info, url, expectedAuthority));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveAuthority(url, expectedAuthority));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -49,12 +50,10 @@ public class Urls_assertHasHost_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/pages/");
     String expectedHost = "example.org";
-    try {
-      urls.assertHasHost(info, url, expectedHost);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveHost(url, expectedHost));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasHost(info, url, expectedHost));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveHost(url, expectedHost));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoParameter_Test.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
@@ -39,14 +40,10 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
     String name = "article";
     List<String> actualValues = newArrayList((String)null);
 
-    try {
-      urls.assertHasNoParameter(info, url, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameter(info, url, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
   }
 
   @Test
@@ -55,14 +52,10 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
     String name = "article";
     List<String> actualValues = newArrayList("10");
 
-    try {
-      urls.assertHasNoParameter(info, url, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameter(info, url, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
   }
 
   @Test
@@ -71,14 +64,10 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
     String name = "article";
     List<String> actualValues = newArrayList(null, "10");
 
-    try {
-      urls.assertHasNoParameter(info, url, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameter(info, url, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(url, name, actualValues));
   }
 
   @Test
@@ -93,14 +82,10 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
     String expectedValue = null;
     List<String> actualValues = newArrayList((String)null);
 
-    try {
-      urls.assertHasNoParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -130,14 +115,10 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
     String expectedValue = "10";
     List<String> actualValues = newArrayList("10");
 
-    try {
-      urls.assertHasNoParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -149,27 +130,19 @@ public class Urls_assertHasNoParameter_Test extends UrlsBaseTest {
   public void should_fail_if_url_has_some_parameters() throws MalformedURLException {
     URL url = new URL("http://assertj.org/news?article=10&locked=false");
 
-    try {
-      urls.assertHasNoParameters(info, url);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameters(url, newLinkedHashSet("article", "locked")));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameters(info, url));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameters(url, newLinkedHashSet("article", "locked")));
   }
 
   @Test
   public void should_fail_if_url_has_one_parameter() throws MalformedURLException {
     URL url = new URL("http://assertj.org/news?article=10");
 
-    try {
-      urls.assertHasNoParameters(info, url);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveNoParameters(url, newLinkedHashSet("article")));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasNoParameters(info, url));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveNoParameters(url, newLinkedHashSet("article")));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasParameter_Test.java
@@ -12,8 +12,9 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -31,14 +32,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     URL url = new URL("http://assertj.org/news");
     String name = "article";
 
-    try {
-      urls.assertHasParameter(info, url, name);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name));
   }
 
   @Test
@@ -57,14 +54,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String name = "article";
     String expectedValue = null;
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
   }
 
   @Test
@@ -79,14 +72,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String expectedValue = null;
     List<String> actualValues = newArrayList("11");
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -96,14 +85,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String expectedValue = null;
     List<String> actualValues = newArrayList("11", "12");
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -112,14 +97,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String name = "article";
     String expectedValue = "10";
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue));
   }
 
   @Test
@@ -129,14 +110,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String expectedValue = "10";
     List<String> actualValues = newArrayList((String)null);
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -146,14 +123,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String expectedValue = "10";
     List<String> actualValues = newArrayList(null, null);
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
   }
 
   @Test
@@ -163,14 +136,10 @@ public class Urls_assertHasParameter_Test extends UrlsBaseTest {
     String expectedValue = "10";
     List<String> actualValues = newArrayList("11");
 
-    try {
-      urls.assertHasParameter(info, url, name, expectedValue);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
-      return;
-    }
+    Throwable error = catchThrowable(() -> urls.assertHasParameter(info, url, name, expectedValue));
 
-    failBecauseExpectedAssertionErrorWasNotThrown();
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveParameter(url, name, expectedValue, actualValues));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasPath_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasPath_Test.java
@@ -12,11 +12,12 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHavePath.shouldHavePath;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -52,13 +53,11 @@ public class Urls_assertHasPath_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/pages/");
     String expectedPath = "/news/";
-    try {
-      urls.assertHasPath(info, url, expectedPath);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePath(url, expectedPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasPath(info, url, expectedPath));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePath(url, expectedPath));
   }
 
   @Test
@@ -66,12 +65,10 @@ public class Urls_assertHasPath_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com");
     String expectedPath = "/news";
-    try {
-      urls.assertHasPath(info, url, expectedPath);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePath(url, expectedPath));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasPath(info, url, expectedPath));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePath(url, expectedPath));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasPort_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasPort_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHavePort.shouldHavePort;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -44,13 +45,11 @@ public class Urls_assertHasPort_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com:8080/pages/");
     int expectedPort = 8888;
-    try {
-      urls.assertHasPort(info, url, expectedPort);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHavePort(url, expectedPort));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasPort(info, url, expectedPort));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHavePort(url, expectedPort));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasProtocol_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasProtocol_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveProtocol.shouldHaveProtocol;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -44,13 +45,11 @@ public class Urls_assertHasProtocol_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://example.com/pages/");
     String expectedProtocol = "ftp";
-    try {
-      urls.assertHasProtocol(info, url, expectedProtocol);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveProtocol(url, expectedProtocol));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasProtocol(info, url, expectedProtocol));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveProtocol(url, expectedProtocol));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasQuery_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasQuery_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveQuery.shouldHaveQuery;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -56,13 +57,11 @@ public class Urls_assertHasQuery_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://assertj.org/news?type=beta");
     String expectedQuery = "type=final";
-    try {
-      urls.assertHasQuery(info, url, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasQuery(info, url, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
   }
 
   @Test
@@ -70,13 +69,11 @@ public class Urls_assertHasQuery_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://assertj.org/news");
     String expectedQuery = "type=final";
-    try {
-      urls.assertHasQuery(info, url, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasQuery(info, url, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
   }
 
   @Test
@@ -84,12 +81,10 @@ public class Urls_assertHasQuery_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://assertj.org/news?type=beta");
     String expectedQuery = null;
-    try {
-      urls.assertHasQuery(info, url, expectedQuery);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasQuery(info, url, expectedQuery));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveQuery(url, expectedQuery));
   }
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasUserInfo_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasUserInfo_Test.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
@@ -49,13 +50,11 @@ public class Urls_assertHasUserInfo_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://test:pass@assertj.org/news");
     String expectedUserInfo = "test:ok";
-    try {
-      urls.assertHasUserInfo(info, url, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasUserInfo(info, url, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
   }
 
   @Test
@@ -64,13 +63,11 @@ public class Urls_assertHasUserInfo_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://assertj.org/news");
     String expectedUserInfo = "test:pass";
-    try {
-      urls.assertHasUserInfo(info, url, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasUserInfo(info, url, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
   }
 
   @Test
@@ -78,13 +75,11 @@ public class Urls_assertHasUserInfo_Test extends UrlsBaseTest {
     AssertionInfo info = someInfo();
     URL url = new URL("http://test:pass@assertj.org");
     String expectedUserInfo = null;
-    try {
-      urls.assertHasUserInfo(info, url, expectedUserInfo);
-    } catch (AssertionError e) {
-      verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
-      return;
-    }
-    failBecauseExpectedAssertionErrorWasNotThrown();
+
+    Throwable error = catchThrowable(() -> urls.assertHasUserInfo(info, url, expectedUserInfo));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldHaveUserInfo(url, expectedUserInfo));
   }
 
 }

--- a/src/test/java/org/assertj/core/test/TestFailures.java
+++ b/src/test/java/org/assertj/core/test/TestFailures.java
@@ -22,42 +22,6 @@ import org.assertj.core.api.Assertions;
  */
 public final class TestFailures {
 
-  /**
-   * <b>Note for developers</b> :
-   *
-   * Avoid using this method to make a test fail.
-   * <p></p>
-   *  This idiom to check an expected behavior when an exception is thrown should be avoided :
-   *  <pre><code class='java'>
-   *    try{
-   *       doSomething();
-   *    }
-   *    catch(MyException e){
-   *      assertTheExceptionState();
-   *      assertOnOtherThingsThanTheException();
-   *      return;
-   *    }
-   *    failBecauseExpectedAssertionErrorWasNotThrown();</pre></code>
-   *
-   * Instead of you should rely on {@link Assertions#catchThrowable} that is straighter and also allows the GIVEN WHEN THEN pattern :
-   *
-   * <pre><code class='java'>
-   *   // GIVEN
-   *   ...
-   *   // WHEN
-   *   Throwable error = catchThrowable(()-> doSomething());
-   *   // THEN
-   *   assertThat(error).isInstanceOf(MyException.class)
-   *                    .withXXX(...);
-   *   assertOnOtherThingsThanTheException();</pre></code>
-   *
-   */
-  //FIXME A developer method probably to deprecate but as currently very used in the testing code, I add only the information in the javadoc
-  @Deprecated
-  public static void failBecauseExpectedAssertionErrorWasNotThrown() {
-    fail("Assertion error expected");
-  }
-
   public static void wasExpectingAssertionError() {
     throw new AssertionErrorExpectedException();
   }


### PR DESCRIPTION
#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : NO

Hi,

This PR removes the deprecated `failBecauseExpectedAssertionErrorWasNotThrown()` method from the tests