### PR TITLE
Allow assertions on the (root) cause message

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -159,6 +159,30 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Verifies that the actual {@code Throwable} has a cause.
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a cause.
+   */
+  public SELF hasCause() {
+    throwables.assertHasCause(info, actual);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Throwable} has a root cause.
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a root cause.
+   */
+  public SELF hasRootCause() {
+    throwables.assertHasRootCause(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} starts with the given description.
    * <p>
    * Examples:

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -171,6 +171,18 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Returns a new assertion object that uses the cause of the current Throwable as the actual Throwable
+   *
+   * @return a new assertion object
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a cause.
+   */
+  public AbstractThrowableAssert<?,?> getCause() {
+    hasCause();
+    return new ThrowableAssert(actual.getCause());
+  }
+
+  /**
    * Verifies that the actual {@code Throwable} has a root cause.
    *
    * @return this assertion object.
@@ -180,6 +192,18 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   public SELF hasRootCause() {
     throwables.assertHasRootCause(info, actual);
     return myself;
+  }
+
+  /**
+   * Returns a new assertion object that uses the root cause of the current Throwable as the actual Throwable
+   *
+   * @return a new assertion object
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a root cause.
+   */
+  public AbstractThrowableAssert<?,?> getRootCause() {
+    hasRootCause();
+    return new ThrowableAssert(org.assertj.core.util.Throwables.getRootCause(actual));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -55,6 +55,8 @@ class SoftProxies {
                                                                                                                       .or(named("extractingByKeys"))
                                                                                                                       .or(named("extractingFromEntries"))
                                                                                                                       .or(named("get"))
+                                                                                                                      .or(named("getCause"))
+                                                                                                                      .or(named("getRootCause"))
                                                                                                                       .or(named("asInstanceOf"))
                                                                                                                       .or(named("succeedsWithin"));
 

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -16,6 +16,7 @@ import java.util.IllegalFormatException;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.util.CheckReturnValue;
+import org.assertj.core.util.Throwables;
 
 /**
  * Assertion methods for {@link java.lang.Throwable} similar to {@link ThrowableAssert} but with assertions methods named
@@ -645,5 +646,32 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
   public ThrowableAssertAlternative<T> describedAs(Description description) {
     delegate.describedAs(description);
     return super.describedAs(description);
+  }
+
+  /**
+   * Checks if the actual {@link Throwable} has a cause and returns a new assertion object where the
+   * cause becomes the actual Throwable in order to further assert properties of the cause {@link Throwable}
+   *
+   * @return a new assertion object with the cause of the current actual becoming the new actual
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no cause.
+   */
+  public ThrowableAssertAlternative<?> havingCause() {
+    delegate.hasCause();
+    Throwable cause = delegate.actual.getCause();
+    return new ThrowableAssertAlternative<>(cause);
+  }
+
+  /**
+   * Checks if the actual {@link Throwable} has a root cause and returns a new assertion object where the
+   * root cause becomes the actual Throwable in order to further assert properties of the cause {@link Throwable}
+   *
+   * @return a new assertion object with the root cause of the current actual becoming the new actual
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} has no root cause.
+   */
+  public ThrowableAssertAlternative<?> havingRootCause() {
+    delegate.hasRootCause();
+    return new ThrowableAssertAlternative<>(Throwables.getRootCause(delegate.actual));
   }
 }

--- a/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
+++ b/src/main/java/org/assertj/core/api/ThrowableAssertAlternative.java
@@ -657,9 +657,8 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    * @throws AssertionError if the actual {@code Throwable} has no cause.
    */
   public ThrowableAssertAlternative<?> havingCause() {
-    delegate.hasCause();
-    Throwable cause = delegate.actual.getCause();
-    return new ThrowableAssertAlternative<>(cause);
+    AbstractThrowableAssert<?,?> causeAssert = delegate.getCause();
+    return new ThrowableAssertAlternative<>(causeAssert.actual);
   }
 
   /**
@@ -671,7 +670,7 @@ public class ThrowableAssertAlternative<T extends Throwable> extends AbstractAss
    * @throws AssertionError if the actual {@code Throwable} has no root cause.
    */
   public ThrowableAssertAlternative<?> havingRootCause() {
-    delegate.hasRootCause();
-    return new ThrowableAssertAlternative<>(Throwables.getRootCause(delegate.actual));
+    AbstractThrowableAssert<?, ?> rootCauseAssert = delegate.getRootCause();
+    return new ThrowableAssertAlternative<>(rootCauseAssert.actual);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveCause.java
@@ -31,6 +31,10 @@ public class ShouldHaveCause extends BasicErrorMessageFactory {
     return new ShouldHaveCause(actualCause, expectedCause);
   }
 
+  public static ErrorMessageFactory shouldHaveCause(Throwable actualCause) {
+    return new BasicErrorMessageFactory("expecting %s to have a cause but it did not", actualCause);
+  }
+
   private ShouldHaveCause(Throwable actualCause, Throwable expectedCause) {
     super("%n" +
           "Expecting a cause with type:%n" +

--- a/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveRootCause.java
@@ -42,6 +42,10 @@ public class ShouldHaveRootCause extends BasicErrorMessageFactory {
     return new ShouldHaveRootCause(actual, actualCause, expectedCause);
   }
 
+  public static ErrorMessageFactory shouldHaveRootCause(Throwable actualCause) {
+    return new BasicErrorMessageFactory("expecting %s to have a root cause but it did not", actualCause);
+  }
+
   private ShouldHaveRootCause(Throwable actual, Throwable actualCause, Throwable expectedCause) {
     super("%n" +
           "Expecting a root cause with type:%n" +

--- a/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/src/main/java/org/assertj/core/internal/Throwables.java
@@ -165,6 +165,36 @@ public class Throwables {
   }
 
   /**
+   * Asserts that the actual {@code Throwable} has a cause.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a cause.
+   */
+  public void assertHasCause(AssertionInfo info, Throwable actual) {
+    assertNotNull(info, actual);
+    Throwable actualCause = actual.getCause();
+    if (actualCause != null) return;
+    throw failures.failure(info, shouldHaveCause(actual));
+  }
+
+  /**
+   * Asserts that the actual {@code Throwable} has a root cause.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a root cause.
+   */
+  public void assertHasRootCause(AssertionInfo info, Throwable actual) {
+    assertNotNull(info, actual);
+    Throwable rootCause = getRootCause(actual);
+    if (rootCause != null) return;
+    throw failures.failure(info, shouldHaveRootCause(actual));
+  }
+
+  /**
    * Asserts that the message of the actual {@code Throwable} starts with the given description.
    *
    * @param info contains information about the assertion.

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -12,79 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.as;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.in;
-import static org.assertj.core.api.Assertions.not;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
-import static org.assertj.core.api.InstanceOfAssertFactories.type;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.assertj.core.data.TolkienCharacter.Race.ELF;
-import static org.assertj.core.data.TolkienCharacter.Race.HOBBIT;
-import static org.assertj.core.data.TolkienCharacter.Race.MAN;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
-import static org.assertj.core.test.AlwaysEqualComparator.alwaysEqual;
-import static org.assertj.core.test.Maps.mapOf;
-import static org.assertj.core.test.Name.lastNameComparator;
-import static org.assertj.core.test.Name.name;
-import static org.assertj.core.util.Arrays.array;
-import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
-import static org.assertj.core.util.DateUtil.parseDatetime;
-import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.math.BigDecimal;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.time.Duration;
-import java.time.LocalTime;
-import java.time.OffsetTime;
-import java.time.ZoneOffset;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.Spliterator;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicIntegerArray;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongArray;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceArray;
-import java.util.function.Consumer;
-import java.util.function.DoublePredicate;
-import java.util.function.Function;
-import java.util.function.IntPredicate;
-import java.util.function.LongPredicate;
-import java.util.function.Predicate;
-import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-
 import org.assertj.core.api.ClassAssertBaseTest.AnnotatedClass;
 import org.assertj.core.api.ClassAssertBaseTest.AnotherAnnotation;
 import org.assertj.core.api.ClassAssertBaseTest.MyAnnotation;
@@ -105,6 +32,48 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.MultipleFailuresError;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.data.TolkienCharacter.Race.*;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.AlwaysEqualComparator.alwaysEqual;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.Name.lastNameComparator;
+import static org.assertj.core.test.Name.name;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.DateUtil.parseDatetime;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
 
 /**
  * Tests for <code>{@link SoftAssertions}</code>.
@@ -2199,4 +2168,25 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(2)).hasMessageContaining("Expecting actual not to be null");
   }
 
+  @Test
+  void throwable_soft_assertions_should_work_with_navigation_methods() {
+    IllegalArgumentException cause = new IllegalArgumentException("cause message");
+    Throwable throwable = new Throwable("top level", cause);
+
+    softly.assertThat(throwable)
+          .hasMessage("not top level message")
+          .getCause()
+          .hasMessage("not cause message");
+
+    List<Throwable> errorsCollected = softly.errorsCollected();
+    assertThat(errorsCollected).hasSize(2);
+    assertThat(errorsCollected.get(0)).hasMessageContaining("Expecting message to be:\n" +
+                                                              "  <\"not top level message\">\n" +
+                                                              "but was:\n" +
+                                                              "  <\"top level\">");
+    assertThat(errorsCollected.get(1)).hasMessageContaining("Expecting message to be:\n" +
+                                                              "  <\"not cause message\">\n" +
+                                                              "but was:\n" +
+                                                              "  <\"cause message\">");
+  }
 }

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -2169,15 +2169,16 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   @Test
-  void throwable_soft_assertions_should_work_with_navigation_methods() {
+  void throwable_soft_assertions_should_work_with_navigation_method_get_cause() {
+    // GIVEN
     IllegalArgumentException cause = new IllegalArgumentException("cause message");
     Throwable throwable = new Throwable("top level", cause);
-
+    // WHEN
     softly.assertThat(throwable)
           .hasMessage("not top level message")
           .getCause()
           .hasMessage("not cause message");
-
+    // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
     assertThat(errorsCollected).hasSize(2);
     assertThat(errorsCollected.get(0)).hasMessageContaining("Expecting message to be:\n" +
@@ -2188,5 +2189,29 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                                               "  <\"not cause message\">\n" +
                                                               "but was:\n" +
                                                               "  <\"cause message\">");
+  }
+
+  @Test
+  void throwable_soft_assertions_should_work_with_navigation_method_get_root_cause() {
+    // GIVEN
+    NullPointerException rootCause = new NullPointerException("root cause message");
+    IllegalArgumentException cause = new IllegalArgumentException("cause message", rootCause);
+    Throwable throwable = new Throwable("top level", cause);
+    // WHEN
+    softly.assertThat(throwable)
+          .hasMessage("not top level message")
+          .getRootCause()
+          .hasMessage("not root cause message");
+    // THEN
+    List<Throwable> errorsCollected = softly.errorsCollected();
+    assertThat(errorsCollected).hasSize(2);
+    assertThat(errorsCollected.get(0)).hasMessageContaining("Expecting message to be:\n" +
+                                                              "  <\"not top level message\">\n" +
+                                                              "but was:\n" +
+                                                              "  <\"top level\">");
+    assertThat(errorsCollected.get(1)).hasMessageContaining("Expecting message to be:\n" +
+                                                              "  <\"not root cause message\">\n" +
+                                                              "but was:\n" +
+                                                              "  <\"root cause message\">");
   }
 }

--- a/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
+++ b/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
@@ -1,0 +1,30 @@
+package org.assertj.core.api;
+
+import org.assertj.core.util.AssertionsUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ThrowableAssertAlternative havingCause")
+class ThrowableAssertAlternative_havingCause_Test {
+
+  @Test
+  void should_return_cause_if_throwable_has_cause() {
+    Throwable throwable = new Throwable("top level message", new Throwable("cause message"));
+    new ThrowableAssertAlternative<>(throwable)
+      .havingCause()
+      .withMessage("cause message");
+  }
+
+  @Test
+  void should_fail_if_throwable_has_no_cause() {
+    //WHEN
+    ThrowableAssert.ThrowingCallable code = () -> {
+      Throwable throwable = new Throwable("top level message");
+      new ThrowableAssertAlternative<>(throwable)
+        .havingCause();
+    };
+    //THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(code).withMessage("expecting java.lang.Throwable: top level message to have a cause but it did not");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
+++ b/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
@@ -1,30 +1,45 @@
 package org.assertj.core.api;
 
-import org.assertj.core.util.AssertionsUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 @DisplayName("ThrowableAssertAlternative havingCause")
 class ThrowableAssertAlternative_havingCause_Test {
 
   @Test
   void should_return_cause_if_throwable_has_cause() {
-    Throwable throwable = new Throwable("top level message", new Throwable("cause message"));
-    new ThrowableAssertAlternative<>(throwable)
-      .havingCause()
-      .withMessage("cause message");
+    Throwable cause = new Throwable("cause message");
+    Throwable throwable = new Throwable("top level message", cause);
+    assertThat(new ThrowableAssertAlternative<>(throwable)
+                 .havingCause().actual)
+      .isSameAs(cause);
   }
 
   @Test
   void should_fail_if_throwable_has_no_cause() {
+    //GIVEN
+    Throwable throwable = new Throwable("top level message");
+    ThrowableAssertAlternative<Throwable> taa = new ThrowableAssertAlternative<>(throwable);
     //WHEN
-    ThrowableAssert.ThrowingCallable code = () -> {
-      Throwable throwable = new Throwable("top level message");
-      new ThrowableAssertAlternative<>(throwable)
-        .havingCause();
-    };
+    AssertionError error = expectAssertionError(taa::havingCause);
     //THEN
-    AssertionsUtil.assertThatAssertionErrorIsThrownBy(code).withMessage("expecting java.lang.Throwable: top level message to have a cause but it did not");
+    assertThat(error).hasMessage(shouldHaveCause(throwable).create());
   }
 
+  @Test
+  void should_fail_if_throwable_is_null() {
+    //GIVEN
+    Throwable throwable = null;
+    ThrowableAssertAlternative<Throwable> taa = new ThrowableAssertAlternative<>(throwable);
+    //WHEN
+    ThrowableAssert.ThrowingCallable code = taa::havingCause;
+    AssertionError error = expectAssertionError(code);
+    //THEN
+    assertThat(error).hasMessage(shouldNotBeNull().create());
+  }
 }

--- a/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingRootCause_Test.java
+++ b/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingRootCause_Test.java
@@ -1,30 +1,46 @@
 package org.assertj.core.api;
 
-import org.assertj.core.util.AssertionsUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveRootCause.shouldHaveRootCause;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 @DisplayName("ThrowableAssertAlternative havingRootCause")
 class ThrowableAssertAlternative_havingRootCause_Test {
 
   @Test
   void should_return_root_cause_if_throwable_has_cause() {
-    Throwable throwable = new Throwable("top level message", new Throwable("cause message", new Throwable("root message")));
-    new ThrowableAssertAlternative<>(throwable)
-      .havingRootCause()
-      .withMessage("root message");
+    Throwable rootCause = new Throwable("root message");
+    Throwable throwable = new Throwable("top level message", new Throwable("cause message", rootCause));
+
+    assertThat(new ThrowableAssertAlternative<>(throwable)
+                 .havingRootCause().actual)
+      .isSameAs(rootCause);
   }
 
   @Test
   void should_fail_if_throwable_has_no_root_cause() {
+    //GIVEN
+    Throwable throwable = new Throwable("top level message");
+    ThrowableAssertAlternative<Throwable> taa = new ThrowableAssertAlternative<>(throwable);
     //WHEN
-    ThrowableAssert.ThrowingCallable code = () -> {
-      Throwable throwable = new Throwable("top level message");
-      new ThrowableAssertAlternative<>(throwable)
-        .havingRootCause();
-    };
+    AssertionError error = expectAssertionError(taa::havingRootCause);
     //THEN
-    AssertionsUtil.assertThatAssertionErrorIsThrownBy(code).withMessage("expecting java.lang.Throwable: top level message to have a root cause but it did not");
+    assertThat(error).hasMessage(shouldHaveRootCause(throwable).create());
+  }
+
+  @Test
+  void should_fail_if_throwable_is_null() {
+    //GIVEN
+    Throwable throwable = null;
+    ThrowableAssertAlternative<Throwable> taa = new ThrowableAssertAlternative<>(throwable);
+    //WHEN
+    AssertionError error = expectAssertionError(taa::havingRootCause);
+    //THEN
+    assertThat(error).hasMessage(shouldNotBeNull().create());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingRootCause_Test.java
+++ b/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingRootCause_Test.java
@@ -1,0 +1,30 @@
+package org.assertj.core.api;
+
+import org.assertj.core.util.AssertionsUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ThrowableAssertAlternative havingRootCause")
+class ThrowableAssertAlternative_havingRootCause_Test {
+
+  @Test
+  void should_return_root_cause_if_throwable_has_cause() {
+    Throwable throwable = new Throwable("top level message", new Throwable("cause message", new Throwable("root message")));
+    new ThrowableAssertAlternative<>(throwable)
+      .havingRootCause()
+      .withMessage("root message");
+  }
+
+  @Test
+  void should_fail_if_throwable_has_no_root_cause() {
+    //WHEN
+    ThrowableAssert.ThrowingCallable code = () -> {
+      Throwable throwable = new Throwable("top level message");
+      new ThrowableAssertAlternative<>(throwable)
+        .havingRootCause();
+    };
+    //THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(code).withMessage("expecting java.lang.Throwable: top level message to have a root cause but it did not");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasCause_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasCause_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.api.throwable;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.ThrowableAssert;
@@ -44,4 +45,15 @@ public class ThrowableAssert_hasCause_Test extends ThrowableAssertBaseTest {
                                                                        "but type was:%n" +
                                                                        "  <\"java.lang.IllegalStateException\">."));
   }
+
+  @Test
+  void should_fail_if_actual_has_no_cause() {
+    // GIVEN
+    Throwable throwable = new Throwable();
+    // WHEN
+    AssertionError error = expectAssertionError(()-> assertThat(throwable).hasCause());
+    // THEN
+    assertThat(error).hasMessage("expecting java.lang.Throwable to have a cause but it did not");
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCause_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasRootCause_Test.java
@@ -57,4 +57,14 @@ public class ThrowableAssert_hasRootCause_Test extends ThrowableAssertBaseTest {
                                          + "%n%s",
                                          getStackTrace(throwable)));
   }
+
+  @Test
+  void should_fail_if_actual_has_no_root_cause() {
+    // GIVEN
+    Throwable throwable = new Throwable();
+    // WHEN
+    AssertionError error = expectAssertionError(()-> assertThat(throwable).hasRootCause());
+    // THEN
+    assertThat(error).hasMessage("expecting java.lang.Throwable to have a root cause but it did not");
+  }
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveCause_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveCause_create_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
+
+@DisplayName("ShouldHaveCause create")
+public class ShouldHaveCause_create_Test {
+
+
+  @Test
+  void should_create_error_message_for_actual_cause() {
+    //GIVEN
+    Throwable actual = new RuntimeException();
+    //WHEN
+    String message = shouldHaveCause(actual).create();
+    //THEN
+    then(message).isEqualTo("expecting java.lang.RuntimeException to have a cause but it did not");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveRootCause_create_Test.java
@@ -175,4 +175,14 @@ public class ShouldHaveRootCause_create_Test {
                                    "%n%s",
                                    getStackTrace(actual)));
   }
+
+  @Test
+  void should_create_error_message_for_actual_cause() {
+    //GIVEN
+    Throwable actual = new RuntimeException();
+    //WHEN
+    String message = shouldHaveRootCause(actual).create();
+    //THEN
+    then(message).isEqualTo("expecting java.lang.RuntimeException to have a root cause but it did not");
+  }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1776
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


