### PR TITLE
Restructure to allow combining soft assertions entry points

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractBDDSoftAssertions.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 
 import org.assertj.core.util.CheckReturnValue;
 
-public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAssertions {
+public interface AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAssertions {
 
   /**
    * Creates a new, proxied instance of a {@link PathAssert}
@@ -49,7 +49,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object
    */
   @CheckReturnValue
-  public PathAssert then(Path actual) {
+  default PathAssert then(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
 
@@ -62,7 +62,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public <VALUE> OptionalAssert<VALUE> then(Optional<VALUE> actual) {
+  default <VALUE> OptionalAssert<VALUE> then(Optional<VALUE> actual) {
     return proxy(OptionalAssert.class, Optional.class, actual);
   }
 
@@ -74,7 +74,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public OptionalDoubleAssert then(OptionalDouble actual) {
+  default OptionalDoubleAssert then(OptionalDouble actual) {
     return proxy(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
 
@@ -86,7 +86,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public OptionalIntAssert then(OptionalInt actual) {
+  default OptionalIntAssert then(OptionalInt actual) {
     return proxy(OptionalIntAssert.class, OptionalInt.class, actual);
   }
 
@@ -98,7 +98,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public OptionalLongAssert then(OptionalLong actual) {
+  default OptionalLongAssert then(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
   }
 
@@ -109,7 +109,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
   * @return the created assertion object.
   */
   @CheckReturnValue
-  public LocalDateAssert then(LocalDate actual) {
+  default LocalDateAssert then(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
   }
 
@@ -120,7 +120,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public LocalDateTimeAssert then(LocalDateTime actual) {
+  default LocalDateTimeAssert then(LocalDateTime actual) {
     return proxy(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
 
@@ -131,7 +131,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public ZonedDateTimeAssert then(ZonedDateTime actual) {
+  default ZonedDateTimeAssert then(ZonedDateTime actual) {
     return proxy(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
 
@@ -142,7 +142,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public LocalTimeAssert then(LocalTime actual) {
+  default LocalTimeAssert then(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
 
@@ -153,7 +153,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public OffsetTimeAssert then(OffsetTime actual) {
+  default OffsetTimeAssert then(OffsetTime actual) {
     return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
 
@@ -164,7 +164,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public OffsetDateTimeAssert then(OffsetDateTime actual) {
+  default OffsetDateTimeAssert then(OffsetDateTime actual) {
     return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
 
@@ -176,7 +176,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.7.0
    */
   @CheckReturnValue
-  public InstantAssert then(Instant actual) {
+  default InstantAssert then(Instant actual) {
     return proxy(InstantAssert.class, Instant.class, actual);
   }
 
@@ -188,7 +188,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.15.0
    */
   @CheckReturnValue
-  public DurationAssert then(Duration actual) {
+  default DurationAssert then(Duration actual) {
     return proxy(DurationAssert.class, Duration.class, actual);
   }
 
@@ -201,7 +201,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public <RESULT> CompletableFutureAssert<RESULT> then(CompletableFuture<RESULT> actual) {
+  default <RESULT> CompletableFutureAssert<RESULT> then(CompletableFuture<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
 
@@ -216,7 +216,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public <RESULT> CompletableFutureAssert<RESULT> then(CompletionStage<RESULT> actual) {
+  default <RESULT> CompletableFutureAssert<RESULT> then(CompletionStage<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletionStage.class, actual);
   }
 
@@ -231,7 +231,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.5.0
    */
   @CheckReturnValue
-  public <T> ProxyablePredicateAssert<T> then(Predicate<T> actual) {
+  default <T> ProxyablePredicateAssert<T> then(Predicate<T> actual) {
     return proxy(ProxyablePredicateAssert.class, Predicate.class, actual);
   }
 
@@ -243,7 +243,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.5.0
    */
   @CheckReturnValue
-  public IntPredicateAssert then(IntPredicate actual) {
+  default IntPredicateAssert then(IntPredicate actual) {
     return proxy(IntPredicateAssert.class, IntPredicate.class, actual);
   }
 
@@ -255,7 +255,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.5.0
    */
   @CheckReturnValue
-  public DoublePredicateAssert then(DoublePredicate actual) {
+  default DoublePredicateAssert then(DoublePredicate actual) {
     return proxy(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
 
@@ -267,7 +267,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.5.0
    */
   @CheckReturnValue
-  public LongPredicateAssert then(LongPredicate actual) {
+  default LongPredicateAssert then(LongPredicate actual) {
     return proxy(LongPredicateAssert.class, LongPredicate.class, actual);
   }
 
@@ -283,7 +283,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(Stream<? extends ELEMENT> actual) {
+  default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(Stream<? extends ELEMENT> actual) {
     return proxy(ProxyableListAssert.class, Stream.class, actual);
   }
 
@@ -298,7 +298,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> then(DoubleStream actual) {
+  default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> then(DoubleStream actual) {
     return proxy(ProxyableListAssert.class, DoubleStream.class, actual);
   }
 
@@ -313,7 +313,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> then(LongStream actual) {
+  default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> then(LongStream actual) {
     return proxy(ProxyableListAssert.class, LongStream.class, actual);
   }
 
@@ -328,7 +328,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @return the created assertion object.
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> then(IntStream actual) {
+  default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> then(IntStream actual) {
     return proxy(ProxyableListAssert.class, IntStream.class, actual);
   }
 
@@ -341,7 +341,7 @@ public abstract class AbstractBDDSoftAssertions extends Java6AbstractBDDSoftAsse
    * @since 3.14.0
    */
   @CheckReturnValue
-  public <ELEMENT> SpliteratorAssert<ELEMENT> then(Spliterator<ELEMENT> actual) {
+  default <ELEMENT> SpliteratorAssert<ELEMENT> then(Spliterator<ELEMENT> actual) {
     return proxy(SpliteratorAssert.class, Spliterator.class, actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -28,7 +28,8 @@ public class AbstractSoftAssertions implements InstanceOfAssertFactories {
     proxies = new SoftProxies();
   }
 
-  public <T, V> V proxy(Class<V> assertClass, Class<T> actualClass, T actual) {
+  public <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(Class<SELF> assertClass,
+                                                                                    Class<ACTUAL> actualClass, ACTUAL actual) {
     return proxies.createSoftAssertionProxy(assertClass, actualClass, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractStandardSoftAssertions.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 import org.assertj.core.util.CheckReturnValue;
 
 @CheckReturnValue
-public abstract class AbstractStandardSoftAssertions extends Java6AbstractStandardSoftAssertions {
+public interface AbstractStandardSoftAssertions extends Java6AbstractStandardSoftAssertions {
 
   /**
    * Creates a new, proxied instance of a {@link PathAssert}
@@ -49,7 +49,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the path
    * @return the created assertion object
    */
-  public PathAssert assertThat(Path actual) {
+  default PathAssert assertThat(Path actual) {
     return proxy(PathAssert.class, Path.class, actual);
   }
 
@@ -61,7 +61,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public <VALUE> OptionalAssert<VALUE> assertThat(Optional<VALUE> actual) {
+  default <VALUE> OptionalAssert<VALUE> assertThat(Optional<VALUE> actual) {
     return proxy(OptionalAssert.class, Optional.class, actual);
   }
 
@@ -72,7 +72,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public OptionalDoubleAssert assertThat(OptionalDouble actual) {
+  default OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return proxy(OptionalDoubleAssert.class, OptionalDouble.class, actual);
   }
 
@@ -83,7 +83,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public OptionalLongAssert assertThat(OptionalLong actual) {
+  default OptionalLongAssert assertThat(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
   }
 
@@ -94,7 +94,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public OptionalIntAssert assertThat(OptionalInt actual) {
+  default OptionalIntAssert assertThat(OptionalInt actual) {
     return proxy(OptionalIntAssert.class, OptionalInt.class, actual);
   }
 
@@ -104,7 +104,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LocalDateAssert assertThat(LocalDate actual) {
+  default LocalDateAssert assertThat(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
   }
 
@@ -114,7 +114,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LocalDateTimeAssert assertThat(LocalDateTime actual) {
+  default LocalDateTimeAssert assertThat(LocalDateTime actual) {
     return proxy(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
 
@@ -124,7 +124,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
+  default ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
     return proxy(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
 
@@ -134,7 +134,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LocalTimeAssert assertThat(LocalTime actual) {
+  default LocalTimeAssert assertThat(LocalTime actual) {
     return proxy(LocalTimeAssert.class, LocalTime.class, actual);
   }
 
@@ -144,7 +144,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public OffsetTimeAssert assertThat(OffsetTime actual) {
+  default OffsetTimeAssert assertThat(OffsetTime actual) {
     return proxy(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
 
@@ -154,7 +154,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
+  default OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
     return proxy(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
 
@@ -165,7 +165,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.7.0
    */
-  public InstantAssert assertThat(Instant actual) {
+  default InstantAssert assertThat(Instant actual) {
     return proxy(InstantAssert.class, Instant.class, actual);
   }
 
@@ -176,7 +176,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public DurationAssert assertThat(Duration actual) {
+  default DurationAssert assertThat(Duration actual) {
     return proxy(DurationAssert.class, Duration.class, actual);
   }
 
@@ -188,7 +188,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletableFuture<RESULT> actual) {
+  default <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletableFuture<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletableFuture.class, actual);
   }
 
@@ -202,7 +202,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @return the created assertion object.
    */
-  public <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletionStage<RESULT> actual) {
+  default <RESULT> CompletableFutureAssert<RESULT> assertThat(CompletionStage<RESULT> actual) {
     return proxy(CompletableFutureAssert.class, CompletionStage.class, actual);
   }
 
@@ -216,7 +216,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    *
    * @since 3.5.0
    */
-  public <T> ProxyablePredicateAssert<T> assertThat(Predicate<T> actual) {
+  default <T> ProxyablePredicateAssert<T> assertThat(Predicate<T> actual) {
     return proxy(ProxyablePredicateAssert.class, Predicate.class, actual);
   }
 
@@ -227,7 +227,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  public IntPredicateAssert assertThat(IntPredicate actual) {
+  default IntPredicateAssert assertThat(IntPredicate actual) {
     return proxy(IntPredicateAssert.class, IntPredicate.class, actual);
   }
 
@@ -238,7 +238,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  public DoublePredicateAssert assertThat(DoublePredicate actual) {
+  default DoublePredicateAssert assertThat(DoublePredicate actual) {
     return proxy(DoublePredicateAssert.class, DoublePredicate.class, actual);
   }
 
@@ -249,7 +249,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @return the created assertion object.
    * @since 3.5.0
    */
-  public LongPredicateAssert assertThat(LongPredicate actual) {
+  default LongPredicateAssert assertThat(LongPredicate actual) {
     return proxy(LongPredicateAssert.class, LongPredicate.class, actual);
   }
 
@@ -264,7 +264,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link Stream} value.
    * @return the created assertion object.
    */
-  public <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
+  default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
     return proxy(ProxyableListAssert.class, Stream.class, actual);
   }
 
@@ -278,7 +278,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
    */
-  public AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assertThat(DoubleStream actual) {
+  default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assertThat(DoubleStream actual) {
     return proxy(ProxyableListAssert.class, DoubleStream.class, actual);
   }
 
@@ -292,7 +292,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
    */
-  public AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assertThat(LongStream actual) {
+  default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assertThat(LongStream actual) {
     return proxy(ProxyableListAssert.class, LongStream.class, actual);
   }
 
@@ -306,7 +306,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.
    */
-  public AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assertThat(IntStream actual) {
+  default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assertThat(IntStream actual) {
     return proxy(ProxyableListAssert.class, IntStream.class, actual);
   }
 
@@ -317,7 +317,7 @@ public abstract class AbstractStandardSoftAssertions extends Java6AbstractStanda
    * @param actual the actual {@link Spliterator} value.
    * @return the created assertion object.
    */
-  public <ELEMENT> SpliteratorAssert<ELEMENT> assertThat(Spliterator<ELEMENT> actual) {
+  default <ELEMENT> SpliteratorAssert<ELEMENT> assertThat(Spliterator<ELEMENT> actual) {
     return proxy(SpliteratorAssert.class, Spliterator.class, actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
@@ -12,15 +12,10 @@
  */
 package org.assertj.core.api;
 
-/**
- * @deprecated For Android compatible assertions use the latest assertj 2.x version which is based on Java 7 only.
- * <p>
- * BDD-style Android-compatible soft assertions. Duplicated from {@link BDDSoftAssertions}.
- *
- * @see BDDSoftAssertions
- *
- * @since 2.5.0 / 3.5.0
- */
-@Deprecated
-public class Java6BDDSoftAssertions extends AbstractSoftAssertions implements Java6AbstractBDDSoftAssertions {
+import java.util.List;
+
+public interface AssertionErrorCollector {
+  void collectAssertionError(AssertionError error);
+  
+  List<AssertionError> assertionErrorsCollected();
 }

--- a/src/main/java/org/assertj/core/api/AutoCloseableBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AutoCloseableBDDSoftAssertions.java
@@ -120,10 +120,5 @@ package org.assertj.core.api;
  *
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing Assertions (inspired this feature)</a>
  */
-public class AutoCloseableBDDSoftAssertions extends BDDSoftAssertions implements AutoCloseable {
-
-  @Override
-  public void close() throws SoftAssertionError {
-    assertAll();
-  }
+public class AutoCloseableBDDSoftAssertions extends BDDSoftAssertions {
 }

--- a/src/main/java/org/assertj/core/api/AutoCloseableSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AutoCloseableSoftAssertions.java
@@ -116,10 +116,5 @@ package org.assertj.core.api;
  * 
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing Assertions (inspired this feature)</a>
  */
-public class AutoCloseableSoftAssertions extends SoftAssertions implements AutoCloseable {
-
-  @Override
-  public void close() throws SoftAssertionError {
-    assertAll();
-  }
+public class AutoCloseableSoftAssertions extends SoftAssertions {
 }

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertions.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.core.api;
 
-import java.util.List;
+import java.util.function.Consumer;
 
-import org.assertj.core.error.AssertionErrorCreator;
+import org.opentest4j.MultipleFailuresError;
 
 /**
  * <p>
@@ -102,18 +102,17 @@ import org.assertj.core.error.AssertionErrorCreator;
  *
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing Assertions (inspired this feature)</a>
  */
-public class BDDSoftAssertions extends AbstractBDDSoftAssertions {
-
-  private AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
-
+public class BDDSoftAssertions extends AbstractSoftAssertions implements AbstractBDDSoftAssertions {
   /**
-   * Verifies that no proxied assertion methods have failed.
-   *
-   * @throws SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
+   * Convenience method for calling {@link SoftAssertionsProvider#assertSoftly} for these assertion types.
+   * Equivalent to {@code SoftAssertion.assertSoftly(BDDSoftAssertions.class, softly)}.
+   * @param softly the Consumer containing the code that will make the soft assertions.
+   *     Takes one parameter (the actual BDDSoftAssertions instance used to make the assertions).
+   * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
+   * @since 3.16.0
    */
-  public void assertAll() {
-    List<Throwable> errors = errorsCollected();
-    if (!errors.isEmpty()) throw assertionErrorCreator.multipleSoftAssertionsError(errors);
+  public static void thenSoftly(Consumer<BDDSoftAssertions> softly) {
+    SoftAssertionsProvider.assertSoftly(BDDSoftAssertions.class, softly);
   }
 
 }

--- a/src/main/java/org/assertj/core/api/ErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/ErrorCollector.java
@@ -35,7 +35,7 @@ public class ErrorCollector {
   private static final String CLASS_NAME = ErrorCollector.class.getName();
 
   // scope : the current softassertion object
-  private final List<Throwable> errors = new ArrayList<>();
+  private final List<AssertionError> errors = new ArrayList<>();
   // scope : the last assertion call (might be nested)
   private final LastResult lastResult = new LastResult();
 
@@ -78,12 +78,12 @@ public class ErrorCollector {
     errorCollector.errors.add(error);
   }
 
-  public void addError(Throwable error) {
+  public void addError(AssertionError error) {
     errors.add(error);
     lastResult.recordError();
   }
 
-  public List<Throwable> errors() {
+  public List<AssertionError> errors() {
     return Collections.unmodifiableList(errors);
   }
 

--- a/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitBDDSoftAssertions.java
@@ -12,15 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.SoftAssertionsStatement.softAssertionsStatement;
-
-import java.util.List;
-
-import org.assertj.core.util.VisibleForTesting;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 /**
  * Same as {@link SoftAssertions}, but with the following differences: <br>
  * First, it's a junit rule, which can be used without having to call {@link SoftAssertions#assertAll() assertAll()},
@@ -39,16 +30,5 @@ import org.junit.runners.model.Statement;
  *
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */
-public class JUnitBDDSoftAssertions extends AbstractBDDSoftAssertions implements TestRule {
-
-  @Override
-  public Statement apply(final Statement base, Description description) {
-      return softAssertionsStatement(this, base);
-  }
-
-  @VisibleForTesting
-  List<Throwable> getErrors() {
-    return proxies.errorsCollected();
-  }
-
+public class JUnitBDDSoftAssertions extends AbstractSoftAssertions implements AbstractBDDSoftAssertions, SoftAssertionsRule {
 }

--- a/src/main/java/org/assertj/core/api/JUnitJupiterBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitJupiterBDDSoftAssertions.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */
 @Deprecated
-public class JUnitJupiterBDDSoftAssertions extends AbstractBDDSoftAssertions implements AfterEachCallback {
+public class JUnitJupiterBDDSoftAssertions extends AbstractSoftAssertions implements AbstractBDDSoftAssertions, AfterEachCallback {
 
   private AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
 

--- a/src/main/java/org/assertj/core/api/JUnitJupiterSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitJupiterSoftAssertions.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */
 @Deprecated
-public class JUnitJupiterSoftAssertions extends AbstractStandardSoftAssertions implements AfterEachCallback {
+public class JUnitJupiterSoftAssertions extends AbstractSoftAssertions implements AbstractStandardSoftAssertions, AfterEachCallback {
 
   private AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
 

--- a/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/JUnitSoftAssertions.java
@@ -12,12 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.SoftAssertionsStatement.softAssertionsStatement;
-
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 /**
  * Same as {@link SoftAssertions}, but with the following differences: <br>
  * First, it's a junit rule, which can be used without having to call {@link SoftAssertions#assertAll() assertAll()},
@@ -36,11 +30,5 @@ import org.junit.runners.model.Statement;
  *
  * Second, the failures are recognized by IDE's (like IntelliJ IDEA) which open a comparison window.
  */
-public class JUnitSoftAssertions extends AbstractStandardSoftAssertions implements TestRule {
-
-  @Override
-  public Statement apply(final Statement base, Description description) {
-    return softAssertionsStatement(this, base);
-  }
-
+public class JUnitSoftAssertions extends AbstractSoftAssertions implements AbstractStandardSoftAssertions, SoftAssertionsRule {
 }

--- a/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractBDDSoftAssertions.java
@@ -50,16 +50,16 @@ import org.assertj.core.util.CheckReturnValue;
  * @since 2.5.0 / 3.5.0
  */
 @CheckReturnValue
-public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
+public interface Java6AbstractBDDSoftAssertions extends SoftAssertionsProvider {
   // then* methods duplicated from BDDAssertions
 
   /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
-   *
+   *RF
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BigDecimalAssert then(BigDecimal actual) {
+  default BigDecimalAssert then(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
 
@@ -70,7 +70,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public BigIntegerAssert then(BigInteger actual) {
+  default BigIntegerAssert then(BigInteger actual) {
     return proxy(BigIntegerAssert.class, BigInteger.class, actual);
   }
 
@@ -80,7 +80,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanAssert then(boolean actual) {
+  default BooleanAssert then(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -90,7 +90,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanAssert then(Boolean actual) {
+  default BooleanAssert then(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -100,7 +100,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanArrayAssert then(boolean[] actual) {
+  default BooleanArrayAssert then(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
 
@@ -110,7 +110,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteAssert then(byte actual) {
+  default ByteAssert then(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
 
@@ -120,7 +120,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteAssert then(Byte actual) {
+  default ByteAssert then(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
 
@@ -130,7 +130,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteArrayAssert then(byte[] actual) {
+  default ByteArrayAssert then(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
 
@@ -140,7 +140,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharacterAssert then(char actual) {
+  default CharacterAssert then(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
 
@@ -150,7 +150,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharArrayAssert then(char[] actual) {
+  default CharArrayAssert then(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
 
@@ -160,7 +160,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharacterAssert then(Character actual) {
+  default CharacterAssert then(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
 
@@ -172,7 +172,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ProxyableClassAssert then(Class<?> actual) {
+  default ProxyableClassAssert then(Class<?> actual) {
     return proxy(ProxyableClassAssert.class, Class.class, actual);
   }
 
@@ -184,7 +184,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
+  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
 
@@ -195,7 +195,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableIterableAssert<T> then(Iterable<? extends T> actual) {
+  default <T> ProxyableIterableAssert<T> then(Iterable<? extends T> actual) {
     return proxy(ProxyableIterableAssert.class, Iterable.class, actual);
   }
 
@@ -208,7 +208,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> IteratorAssert<T> then(Iterator<? extends T> actual) {
+  default <T> IteratorAssert<T> then(Iterator<? extends T> actual) {
     return proxy(IteratorAssert.class, Iterator.class, actual);
   }
 
@@ -218,7 +218,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleAssert then(double actual) {
+  default DoubleAssert then(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
 
@@ -228,7 +228,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleAssert then(Double actual) {
+  default DoubleAssert then(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
 
@@ -238,7 +238,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleArrayAssert then(double[] actual) {
+  default DoubleArrayAssert then(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
 
@@ -248,7 +248,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FileAssert then(File actual) {
+  default FileAssert then(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
 
@@ -260,7 +260,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <RESULT> FutureAssert<RESULT> then(Future<RESULT> actual) {
+  default <RESULT> FutureAssert<RESULT> then(Future<RESULT> actual) {
     return proxy(FutureAssert.class, Future.class, actual);
   }
 
@@ -270,7 +270,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public InputStreamAssert then(InputStream actual) {
+  default InputStreamAssert then(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
 
@@ -280,7 +280,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatAssert then(float actual) {
+  default FloatAssert then(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
 
@@ -290,7 +290,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatAssert then(Float actual) {
+  default FloatAssert then(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
 
@@ -300,7 +300,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatArrayAssert then(float[] actual) {
+  default FloatArrayAssert then(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
 
@@ -310,7 +310,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntegerAssert then(int actual) {
+  default IntegerAssert then(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -320,7 +320,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntArrayAssert then(int[] actual) {
+  default IntArrayAssert then(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
 
@@ -330,7 +330,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntegerAssert then(Integer actual) {
+  default IntegerAssert then(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -341,7 +341,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableListAssert<T> then(List<? extends T> actual) {
+  default <T> ProxyableListAssert<T> then(List<? extends T> actual) {
     return proxy(ProxyableListAssert.class, List.class, actual);
   }
 
@@ -351,7 +351,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongAssert then(long actual) {
+  default LongAssert then(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
 
@@ -361,7 +361,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongAssert then(Long actual) {
+  default LongAssert then(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
 
@@ -371,7 +371,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongArrayAssert then(long[] actual) {
+  default LongArrayAssert then(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
 
@@ -382,7 +382,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param <T> the type of the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableObjectAssert<T> then(T actual) {
+  default <T> ProxyableObjectAssert<T> then(T actual) {
     return proxy(ProxyableObjectAssert.class, Object.class, actual);
   }
 
@@ -393,7 +393,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableObjectArrayAssert<T> then(T[] actual) {
+  default <T> ProxyableObjectArrayAssert<T> then(T[] actual) {
     return proxy(ProxyableObjectArrayAssert.class, Object[].class, actual);
   }
 
@@ -407,7 +407,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <K, V> ProxyableMapAssert<K, V> then(Map<K, V> actual) {
+  default <K, V> ProxyableMapAssert<K, V> then(Map<K, V> actual) {
     return proxy(ProxyableMapAssert.class, Map.class, actual);
   }
 
@@ -417,7 +417,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortAssert then(short actual) {
+  default ShortAssert then(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
 
@@ -427,7 +427,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortAssert then(Short actual) {
+  default ShortAssert then(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
 
@@ -437,7 +437,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortArrayAssert then(short[] actual) {
+  default ShortArrayAssert then(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
 
@@ -447,7 +447,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharSequenceAssert then(CharSequence actual) {
+  default CharSequenceAssert then(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -458,7 +458,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public CharSequenceAssert then(StringBuilder actual) {
+  default CharSequenceAssert then(StringBuilder actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -469,7 +469,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public CharSequenceAssert then(StringBuffer actual) {
+  default CharSequenceAssert then(StringBuffer actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -479,7 +479,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public StringAssert then(String actual) {
+  default StringAssert then(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
 
@@ -489,7 +489,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DateAssert then(Date actual) {
+  default DateAssert then(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
 
@@ -500,7 +500,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public AtomicBooleanAssert then(AtomicBoolean actual) {
+  default AtomicBooleanAssert then(AtomicBoolean actual) {
     return proxy(AtomicBooleanAssert.class, AtomicBoolean.class, actual);
   }
 
@@ -511,7 +511,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public AtomicIntegerAssert then(AtomicInteger actual) {
+  default AtomicIntegerAssert then(AtomicInteger actual) {
     return proxy(AtomicIntegerAssert.class, AtomicInteger.class, actual);
   }
 
@@ -522,7 +522,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public AtomicIntegerArrayAssert then(AtomicIntegerArray actual) {
+  default AtomicIntegerArrayAssert then(AtomicIntegerArray actual) {
     return proxy(AtomicIntegerArrayAssert.class, AtomicIntegerArray.class, actual);
   }
 
@@ -534,7 +534,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> then(AtomicIntegerFieldUpdater<OBJECT> actual) {
+  default <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> then(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return proxy(AtomicIntegerFieldUpdaterAssert.class, AtomicIntegerFieldUpdater.class, actual);
   }
 
@@ -545,7 +545,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public AtomicLongAssert then(AtomicLong actual) {
+  default AtomicLongAssert then(AtomicLong actual) {
     return proxy(AtomicLongAssert.class, AtomicLong.class, actual);
   }
 
@@ -556,7 +556,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public AtomicLongArrayAssert then(AtomicLongArray actual) {
+  default AtomicLongArrayAssert then(AtomicLongArray actual) {
     return proxy(AtomicLongArrayAssert.class, AtomicLongArray.class, actual);
   }
 
@@ -568,7 +568,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> then(AtomicLongFieldUpdater<OBJECT> actual) {
+  default <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> then(AtomicLongFieldUpdater<OBJECT> actual) {
     return proxy(AtomicLongFieldUpdaterAssert.class, AtomicLongFieldUpdater.class, actual);
   }
 
@@ -580,7 +580,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <VALUE> AtomicReferenceAssert<VALUE> then(AtomicReference<VALUE> actual) {
+  default <VALUE> AtomicReferenceAssert<VALUE> then(AtomicReference<VALUE> actual) {
     return proxy(AtomicReferenceAssert.class, AtomicReference.class, actual);
   }
 
@@ -592,7 +592,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> then(AtomicReferenceArray<ELEMENT> actual) {
+  default <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> then(AtomicReferenceArray<ELEMENT> actual) {
     return proxy(AtomicReferenceArrayAssert.class, AtomicReferenceArray.class, actual);
   }
 
@@ -605,7 +605,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> then(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
+  default <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> then(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return proxy(AtomicReferenceFieldUpdaterAssert.class, AtomicReferenceFieldUpdater.class, actual);
   }
 
@@ -617,7 +617,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <VALUE> AtomicMarkableReferenceAssert<VALUE> then(AtomicMarkableReference<VALUE> actual) {
+  default <VALUE> AtomicMarkableReferenceAssert<VALUE> then(AtomicMarkableReference<VALUE> actual) {
     return proxy(AtomicMarkableReferenceAssert.class, AtomicMarkableReference.class, actual);
   }
 
@@ -629,7 +629,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public <VALUE> AtomicStampedReferenceAssert<VALUE> then(AtomicStampedReference<VALUE> actual) {
+  default <VALUE> AtomicStampedReferenceAssert<VALUE> then(AtomicStampedReference<VALUE> actual) {
     return proxy(AtomicStampedReferenceAssert.class, AtomicStampedReference.class, actual);
   }
 
@@ -639,7 +639,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  public ThrowableAssert then(Throwable actual) {
+  default ThrowableAssert then(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
 
@@ -649,7 +649,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * <p>
    * Java 8 example :
    * <pre><code class='java'> {@literal @}Test
-   *  public void testException() {
+   *  default void testException() {
    *    BDDSoftAssertions softly = new BDDSoftAssertions();
    *    softly.thenThrownBy(() -&gt; { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
    *                                                                .hasMessageContaining("boom");
@@ -660,7 +660,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * softly.thenThrownBy(new ThrowingCallable() {
    *
    *   {@literal @}Override
-   *   public Void call() throws Exception {
+   *   default Void call() throws Exception {
    *     throw new Exception("boom!");
    *   }
    *
@@ -686,7 +686,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  default AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return then(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -696,7 +696,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * <p>
    * Example:
    * <pre><code class='java'> {@literal @}Test
-   *  public void testException() {
+   *  default void testException() {
    *    BDDSoftAssertions softly = new BDDSoftAssertions();
    *    // if this assertion failed (but it doesn't), the error message would start with [Test explosive code]
    *    softly.thenThrownBy(() -&gt; { throw new IOException("boom!") }, "Test explosive code")
@@ -724,7 +724,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
+  default AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                       String description, Object... args) {
     return then(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -764,7 +764,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -789,7 +789,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @return the created assertion object.
    * @since 3.12.0
    */
-  public <T> ProxyableObjectAssert<T> thenObject(T actual) {
+  default <T> ProxyableObjectAssert<T> thenObject(T actual) {
     return then(actual);
   }
 
@@ -799,7 +799,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public UriAssert then(URI actual) {
+  default UriAssert then(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
 
@@ -809,7 +809,7 @@ public class Java6AbstractBDDSoftAssertions extends AbstractSoftAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public AbstractUrlAssert<?> then(URL actual) {
+  default AbstractUrlAssert<?> then(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6AbstractStandardSoftAssertions.java
@@ -50,15 +50,14 @@ import org.assertj.core.util.CheckReturnValue;
  * @since 2.5.0 / 3.5.0
  */
 @CheckReturnValue
-public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAssertions {
-
+public interface Java6AbstractStandardSoftAssertions extends SoftAssertionsProvider {
   /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BigDecimalAssert assertThat(BigDecimal actual) {
+  default BigDecimalAssert assertThat(BigDecimal actual) {
     return proxy(BigDecimalAssert.class, BigDecimal.class, actual);
   }
 
@@ -69,7 +68,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public BigIntegerAssert assertThat(BigInteger actual) {
+  default BigIntegerAssert assertThat(BigInteger actual) {
     return proxy(BigIntegerAssert.class, BigInteger.class, actual);
   }
 
@@ -79,7 +78,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanAssert assertThat(boolean actual) {
+  default BooleanAssert assertThat(boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -89,7 +88,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanAssert assertThat(Boolean actual) {
+  default BooleanAssert assertThat(Boolean actual) {
     return proxy(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -99,7 +98,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public BooleanArrayAssert assertThat(boolean[] actual) {
+  default BooleanArrayAssert assertThat(boolean[] actual) {
     return proxy(BooleanArrayAssert.class, boolean[].class, actual);
   }
 
@@ -109,7 +108,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteAssert assertThat(byte actual) {
+  default ByteAssert assertThat(byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
 
@@ -119,7 +118,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteAssert assertThat(Byte actual) {
+  default ByteAssert assertThat(Byte actual) {
     return proxy(ByteAssert.class, Byte.class, actual);
   }
 
@@ -129,7 +128,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ByteArrayAssert assertThat(byte[] actual) {
+  default ByteArrayAssert assertThat(byte[] actual) {
     return proxy(ByteArrayAssert.class, byte[].class, actual);
   }
 
@@ -139,7 +138,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharacterAssert assertThat(char actual) {
+  default CharacterAssert assertThat(char actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
 
@@ -149,7 +148,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharArrayAssert assertThat(char[] actual) {
+  default CharArrayAssert assertThat(char[] actual) {
     return proxy(CharArrayAssert.class, char[].class, actual);
   }
 
@@ -159,7 +158,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharacterAssert assertThat(Character actual) {
+  default CharacterAssert assertThat(Character actual) {
     return proxy(CharacterAssert.class, Character.class, actual);
   }
 
@@ -171,7 +170,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ProxyableClassAssert assertThat(Class<?> actual) {
+  default ProxyableClassAssert assertThat(Class<?> actual) {
     return proxy(ProxyableClassAssert.class, Class.class, actual);
   }
 
@@ -183,7 +182,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
+  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
 
@@ -196,7 +195,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableIterableAssert<T> assertThat(Iterable<? extends T> actual) {
+  default <T> ProxyableIterableAssert<T> assertThat(Iterable<? extends T> actual) {
     return proxy(ProxyableIterableAssert.class, Iterable.class, actual);
   }
 
@@ -209,7 +208,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> IteratorAssert<T> assertThat(Iterator<? extends T> actual) {
+  default <T> IteratorAssert<T> assertThat(Iterator<? extends T> actual) {
     return proxy(IteratorAssert.class, Iterator.class, actual);
   }
 
@@ -219,7 +218,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleAssert assertThat(double actual) {
+  default DoubleAssert assertThat(double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
 
@@ -229,7 +228,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleAssert assertThat(Double actual) {
+  default DoubleAssert assertThat(Double actual) {
     return proxy(DoubleAssert.class, Double.class, actual);
   }
 
@@ -239,7 +238,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DoubleArrayAssert assertThat(double[] actual) {
+  default DoubleArrayAssert assertThat(double[] actual) {
     return proxy(DoubleArrayAssert.class, double[].class, actual);
   }
 
@@ -249,7 +248,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FileAssert assertThat(File actual) {
+  default FileAssert assertThat(File actual) {
     return proxy(FileAssert.class, File.class, actual);
   }
 
@@ -260,7 +259,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value
    * @return the created assertion object
    */
-  public <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
+  default <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
     return proxy(FutureAssert.class, Future.class, actual);
   }
 
@@ -270,7 +269,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public InputStreamAssert assertThat(InputStream actual) {
+  default InputStreamAssert assertThat(InputStream actual) {
     return proxy(InputStreamAssert.class, InputStream.class, actual);
   }
 
@@ -280,7 +279,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatAssert assertThat(float actual) {
+  default FloatAssert assertThat(float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
 
@@ -290,7 +289,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatAssert assertThat(Float actual) {
+  default FloatAssert assertThat(Float actual) {
     return proxy(FloatAssert.class, Float.class, actual);
   }
 
@@ -300,7 +299,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public FloatArrayAssert assertThat(float[] actual) {
+  default FloatArrayAssert assertThat(float[] actual) {
     return proxy(FloatArrayAssert.class, float[].class, actual);
   }
 
@@ -310,7 +309,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntegerAssert assertThat(int actual) {
+  default IntegerAssert assertThat(int actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -320,7 +319,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntArrayAssert assertThat(int[] actual) {
+  default IntArrayAssert assertThat(int[] actual) {
     return proxy(IntArrayAssert.class, int[].class, actual);
   }
 
@@ -330,7 +329,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public IntegerAssert assertThat(Integer actual) {
+  default IntegerAssert assertThat(Integer actual) {
     return proxy(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -343,7 +342,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableListAssert<T> assertThat(List<? extends T> actual) {
+  default <T> ProxyableListAssert<T> assertThat(List<? extends T> actual) {
     return proxy(ProxyableListAssert.class, List.class, actual);
   }
 
@@ -353,7 +352,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongAssert assertThat(long actual) {
+  default LongAssert assertThat(long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
 
@@ -363,7 +362,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongAssert assertThat(Long actual) {
+  default LongAssert assertThat(Long actual) {
     return proxy(LongAssert.class, Long.class, actual);
   }
 
@@ -373,7 +372,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public LongArrayAssert assertThat(long[] actual) {
+  default LongArrayAssert assertThat(long[] actual) {
     return proxy(LongArrayAssert.class, long[].class, actual);
   }
 
@@ -384,7 +383,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <T> the type of the actual value.
    * @return the created assertion object.
    */
-  public <T> ProxyableObjectAssert<T> assertThat(T actual) {
+  default <T> ProxyableObjectAssert<T> assertThat(T actual) {
     return proxy(ProxyableObjectAssert.class, Object.class, actual);
   }
 
@@ -395,7 +394,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <T> the type values of the actual array.
    * @return the created assertion object.
    */
-  public <T> ProxyableObjectArrayAssert<T> assertThat(T[] actual) {
+  default <T> ProxyableObjectArrayAssert<T> assertThat(T[] actual) {
     return proxy(ProxyableObjectArrayAssert.class, Object[].class, actual);
   }
 
@@ -409,7 +408,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <K, V> ProxyableMapAssert<K, V> assertThat(Map<K, V> actual) {
+  default <K, V> ProxyableMapAssert<K, V> assertThat(Map<K, V> actual) {
     return proxy(ProxyableMapAssert.class, Map.class, actual);
   }
 
@@ -419,7 +418,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortAssert assertThat(short actual) {
+  default ShortAssert assertThat(short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
 
@@ -429,7 +428,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortAssert assertThat(Short actual) {
+  default ShortAssert assertThat(Short actual) {
     return proxy(ShortAssert.class, Short.class, actual);
   }
 
@@ -439,7 +438,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public ShortArrayAssert assertThat(short[] actual) {
+  default ShortArrayAssert assertThat(short[] actual) {
     return proxy(ShortArrayAssert.class, short[].class, actual);
   }
 
@@ -449,7 +448,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public CharSequenceAssert assertThat(CharSequence actual) {
+  default CharSequenceAssert assertThat(CharSequence actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -460,7 +459,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public CharSequenceAssert assertThat(StringBuilder actual) {
+  default CharSequenceAssert assertThat(StringBuilder actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -471,7 +470,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public CharSequenceAssert assertThat(StringBuffer actual) {
+  default CharSequenceAssert assertThat(StringBuffer actual) {
     return proxy(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -481,7 +480,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public StringAssert assertThat(String actual) {
+  default StringAssert assertThat(String actual) {
     return proxy(StringAssert.class, String.class, actual);
   }
 
@@ -491,7 +490,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public DateAssert assertThat(Date actual) {
+  default DateAssert assertThat(Date actual) {
     return proxy(DateAssert.class, Date.class, actual);
   }
 
@@ -502,7 +501,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * @return the created assertion object.
    */
-  public AtomicBooleanAssert assertThat(AtomicBoolean actual) {
+  default AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return proxy(AtomicBooleanAssert.class, AtomicBoolean.class, actual);
   }
 
@@ -513,7 +512,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * @return the created assertion object.
    */
-  public AtomicIntegerAssert assertThat(AtomicInteger actual) {
+  default AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return proxy(AtomicIntegerAssert.class, AtomicInteger.class, actual);
   }
 
@@ -524,7 +523,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * @return the created assertion object.
    */
-  public AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
+  default AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return proxy(AtomicIntegerArrayAssert.class, AtomicIntegerArray.class, actual);
   }
 
@@ -536,7 +535,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  public <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assertThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
+  default <OBJECT> AtomicIntegerFieldUpdaterAssert<OBJECT> assertThat(AtomicIntegerFieldUpdater<OBJECT> actual) {
     return proxy(AtomicIntegerFieldUpdaterAssert.class, AtomicIntegerFieldUpdater.class, actual);
   }
 
@@ -547,7 +546,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * @return the created assertion object.
    */
-  public AtomicLongAssert assertThat(AtomicLong actual) {
+  default AtomicLongAssert assertThat(AtomicLong actual) {
     return proxy(AtomicLongAssert.class, AtomicLong.class, actual);
   }
 
@@ -558,7 +557,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * @return the created assertion object.
    */
-  public AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
+  default AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return proxy(AtomicLongArrayAssert.class, AtomicLongArray.class, actual);
   }
 
@@ -570,7 +569,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  public <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assertThat(AtomicLongFieldUpdater<OBJECT> actual) {
+  default <OBJECT> AtomicLongFieldUpdaterAssert<OBJECT> assertThat(AtomicLongFieldUpdater<OBJECT> actual) {
     return proxy(AtomicLongFieldUpdaterAssert.class, AtomicLongFieldUpdater.class, actual);
   }
 
@@ -582,7 +581,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <VALUE> the type of object referred to by the {@link AtomicReference}.
    * @return the created assertion object.
    */
-  public <VALUE> AtomicReferenceAssert<VALUE> assertThat(AtomicReference<VALUE> actual) {
+  default <VALUE> AtomicReferenceAssert<VALUE> assertThat(AtomicReference<VALUE> actual) {
     return proxy(AtomicReferenceAssert.class, AtomicReference.class, actual);
   }
 
@@ -593,7 +592,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assertThat(AtomicReferenceArray<ELEMENT> actual) {
+  default <ELEMENT> AtomicReferenceArrayAssert<ELEMENT> assertThat(AtomicReferenceArray<ELEMENT> actual) {
     return proxy(AtomicReferenceArrayAssert.class, AtomicReferenceArray.class, actual);
   }
 
@@ -606,7 +605,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param <OBJECT> the type of the object holding the updatable field.
    * @return the created assertion object.
    */
-  public <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assertThat(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
+  default <FIELD, OBJECT> AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT> assertThat(AtomicReferenceFieldUpdater<OBJECT, FIELD> actual) {
     return proxy(AtomicReferenceFieldUpdaterAssert.class, AtomicReferenceFieldUpdater.class, actual);
   }
 
@@ -617,7 +616,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <VALUE> AtomicMarkableReferenceAssert<VALUE> assertThat(AtomicMarkableReference<VALUE> actual) {
+  default <VALUE> AtomicMarkableReferenceAssert<VALUE> assertThat(AtomicMarkableReference<VALUE> actual) {
     return proxy(AtomicMarkableReferenceAssert.class, AtomicMarkableReference.class, actual);
   }
 
@@ -628,7 +627,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public <VALUE> AtomicStampedReferenceAssert<VALUE> assertThat(AtomicStampedReference<VALUE> actual) {
+  default <VALUE> AtomicStampedReferenceAssert<VALUE> assertThat(AtomicStampedReference<VALUE> actual) {
     return proxy(AtomicStampedReferenceAssert.class, AtomicStampedReference.class, actual);
   }
 
@@ -638,7 +637,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  public ThrowableAssert assertThat(Throwable actual) {
+  default ThrowableAssert assertThat(Throwable actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
   }
 
@@ -647,7 +646,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    *
    * Java 8 example :
    * <pre><code class='java'>  {@literal @}Test
-   *  public void testException() {
+   *  default void testException() {
    *    SoftAssertions softly = new SoftAssertions();
    *    softly.assertThatThrownBy(() -&gt; { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
    *                                                                      .hasMessageContaining("boom");
@@ -658,7 +657,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * softly.assertThatThrownBy(new ThrowingCallable() {
    *
    *   {@literal @}Override
-   *   public Void call() throws Exception {
+   *   default Void call() throws Exception {
    *     throw new Exception("boom!");
    *   }
    *
@@ -669,7 +668,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -679,7 +678,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * <p>
    * Example:
    * <pre><code class='java'> {@literal @}Test
-   *  public void testException() {
+   *  default void testException() {
    *    SoftAssertions softly = new SoftAssertions();
    *    // if this assertion failed (but it doesn't), the error message would start with [Test explosive code]
    *    softly.assertThatThrownBy(() -&gt; { throw new IOException("boom!") }, "Test explosive code")
@@ -707,7 +706,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                             String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -753,7 +752,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -778,7 +777,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @return the created assertion object.
    * @since 3.12.0
    */
-  public <T> ProxyableObjectAssert<T> assertThatObject(T actual) {
+  default <T> ProxyableObjectAssert<T> assertThatObject(T actual) {
     return assertThat(actual);
   }
 
@@ -788,7 +787,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public UriAssert assertThat(URI actual) {
+  default UriAssert assertThat(URI actual) {
     return proxy(UriAssert.class, URI.class, actual);
   }
 
@@ -798,7 +797,7 @@ public abstract class Java6AbstractStandardSoftAssertions extends AbstractSoftAs
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public AbstractUrlAssert<?> assertThat(URL actual) {
+  default AbstractUrlAssert<?> assertThat(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/Java6JUnitBDDSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6JUnitBDDSoftAssertions.java
@@ -12,12 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.api.SoftAssertionsStatement.softAssertionsStatement;
-
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 /**
  * @deprecated For Android compatible assertions use the latest assertj 2.x version which is based on Java 7 only.
  * <p>
@@ -28,11 +22,5 @@ import org.junit.runners.model.Statement;
  * @since 2.5.0 / 3.5.0
  */
 @Deprecated
-public class Java6JUnitBDDSoftAssertions extends Java6AbstractBDDSoftAssertions
-    implements TestRule {
-
-  @Override
-  public Statement apply(final Statement base, Description description) {
-    return softAssertionsStatement(this, base);
-  }
+public class Java6JUnitBDDSoftAssertions extends AbstractSoftAssertions implements Java6AbstractBDDSoftAssertions, SoftAssertionsRule {
 }

--- a/src/main/java/org/assertj/core/api/Java6SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6SoftAssertions.java
@@ -12,12 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.groups.Properties.extractProperty;
-
-import java.util.List;
-
-import org.assertj.core.error.AssertionErrorCreator;
-
 /**
  * @deprecated For Android compatible assertions use the latest assertj 2.x version which is based on Java 7 only.
  * <p>
@@ -28,20 +22,5 @@ import org.assertj.core.error.AssertionErrorCreator;
  * @since 2.5.0 / 3.5.0
  */
 @Deprecated
-public class Java6SoftAssertions extends Java6AbstractStandardSoftAssertions {
-
-  private AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
-
-  /**
-   * Verifies that no proxied assertion methods have failed.
-   *
-   * @throws SoftAssertionError if any proxied assertion objects threw
-   */
-  public void assertAll() {
-    List<Throwable> errors = errorsCollected();
-    if (!errors.isEmpty()) {
-      assertionErrorCreator.tryThrowingMultipleFailuresError(errors);
-      throw new SoftAssertionError(extractProperty("message", String.class).from(errors));
-    }
-  }
+public class Java6SoftAssertions extends AbstractSoftAssertions implements Java6AbstractStandardSoftAssertions {
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertions.java
@@ -12,10 +12,8 @@
  */
 package org.assertj.core.api;
 
-import java.util.List;
 import java.util.function.Consumer;
 
-import org.assertj.core.error.AssertionErrorCreator;
 import org.opentest4j.MultipleFailuresError;
 
 /**
@@ -97,7 +95,7 @@ import org.opentest4j.MultipleFailuresError;
  *   });
  * }</code></pre>
  *
- * <p>You can also compose several soft assertions together using the {@link SoftAssertions#assertAlso(SoftAssertions)} method</p>
+ * <p>You can also compose several soft assertions together using the {@link SoftAssertionsProvider#assertAlso(AssertionErrorCollector)} method</p>
  * <pre><code class='java'> public SoftAssertions check_kitchen() {
  *   SoftAssertions softly = new SoftAssertions();
  *   softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
@@ -132,7 +130,7 @@ import org.opentest4j.MultipleFailuresError;
  * <p>
  * SoftAssertions works by providing you with proxies of the AssertJ assertion objects (those created by
  * {@link Assertions}#assertThat...) whose assertion failures are caught and stored. Only when you call
- * {@link SoftAssertions#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of those
+ * {@link SoftAssertionsProvider#assertAll()} will a {@link SoftAssertionError} be thrown containing the error messages of those
  * previously caught assertion failures.
  * </p>
  *
@@ -152,54 +150,15 @@ import org.opentest4j.MultipleFailuresError;
  *
  * @see <a href="http://beust.com/weblog/2012/07/29/reinventing-assertions/">Reinventing Assertions (inspired this feature)</a>
  */
-public class SoftAssertions extends AbstractStandardSoftAssertions {
-
-  private AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
-
+public class SoftAssertions extends AbstractSoftAssertions implements AbstractStandardSoftAssertions {
   /**
-   * Verifies that no soft assertions have failed.
-   *
+   * Convenience method for calling {@link SoftAssertionsProvider#assertSoftly} for these assertion types.
+   * Equivalent to {@code SoftAssertion.assertSoftly(SoftAssertions.class, softly)}.
+   * @param softly the Consumer containing the code that will make the soft assertions.
+   *     Takes one parameter (the SoftAssertions instance used to make the assertions).
    * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
    */
-  public void assertAll() {
-    List<Throwable> errors = errorsCollected();
-    if (!errors.isEmpty()) throw assertionErrorCreator.multipleSoftAssertionsError(errors);
-  }
-
-  /**
-   * Add all assertion errors of <code>softly</code> argument to current <code>{@link SoftAssertions}</code> instance.
-   *
-   * @param softly the <code>{@link SoftAssertions}</code> assertion error source
-   */
-  public void assertAlso(SoftAssertions softly) {
-    softly.errorsCollected().forEach(proxies::collectError);
-  }
-
-  /**
-  * Use this to avoid having to call assertAll manually.
-  *
-  * <pre><code class='java'> &#064;Test
-  * public void host_dinner_party_where_nobody_dies() {
-  *   Mansion mansion = new Mansion();
-  *   mansion.hostPotentiallyMurderousDinnerParty();
-  *   SoftAssertions.assertSoftly(softly -&gt; {
-  *     softly.assertThat(mansion.guests()).as(&quot;Living Guests&quot;).isEqualTo(7);
-  *     softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
-  *     softly.assertThat(mansion.library()).as(&quot;Library&quot;).isEqualTo(&quot;clean&quot;);
-  *     softly.assertThat(mansion.revolverAmmo()).as(&quot;Revolver Ammo&quot;).isEqualTo(6);
-  *     softly.assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
-  *     softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
-  *     softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
-  *   });
-  * }</code></pre>
-  *
-  * @param softly the SoftAssertions instance that you can call your own assertions on.
-  * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
-  * @since 3.6.0
-  */
-public static void assertSoftly(Consumer<SoftAssertions> softly) {
-      SoftAssertions assertions = new SoftAssertions();
-      softly.accept(assertions);
-      assertions.assertAll();
+  public static void assertSoftly(Consumer<SoftAssertions> softly) {
+    SoftAssertionsProvider.assertSoftly(SoftAssertions.class, softly);
   }
 }

--- a/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.function.Consumer;
+
+import org.opentest4j.MultipleFailuresError;
+
+/**
+ * Parent interface for soft assertion implementations.
+ * 
+ * @author Fr Jeremy Krieg
+ * @see AbstractSoftAssertions
+ * @see SoftAssertions
+ */
+public interface SoftAssertionsProvider extends AssertionErrorCollector, AutoCloseable {
+
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /**
+   * Creates a proxied assertion class of the given type. The returned value
+   * is an assertion object compatible with the supplied assertion class, but
+   * instead of throwing errors it will collect them and store them using
+   * {@link #collectAssertionError(AssertionError) collectAssertionError()}.
+   * 
+   * @param <SELF> The type of the assertion class
+   * @param <ACTUAL> The type of the object-under-test
+   * @param assertClass Class instance for the assertion type.
+   * @param actualClass Class instance for the type of the object-under-test.
+   * @param actual The actual object-under-test. 
+   * @return A proxied assertion class for the given object-under-test.
+   */
+  <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(Class<SELF> assertClass, Class<ACTUAL> actualClass,
+                                                                             ACTUAL actual);
+
+  /**
+   * Verifies that no soft assertions have failed.
+   *
+   * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
+   */
+  void assertAll();
+
+  /**
+   * Allows the SoftAssertionsProvider to be used as an {@code AutoClosable} by calling {@link #assertAll()}.
+   * 
+   * @see #assertAll
+   */
+  @Override
+  default void close() {
+    assertAll();
+  }
+  
+  /**
+   * Add all errors of <code>collector</code> argument to current <code>{@link SoftAssertionsProvider}</code> instance.
+   *
+   * @param collector the <code>{@link AssertionErrorCollector}</code> error source
+   */
+  default void assertAlso(AssertionErrorCollector collector) {
+    collector.assertionErrorsCollected().forEach(this::collectAssertionError);
+  }
+
+  /**
+   * Returns the result of last soft assertion which can be used to decide what the next one should be.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Person person = ...
+   * SoftAssertions soft = new SoftAssertions();
+   * if (soft.assertThat(person.getAddress()).isNotNull().wasSuccess()) {
+   *     soft.assertThat(person.getAddress().getStreet()).isNotNull();
+   * }</code></pre>
+   *
+   * @return true if the last assertion was a success.
+   */
+  boolean wasSuccess();
+
+  /**
+   * Catch and collect assertion errors coming from standard and <b>custom</b> assertions.
+   * <p>
+   * Example :
+   * <pre><code class='java'> SoftAssertions softly = new SoftAssertions();
+   * softly.check(() -&gt; Assertions.assertThat(…).…);
+   * softly.check(() -&gt; CustomAssertions.assertThat(…).…);
+   * softly.assertAll(); </code></pre>
+   *
+   * @param assertion an assertion call.
+   */
+  default void check(ThrowingRunnable assertion) {
+    try {
+      assertion.run();
+    } catch (AssertionError error) {
+      collectAssertionError(error);
+    } catch (RuntimeException runtimeException) {
+      throw runtimeException;
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  /**
+  * Use this to avoid having to call assertAll manually.
+  *
+  * <pre><code class='java'> &#064;Test
+  * public void host_dinner_party_where_nobody_dies() {
+  *   Mansion mansion = new Mansion();
+  *   mansion.hostPotentiallyMurderousDinnerParty();
+  *   SoftAssertion.assertSoftly(SoftAssertions.class, softly -&gt; {
+  *     softly.assertThat(mansion.guests()).as(&quot;Living Guests&quot;).isEqualTo(7);
+  *     softly.assertThat(mansion.kitchen()).as(&quot;Kitchen&quot;).isEqualTo(&quot;clean&quot;);
+  *     softly.assertThat(mansion.library()).as(&quot;Library&quot;).isEqualTo(&quot;clean&quot;);
+  *     softly.assertThat(mansion.revolverAmmo()).as(&quot;Revolver Ammo&quot;).isEqualTo(6);
+  *     softly.assertThat(mansion.candlestick()).as(&quot;Candlestick&quot;).isEqualTo(&quot;pristine&quot;);
+  *     softly.assertThat(mansion.colonel()).as(&quot;Colonel&quot;).isEqualTo(&quot;well kempt&quot;);
+  *     softly.assertThat(mansion.professor()).as(&quot;Professor&quot;).isEqualTo(&quot;well kempt&quot;);
+  *   });
+  * }</code></pre>
+  *
+  * @param <S> the concrete type of soft assertions to use.
+  * @param type the class object of the concrete type of soft assertions to use.
+  * @param softly the Consumer containing the code that will make the soft assertions.
+  *     Takes one parameter (the SoftAssertion instance used to make the assertions).
+  * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link AssertionError}
+  * @since 3.16.0
+  */
+  static <S extends SoftAssertionsProvider> void assertSoftly(Class<S> type, Consumer<S> softly) {
+    S assertions;
+    try {
+      assertions = type.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+    softly.accept(assertions);
+    assertions.assertAll();
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/SoftAssertionsRule.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionsRule.java
@@ -14,24 +14,13 @@ package org.assertj.core.api;
 
 import static org.assertj.core.api.SoftAssertionsStatement.softAssertionsStatement;
 
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-/**
- * @deprecated For Android compatible assertions use the latest assertj 2.x version which is based on Java 7 only.
- * <p>
- * JUnitSoftAssertions rule compatible with Android. Duplicated from {@link JUnitSoftAssertions}.
- *
- * @see JUnitSoftAssertions
- *
- * @since 2.5.0 / 3.5.0
- */
-@Deprecated
-public class Java6JUnitSoftAssertions extends AbstractSoftAssertions
-    implements Java6AbstractStandardSoftAssertions, SoftAssertionsRule {
-
+public interface SoftAssertionsRule extends SoftAssertionsProvider, TestRule {
   @Override
-  public Statement apply(final Statement base, Description description) {
+  default public Statement apply(final Statement base, Description description) {
     return softAssertionsStatement(this, base);
   }
 }

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -98,11 +98,11 @@ class SoftProxies {
     return collector.wasSuccess();
   }
 
-  void collectError(Throwable error) {
+  void collectError(AssertionError error) {
     collector.addError(error);
   }
 
-  List<Throwable> errorsCollected() {
+  List<AssertionError> errorsCollected() {
     return collector.errors();
   }
 

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -106,12 +106,13 @@ class SoftProxies {
     return collector.errors();
   }
 
-  // TODO V extends AbstractAssert ?
-  <V, T> V createSoftAssertionProxy(Class<V> assertClass, Class<T> actualClass, T actual) {
+  <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF createSoftAssertionProxy(Class<SELF> assertClass,
+                                                                                                Class<ACTUAL> actualClass,
+                                                                                                ACTUAL actual) {
     try {
-      Class<? extends V> proxyClass = createSoftAssertionProxyClass(assertClass);
-      Constructor<? extends V> constructor = proxyClass.getConstructor(actualClass);
-      V proxiedAssert = constructor.newInstance(actual);
+      Class<? extends SELF> proxyClass = createSoftAssertionProxyClass(assertClass);
+      Constructor<? extends SELF> constructor = proxyClass.getConstructor(actualClass);
+      SELF proxiedAssert = constructor.newInstance(actual);
       // instance is a AssertJProxySetup since it is a generated proxy implementing it (see createProxy)
       ((AssertJProxySetup) proxiedAssert).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
       return proxiedAssert;
@@ -121,9 +122,10 @@ class SoftProxies {
   }
 
   @SuppressWarnings("unchecked")
-  private static <V> Class<? extends V> createSoftAssertionProxyClass(Class<V> assertClass) {
+  private static <ASSERT extends Assert<?, ?>> Class<ASSERT> createSoftAssertionProxyClass(Class<ASSERT> assertClass) {
     SimpleKey cacheKey = new SimpleKey(assertClass);
-    return (Class<V>) CACHE.findOrInsert(SoftProxies.class.getClassLoader(), cacheKey, () -> generateProxyClass(assertClass));
+    return (Class<ASSERT>) CACHE.findOrInsert(SoftProxies.class.getClassLoader(), cacheKey,
+                                              () -> generateProxyClass(assertClass));
   }
 
   IterableSizeAssert<?> createIterableSizeAssertProxy(IterableSizeAssert<?> iterableSizeAssert) {

--- a/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsErrorsCollectedTest.java
+++ b/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsErrorsCollectedTest.java
@@ -12,12 +12,11 @@
  */
 package org.assertj.core.api.abstract_; // Make sure that package-private access is lost
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AbstractStandardSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This tests that classes extended from {@link AbstractStandardSoftAssertions} will have access to the list of
@@ -25,23 +24,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class SoftAssertionsErrorsCollectedTest {
   private final Object objectForTesting = null;
-  private final TestCollector softly = new TestCollector();
+  private final SoftAssertions softly = new SoftAssertions();
 
   @Test
   public void return_empty_list_of_errors() {
     softly.assertThat(objectForTesting).isNull(); // No errors to collect
-    assertThat(softly.getErrors()).isEmpty();
+    assertThat(softly.errorsCollected()).isEmpty();
+    assertThat(softly.errorsCollected()).isEqualTo(softly.assertionErrorsCollected());
   }
 
   @Test
   public void returns_nonempty_list_of_errors() {
     softly.assertThat(objectForTesting).isNotNull(); // This should allow something to be collected
-    assertThat(softly.getErrors()).hasAtLeastOneElementOfType(Throwable.class);
-  }
-
-  private class TestCollector extends AbstractStandardSoftAssertions {
-    public List<Throwable> getErrors() {
-      return errorsCollected();
-    }
+    assertThat(softly.errorsCollected()).hasAtLeastOneElementOfType(Throwable.class);
+    assertThat(softly.errorsCollected()).isEqualTo(softly.assertionErrorsCollected());
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsMultipleProjectsTest.java
+++ b/src/test/java/org/assertj/core/api/abstract_/SoftAssertionsMultipleProjectsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_; // Make sure that package-private access is lost
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.AbstractStandardSoftAssertions;
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This tests that classes extended from {@link AbstractStandardSoftAssertions} will have access to the list of
+ * collected errors that the various proxies have collected.
+ */
+public class SoftAssertionsMultipleProjectsTest {
+
+  static class MyClass1 {
+
+  }
+
+  static class MyClass2 {
+
+  }
+
+  static class MyClass1Assert extends AbstractAssert<MyClass1Assert, MyClass1> {
+    public MyClass1Assert(MyClass1 actual) {
+      super(actual, MyClass1Assert.class);
+    }
+
+    public MyClass1Assert isClassy() {
+      throw new AssertionError("Not classy");
+    }
+
+    public MyClass1Assert isNotClassy() {
+      return this;
+    }
+  }
+
+  static class MyClass2Assert extends AbstractAssert<MyClass2Assert, MyClass2> {
+    public MyClass2Assert(MyClass2 actual) {
+      super(actual, MyClass2Assert.class);
+    }
+
+    public MyClass2Assert isClassy() {
+      return this;
+    }
+
+    public MyClass2Assert isNotClassy() {
+      throw new AssertionError("Classy");
+    }
+  }
+
+  static interface Class1SoftAssertions extends SoftAssertionsProvider {
+    default MyClass1Assert assertThat(MyClass1 actual) {
+      return proxy(MyClass1Assert.class, MyClass1.class, actual);
+    }
+  }
+
+  static interface Class2SoftAssertions extends SoftAssertionsProvider {
+    default MyClass2Assert assertThat(MyClass2 actual) {
+      return proxy(MyClass2Assert.class, MyClass2.class, actual);
+    }
+  }
+
+  static class UberSoftAssertions extends AbstractSoftAssertions
+      implements Class1SoftAssertions, Class2SoftAssertions, AbstractStandardSoftAssertions {
+  }
+
+  private final MyClass1 class1ForTesting = null;
+  private final MyClass2 class2ForTesting = null;
+  private final UberSoftAssertions softly = new UberSoftAssertions();
+
+  @Test
+  public void return_empty_list_of_errors_for_passing_assertions() {
+    softly.assertThat(class1ForTesting).isNotClassy(); // No errors to collect
+    softly.assertThat(class2ForTesting).isClassy(); // No errors to collect
+    softly.assertThat("String").isEqualTo("String"); // No errors to collect
+    assertThat(softly.errorsCollected()).isEmpty();
+    assertThat(softly.errorsCollected()).isEqualTo(softly.assertionErrorsCollected());
+  }
+
+  @Test
+  public void returns_list_of_errors_in_the_order_they_were_asserted() {
+    softly.assertThat(class1ForTesting).isClassy();
+    softly.assertThat(class2ForTesting).isNotClassy();
+    softly.assertThat("String").isEqualTo("Strung");
+    List<Throwable> errorsCollected = softly.errorsCollected();
+    assertThat(errorsCollected).as("size").hasSize(3);
+    assertThat(errorsCollected.get(0)).as("0").hasMessage("Not classy");
+    assertThat(errorsCollected.get(1)).as("1").hasMessage("Classy");
+    assertThat(errorsCollected.get(2)).as("2").hasMessageMatching("(?s).*String.*equal to.*Strung.*not.*");
+    assertThat(errorsCollected).isEqualTo(softly.assertionErrorsCollected());
+  }
+}


### PR DESCRIPTION
Changes soft assertions entry point implementations to be interfaces with default methods, rather than classes. This allows you to combine multiple of them into a single entry point class.

#### Check List:
* Fixes #1569
* Unit tests : YES
* Javadoc with a code example (on API only) : Not yet (will add if core team is happy with the implementation)
