### PR TITLE
Reduce areEqual() usage in favor of java.util.Objects.equals()

### DIFF
--- a/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
@@ -15,7 +15,6 @@ package org.assertj.core.api.recursive.comparison;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Objects.areEqual;
 
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +90,7 @@ public class ComparisonDifference implements Comparable<ComparisonDifference> {
     String actualRepresentation = representation.toStringOf(actual);
     String expectedRepresentation = representation.toStringOf(expected);
 
-    boolean sameRepresentation = areEqual(actualRepresentation, expectedRepresentation);
+    boolean sameRepresentation = Objects.equals(actualRepresentation, expectedRepresentation);
     String unambiguousActualRepresentation = sameRepresentation
         ? representation.unambiguousToStringOf(actual)
         : actualRepresentation;

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import org.assertj.core.internal.DeepDifference;
+import org.assertj.core.util.Objects;
 
 /**
  * Based on {@link DeepDifference} but takes a {@link RecursiveComparisonConfiguration}, {@link DeepDifference}
@@ -668,7 +669,7 @@ public class RecursiveComparisonDifferenceCalculator {
     Comparator typeComparator = recursiveComparisonConfiguration.getComparatorForType(fieldType);
     if (typeComparator != null) return typeComparator.compare(actualFieldValue, expectedFieldValue) == 0;
     // default comparison using equals
-    return org.assertj.core.util.Objects.areEqual(actualFieldValue, expectedFieldValue);
+    return Objects.areEqual(actualFieldValue, expectedFieldValue);
   }
 
   private static ComparisonDifference expectedAndActualTypeDifference(Object actual, Object expected) {

--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -17,6 +17,8 @@ import static org.assertj.core.util.Objects.HASH_CODE_PRIME;
 import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Objects.hashCodeFor;
 
+import java.util.Objects;
+
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ComparisonStrategy;
@@ -134,7 +136,7 @@ public class ShouldBeEqual implements AssertionErrorFactory {
   }
 
   private boolean actualAndExpectedHaveSameStringRepresentation() {
-    return areEqual(representation.toStringOf(actual), representation.toStringOf(expected));
+    return Objects.equals(representation.toStringOf(actual), representation.toStringOf(expected));
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
@@ -18,12 +18,12 @@ import static org.assertj.core.util.Strings.escapePercent;
 import static org.assertj.core.util.Strings.join;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.assertj.core.api.recursive.comparison.ComparisonDifference;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.assertj.core.internal.DeepDifference.Difference;
 import org.assertj.core.presentation.Representation;
-import org.assertj.core.util.Objects;
 
 public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorMessageFactory {
 
@@ -77,7 +77,7 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorM
     String actualFieldValue = representation.toStringOf(difference.getActual());
     String otherFieldValue = representation.toStringOf(difference.getOther());
 
-    boolean sameRepresentation = Objects.areEqual(actualFieldValue, otherFieldValue);
+    boolean sameRepresentation = Objects.equals(actualFieldValue, otherFieldValue);
 
     String actualFieldValueRepresentation = sameRepresentation
         ? representation.unambiguousToStringOf(difference.getActual())

--- a/src/main/java/org/assertj/core/error/ShouldHaveCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveCause.java
@@ -12,8 +12,9 @@
  */
 package org.assertj.core.error;
 
-import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
+
+import java.util.Objects;
 
 public class ShouldHaveCause extends BasicErrorMessageFactory {
 
@@ -22,10 +23,10 @@ public class ShouldHaveCause extends BasicErrorMessageFactory {
     // actualCause has no cause
     if (actualCause == null) return new ShouldHaveCause(expectedCause);
     // same message => different type
-    if (areEqual(actualCause.getMessage(), expectedCause.getMessage()))
+    if (Objects.equals(actualCause.getMessage(), expectedCause.getMessage()))
       return new ShouldHaveCause(actualCause, expectedCause.getClass());
     // same type => different message
-    if (areEqual(actualCause.getClass(), expectedCause.getClass()))
+    if (Objects.equals(actualCause.getClass(), expectedCause.getClass()))
       return new ShouldHaveCause(actualCause, expectedCause.getMessage());
     return new ShouldHaveCause(actualCause, expectedCause);
   }

--- a/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
@@ -12,10 +12,11 @@
  */
 package org.assertj.core.error;
 
-import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Strings.escapePercent;
 import static org.assertj.core.util.Throwables.getStackTrace;
+
+import java.util.Objects;
 
 public class ShouldHaveRootCause extends BasicErrorMessageFactory {
 
@@ -33,10 +34,10 @@ public class ShouldHaveRootCause extends BasicErrorMessageFactory {
     // actualCause has no cause
     if (actualCause == null) return new ShouldHaveRootCause(actual, expectedCause);
     // same message => different type
-    if (areEqual(actualCause.getMessage(), expectedCause.getMessage()))
+    if (Objects.equals(actualCause.getMessage(), expectedCause.getMessage()))
       return new ShouldHaveRootCause(actual, actualCause, expectedCause.getClass());
     // same type => different message
-    if (areEqual(actualCause.getClass(), expectedCause.getClass()))
+    if (Objects.equals(actualCause.getClass(), expectedCause.getClass()))
       return new ShouldHaveRootCause(actual, actualCause, expectedCause.getMessage());
     return new ShouldHaveRootCause(actual, actualCause, expectedCause);
   }

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -40,7 +40,6 @@ import static org.assertj.core.error.ShouldNotContain.directoryShouldNotContain;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.internal.Digests.digestDiff;
 import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.io.File;
@@ -369,7 +368,7 @@ public class Files {
     assertNotNull(info, actual);
     try {
       if (actual.getParentFile() != null
-          && areEqual(expected.getCanonicalFile(), actual.getParentFile().getCanonicalFile()))
+          && java.util.Objects.equals(expected.getCanonicalFile(), actual.getParentFile().getCanonicalFile()))
         return;
     } catch (IOException e) {
       throw new UncheckedIOException(String.format("Unable to get canonical form of [%s] or [%s].", actual, expected), e);

--- a/src/main/java/org/assertj/core/internal/Numbers.java
+++ b/src/main/java/org/assertj/core/internal/Numbers.java
@@ -21,10 +21,11 @@ import static org.assertj.core.internal.CommonValidations.checkNumberIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkOffsetIsNotNull;
 import static org.assertj.core.internal.CommonValidations.checkPercentageIsNotNull;
 
+import java.util.Objects;
+
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
-import org.assertj.core.util.Objects;
 
 /**
  * Base class of reusable assertions for numbers.
@@ -267,7 +268,7 @@ public abstract class Numbers<NUMBER extends Number & Comparable<NUMBER>> extend
   }
 
   protected boolean areEqual(final NUMBER value, final NUMBER other) {
-    return Objects.areEqual(value, other);
+    return Objects.equals(value, other);
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -36,7 +36,6 @@ import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsEmpty;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 import static org.assertj.core.internal.CommonValidations.checkTypeIsNotNull;
-import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Throwables.getRootCause;
 
 import java.util.LinkedHashSet;
@@ -84,7 +83,7 @@ public class Throwables {
    */
   public void assertHasMessage(AssertionInfo info, Throwable actual, String expectedMessage) {
     assertNotNull(info, actual);
-    if (areEqual(actual.getMessage(), expectedMessage)) return;
+    if (java.util.Objects.equals(actual.getMessage(), expectedMessage)) return;
     throw failures.failure(info, shouldHaveMessage(actual, expectedMessage), actual.getMessage(), expectedMessage);
   }
 
@@ -129,7 +128,7 @@ public class Throwables {
       assertHasNoCause(info, actual);
       return;
     }
-    if (actualRootCause == null) throw failures.failure(info, shouldHaveRootCause(actual,null, expectedRootCause));
+    if (actualRootCause == null) throw failures.failure(info, shouldHaveRootCause(actual, null, expectedRootCause));
     if (!compareThrowable(actualRootCause, expectedRootCause))
       throw failures.failure(info, shouldHaveRootCause(actual, actualRootCause, expectedRootCause));
   }
@@ -145,8 +144,9 @@ public class Throwables {
     assertNotNull(info, actual);
     Throwable rootCause = getRootCause(actual);
     if (null == rootCause) throw failures.failure(info, shouldHaveRootCauseWithMessage(actual, rootCause, expectedMessage));
-    if (areEqual(rootCause.getMessage(), expectedMessage)) return;
-    throw failures.failure(info, shouldHaveRootCauseWithMessage(actual, rootCause, expectedMessage), rootCause.getMessage(), expectedMessage);
+    if (java.util.Objects.equals(rootCause.getMessage(), expectedMessage)) return;
+    throw failures.failure(info, shouldHaveRootCauseWithMessage(actual, rootCause, expectedMessage), rootCause.getMessage(),
+                           expectedMessage);
   }
 
   /**
@@ -409,8 +409,8 @@ public class Throwables {
     assertNotNull(info, actual);
     requireNonNull(expectedSuppressedException, "The expected suppressed exception should not be null");
     Throwable[] suppressed = actual.getSuppressed();
-    for (int i = 0; i < suppressed.length; i++) {
-      if (compareThrowable(suppressed[i], expectedSuppressedException)) return;
+    for (Throwable throwable : suppressed) {
+      if (compareThrowable(throwable, expectedSuppressedException)) return;
     }
     throw failures.failure(info, shouldHaveSuppressedException(actual, expectedSuppressedException));
   }
@@ -449,7 +449,7 @@ public class Throwables {
   }
 
   private static boolean compareThrowable(Throwable actual, Throwable expected) {
-    return areEqual(actual.getMessage(), expected.getMessage())
-           && areEqual(actual.getClass(), expected.getClass());
+    return java.util.Objects.equals(actual.getMessage(), expected.getMessage())
+           && java.util.Objects.equals(actual.getClass(), expected.getClass());
   }
 }

--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -24,7 +24,6 @@ import static org.assertj.core.error.uri.ShouldHaveQuery.shouldHaveQuery;
 import static org.assertj.core.error.uri.ShouldHaveScheme.shouldHaveScheme;
 import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.internal.Comparables.assertNotNull;
-import static org.assertj.core.util.Objects.areEqual;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -33,6 +32,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
@@ -58,12 +58,12 @@ public class Uris {
 
   public void assertHasScheme(final AssertionInfo info, final URI actual, final String scheme) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getScheme(), scheme)) throw failures.failure(info, shouldHaveScheme(actual, scheme));
+    if (!Objects.equals(actual.getScheme(), scheme)) throw failures.failure(info, shouldHaveScheme(actual, scheme));
   }
 
   public void assertHasPath(AssertionInfo info, URI actual, String path) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
+    if (!Objects.equals(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
   }
 
   public void assertHasPort(AssertionInfo info, URI actual, Integer expected) {
@@ -73,28 +73,28 @@ public class Uris {
 
   public void assertHasHost(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
+    if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
   }
 
   public void assertHasAuthority(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getAuthority(), expected))
+    if (!Objects.equals(actual.getAuthority(), expected))
       throw failures.failure(info, shouldHaveAuthority(actual, expected));
   }
 
   public void assertHasFragment(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getFragment(), expected)) throw failures.failure(info, shouldHaveFragment(actual, expected));
+    if (!Objects.equals(actual.getFragment(), expected)) throw failures.failure(info, shouldHaveFragment(actual, expected));
   }
 
   public void assertHasQuery(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getQuery(), expected)) throw failures.failure(info, shouldHaveQuery(actual, expected));
+    if (!Objects.equals(actual.getQuery(), expected)) throw failures.failure(info, shouldHaveQuery(actual, expected));
   }
 
   public void assertHasUserInfo(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
+    if (!Objects.equals(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
   }
 
   static Map<String, List<String>> getParameters(String query) {

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -25,12 +25,12 @@ import static org.assertj.core.error.uri.ShouldHaveQuery.shouldHaveQuery;
 import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.internal.Comparables.assertNotNull;
 import static org.assertj.core.internal.Uris.getParameters;
-import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
@@ -50,13 +50,13 @@ public class Urls {
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getProtocol(), protocol)) throw failures.failure(info, shouldHaveProtocol(actual, protocol));
+    if (!Objects.equals(actual.getProtocol(), protocol)) throw failures.failure(info, shouldHaveProtocol(actual, protocol));
   }
 
   public void assertHasPath(AssertionInfo info, URL actual, String path) {
     assertNotNull(info, actual);
     checkArgument(path != null, "Expecting given path not to be null");
-    if (!areEqual(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
+    if (!Objects.equals(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
   }
 
   public void assertHasPort(AssertionInfo info, URL actual, int expected) {
@@ -66,28 +66,28 @@ public class Urls {
 
   public void assertHasHost(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
+    if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
   }
 
   public void assertHasAuthority(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getAuthority(), expected))
+    if (!Objects.equals(actual.getAuthority(), expected))
       throw failures.failure(info, shouldHaveAuthority(actual, expected));
   }
 
   public void assertHasQuery(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getQuery(), expected)) throw failures.failure(info, shouldHaveQuery(actual, expected));
+    if (!Objects.equals(actual.getQuery(), expected)) throw failures.failure(info, shouldHaveQuery(actual, expected));
   }
 
   public void assertHasAnchor(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getRef(), expected)) throw failures.failure(info, shouldHaveAnchor(actual, expected));
+    if (!Objects.equals(actual.getRef(), expected)) throw failures.failure(info, shouldHaveAnchor(actual, expected));
   }
 
   public void assertHasUserInfo(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    if (!areEqual(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
+    if (!Objects.equals(actual.getUserInfo(), expected)) throw failures.failure(info, shouldHaveUserInfo(actual, expected));
   }
 
   public void assertHasParameter(AssertionInfo info, URL actual, String name) {

--- a/src/main/java/org/assertj/core/util/Objects.java
+++ b/src/main/java/org/assertj/core/util/Objects.java
@@ -12,7 +12,8 @@
  */
 package org.assertj.core.util;
 
-import static org.assertj.core.util.Arrays.*;
+import static org.assertj.core.util.Arrays.isArray;
+import static org.assertj.core.util.Arrays.isNullOrEmpty;
 
 import java.lang.reflect.Array;
 
@@ -35,10 +36,7 @@ public final class Objects {
    * @return {@code true} if the given objects are equal or if both objects are {@code null}.
    */
   public static boolean areEqual(Object o1, Object o2) {
-    if (o1 == null) {
-      return o2 == null;
-    }
-    if (o1.equals(o2)) {
+    if (java.util.Objects.equals(o1, o2)) {
       return true;
     }
     return areEqualArrays(o1, o2);
@@ -91,7 +89,9 @@ public final class Objects {
    */
   public static int hashCodeFor(Object o) {
     if (o == null) return 0;
-    return isArray(o) && !o.getClass().getComponentType().isPrimitive() ? java.util.Arrays.deepHashCode((Object[]) o) : o.hashCode() ;
+    return isArray(o) && !o.getClass().getComponentType().isPrimitive()
+        ? java.util.Arrays.deepHashCode((Object[]) o)
+        : o.hashCode();
   }
 
   /**


### PR DESCRIPTION
The wish would be to drop `org.assertj.core.util.Objects.areEqual()` in favor of `java.util.Objects.equals()` but it cannot be done in one take as `areEqual()` also does deep comparison for arrays.

This PR replaces `areEqual()` only where the type is well known at compile time (i.e., not `Object`).