### PR TITLE
Feat new method is directory recursively containing

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -940,6 +940,97 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
+   * Verify that the actual {@code File} directory or any of its subdirectories (recursively) contains at least one file
+   * matching the given {@code String} interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
+   * <p>
+   * That methods peforms the same assertion as {@link #isDirectoryContaining(String syntaxAndPattern)}  but recursively.
+   * <p>
+   * Note that the actual {@link File} must exist and be a directory.
+   * <p>
+   * Given the following directory structure:
+   * <pre><code class="text">
+   * root
+   * |-- foo
+   * |    |-- foobar
+   * |         |-- foo-file-1.ext
+   * |-- foo-file-2.ext</code>
+   * </pre>
+   *
+   * Here are some assertions examples:
+   * <pre><code class="java"> File root = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(root).isDirectoryRecursivelyContaining("glob:**foo")
+   *                 .isDirectoryRecursivelyContaining("glob:**ooba*")
+   *                 .isDirectoryRecursivelyContaining("glob:**file-1.ext")
+   *                 .isDirectoryRecursivelyContaining("regex:.*file-2.*")
+   *                 .isDirectoryRecursivelyContaining("glob:**.{ext,dummy}");
+   *
+   * // The following assertions fail:
+   * assertThat(root).isDirectoryRecursivelyContaining("glob:**fooba");
+   * assertThat(root).isDirectoryRecursivelyContaining("glob:**.bin");
+   * assertThat(root).isDirectoryRecursivelyContaining("glob:**.{java,class}"); </code></pre>
+   *
+   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
+   * @throws AssertionError       if actual is {@code null}.
+   * @throws AssertionError       if actual does not exist.
+   * @throws AssertionError       if actual is not a directory.
+   * @throws AssertionError       if actual does not contain recursively any files matching the given path matcher.
+   * @see FileSystem#getPathMatcher(String)
+   * @since 3.16.0
+   */
+  public SELF isDirectoryRecursivelyContaining(String syntaxAndPattern) {
+    files.assertIsDirectoryRecursivelyContaining(info, actual, syntaxAndPattern);
+    return myself;
+  }
+
+  /**
+   * Verify that the actual {@code File} directory or any of its subdirectories (recursively) contains at least one file
+   * matching the given {@code Predicate<File>}.
+   * <p>
+   * That methods peforms the same assertion as {@link #isDirectoryContaining(Predicate filter)}  but recursively.
+   * <p>
+   * Note that the actual {@link File} must exist and be a directory.
+   * <p>
+   * Given the following directory structure:
+   * <pre><code class="text">
+   * root
+   * |-- foo
+   * |    |-- foobar
+   * |         |-- foo-file-1.ext
+   * |-- foo-file-2.ext</code>
+   * </pre>
+   *
+   * Here are some assertions examples:
+   * <pre><code class="java"> File root = new File("root");
+   *
+   * // The following assertions succeed:
+   * assertThat(root).isDirectoryRecursivelyContaining(file -&gt; file.getName().startsWith("foo-file-1"))
+   *                 .isDirectoryRecursivelyContaining(file -&gt; file.getName().endsWith("file-2.ext"))
+   *                 .isDirectoryRecursivelyContaining(file -&gt; file.getName().equals("foo"))
+   *                 .isDirectoryRecursivelyContaining(file -&gt; file.getParentFile().getName().equals("foo"))
+   *
+   * // The following assertions fail:
+   * assertThat(root).isDirectoryRecursivelyContaining(file -&gt; file.getName().equals("foo-file-1"))
+   * assertThat(root).isDirectoryRecursivelyContaining(file -&gt; file.getName().equals("foo/foobar")); </code></pre>
+   *
+   * @param filter the filter for files located inside {@code actual}'s directory.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given filter is {@code null}.
+   * @throws AssertionError       if actual is {@code null}.
+   * @throws AssertionError       if actual does not exist.
+   * @throws AssertionError       if actual is not a directory.
+   * @throws AssertionError       if actual does not contain recursively any files matching the given predicate.
+   * @since 3.16.0
+   */
+  public SELF isDirectoryRecursivelyContaining(Predicate<File> filter) {
+    files.assertIsDirectoryRecursivelyContaining(info, actual, filter);
+    return myself;
+  }
+
+  /**
    * Verify that the actual {@code File} is a directory that does not contain any files matching the given {@code Predicate<File>}.
    * <p>
    * Note that the actual {@link File} must exist and be a directory.

--- a/src/main/java/org/assertj/core/error/ShouldContainRecursively.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainRecursively.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.util.Strings.escapePercent;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a group of elements contains recursively a given set of values failed.
+ *
+ * @author David Haccoun
+ * @author Joel Costigliola
+ */
+public class ShouldContainRecursively extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory directoryShouldContainRecursively(File actual, List<String> directoryContent, String filterDescription) {
+    return new ShouldContainRecursively(actual, directoryContent, filterDescription);
+  }
+
+  private ShouldContainRecursively(Object actual, List<String> directoryContent, String filterDescription) {
+    // not passing directoryContent and filterDescription as parameter to avoid AssertJ default String formatting
+    super("%nExpecting directory or any of its subdirectories(recursively):%n" +
+          "  <%s>%n" +
+          "to contain at least one file matching " + escapePercent(filterDescription) + " but there was none.%n" +
+          "The directory content was:%n  " + escapePercent(directoryContent.toString()),
+          actual);
+  }
+
+}

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -366,7 +366,7 @@ public class Paths {
   }
 
   public void assertIsDirectoryContaining(AssertionInfo info, Path actual, String syntaxAndPattern) {
-    requireNonNull(syntaxAndPattern, "The syntax and pattern to build PathMatcher should not be null");
+    requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
     PathMatcher pathMatcher = pathMatcher(info, actual, syntaxAndPattern);
     assertIsDirectoryContaining(info, actual, pathMatcher::matches, format("the '%s' pattern", syntaxAndPattern));
   }
@@ -377,7 +377,7 @@ public class Paths {
   }
 
   public void assertIsDirectoryNotContaining(AssertionInfo info, Path actual, String syntaxAndPattern) {
-    requireNonNull(syntaxAndPattern, "The syntax and pattern to build PathMatcher should not be null");
+    requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
     PathMatcher pathMatcher = pathMatcher(info, actual, syntaxAndPattern);
     assertIsDirectoryNotContaining(info, actual, pathMatcher::matches, format("the '%s' pattern", syntaxAndPattern));
   }

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryRecursivelyContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryRecursivelyContaining_Predicate_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import java.io.File;
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryRecursivelyContaining(Predicate)}</code>
+ *
+ * @author David Haccoun
+ */
+public class FileAssert_isDirectoryRecursivelyContaining_Predicate_Test extends FileAssertBaseTest {
+
+  private final Predicate<File> anyFilter = path -> true;
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryRecursivelyContaining(anyFilter);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryRecursivelyContaining(getInfo(assertions), getActual(assertions), anyFilter);
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link FileAssert#isDirectoryRecursivelyContaining(String)}</code>
+ *
+ * @author David Haccoun
+ */
+public class FileAssert_isDirectoryRecursivelyContaining_SyntaxAndPattern_Test extends FileAssertBaseTest {
+
+  private final String syntaxAndPattern = "glob:*.java";
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isDirectoryRecursivelyContaining(syntaxAndPattern);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertIsDirectoryRecursivelyContaining(getInfo(assertions), getActual(assertions), syntaxAndPattern);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/FilesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/FilesBaseTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -106,7 +107,7 @@ public class FilesBaseTest {
     try {
       given(nioFilesWrapper.newInputStream(path.toPath())).willReturn(new ByteArrayInputStream(new byte[0]));
     } catch (IOException e) {
-      assertThat(e).describedAs("Should not happen").isNull();
+      throw new UncheckedIOException("error during nioFilesWrapper mock recording", e);
     }
     return path;
   }

--- a/src/test/java/org/assertj/core/internal/FilesSimpleBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/FilesSimpleBaseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.*;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * New base class for testing <code>{@link Files}</code>.
+ * <p>That is a lighter alternative to {@link FilesBaseTest}.<br>
+ * Contrary to {@link FilesBaseTest}, {@link FilesSimpleBaseTest}  doesn't try to abstract and mock the filesystem API.
+ * <br>
+ *   Please update that javadoc if the philosophy of that simple base test class evolves
+ * </p>
+ *
+ * @author David Haccoun
+ */
+public abstract class FilesSimpleBaseTest {
+
+  protected static final AssertionInfo INFO = someInfo();
+
+  protected Path tempDir;
+  protected File tempDirAsFile;
+
+  protected Files files;
+  protected Failures failures;
+
+  @BeforeEach
+  public void setUp(@TempDir Path tempDir) {
+    this.tempDir = tempDir;
+    tempDirAsFile = tempDir.toFile();
+    failures = spy(new Failures());
+    files = new Files();
+    files.failures = failures;
+  }
+
+  public Path createDirectory(Path parent, String name, String... files) {
+    Path directory = parent.resolve(name);
+    try {
+      java.nio.file.Files.createDirectory(directory);
+      Arrays.stream(files)
+            .forEach(f -> createFile(directory, f));
+    } catch (IOException e) {
+      throw new UncheckedIOException("error during fixture directory creation", e);
+    }
+
+    return directory;
+  }
+
+  public Path createDirectoryWithDefaultParent(String name, String... files) {
+    return createDirectory(tempDir, name, files);
+  }
+
+  private void createFile(Path directory, String f) {
+    try {
+      java.nio.file.Files.createFile(directory.resolve(f));
+    } catch (IOException e) {
+      throw new UncheckedIOException("error during fixture file creation", e);
+    }
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
@@ -100,7 +100,7 @@ public class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends Fil
     String pathMatcherPattern = null;
     // THEN
     assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, pathMatcherPattern))
-                                    .withMessage("The syntax and pattern to build PathMatcher should not be null");
+                                    .withMessage("The syntax and pattern should not be null");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -75,7 +75,7 @@ public class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends 
     String pathMatcherPattern = null;
     // THEN
     assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, pathMatcherPattern))
-                                    .withMessage("The syntax and pattern to build PathMatcher should not be null");
+                                    .withMessage("The syntax and pattern should not be null");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
@@ -52,18 +52,16 @@ public class Files_assertIsDirectoryRecursivelyContaining_Predicate_Test extends
 
     @BeforeEach
     void createFixturePaths() throws IOException {
-      // @format:off
-    // The layout :
-    //  root
-    //  |-- foo
-    //  |    |-- foobar
-    //  |         |-- foobar1.data
-    //  |         |-- foobar2.json
-    //  |-- foo2.data
+    // @format:off
+      // The layout :
+      //  root
+      //  |-- foo
+      //  |    |-- foobar
+      //  |         |-- foobar1.data
+      //  |         |-- foobar2.json
+      //  |-- foo2.data
     // @format:on
       Path rootDir = createDirectoryWithDefaultParent("root", "foo2.data");
-      java.nio.file.Files.list(rootDir).forEach(System.out::println);
-
       Path fooDir = createDirectory(rootDir, "foo");
       createDirectory(fooDir, "foobar", "foobar1.data", "foobar2.json");
     }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesSimpleBaseTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainRecursively.directoryShouldContainRecursively;
+import static org.assertj.core.internal.Files.toAbsolutePaths;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.assertj.core.util.Lists.list;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryRecursivelyContaining(AssertionInfo, File, java.util.function.Predicate)}</code>
+ *
+ * @author David Haccoun
+ */
+public class Files_assertIsDirectoryRecursivelyContaining_Predicate_Test extends FilesSimpleBaseTest {
+
+  private static final String THE_GIVEN_FILTER_DESCRIPTION = "the given filter";
+
+  @TestInstance(PER_CLASS)
+  @Nested
+  class Actual_matches {
+
+    @BeforeEach
+    void createFixturePaths() throws IOException {
+      // @format:off
+    // The layout :
+    //  root
+    //  |-- foo
+    //  |    |-- foobar
+    //  |         |-- foobar1.data
+    //  |         |-- foobar2.json
+    //  |-- foo2.data
+    // @format:on
+      Path rootDir = createDirectoryWithDefaultParent("root", "foo2.data");
+      java.nio.file.Files.list(rootDir).forEach(System.out::println);
+
+      Path fooDir = createDirectory(rootDir, "foo");
+      createDirectory(fooDir, "foobar", "foobar1.data", "foobar2.json");
+    }
+
+    @ParameterizedTest
+    @MethodSource("foundMatchProvider")
+    void should_pass_if_actual_contains_any_files_matching_the_given_predicate(Predicate<File> predicate) {
+      // WHEN-THEN
+      files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, predicate);
+    }
+
+    private Stream<Predicate<File>> foundMatchProvider() {
+      return Stream.of(f -> f.getName().contains("bar2"), // one match
+                       f -> f.getName().equals("foobar2.json"), // one match
+                       f -> f.getName().contains("foobar"), // some matches
+                       f -> f.getParentFile().getName().equals("foobar"), // some matches
+                       f -> f.getName().contains("foo")); // all matches
+    }
+
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_exist() {
+    // GIVEN
+    File notExistingFile = new File("foo/bar/doesnt-exist-file");
+    Predicate<File> anyPredicate = f -> true;
+    // WHEN
+    expectAssertionError(() -> {
+      files.assertIsDirectoryRecursivelyContaining(INFO, notExistingFile, anyPredicate);
+    });
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(notExistingFile));
+  }
+
+  @Test
+  void should_fail_if_actual_exists_but_is_not_a_directory() throws IOException {
+    // GIVEN
+    File existingFile = java.nio.file.Files.createFile(tempDir.resolve("FooFile.txt")).toFile();
+    Predicate<File> anyPredicate = f -> true;
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, existingFile, anyPredicate));
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(existingFile));
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty() {
+    // GIVEN
+    Predicate<File> anyPredicate = f -> true;
+
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, anyPredicate));
+    // THEN
+    verify(failures)
+        .failure(INFO,
+                 directoryShouldContainRecursively(tempDirAsFile, emptyList(), THE_GIVEN_FILTER_DESCRIPTION));
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_any_files_matching_the_given_pathMatcherPattern() {
+    // GIVEN
+    Path fooDir = createDirectory(tempDir, "foo", "foo2.data");
+    createDirectory(fooDir, "foo3");
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, f -> f.getName().equals("foo2")));
+    // THEN
+    verify(failures)
+        .failure(INFO,
+                 directoryShouldContainRecursively(tempDirAsFile,
+                                                   toAbsolutePaths(list(new File(tempDirAsFile, "foo"),
+                                                                        new File(tempDirAsFile,
+                                                                                 "foo/foo2.data"),
+                                                                        new File(tempDirAsFile, "foo/foo3")
+                                                   )),
+                                                   THE_GIVEN_FILTER_DESCRIPTION));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.files;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesSimpleBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
+import static org.assertj.core.error.ShouldContainRecursively.directoryShouldContainRecursively;
+import static org.assertj.core.internal.Files.toAbsolutePaths;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Files#assertIsDirectoryRecursivelyContaining(AssertionInfo, File, String)}</code>
+ *
+ * @author David Haccoun
+ */
+public class Files_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test extends FilesSimpleBaseTest {
+
+  private static final String TXT_EXTENSION_PATTERN = "regex:.+\\.txt";
+  private static final String TXT_EXTENSION_PATTERN_DESCRIPTION = format("the '%s' pattern",
+                                                                         TXT_EXTENSION_PATTERN);
+
+  @ParameterizedTest
+  @ValueSource(strings = { "regex:.+oo2\\.data", "regex:.+\\.json", "regex:.+bar2\\.json" })
+  void should_pass_if_actual_contains_one_file_matching_the_given_pathMatcherPattern(String pattern) {
+    // GIVEN
+    createDefaultFixturePaths();
+    // WHEN-THEN
+    files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, pattern);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "regex:.+\\.data", "regex:.+foobar.*", "regex:.+root.+foo.*" })
+  void should_pass_if_actual_contains_some_files_matching_the_given_pathMatcherPattern(String pattern) {
+    // GIVEN
+    createDefaultFixturePaths();
+    // WHEN-THEN
+    files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, pattern);
+  }
+
+  private void createDefaultFixturePaths() {
+    // @format:off
+    // The layout :
+    //  root
+    //  |-- foo
+    //  |    |-- foobar
+    //  |         |-- foobar1.data
+    //  |         |-- foobar2.json
+    //  |-- foo2.data
+    // @format:on
+    Path rootDir = createDirectoryWithDefaultParent("root", "foo2.data");
+    Path fooDir = createDirectory(rootDir, "foo");
+    createDirectory(fooDir, "foobar", "foobar1.data", "foobar2.json");
+  }
+
+  @Test
+  void should_pass_if_all_actual_files_matching_the_given_pathMatcherPattern() {
+    // GIVEN
+    Path fooDir = createDirectory(tempDir, "foo", "foo2.data");
+    createDirectory(fooDir, "foo3");
+    // WHEN-THEN
+    files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, "regex:.*foo.*|.*tmp");
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_exist() {
+    // GIVEN
+    File notExistingFile = new File("foo/bar/doesnt-exist-file");
+    // WHEN
+    expectAssertionError(() -> files.assertIsDirectoryRecursivelyContaining(INFO, notExistingFile,
+                                                                            TXT_EXTENSION_PATTERN));
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(notExistingFile));
+  }
+
+  @Test
+  void should_fail_if_actual_exists_but_is_not_a_directory() throws IOException {
+    // GIVEN
+    File existingFile = java.nio.file.Files.createFile(tempDir.resolve("FooFile.txt")).toFile();
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, existingFile, TXT_EXTENSION_PATTERN));
+    // THEN
+    verify(failures).failure(INFO, shouldBeDirectory(existingFile));
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty() {
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, TXT_EXTENSION_PATTERN));
+    // THEN
+    verify(failures)
+        .failure(INFO, directoryShouldContainRecursively(tempDirAsFile, emptyList(), TXT_EXTENSION_PATTERN_DESCRIPTION));
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_any_files_matching_the_given_pathMatcherPattern() {
+    // GIVEN
+    Path fooDir = createDirectory(tempDir, "foo", "foo2.data");
+    createDirectory(fooDir, "foo3");
+    // WHEN
+    expectAssertionError(
+        () -> files.assertIsDirectoryRecursivelyContaining(INFO, tempDirAsFile, TXT_EXTENSION_PATTERN));
+    // THEN
+    verify(failures)
+        .failure(INFO,
+                 directoryShouldContainRecursively(tempDirAsFile, toAbsolutePaths(list(new File(tempDirAsFile, "foo"),
+                                                                            new File(tempDirAsFile,
+                                                                                     "foo/foo2.data"),
+                                                                            new File(tempDirAsFile, "foo/foo3")
+                                        )),
+                                        TXT_EXTENSION_PATTERN_DESCRIPTION));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
@@ -95,7 +95,7 @@ public class Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test extends Moc
     String filter = null;
     // THEN
     assertThatNullPointerException().isThrownBy(() -> paths.assertIsDirectoryContaining(INFO, null, filter))
-                                    .withMessage("The syntax and pattern to build PathMatcher should not be null");
+                                    .withMessage("The syntax and pattern should not be null");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -77,7 +77,7 @@ public class Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends 
     String pattern = null;
     // THEN
     assertThatNullPointerException().isThrownBy(() -> paths.assertIsDirectoryNotContaining(INFO, null, pattern))
-                                    .withMessage("The syntax and pattern to build PathMatcher should not be null");
+                                    .withMessage("The syntax and pattern should not be null");
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #1740
* Unit tests : YES
* Javadoc with a code example (on API only) : YES 

Hello,

As discussed on the #1740 issue, here is a first version for `FileAssertion.isDirectoryRecursivelyContaining(String syntaxAndPattern)` and its internal functions.  
I wait for your feedback (when you have some time sure :-) ).

Note : I have the feeling that some modified files were not formatted with the last code formatter, so I have stuck to reformat only code that I added.





