### PR TITLE
Add Sonar scan on push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,23 @@ jobs:
           java-version: 11
       - name: Test
         run: ./mvnw -V --no-transfer-progress clean verify javadoc:javadoc
+
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    if: github.repository == 'joel-costigliola/assertj-core' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Test with Sonar
+        run: >
+          ./mvnw -V --no-transfer-progress clean verify javadoc:javadoc org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.organization=assertj
+          -Dsonar.projectKey=joel-costigliola_assertj-core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This workflow requires a `SONAR_TOKEN` secret.