### PR TITLE
Add hasNoSuperclass() to AbstractClassAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -352,20 +352,11 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   /**
    * Verifies that the actual {@code Class} has the given class as direct superclass (as in {@link Class#getSuperclass()}).
    * <p>
+   * The {@code superclass} should always be not {@code null}, use {@link #hasNoSuperclass()} to verify the absence of
+   * the superclass.
+   * <p>
    * Example:
-   * <pre><code class='java'> // this assertion succeeds as Object has no superclass:
-   * assertThat(Object.class).hasSuperclass(null);
-   *
-   * // this assertion succeeds as interfaces have no superclass:
-   * assertThat(Cloneable.class).hasSuperclass(null);
-   *
-   * // this assertion succeeds as primitive types have no superclass:
-   * assertThat(Integer.TYPE).hasSuperclass(null);
-   *
-   * // this assertion succeeds as void type has no superclass:
-   * assertThat(Void.TYPE).hasSuperclass(null);
-   *
-   * // this assertion succeeds:
+   * <pre><code class='java'> // this assertion succeeds:
    * assertThat(Integer.class).hasSuperclass(Number.class);
    *
    * // this assertion succeeds as superclass for array classes is Object:
@@ -379,12 +370,45 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    *
    * @param superclass the class which must be the direct superclass of actual.
    * @return {@code this} assertions object
+   * @throws NullPointerException if {@code superclass} is {@code null}.
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} doesn't have the given class as direct superclass.
    * @since 3.15.0
+   * @see #hasNoSuperclass()
    */
   public SELF hasSuperclass(Class<?> superclass) {
     classes.assertHasSuperclass(info, actual, superclass);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has no superclass (as in {@link Class#getSuperclass()}, when {@code null}
+   * is returned).
+   * <p>
+   * Example:
+   * <pre><code class='java'> // this assertion succeeds as Object has no superclass:
+   * assertThat(Object.class).hasNoSuperclass();
+   *
+   * // this assertion succeeds as interfaces have no superclass:
+   * assertThat(Cloneable.class).hasNoSuperclass();
+   *
+   * // this assertion succeeds as primitive types have no superclass:
+   * assertThat(Integer.TYPE).hasNoSuperclass();
+   *
+   * // this assertion succeeds as void type has no superclass:
+   * assertThat(Void.TYPE).hasNoSuperclass();
+   *
+   * // this assertion fails as Integer has Number as superclass:
+   * assertThat(Integer.class).hasSuperclass(Number.class);</code></pre>
+   *
+   * @return {@code this} assertions object
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} has a superclass.
+   * @since 3.15.0
+   * @see #hasSuperclass(Class)
+   */
+  public SELF hasNoSuperclass() {
+    classes.assertHasNoSuperclass(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveNoSuperclass.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveNoSuperclass.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.StringJoiner;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class has no superclass failed.
+ * 
+ * @author Stefano Cordio
+ */
+public class ShouldHaveNoSuperclass extends BasicErrorMessageFactory {
+
+  private static final String SHOULD_HAVE_NO_SUPERCLASS = new StringJoiner("%n", "%n", "").add("Expecting")
+                                                                                          .add("  <%s>")
+                                                                                          .add("to have no superclass, but had:")
+                                                                                          .add("  <%s>")
+                                                                                          .toString();
+
+  /**
+   * Creates a new <code>{@link ShouldHaveNoSuperclass}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveNoSuperclass(Class<?> actual) {
+    return new ShouldHaveNoSuperclass(actual);
+  }
+
+  private ShouldHaveNoSuperclass(Class<?> actual) {
+    super(SHOULD_HAVE_NO_SUPERCLASS, actual, actual.getSuperclass());
+  }
+
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveSuperclass.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSuperclass.java
@@ -25,9 +25,14 @@ public class ShouldHaveSuperclass extends BasicErrorMessageFactory {
                                                                                        .add("  <%s>")
                                                                                        .add("to have superclass:")
                                                                                        .add("  <%s>")
-                                                                                       .add("but had:")
-                                                                                       .add("  <%s>")
                                                                                        .toString();
+
+  private static final String BUT_HAD_NONE = new StringJoiner("%n", "%n", "").add("but had none.")
+                                                                             .toString();
+
+  private static final String BUT_HAD = new StringJoiner("%n", "%n", "").add("but had:")
+                                                                        .add("  <%s>")
+                                                                        .toString();
 
   /**
    * Creates a new <code>{@link ShouldHaveSuperclass}</code>.
@@ -37,11 +42,19 @@ public class ShouldHaveSuperclass extends BasicErrorMessageFactory {
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldHaveSuperclass(Class<?> actual, Class<?> superclass) {
-    return new ShouldHaveSuperclass(actual, superclass);
+    Class<?> actualSuperclass = actual.getSuperclass();
+    if (actualSuperclass == null) {
+      return new ShouldHaveSuperclass(actual, superclass);
+    }
+    return new ShouldHaveSuperclass(actual, superclass, actualSuperclass);
   }
 
-  private ShouldHaveSuperclass(Class<?> actual, Class<?> superclass) {
-    super(SHOULD_HAVE_SUPERCLASS, actual, superclass, actual.getSuperclass());
+  private ShouldHaveSuperclass(Class<?> actual, Class<?> expectedSuperclass) {
+    super(SHOULD_HAVE_SUPERCLASS + BUT_HAD_NONE, actual, expectedSuperclass);
+  }
+
+  private ShouldHaveSuperclass(Class<?> actual, Class<?> expectedSuperclass, Class<?> actualSuperclass) {
+    super(SHOULD_HAVE_SUPERCLASS + BUT_HAD, actual, expectedSuperclass, actualSuperclass);
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Classes.java
+++ b/src/main/java/org/assertj/core/internal/Classes.java
@@ -32,7 +32,9 @@ import static org.assertj.core.error.ShouldHaveMethods.shouldHaveMethods;
 import static org.assertj.core.error.ShouldHaveMethods.shouldNotHaveMethods;
 import static org.assertj.core.error.ShouldHaveNoFields.shouldHaveNoDeclaredFields;
 import static org.assertj.core.error.ShouldHaveNoFields.shouldHaveNoPublicFields;
+import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
 import static org.assertj.core.error.ShouldHaveSuperclass.shouldHaveSuperclass;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.error.ShouldOnlyHaveFields.shouldOnlyHaveDeclaredFields;
 import static org.assertj.core.error.ShouldOnlyHaveFields.shouldOnlyHaveFields;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -264,15 +266,32 @@ public class Classes {
    *
    * @param info       contains information about the assertion.
    * @param actual     the "actual" {@code Class}.
-   * @param superclass the direct superclass, which can be null according to {@link Class#getSuperclass()}.
+   * @param superclass the direct superclass, which should not be null.
+   * @throws NullPointerException if {@code superclass} is {@code null}.
    * @throws AssertionError if {@code actual} is {@code null}.
-   * @throws AssertionError if the actual {@code Class} superclass does not have the expected superclass.
+   * @throws AssertionError if the actual {@code Class} does not have the expected superclass.
    */
   public void assertHasSuperclass(AssertionInfo info, Class<?> actual, Class<?> superclass) {
     assertNotNull(info, actual);
+    requireNonNull(superclass, shouldNotBeNull("superclass").create());
     Class<?> actualSuperclass = actual.getSuperclass();
-    if ((actualSuperclass == null && superclass != null) || (actualSuperclass != null && !actualSuperclass.equals(superclass))) {
+    if (actualSuperclass == null || !actualSuperclass.equals(superclass)) {
       throw failures.failure(info, shouldHaveSuperclass(actual, superclass));
+    }
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has no superclass.
+   *
+   * @param info       contains information about the assertion.
+   * @param actual     the "actual" {@code Class}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} has a superclass.
+   */
+  public void assertHasNoSuperclass(AssertionInfo info, Class<?> actual) {
+    assertNotNull(info, actual);
+    if (actual.getSuperclass() != null) {
+      throw failures.failure(info, shouldHaveNoSuperclass(actual));
     }
   }
 

--- a/src/test/java/org/assertj/core/api/classes/ClassAssert_hasNoSuperclass_Test.java
+++ b/src/test/java/org/assertj/core/api/classes/ClassAssert_hasNoSuperclass_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ClassAssert;
+import org.assertj.core.api.ClassAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Tests for <code>{@link ClassAssert#hasNoSuperclass()}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("ClassAssert hasNoSuperclass")
+class ClassAssert_hasNoSuperclass_Test extends ClassAssertBaseTest {
+
+  @Override
+  protected ClassAssert invoke_api_method() {
+    return assertions.hasNoSuperclass();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(classes).assertHasNoSuperclass(getInfo(assertions), getActual(assertions));
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveNoSuperclass_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveNoSuperclass_create_Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ShouldHaveNoSuperclass#create(Description, Representation)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("ShouldHaveNoSuperclass create")
+class ShouldHaveNoSuperclass_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // WHEN
+    String message = shouldHaveNoSuperclass(String.class).create(new TestDescription("TEST"),
+                                                                 STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %n" +
+                                   "Expecting%n" +
+                                   "  <java.lang.String>%n" +
+                                   "to have no superclass, but had:%n" +
+                                   "  <java.lang.Object>"));
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveSuperclass_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSuperclass_create_Test.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class ShouldHaveSuperclass_create_Test {
 
   @Test
-  void should_create_error_message() {
+  void should_create_error_message_if_actual_has_superclass() {
     // WHEN
     String message = shouldHaveSuperclass(String.class, Integer.class).create(new TestDescription("TEST"),
                                                                               STANDARD_REPRESENTATION);
@@ -44,6 +44,20 @@ class ShouldHaveSuperclass_create_Test {
                                    "  <java.lang.Integer>%n" +
                                    "but had:%n" +
                                    "  <java.lang.Object>"));
+  }
+
+  @Test
+  void should_create_error_message_if_actual_has_no_superclass() {
+    // WHEN
+    String message = shouldHaveSuperclass(Object.class, Integer.class).create(new TestDescription("TEST"),
+                                                                              STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %n" +
+                                   "Expecting%n" +
+                                   "  <java.lang.Object>%n" +
+                                   "to have superclass:%n" +
+                                   "  <java.lang.Integer>%n" +
+                                   "but had none."));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasNoSuperclass_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasNoSuperclass_Test.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.core.internal.classes;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.internal.ClassesBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Classes assertHasNoSuperclass")
+class Classes_assertHasNoSuperclass_Test extends ClassesBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Class<?> actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> classes.assertHasNoSuperclass(someInfo(), actual));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_has_a_superclass() {
+    // GIVEN
+    Class<?> actual = Integer.class;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> classes.assertHasNoSuperclass(someInfo(), actual));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoSuperclass(actual).create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nullSuperclassTypes")
+  void should_pass_if_actual_has_no_superclass(Class<?> actual) {
+    // WHEN/THEN
+    classes.assertHasNoSuperclass(someInfo(), actual);
+  }
+
+  private static Stream<Class<?>> nullSuperclassTypes() {
+    return Stream.of(Object.class,
+                     Cloneable.class, // any interface
+                     Boolean.TYPE,
+                     Byte.TYPE,
+                     Character.TYPE,
+                     Double.TYPE,
+                     Float.TYPE,
+                     Integer.TYPE,
+                     Long.TYPE,
+                     Short.TYPE,
+                     Void.TYPE);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/classes/Classes_assertHasSuperclass_Test.java
+++ b/src/test/java/org/assertj/core/internal/classes/Classes_assertHasSuperclass_Test.java
@@ -12,20 +12,18 @@
  */
 package org.assertj.core.internal.classes;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldHaveSuperclass.shouldHaveSuperclass;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-
-import java.util.stream.Stream;
 
 import org.assertj.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Classes assertHasSuperclass")
@@ -42,6 +40,18 @@ class Classes_assertHasSuperclass_Test extends ClassesBaseTest {
   }
 
   @Test
+  void should_fail_if_null_class_is_given() {
+    // GIVEN
+    Class<?> actual = Integer.class;
+    Class<?> superclass = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> classes.assertHasSuperclass(someInfo(), actual, superclass));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("superclass").create());
+  }
+
+  @Test
   void should_pass_if_actual_has_given_class_as_direct_superclass() {
     // GIVEN
     Class<?> actual = Integer.class;
@@ -51,7 +61,6 @@ class Classes_assertHasSuperclass_Test extends ClassesBaseTest {
   }
 
   @ParameterizedTest
-  @NullSource
   @ValueSource(classes = { Object.class, Comparable.class, String.class })
   void should_fail_if_actual_has_not_given_class_as_direct_superclass(Class<?> superclass) {
     // GIVEN
@@ -68,27 +77,6 @@ class Classes_assertHasSuperclass_Test extends ClassesBaseTest {
     Class<?> actual = Integer[].class;
     // WHEN/THEN
     classes.assertHasSuperclass(someInfo(), actual, Object.class);
-  }
-
-  @ParameterizedTest
-  @MethodSource("nullSuperclassTypes")
-  void should_pass_if_actual_has_no_superclass_and_null_is_given(Class<?> actual) {
-    // WHEN/THEN
-    classes.assertHasSuperclass(someInfo(), actual, null);
-  }
-
-  private static Stream<Class<?>> nullSuperclassTypes() {
-    return Stream.of(Object.class,
-                     Cloneable.class, // any interface
-                     Boolean.TYPE,
-                     Byte.TYPE,
-                     Character.TYPE,
-                     Double.TYPE,
-                     Float.TYPE,
-                     Integer.TYPE,
-                     Long.TYPE,
-                     Short.TYPE,
-                     Void.TYPE);
   }
 
 }


### PR DESCRIPTION
Main behavior change: `hasSuperclass(Class<?>)` now fails with `null` parameter.

#### Check List:
* Fixes https://github.com/joel-costigliola/assertj-core/pull/1743#discussion_r362622859
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


