### PR TITLE
Support four arguments for satisfiesAnyOf()

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -742,6 +742,45 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
     return satisfiesAnyOfAssertionsGroups(assertions1, assertions2, assertions3);
   }
 
+  /**
+   * Verifies that the actual object under test satisfies at least one of the given assertions group expressed as {@link Consumer}s.
+   * <p>
+   * This allows users to perform <b>OR like assertions</b> since only one the assertions group has to be met.
+   * <p>
+   * {@link #overridingErrorMessage(String, Object...) Overriding error message} is not supported as it would prevent from
+   * getting the error messages of the failing assertions, these are valuable to figure out what went wrong.<br>
+   * Describing the assertion is supported (for example with {@link #as(String, Object...)}).
+   * <p>
+   * Example:
+   * <pre><code class='java'> TolkienCharacter smaug = new TolkienCharacter("Smaug", DRAGON);
+   *
+   * Consumer&lt;TolkienCharacter&gt; isHobbit = tolkienCharacter -&gt; assertThat(tolkienCharacter.getRace()).isEqualTo(HOBBIT);
+   * Consumer&lt;TolkienCharacter&gt; isElf = tolkienCharacter -&gt; assertThat(tolkienCharacter.getRace()).isEqualTo(ELF);
+   * Consumer&lt;TolkienCharacter&gt; isOrc = tolkienCharacter -&gt; assertThat(tolkienCharacter.getRace()).isEqualTo(ORC);
+   * Consumer&lt;TolkienCharacter&gt; isDragon = tolkienCharacter -&gt; assertThat(tolkienCharacter.getRace()).isEqualTo(DRAGON);
+   *
+   * // assertion succeeds:
+   * assertThat(smaug).satisfiesAnyOf(isElf, isHobbit, isOrc, isDragon);
+   *
+   * // assertion fails:
+   * TolkienCharacter boromir = new TolkienCharacter("Boromir", MAN);
+   * assertThat(boromir).satisfiesAnyOf(isHobbit, isElf, isOrc, isDragon);</code></pre>
+   *
+   * @param assertions1 the first group of assertions to run against the object under test - must not be null.
+   * @param assertions2 the second group of assertions to run against the object under test - must not be null.
+   * @param assertions3 the third group of assertions to run against the object under test - must not be null.
+   * @param assertions4 the third group of assertions to run against the object under test - must not be null.
+   * @return this assertion object.
+   *
+   * @throws IllegalArgumentException if any given assertions group is null
+   * @since 3.16.0
+   */
+  // Does not take a Consumer<ACTUAL>... to avoid to use @SafeVarargs to suppress the generic array type safety warning.
+  // @SafeVarargs requires methods to be final which breaks the proxying mechanism used by soft assertions and assumptions
+  public SELF satisfiesAnyOf(Consumer<ACTUAL> assertions1, Consumer<ACTUAL> assertions2, Consumer<ACTUAL> assertions3, Consumer<ACTUAL> assertions4) {
+    return satisfiesAnyOfAssertionsGroups(assertions1, assertions2, assertions3, assertions4);
+  }
+
   // can be final as it is not proxied
   @SafeVarargs
   private final SELF satisfiesAnyOfAssertionsGroups(Consumer<ACTUAL>... assertionsGroups) throws AssertionError {

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.data.TolkienCharacter.Race.DRAGON;
 import static org.assertj.core.data.TolkienCharacter.Race.DWARF;
 import static org.assertj.core.data.TolkienCharacter.Race.ELF;
 import static org.assertj.core.data.TolkienCharacter.Race.HOBBIT;
@@ -37,9 +38,11 @@ public class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
 
   private TolkienCharacter frodo = TolkienCharacter.of("Frodo", 33, HOBBIT);
   private TolkienCharacter legolas = TolkienCharacter.of("Legolas", 1000, ELF);
+  private TolkienCharacter smaug = TolkienCharacter.of("Smaug", 171, DRAGON);
   private Consumer<TolkienCharacter> isHobbit = tolkienCharacter -> assertThat(tolkienCharacter.getRace()).isEqualTo(HOBBIT);
   private Consumer<TolkienCharacter> isElf = tolkienCharacter -> assertThat(tolkienCharacter.getRace()).isEqualTo(ELF);
   private Consumer<TolkienCharacter> isDwarf = tolkienCharacter -> assertThat(tolkienCharacter.getRace()).isEqualTo(DWARF);
+  private Consumer<TolkienCharacter> isDragon = tolkienCharacter -> assertThat(tolkienCharacter.getRace()).isEqualTo(DRAGON);
 
   @Override
   protected ConcreteAssert invoke_api_method() {
@@ -70,6 +73,8 @@ public class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
     assertThat(frodo).satisfiesAnyOf(isHobbit, isElf);
     assertThat(legolas).satisfiesAnyOf(isHobbit, isElf, isDwarf)
                        .satisfiesAnyOf(isHobbit, isElf);
+    assertThat(smaug).satisfiesAnyOf(isHobbit, isElf, isDwarf, isDragon)
+                     .satisfiesAnyOf(isHobbit, isDwarf, isDragon);
   }
 
   @Test
@@ -78,7 +83,7 @@ public class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
     Consumer<TolkienCharacter> namesStartsWithF = tolkienCharacter -> assertThat(tolkienCharacter.getName()).startsWith("F");
     // THEN
     assertThat(frodo).satisfiesAnyOf(isHobbit, namesStartsWithF)
-                     .satisfiesAnyOf(isHobbit, namesStartsWithF, isHobbit);
+                     .satisfiesAnyOf(isHobbit, namesStartsWithF, isHobbit, isDragon);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/data/TolkienCharacter.java
+++ b/src/test/java/org/assertj/core/data/TolkienCharacter.java
@@ -20,7 +20,7 @@ public class TolkienCharacter {
   }
 
   public enum Race {
-    HOBBIT, MAIA, ELF, DWARF, MAN
+    HOBBIT, MAIA, ELF, DWARF, MAN, DRAGON
   }
 
   public final String name;


### PR DESCRIPTION
In a recent project this was necessary/useful and since there was no particular reason not to support it other than a missing use case, this seemed a good reason to support it from now on.


 Fixes : NA
 Unit tests : YES
 Javadoc with a code example (on API only) : YES



