### PR TITLE
Optimize Charset finding in tests.

### DIFF
--- a/src/test/java/org/assertj/core/api/FileAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/FileAssertBaseTest.java
@@ -12,12 +12,14 @@
  */
 package org.assertj.core.api;
 
-import static org.mockito.Mockito.mock;
+import org.assertj.core.internal.Files;
 
 import java.io.File;
 import java.nio.charset.Charset;
 
-import org.assertj.core.internal.Files;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.assertj.core.util.AssertionsUtil.getOtherCharset;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -41,10 +43,8 @@ public abstract class FileAssertBaseTest extends BaseTestTemplate<FileAssert, Fi
     files = mock(Files.class);
     assertions.files = files;
 
-    defaultCharset = Charset.defaultCharset();
-    for (Charset charset : Charset.availableCharsets().values()) {
-      if (!charset.equals(defaultCharset)) otherCharset = charset;
-    }
+    defaultCharset = defaultCharset();
+    otherCharset = getOtherCharset(defaultCharset);
   }
 
   protected Files getFiles(FileAssert someAssertions) {

--- a/src/test/java/org/assertj/core/api/PathAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/PathAssertBaseTest.java
@@ -12,12 +12,14 @@
  */
 package org.assertj.core.api;
 
-import static org.mockito.Mockito.mock;
+import org.assertj.core.internal.Paths;
 
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 
-import org.assertj.core.internal.Paths;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.assertj.core.util.AssertionsUtil.getOtherCharset;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -39,10 +41,8 @@ public abstract class PathAssertBaseTest extends BaseTestTemplate<PathAssert, Pa
     super.inject_internal_objects();
     paths = mock(Paths.class);
     assertions.paths = paths;
-    defaultCharset = Charset.defaultCharset();
-    for (Charset charset : Charset.availableCharsets().values()) {
-      if (!charset.equals(defaultCharset)) otherCharset = charset;
-    }
+    defaultCharset = defaultCharset();
+    otherCharset = getOtherCharset(defaultCharset);
   }
 
   protected Charset getCharset(PathAssert someAssertions) {

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasSameTextualContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasSameTextualContentAs_Test.java
@@ -12,18 +12,18 @@
  */
 package org.assertj.core.api.file;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.util.TempFileUtil.createTempFileWithContent;
-import static org.mockito.Mockito.verify;
-
-import java.io.File;
-import java.nio.charset.Charset;
-
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.TURKISH_CHARSET;
+import static org.assertj.core.util.TempFileUtil.createTempFileWithContent;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for <code>{@link FileAssert#hasSameTextualContentAs(File)}</code>.
@@ -54,21 +54,18 @@ public class FileAssert_hasSameTextualContentAs_Test extends FileAssertBaseTest 
   @Test
   public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
     // GIVEN
-    Charset turkishCharset = Charset.forName("windows-1254");
-    File actual = createTempFileWithContent("Gerçek", turkishCharset);
+    File actual = createTempFileWithContent("Gerçek", TURKISH_CHARSET);
     File expected = createTempFileWithContent("Gerçek", defaultCharset);
     // WHEN/THEN
-    then(actual).usingCharset(turkishCharset)
-                .hasSameTextualContentAs(expected);
+    then(actual).usingCharset(TURKISH_CHARSET).hasSameTextualContentAs(expected);
   }
 
   @Test
   public void should_allow_charset_to_be_specified_for_reading_expected_file_content() throws Exception {
     // GIVEN
-    Charset turkishCharset = Charset.forName("windows-1254");
     File actual = createTempFileWithContent("Gerçek", defaultCharset);
-    File expected = createTempFileWithContent("Gerçek", turkishCharset);
+    File expected = createTempFileWithContent("Gerçek", TURKISH_CHARSET);
     // WHEN/THEN
-    then(actual).hasSameTextualContentAs(expected, turkishCharset);
+    then(actual).hasSameTextualContentAs(expected, TURKISH_CHARSET);
   }
 }

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSameTextualContentAs_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSameTextualContentAs_Test.java
@@ -12,19 +12,19 @@
  */
 package org.assertj.core.api.path;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.util.TempFileUtil.createTempPathWithContent;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-
 import org.assertj.core.api.PathAssert;
 import org.assertj.core.api.PathAssertBaseTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.TURKISH_CHARSET;
+import static org.assertj.core.util.TempFileUtil.createTempPathWithContent;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("PathAssert hasSameTextualContentAs")
 public class PathAssert_hasSameTextualContentAs_Test extends PathAssertBaseTest {
@@ -49,21 +49,18 @@ public class PathAssert_hasSameTextualContentAs_Test extends PathAssertBaseTest 
   @Test
   public void should_use_charset_specified_by_usingCharset_to_read_actual_file_content() throws Exception {
     // GIVEN
-    Charset turkishCharset = Charset.forName("windows-1254");
-    Path actual = createTempPathWithContent("Gerçek", turkishCharset);
+    Path actual = createTempPathWithContent("Gerçek", TURKISH_CHARSET);
     Path expected = createTempPathWithContent("Gerçek", defaultCharset);
     // WHEN/THEN
-    then(actual).usingCharset(turkishCharset)
-                .hasSameTextualContentAs(expected);
+    then(actual).usingCharset(TURKISH_CHARSET).hasSameTextualContentAs(expected);
   }
 
   @Test
   public void should_allow_charset_to_be_specified_for_reading_expected_file_content() throws Exception {
     // GIVEN
-    Charset turkishCharset = Charset.forName("windows-1254");
     Path actual = createTempPathWithContent("Gerçek", defaultCharset);
-    Path expected = createTempPathWithContent("Gerçek", turkishCharset);
+    Path expected = createTempPathWithContent("Gerçek", TURKISH_CHARSET);
     // WHEN/THEN
-    then(actual).hasSameTextualContentAs(expected, turkishCharset);
+    then(actual).hasSameTextualContentAs(expected, TURKISH_CHARSET);
   }
 }

--- a/src/test/java/org/assertj/core/util/AssertionsUtil.java
+++ b/src/test/java/org/assertj/core/util/AssertionsUtil.java
@@ -12,16 +12,22 @@
  */
 package org.assertj.core.util;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.api.ThrowableAssertAlternative;
+import org.junit.AssumptionViolatedException;
+
+import java.nio.charset.Charset;
+
+import static java.nio.charset.Charset.forName;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.api.ThrowableAssertAlternative;
-import org.junit.AssumptionViolatedException;
-
 public class AssertionsUtil {
+  public static final Charset TURKISH_CHARSET = forName("windows-1254");
 
   public static AssertionError expectAssertionError(ThrowingCallable shouldRaiseAssertionError) {
     AssertionError error = catchThrowableOfType(shouldRaiseAssertionError, AssertionError.class);
@@ -35,5 +41,9 @@ public class AssertionsUtil {
 
   public static void expectAssumptionViolatedException(ThrowingCallable shouldRaiseError) {
     assertThatThrownBy(shouldRaiseError).isInstanceOf(AssumptionViolatedException.class);
+  }
+
+  public static Charset getOtherCharset(Charset charset) {
+    return charset.equals(UTF_8) ? UTF_16 : UTF_8;
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes : Charset finding in tests is not optimized
* Unit tests : NA
* Javadoc with a code example (on API only) : NA


