### PR TITLE
ByteArrayAssert.containsExactly(byte...) error message will mention …

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -768,7 +768,7 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
    *                              or values are the same but the order is not.
    */
   public SELF containsExactly(byte... values) {
-    objects.assertEqual(info, actual, values);
+    arrays.assertContainsExactly(info, actual, values);
     return myself;
   }
 

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsExactly_Test.java
@@ -12,15 +12,17 @@
  */
 package org.assertj.core.api.bytearray;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.test.ByteArrays.arrayOf;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.ByteArrayAssert;
 import org.assertj.core.api.ByteArrayAssertBaseTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.ByteArrayAssert#containsExactly(byte...)}</code>.
- * 
+ *
  * @author Jean-Christophe Gay
  */
 public class ByteArrayAssert_containsExactly_Test extends ByteArrayAssertBaseTest {
@@ -32,6 +34,11 @@ public class ByteArrayAssert_containsExactly_Test extends ByteArrayAssertBaseTes
 
   @Override
   protected void verify_internal_effects() {
-    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+    verify(arrays).assertContainsExactly(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+  }
+
+  @Test
+  public void invoke_api_like_user() {
+    assertThat(new byte[] { 1, 2, 3 }).containsExactly((byte) 1, (byte) 2, (byte) 3);
   }
 }


### PR DESCRIPTION
… not found and not expected items (#1801)

#### Check List:
* Fixes #1801 
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


