### PR TITLE
Add protected extracting to AbstractAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -666,7 +666,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public AbstractObjectAssert<?, ?> extracting(String propertyOrField) {
-    return internalExtracting(propertyOrField);
+    return super.extracting(propertyOrField, this::newObjectAssert);
   }
 
   /**
@@ -712,14 +712,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
                                                                  InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    return internalExtracting(propertyOrField).asInstanceOf(assertFactory);
-  }
-
-  private AbstractObjectAssert<?, ?> internalExtracting(String propertyOrField) {
-    Object value = byName(propertyOrField).apply(actual);
-    String extractedPropertyOrFieldDescription = extractedDescriptionOf(propertyOrField);
-    String description = mostRelevantDescription(info.description(), extractedPropertyOrFieldDescription);
-    return newObjectAssert(value).withAssertionState(myself).as(description);
+    return super.extracting(propertyOrField, this::newObjectAssert).asInstanceOf(assertFactory);
   }
 
   /**
@@ -744,8 +737,9 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @param extractors the extractor functions to extract values from the Object under test.
    * @return a new assertion object whose object under test is the list containing the extracted values
    */
+  @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(@SuppressWarnings("unchecked") Function<? super ACTUAL, ?>... extractors) {
+  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, ?>... extractors) {
     requireNonNull(extractors, shouldNotBeNull("extractors").create());
     List<Object> values = Stream.of(extractors)
                                 .map(extractor -> extractor.apply(actual))
@@ -784,7 +778,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public <T> AbstractObjectAssert<?, T> extracting(Function<? super ACTUAL, T> extractor) {
-    return internalExtracting(extractor);
+    return super.extracting(extractor, this::newObjectAssert);
   }
 
   /**
@@ -822,13 +816,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super ACTUAL, T> extractor,
                                                                     InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    return internalExtracting(extractor).asInstanceOf(assertFactory);
-  }
-
-  private <T> AbstractObjectAssert<?, T> internalExtracting(Function<? super ACTUAL, T> extractor) {
-    requireNonNull(extractor, shouldNotBeNull("extractor").create());
-    T extractedValue = extractor.apply(actual);
-    return newObjectAssert(extractedValue).withAssertionState(myself);
+    return super.extracting(extractor, this::newObjectAssert).asInstanceOf(assertFactory);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/NavigationMethodBaseTest.java
+++ b/src/test/java/org/assertj/core/api/NavigationMethodBaseTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
+
+import java.util.UUID;
+
+import org.assertj.core.util.introspection.PropertyOrFieldSupport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Base tests for navigation methods which create a new assertion.
+ *
+ * @author Stefano Cordio
+ */
+public interface NavigationMethodBaseTest<ASSERT extends AbstractAssert<ASSERT, ?>> {
+
+  ASSERT getAssertion();
+
+  AbstractAssert<?, ?> invoke_navigation_method(ASSERT assertion);
+
+  @Test
+  default void should_honor_registered_comparator() {
+    // GIVEN
+    ASSERT assertion = getAssertion().usingComparator(ALWAY_EQUALS);
+    // WHEN
+    AbstractAssert<?, ?> result = invoke_navigation_method(assertion);
+    // THEN
+    result.isEqualTo(UUID.randomUUID()); // random value to avoid false positives
+  }
+
+  @Test
+  default void should_keep_existing_assertion_state() {
+    // GIVEN
+    ASSERT assertion = getAssertion().as("description")
+                                     .withFailMessage("error message")
+                                     .withRepresentation(UNICODE_REPRESENTATION)
+                                     .usingComparator(ALWAY_EQUALS);
+    // WHEN
+    AbstractAssert<?, ?> result = invoke_navigation_method(assertion);
+    // THEN
+    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
+                .extracting(AbstractAssert::getWritableAssertionInfo)
+                .isEqualToComparingFieldByField(assertion.info);
+  }
+
+  static Object extractObjectField(AbstractAssert<?, ?> assertion) {
+    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AbstractAssert;
@@ -24,18 +23,18 @@ import org.assertj.core.api.AbstractAssertBaseTest;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.ConcreteAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.presentation.UnicodeRepresentation;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Tests for <code>{@link AbstractAssert#asInstanceOf(InstanceOfAssertFactory)}</code>.
  *
  * @author Stefano Cordio
  */
-@ExtendWith(MockitoExtension.class)
-class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends AbstractAssertBaseTest {
+@DisplayName("AbstractAssert asInstanceOf(InstanceOfAssertFactory)")
+class AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test extends AbstractAssertBaseTest
+    implements NavigationMethodBaseTest<ConcreteAssert> {
 
   @Override
   protected ConcreteAssert invoke_api_method() {
@@ -53,6 +52,16 @@ class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends Abst
     // Test disabled since asInstanceOf does not return this.
   }
 
+  @Override
+  public ConcreteAssert getAssertion() {
+    return assertions;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(ConcreteAssert assertion) {
+    return assertion.asInstanceOf(LONG);
+  }
+
   @Test
   void should_throw_npe_if_no_factory_is_given() {
     // WHEN
@@ -68,20 +77,6 @@ class AbstractAssert_asInstanceOf_with_instanceOfAssertFactory_Test extends Abst
     AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);
     // THEN
     then(result).isInstanceOf(AbstractLongAssert.class);
-  }
-
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    assertions.as("description")
-              .withFailMessage("error message")
-              .withRepresentation(UNICODE_REPRESENTATION);
-    // WHEN
-    AbstractAssert<?, ?> result = assertions.asInstanceOf(LONG);
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", objects)
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(getInfo(assertions));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.CHAR_SEQUENCE;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+
+import java.util.function.Function;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.abstract_.AbstractAssert_extracting_with_Function_and_AssertFactory_Test.TestAssert;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link AbstractAssert#extracting(Function, AssertFactory)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("AbstractAssert extracting(Function, AssertFactory)")
+class AbstractAssert_extracting_with_Function_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
+
+  private TestAssert underTest;
+
+  @BeforeEach
+  void setup() {
+    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+    underTest = new TestAssert(luke);
+  }
+
+  @Test
+  void should_throw_npe_if_the_given_extractor_is_null() {
+    // GIVEN
+    Function<Employee, Object> extractor = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.extracting(extractor, Assertions::assertThat));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("extractor").create());
+  }
+
+  @Test
+  void should_throw_npe_if_the_given_assert_factory_is_null() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.extracting(Employee::getAge, null));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("assertFactory").create());
+  }
+
+  @Test
+  void should_pass_allowing_assertions_on_value_extracted_with_method_reference() {
+    // WHEN
+    AbstractAssert<?, ?> result = underTest.extracting(Employee::getAge, Assertions::assertThat);
+    // THEN
+    result.isEqualTo(26);
+  }
+
+  @Test
+  void should_pass_allowing_assertions_on_value_extracted_with_lambda() {
+    // GIVEN
+    Function<Employee, String> firstName = employee -> employee.getName().getFirst();
+    // WHEN
+    AbstractAssert<?, ?> result = underTest.extracting(firstName, Assertions::assertThat);
+    // THEN
+    result.isEqualTo("Luke");
+  }
+
+  @Test
+  void should_pass_allowing_narrowed_assertions_on_value_extracted_with_instanceOfAssertFactory() {
+    // WHEN
+    AbstractIntegerAssert<?> result = underTest.extracting(Employee::getAge, INTEGER);
+    // THEN
+    result.isNotZero();
+  }
+
+  @Test
+  void should_pass_allowing_parent_type_narrowed_assertions_on_value_extracted_with_parent_type_factory() {
+    // GIVEN
+    Function<Employee, String> firstName = employee -> employee.getName().getFirst();
+    // WHEN
+    AbstractCharSequenceAssert<?, ?> result = underTest.extracting(firstName, CHAR_SEQUENCE);
+    // THEN
+    result.startsWith("Lu");
+  }
+
+  @Test
+  void should_rethrow_any_extractor_function_exception() {
+    // GIVEN
+    RuntimeException explosion = new RuntimeException("boom!");
+    Function<Employee, String> bomb = employee -> {
+      throw explosion;
+    };
+    // WHEN
+    Throwable error = catchThrowable(() -> underTest.extracting(bomb, Assertions::assertThat));
+    // THEN
+    then(error).isSameAs(explosion);
+  }
+
+  @Override
+  public TestAssert getAssertion() {
+    return underTest;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(TestAssert assertion) {
+    return assertion.extracting(Employee::getAge, Assertions::assertThat);
+  }
+
+  static class TestAssert extends AbstractAssert<TestAssert, Employee> {
+
+    TestAssert(Employee actual) {
+      super(actual, TestAssert.class);
+    }
+
+    // re-declare to allow test access
+    @Override
+    protected <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super Employee, ? extends T> extractor,
+                                                                         AssertFactory<T, ASSERT> assertFactory) {
+      return super.extracting(extractor, assertFactory);
+    }
+
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.abstract_.AbstractAssert_extracting_with_String_and_AssertFactory_Test.TestAssert;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.assertj.core.util.introspection.IntrospectionError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link AbstractAssert#extracting(String, AssertFactory)}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("AbstractAssert extracting(String, AssertFactory)")
+class AbstractAssert_extracting_with_String_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
+
+  private TestAssert underTest;
+
+  @BeforeEach
+  void setup() {
+    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+    underTest = new TestAssert(luke);
+  }
+
+  @Test
+  void should_throw_npe_if_the_given_propertyOrField_is_null() {
+    // GIVEN
+    String propertyOrField = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.extracting(propertyOrField, Assertions::assertThat));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("propertyOrField").create());
+  }
+
+  @Test
+  void should_throw_npe_if_the_given_assert_factory_is_null() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.extracting("age", null));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("assertFactory").create());
+  }
+
+  @Test
+  void should_throw_IntrospectionError_if_given_field_name_cannot_be_read() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.extracting("foo", Assertions::assertThat));
+    // THEN
+    then(thrown).isInstanceOf(IntrospectionError.class)
+                .hasMessageContaining("Can't find any field or property with name 'foo'.");
+  }
+
+  @Test
+  void should_pass_allowing_assertions_on_property_value() {
+    // WHEN
+    AbstractAssert<?, ?> result = underTest.extracting("age", Assertions::assertThat);
+    // THEN
+    result.isEqualTo(26);
+  }
+
+  @Test
+  void should_pass_allowing_assertions_on_inner_property_value() {
+    // WHEN
+    AbstractAssert<?, ?> result = underTest.extracting("name.first", Assertions::assertThat);
+    // THEN
+    result.isEqualTo("Luke");
+  }
+
+  @Test
+  void should_pass_allowing_narrowed_assertions_on_property_value_extracted_with_instanceOfAssertFactory() {
+    // WHEN
+    AbstractIntegerAssert<?> result = underTest.extracting("age", INTEGER);
+    // THEN
+    result.isNotZero();
+  }
+
+  @Test
+  void should_use_property_field_name_as_description_when_extracting_single_property() {
+    // WHEN
+    AssertionError error = expectAssertionError(() -> underTest.extracting("name.first", Assertions::assertThat)
+                                                               .isNull());
+    // THEN
+    then(error).hasMessageContaining("[Extracted: name.first]");
+  }
+
+  @Override
+  public TestAssert getAssertion() {
+    return underTest;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(TestAssert assertion) {
+    return assertion.extracting("age", Assertions::assertThat);
+  }
+
+  static class TestAssert extends AbstractAssert<TestAssert, Object> {
+
+    TestAssert(Object actual) {
+      super(actual, TestAssert.class);
+    }
+
+    // re-declare to allow test access
+    @Override
+    protected <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
+                                                                      AssertFactory<Object, ASSERT> assertFactory) {
+      return super.extracting(propertyOrField, assertFactory);
+    }
+
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_Test.java
@@ -14,9 +14,6 @@ package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -26,7 +23,7 @@ import java.util.Map;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.MapAssert;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +34,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("MapAssert extractingByKey(KEY)")
-class MapAssert_extractingByKey_with_Key_Test {
+class MapAssert_extractingByKey_with_Key_Test implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -92,25 +89,14 @@ class MapAssert_extractingByKey_with_Key_Test {
     then(error).hasMessageContaining("[check name]");
   }
 
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    MapAssert<Object, Object> assertion = assertThat(map).as("description")
-                                                         .withFailMessage("error message")
-                                                         .withRepresentation(UNICODE_REPRESENTATION)
-                                                         .usingComparator(ALWAY_EQUALS)
-                                                         .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
-                                                         .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
-    // WHEN
-    AbstractObjectAssert<?, Object> result = assertion.extractingByKey(NAME);
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
+  @Override
+  public MapAssert<Object, Object> getAssertion() {
+    return assertThat(map);
   }
 
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+    return assertion.extractingByKey(NAME);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -32,7 +29,7 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.MapAssert;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +40,8 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("MapAssert extractingByKey(KEY, InstanceOfAssertFactory)")
-class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test {
+class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test
+    implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -61,7 +59,7 @@ class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test {
     Throwable thrown = catchThrowable(() -> assertThat(map).extractingByKey(NAME, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
-                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());;
+                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());
   }
 
   @Test
@@ -106,25 +104,14 @@ class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test {
     then(error).hasMessageContaining("[Extracted: name]");
   }
 
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    MapAssert<Object, Object> assertion = assertThat(map).as("description")
-                                                         .withFailMessage("error message")
-                                                         .withRepresentation(UNICODE_REPRESENTATION)
-                                                         .usingComparator(ALWAY_EQUALS)
-                                                         .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
-                                                         .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
-    // WHEN
-    AbstractStringAssert<?> result = assertion.extractingByKey(NAME, as(STRING));
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
+  @Override
+  public MapAssert<Object, Object> getAssertion() {
+    return assertThat(map);
   }
 
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+    return assertion.extractingByKey(NAME, as(STRING));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKeys_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKeys_Test.java
@@ -14,9 +14,6 @@ package org.assertj.core.api.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -27,8 +24,8 @@ import java.util.Map;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.ObjectAssert;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("MapAssert extractingByKeys(KEY...)")
-class MapAssert_extractingByKeys_Test {
+class MapAssert_extractingByKeys_Test implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -93,25 +90,14 @@ class MapAssert_extractingByKeys_Test {
     then(error).hasMessageContaining("[Extracted: name, age]");
   }
 
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    MapAssert<Object, Object> assertion = assertThat(map).as("description")
-                                                         .withFailMessage("error message")
-                                                         .withRepresentation(UNICODE_REPRESENTATION)
-                                                         .usingComparator(ALWAY_EQUALS)
-                                                         .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
-                                                         .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
-    // WHEN
-    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertion.extractingByKeys(NAME, "age");
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
+  @Override
+  public MapAssert<Object, Object> getAssertion() {
+    return assertThat(map);
   }
 
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+    return assertion.extractingByKeys(NAME, "age");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.BIG_DECIMAL;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS_STRING;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.BigDecimalComparator.BIG_DECIMAL_COMPARATOR;
 
@@ -31,14 +28,13 @@ import java.util.Comparator;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractBigDecimalAssert;
 import org.assertj.core.api.AbstractLongAssert;
-import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
 import org.assertj.core.util.introspection.IntrospectionError;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,7 +45,8 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("ObjectAssert extracting(String, InstanceOfAssertFactory)")
-class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
+class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
+    implements NavigationMethodBaseTest<ObjectAssert<Employee>> {
 
   private Employee luke;
 
@@ -64,7 +61,7 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
     Throwable thrown = catchThrowable(() -> assertThat(luke).extracting("id", null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
-                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());;
+                .hasMessage(shouldNotBeNull("instanceOfAssertFactory").create());
   }
 
   @Test
@@ -110,27 +107,6 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
   }
 
   @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    AbstractObjectAssert<?, Employee> assertion = assertThat(luke).as("description")
-                                                                  .withFailMessage("error message")
-                                                                  .withRepresentation(UNICODE_REPRESENTATION)
-                                                                  .usingComparator(ALWAY_EQUALS)
-                                                                  .usingComparatorForFields(ALWAY_EQUALS_STRING, "foo")
-                                                                  .usingComparatorForType(ALWAY_EQUALS_STRING, String.class);
-    // WHEN
-    AbstractStringAssert<?> result = assertion.extracting("name.first", STRING);
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
-  }
-
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
-  }
-
-  @Test
   void should_allow_to_specify_type_comparator_after_using_extracting_with_single_parameter_on_object() {
     // GIVEN
     Person obiwan = new Person("Obi-Wan");
@@ -145,6 +121,16 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test {
                                                            .usingComparator(heightComparator);
     // THEN
     result.isEqualTo(new BigDecimal("1.82"));
+  }
+
+  @Override
+  public ObjectAssert<Employee> getAssertion() {
+    return assertThat(luke);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(ObjectAssert<Employee> assertion) {
+    return assertion.extracting("name.first", STRING);
   }
 
   @SuppressWarnings("unused")

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
@@ -15,8 +15,6 @@ package org.assertj.core.api.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -24,8 +22,8 @@ import java.util.Optional;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.OptionalAssert;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * @author Filip Hrisafov
  */
 @DisplayName("OptionalAssert get")
-class OptionalAssert_get_Test {
+class OptionalAssert_get_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");
 
@@ -67,23 +65,14 @@ class OptionalAssert_get_Test {
     result.isEqualTo("Frodo");
   }
 
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    OptionalAssert<String> assertion = assertThat(optional).as("description")
-                                                           .withFailMessage("error message")
-                                                           .withRepresentation(UNICODE_REPRESENTATION)
-                                                           .usingComparator(ALWAY_EQUALS);
-    // WHEN
-    AbstractObjectAssert<?, String> result = assertion.get();
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
+  @Override
+  public OptionalAssert<String> getAssertion() {
+    return assertThat(optional);
   }
 
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(OptionalAssert<String> assertion) {
+    return assertion.get();
   }
 
 }

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.ALWAY_EQUALS;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
@@ -29,8 +27,8 @@ import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.OptionalAssert;
-import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +38,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("OptionalAssert get(InstanceOfAssertFactory)")
-class OptionalAssert_get_with_InstanceOfAssertFactory_Test {
+class OptionalAssert_get_with_InstanceOfAssertFactory_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");
 
@@ -89,23 +87,14 @@ class OptionalAssert_get_with_InstanceOfAssertFactory_Test {
     then(assertionError).hasMessageContainingAll("Expecting:", "to be an instance of:", "but was instance of:");
   }
 
-  @Test
-  void should_keep_existing_assertion_state() {
-    // GIVEN
-    OptionalAssert<String> assertion = assertThat(optional).as("description")
-                                                           .withFailMessage("error message")
-                                                           .withRepresentation(UNICODE_REPRESENTATION)
-                                                           .usingComparator(ALWAY_EQUALS);
-    // WHEN
-    AbstractStringAssert<?> result = assertion.get(STRING);
-    // THEN
-    then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
-                .extracting(AbstractAssert::getWritableAssertionInfo)
-                .isEqualToComparingFieldByField(assertion.info);
+  @Override
+  public OptionalAssert<String> getAssertion() {
+    return assertThat(optional);
   }
 
-  private static Object extractObjectField(AbstractAssert<?, ?> assertion) {
-    return PropertyOrFieldSupport.EXTRACTION.getValueOf("objects", assertion);
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(OptionalAssert<String> assertion) {
+    return assertion.get(STRING);
   }
 
 }


### PR DESCRIPTION
The PR is not ready yet, tests and javadoc need some reworking.

@kriegfrj @bjhargrave would this help your needs?

@joel-costigliola I added the `isPublic()` matcher to `METHODS_CHANGING_THE_OBJECT_UNDER_TEST` in `SoftProxies` to allow a protected `extracting` without changing the method name. At the moment I don't see any side effect but please let me know your opinion about it. ✅  Applied in 353484157d2b308950f36c0e48440f4d91ede45f.

#### Check List:
* Fixes #1731
* Unit tests : YES
* Javadoc with a code example (on API only) : YES