### PR TITLE
Add isValidBase64 to AbstractStringAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -219,6 +219,30 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
   }
 
   /**
+   * Verifies that the actual value is a valid Base64 encoded string.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertions succeeds
+   * assertThat(&quot;QXNzZXJ0Sg==&quot;).isValidBase64();
+   *
+   * // assertion succeeds even without padding as it is optional by specification
+   * assertThat(&quot;QXNzZXJ0Sg&quot;).isValidBase64();
+   *
+   * // assertion fails as it has invalid Base64 characters
+   * assertThat(&quot;inv@lid&quot;).isValidBase64();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not a valid Base64 encoded string.
+   *
+   * @since 3.16.0
+   */
+  public SELF isValidBase64() {
+    strings.assertIsValidBase64(info, actual);
+    return myself;
+  }
+
+  /**
    * Use the given custom comparator instead of relying on {@link String} natural comparator for the incoming assertions.
    * <p>
    * The custom comparator is bound to an assertion instance, meaning that if a new assertion instance is created

--- a/src/main/java/org/assertj/core/error/ShouldBeValidBase64.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeValidBase64.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message that indicates an assertion that verifies that a string is a valid Base64 encoded string failed.
+ * 
+ * @author Stefano Cordio
+ */
+public class ShouldBeValidBase64 extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeValidBase64}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeValidBase64(String actual) {
+    return new ShouldBeValidBase64(actual);
+  }
+
+  private ShouldBeValidBase64(String actual) {
+    super("%nExpecting <%s> to be a valid Base64 encoded string", actual);
+  }
+
+}

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -18,6 +18,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.error.ShouldBeValidBase64.shouldBeValidBase64;
 import static org.assertj.core.error.ShouldBeBlank.shouldBeBlank;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
@@ -73,6 +74,7 @@ import static org.assertj.core.util.xml.XmlStringPrettyFormatter.xmlPrettyFormat
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringReader;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -1122,9 +1124,26 @@ public class Strings {
     throw failures.failure(info, shouldBeUpperCase(actual));
   }
 
+  /***
+   * Verifies that actual is a valid Base64 encoded string.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence} (new lines will be ignored).
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if {@code actual} is not a valid Base64 encoded string.
+   */
+  public void assertIsValidBase64(AssertionInfo info, String actual) {
+    assertNotNull(info, actual);
+    try {
+      Base64.getDecoder().decode(actual);
+    } catch (IllegalArgumentException e) {
+      throw failures.failure(info, shouldBeValidBase64(actual));
+    }
+  }
+
   private static String removeNewLines(CharSequence text) {
     String normalizedText = normalizeNewlines(text);
-    return normalizedText.toString().replace("\n", "");
+    return normalizedText.replace("\n", "");
   }
 
   private void doCommonCheckForCharSequence(AssertionInfo info, CharSequence actual, CharSequence[] sequence) {

--- a/src/test/java/org/assertj/core/api/StringAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/StringAssertBaseTest.java
@@ -17,16 +17,18 @@ import static org.mockito.Mockito.mock;
 import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.Strings;
 
-
 public abstract class StringAssertBaseTest extends BaseTestTemplate<StringAssert, String> {
 
   protected Comparables comparables;
+  protected Strings strings;
 
   @Override
   protected void inject_internal_objects() {
     super.inject_internal_objects();
     comparables = mock(Comparables.class);
     assertions.comparables = comparables;
+    strings = mock(Strings.class);
+    assertions.strings = strings;
   }
 
   @Override

--- a/src/test/java/org/assertj/core/api/string_/StringAssert_isValidBase64_Test.java
+++ b/src/test/java/org/assertj/core/api/string_/StringAssert_isValidBase64_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Tests for <code>{@link StringAssert#isValidBase64()}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("StringAssert isValidBase64")
+class StringAssert_isValidBase64_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    return assertions.isValidBase64();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertIsValidBase64(getInfo(assertions), getActual(assertions));
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldBeValidBase64_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeValidBase64_create_Test.java
@@ -14,7 +14,7 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
+import static org.assertj.core.error.ShouldBeValidBase64.shouldBeValidBase64;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.description.Description;
@@ -28,19 +28,15 @@ import org.junit.jupiter.api.Test;
  *
  * @author Stefano Cordio
  */
-@DisplayName("ShouldHaveNoSuperclass create")
-class ShouldHaveNoSuperclass_create_Test {
+@DisplayName("ShouldBeValidBase64 create")
+class ShouldBeValidBase64_create_Test {
 
   @Test
   void should_create_error_message() {
     // WHEN
-    String message = shouldHaveNoSuperclass(String.class).create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
+    String message = shouldBeValidBase64("string %s").create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(format("[TEST] %n" +
-                                   "Expecting%n" +
-                                   "  <java.lang.String>%n" +
-                                   "to have no superclass, but had:%n" +
-                                   "  <java.lang.Object>"));
+    then(message).isEqualTo(format("[TEST] %nExpecting <\"string %%s\"> to be a valid Base64 encoded string"));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StringsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/StringsBaseTest.java
@@ -12,12 +12,10 @@
  */
 package org.assertj.core.internal;
 
-
 import static org.mockito.Mockito.spy;
 
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.BeforeEach;
-
 
 /**
  * 

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsValidBase64_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsValidBase64_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeValidBase64.shouldBeValidBase64;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Strings assertIsValidBase64")
+class Strings_assertIsValidBase64_Test extends StringsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    String actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertIsValidBase64(someInfo(), actual));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_has_invalid_Base64_characters() {
+    // GIVEN
+    String actual = "inv@lid";
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertIsValidBase64(someInfo(), actual));
+    // THEN
+    then(assertionError).hasMessage(shouldBeValidBase64(actual).create());
+  }
+
+  @Test
+  void should_succeeds_if_actual_is_Base64_encoded_with_padding() {
+    // GIVEN
+    String actual = "QXNzZXJ0Sg==";
+    // WHEN/THEN
+    strings.assertIsValidBase64(someInfo(), actual);
+  }
+
+  @Test
+  void should_succeeds_if_actual_is_Base64_encoded_without_padding() {
+    // GIVEN
+    String actual = "QXNzZXJ0Sg";
+    // WHEN/THEN
+    strings.assertIsValidBase64(someInfo(), actual);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes partially #1805
* Unit tests : YES
* Javadoc with a code example (on API only) : YES