### PR TITLE
Deprecate areEqual() and areEqualArrays(), introduce EqualsVerifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
       <version>3.9</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.1.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/assertj/core/groups/Tuple.java
+++ b/src/main/java/org/assertj/core/groups/Tuple.java
@@ -12,45 +12,39 @@
  */
 package org.assertj.core.groups;
 
-import static java.util.Collections.addAll;
 import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
-import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Objects.areEqual;
+import static org.assertj.core.util.Lists.list;
 
+import java.util.Arrays;
 import java.util.List;
 
-public class Tuple {
+public final class Tuple {
 
-  private final List<Object> datas = newArrayList();
+  private final List<Object> values;
 
   public Tuple(Object... values) {
-    addAll(datas, values);
+    this.values = list(values);
   }
 
   public Object[] toArray() {
-    return datas.toArray();
+    return values.toArray();
   }
 
   public List<Object> toList() {
-    return datas;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + datas.hashCode();
-    return result;
+    return values;
   }
 
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (obj == null) return false;
     if (!(obj instanceof Tuple)) return false;
     Tuple other = (Tuple) obj;
-    // datas can't be null
-    return areEqual(datas.toArray(), other.datas.toArray());
+    return Arrays.deepEquals(values.toArray(), other.values.toArray());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.deepHashCode(values.toArray());
   }
 
   @Override

--- a/src/main/java/org/assertj/core/internal/ExtendedByTypesComparator.java
+++ b/src/main/java/org/assertj/core/internal/ExtendedByTypesComparator.java
@@ -17,6 +17,7 @@ import static org.assertj.core.internal.ComparatorBasedComparisonStrategy.NOT_EQ
 import static org.assertj.core.util.Objects.areEqual;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Compares objects using passed or standard default comparator extended with comparators by type.
@@ -32,7 +33,7 @@ public class ExtendedByTypesComparator implements Comparator<Object> {
          new Comparator<Object>() {
            @Override
            public int compare(Object actual, Object other) {
-             return areEqual(actual, other) ? 0 : NOT_EQUAL;
+             return Objects.deepEquals(actual, other) ? 0 : NOT_EQUAL;
            }
 
            @Override

--- a/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
@@ -24,9 +24,9 @@ import org.assertj.core.util.Streams;
 
 /**
  * Implements {@link ComparisonStrategy} contract with a comparison strategy based on
- * {@link Objects#areEqual(Object, Object)} method, it is also based on {@link Comparable#compareTo(Object)} when Object
+ * {@link java.util.Objects#deepEquals(Object, Object)} method, it is also based on {@link Comparable#compareTo(Object)} when Object
  * are {@link Comparable} method.
- * 
+ *
  * @author Joel Costigliola
  */
 public class StandardComparisonStrategy extends AbstractComparisonStrategy {
@@ -35,7 +35,7 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
 
   /**
    * Returns the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance of this class.
    */
   public static StandardComparisonStrategy instance() {
@@ -44,7 +44,7 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
 
   /**
    * Creates a new <code>{@link StandardComparisonStrategy}</code>, comparison strategy being based on
-   * {@link Objects#areEqual(Object, Object)}.
+   * {@link java.util.Objects#deepEquals(Object, Object)}.
    */
   protected StandardComparisonStrategy() {
     // empty
@@ -66,25 +66,25 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
   }
 
   /**
-   * Returns true if actual and other are equal based on {@link Objects#areEqual(Object, Object)}, false otherwise.
-   * 
+   * Returns true if actual and other are equal based on {@link java.util.Objects#deepEquals(Object, Object)}, false otherwise.
+   *
    * @param actual the object to compare to other
    * @param other the object to compare to actual
-   * @return true if actual and other are equal based on {@link Objects#areEqual(Object, Object)}, false otherwise.
+   * @return true if actual and other are equal based on {@link java.util.Objects#deepEquals(Object, Object)}, false otherwise.
    */
   @Override
   public boolean areEqual(Object actual, Object other) {
-    return Objects.areEqual(actual, other);
+    return java.util.Objects.deepEquals(actual, other);
   }
 
   /**
-   * Returns true if given {@link Iterable} contains given value based on {@link Objects#areEqual(Object, Object)},
+   * Returns true if given {@link Iterable} contains given value based on {@link java.util.Objects#deepEquals(Object, Object)},
    * false otherwise.<br>
    * If given {@link Iterable} is null, return false.
-   * 
+   *
    * @param iterable the {@link Iterable} to search value in
    * @param value the object to look for in given {@link Iterable}
-   * @return true if given {@link Iterable} contains given value based on {@link Objects#areEqual(Object, Object)},
+   * @return true if given {@link Iterable} contains given value based on {@link java.util.Objects#deepEquals(Object, Object)},
    *         false otherwise.
    */
   @Override
@@ -115,6 +115,7 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
       }
     }
   }
+
   /**
    * {@inheritDoc}
    */
@@ -133,9 +134,9 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
   }
 
   /**
-   * Returns any duplicate elements from the given collection according to {@link Objects#areEqual(Object, Object)}
+   * Returns any duplicate elements from the given collection according to {@link java.util.Objects#deepEquals(Object, Object)}
    * comparison strategy.
-   * 
+   *
    * @param iterable the given {@link Iterable} we want to extract duplicate elements.
    * @return an {@link Iterable} containing the duplicate elements of the given one. If no duplicates are found, an
    *         empty {@link Iterable} is returned.
@@ -161,16 +162,18 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
     return string.contains(sequence);
   }
 
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   public boolean isGreaterThan(Object actual, Object other) {
     checkArgumentIsComparable(actual);
-    return Comparable.class.cast(actual).compareTo(other) > 0;
+    return ((Comparable) actual).compareTo(other) > 0;
   }
 
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   public boolean isLessThan(Object actual, Object other) {
     checkArgumentIsComparable(actual);
-    return Comparable.class.cast(actual).compareTo(other) < 0;
+    return ((Comparable) actual).compareTo(other) < 0;
   }
 
   private void checkArgumentIsComparable(Object actual) {

--- a/src/main/java/org/assertj/core/util/Objects.java
+++ b/src/main/java/org/assertj/core/util/Objects.java
@@ -15,8 +15,6 @@ package org.assertj.core.util;
 import static org.assertj.core.util.Arrays.isArray;
 import static org.assertj.core.util.Arrays.isNullOrEmpty;
 
-import java.lang.reflect.Array;
-
 /**
  * Utility methods related to objects.
  *
@@ -29,38 +27,42 @@ public final class Objects {
   public static final int HASH_CODE_PRIME = 31;
 
   /**
-   * Returns {@code true} if the given objects are equal or if both objects are {@code null}.
+   * Returns {@code true} if the arguments are deeply equal to each other, {@code false} otherwise.
+   * <p>
+   * Two {@code null} values are deeply equal. If both arguments are arrays, the algorithm in
+   * {@link java.util.Arrays#deepEquals} is used to determine equality.
+   * Otherwise, equality is determined by using the {@link Object#equals} method of the first argument.
    *
-   * @param o1 one of the objects to compare.
-   * @param o2 one of the objects to compare.
-   * @return {@code true} if the given objects are equal or if both objects are {@code null}.
+   * @param o1 an object.
+   * @param o2 an object to be compared with {@code o1} for deep equality.
+   * @return {@code true} if the arguments are deeply equal to each other, {@code false} otherwise.
+   * 
+   * @deprecated Use {@link java.util.Objects#deepEquals(Object, Object)} instead.
    */
+  @Deprecated
   public static boolean areEqual(Object o1, Object o2) {
-    if (java.util.Objects.equals(o1, o2)) {
-      return true;
-    }
-    return areEqualArrays(o1, o2);
+    return java.util.Objects.deepEquals(o1, o2);
   }
 
+  /**
+   * Returns {@code true} if the arguments are arrays and deeply equal to each other, {@code false} otherwise.
+   * <p>
+   * Once verified that the arguments are arrays, the algorithm in {@link java.util.Arrays#deepEquals} is used
+   * to determine equality.
+   *
+   * @param o1 an object.
+   * @param o2 an object to be compared with {@code o1} for deep equality.
+   * @return {@code true} if the arguments are arrays and deeply equal to each other, {@code false} otherwise.
+   *
+   * @deprecated Use either {@link java.util.Objects#deepEquals(Object, Object)} or
+   *             {@link java.util.Arrays#deepEquals(Object[], Object[])}.
+   */
+  @Deprecated
   public static boolean areEqualArrays(Object o1, Object o2) {
     if (!isArray(o1) || !isArray(o2)) {
       return false;
     }
-    if (o1 == o2) {
-      return true;
-    }
-    int size = Array.getLength(o1);
-    if (Array.getLength(o2) != size) {
-      return false;
-    }
-    for (int i = 0; i < size; i++) {
-      Object e1 = Array.get(o1, i);
-      Object e2 = Array.get(o2, i);
-      if (!areEqual(e1, e2)) {
-        return false;
-      }
-    }
-    return true;
+    return java.util.Objects.deepEquals(o1, o2);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/Tuple_Test.java
+++ b/src/test/java/org/assertj/core/api/Tuple_Test.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class Tuple_Test {
 
   @Test
@@ -77,6 +79,14 @@ public class Tuple_Test {
                     .contains(tuple("1".getBytes(), "Foo"))
                     .contains(tuple("2".getBytes(), "Bar"))
                     .contains(tuple("3".getBytes(), "Baz"));
+  }
+
+  @Test
+  void should_honor_equals_contract() {
+    // WHEN/THEN
+    EqualsVerifier.forClass(Tuple.class)
+                  .withNonnullFields("values")
+                  .verify();
   }
 
   @SuppressWarnings("unused")

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
@@ -80,10 +80,10 @@ public class Objects_assertEqual_Test extends ObjectsBaseTest {
   }
 
   @Test
-  public void should_fail_with_my_exception_if_compared_with_null() {
+  public void should_fail_if_compared_with_null() {
     Throwable error = catchThrowable(() -> objects.assertEqual(someInfo(), new MyObject(), null));
 
-    assertThat(error).isInstanceOf(MyObject.NullEqualsException.class);
+    assertThat(error).isInstanceOf(AssertionError.class);
   }
 
   @Test


### PR DESCRIPTION
Following #1764, this PR deprecates and reduces a bit more the usage of `areEqual()` and `areEqualArrays()`. Also it shows how an `EqualsVerifier` test would look like.