### PR TITLE
Support custom soft assertions in SoftAssertionExtension

### DIFF
--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
@@ -17,11 +17,12 @@ import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertionsProvider;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -31,30 +32,38 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.platform.commons.annotation.Testable;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 /**
- * Extension for JUnit Jupiter that provides support for injecting an instance
- * of {@link SoftAssertions} or {@link BDDSoftAssertions} into test methods.
+ * Extension for JUnit Jupiter that provides support for injecting a concrete
+ * implementation of {@link SoftAssertionsProvider} into test methods. Two examples that
+ * come packaged with AssertJ are {@link SoftAssertions} and
+ * {@link BDDSoftAssertions}, but custom implementations are also supported as
+ * long as they have a default constructor.
  *
  * <h2>Applicability</h2>
  *
- * <p>In this context, the term "test method" refers to any method annotated with
+ * <p>
+ * In this context, the term "test method" refers to any method annotated with
  * {@code @Test}, {@code @RepeatedTest}, {@code @ParameterizedTest},
  * {@code @TestFactory}, or {@code @TestTemplate}.<br>
- * This extension does not inject {@code SoftAssertions} or {@code BDDSoftAssertions} arguments into test
+ * This extension does not inject {@code SoftAssertionsProvider} arguments into test
  * constructors or lifecycle methods.
  *
  * <h2>Scope</h2>
  *
- * <p>The scope of the {@code SoftAssertions} or {@code BDDSoftAssertions} instance
- * managed by this extension begins when a parameter of type {@code SoftAssertions}
- * or {@code BDDSoftAssertions} is resolved for a test method.<br>
- * The scope of the instance ends after the test method has been executed, this is when
- * {@code assertAll()} will be invoked on the instance to verify that no soft assertions failed.
+ * <p>
+ * The scope of the {@code SoftAssertionsProvider} instance managed by this extension
+ * begins when a parameter of type {@code SoftAssertionsProvider} is resolved for a test
+ * method.<br>
+ * The scope of the instance ends after the test method has been executed, this
+ * is when {@code assertAll()} will be invoked on the instance to verify that no
+ * soft assertions failed.
  *
  * <h3>Example with {@code SoftAssertions}</h3>
  *
- * <pre><code class='java'> {@literal @}ExtendWith(SoftAssertionsExtension.class)
+ * <pre>
+ * <code class='java'> {@literal @}ExtendWith(SoftAssertionsExtension.class)
  * class ExampleTestCase {
  *
  *    {@literal @}Test
@@ -63,11 +72,13 @@ import org.junit.platform.commons.annotation.Testable;
  *       softly.assertThat(Arrays.asList(1, 2)).containsOnly(1);
  *       softly.assertThat(1 + 1).isEqualTo(2);
  *    }
- * }</code></pre>
+ * }</code>
+ * </pre>
  *
  * <h3>Example with {@code BDDSoftAssertions}</h3>
  *
- * <pre><code class='java'> {@literal @}ExtendWith(SoftAssertionsExtension.class)
+ * <pre>
+ * <code class='java'> {@literal @}ExtendWith(SoftAssertionsExtension.class)
  * class ExampleTestCase {
  *
  *    {@literal @}Test
@@ -76,7 +87,8 @@ import org.junit.platform.commons.annotation.Testable;
  *       softly.then(Arrays.asList(1, 2)).containsOnly(1);
  *       softly.then(1 + 1).isEqualTo(2);
  *    }
- * }</code></pre>
+ * }</code>
+ * </pre>
  *
  * @author Sam Brannen
  * @since 3.13
@@ -94,7 +106,18 @@ public class SoftAssertionsExtension implements ParameterResolver, AfterTestExec
     // @Testable is used as a meta-annotation on @Test, @TestFactory, @TestTemplate, etc.
     boolean isTestableMethod = executable instanceof Method && isAnnotated(executable, Testable.class);
     if (!isTestableMethod) {
-      throw new ParameterResolutionException(format("Configuration error: cannot resolve SoftAssertions or BDDSoftAssertions for [%s]. Only test methods are supported.",
+      throw new ParameterResolutionException(format("Configuration error: cannot resolve SoftAssertionsProvider instances for [%s]. Only test methods are supported.",
+                                                    executable));
+    }
+    Class<?> type = parameterContext.getParameter().getType();
+    if (Modifier.isAbstract(type.getModifiers())) {
+      throw new ParameterResolutionException(format("Configuration error: the resolved SoftAssertionsProvider implementation [%s] is abstract and cannot be instantiated.",
+                                                    executable));
+    }
+    try {
+      type.getDeclaredConstructor();
+    } catch (Exception e) {
+      throw new ParameterResolutionException(format("Configuration error: the resolved SoftAssertionsProvider implementation [%s] has no default constructor and cannot be instantiated.",
                                                     executable));
     }
     return true;
@@ -102,27 +125,24 @@ public class SoftAssertionsExtension implements ParameterResolver, AfterTestExec
 
   @Override
   public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-    // The parameter type is guaranteed to be either SoftAssertions or BDDSoftAssertions
-    return getStore(extensionContext).getOrComputeIfAbsent(parameterContext.getParameter().getType());
+    // The parameter type is guaranteed to be an instance of SoftAssertionsProvider
+    @SuppressWarnings("unchecked")
+    Class<? extends SoftAssertionsProvider> type = (Class<? extends SoftAssertionsProvider>) parameterContext.getParameter()
+                                                                                                             .getType();
+    return getStore(extensionContext).getOrComputeIfAbsent(SoftAssertionsProvider.class,
+                                                           unused -> ReflectionSupport.newInstance(type),
+                                                           SoftAssertionsProvider.class);
   }
 
   @Override
   public void afterTestExecution(ExtensionContext extensionContext) {
-    assertAll(extensionContext, SoftAssertions.class, SoftAssertions::assertAll);
-    assertAll(extensionContext, BDDSoftAssertions.class, BDDSoftAssertions::assertAll);
-  }
-
-  /*
-   * Invoke {@code assertAll} on the object of specified {@code type}, if the
-   * supplied {@code ExtensionContext} contains the object keyed by its type.
-   */
-  private static <T> void assertAll(ExtensionContext extensionContext, Class<T> type, Consumer<T> assertAll) {
-    Optional.ofNullable(getStore(extensionContext).remove(type, type)).ifPresent(assertAll);
+    Optional.ofNullable(getStore(extensionContext).remove(SoftAssertionsProvider.class, SoftAssertionsProvider.class))
+            .ifPresent(SoftAssertionsProvider::assertAll);
   }
 
   private static boolean isUnsupportedParameterType(Parameter parameter) {
     Class<?> type = parameter.getType();
-    return type != SoftAssertions.class && type != BDDSoftAssertions.class;
+    return !SoftAssertionsProvider.class.isAssignableFrom(type);
   }
 
   private static Store getStore(ExtensionContext extensionContext) {

--- a/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
@@ -40,8 +40,9 @@ import org.junit.jupiter.params.provider.CsvSource;
  * @author Sam Brannen
  * @since 3.13
  * @see SoftAssertionsExtensionIntegrationTest
+ * @see CustomSoftAssertionsExtensionIntegrationTest
  */
-@DisplayName("JUnit Jupiter BDD Soft Assertions extension integration tests")
+@DisplayName("JUnit Jupiter BDD Soft Assertions extension integration tests (BDD)")
 class BDDSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 
 	@Override

--- a/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.core.api.ProxyableListAssert;
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Integration tests for {@link SoftAssertionsExtension} with a custom implementation of {@link SoftAssertionsProvider}.
+ *
+ * @author Sam Brannen
+ * @author Fr Jeremy Krieg
+ * @since 3.16
+ * @see SoftAssertionsExtensionIntegrationTest
+ * @see BDDSoftAssertionsExtensionIntegrationTest
+ */
+@DisplayName("JUnit Jupiter Soft Assertions extension integration tests (custom)")
+class CustomSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
+
+  @Override
+  protected Class<?> getTestInstancePerMethodTestCase() {
+    return TestInstancePerMethodExample.class;
+  }
+
+  @Override
+  protected Class<?> getTestInstancePerClassTestCase() {
+    return TestInstancePerClassExample.class;
+  }
+
+  @Override
+  protected Class<?> getTestInstancePerMethodNestedTestCase() {
+    return TestInstancePerMethodNestedExample.class;
+  }
+
+  @Override
+  protected Class<?> getTestInstancePerClassNestedTestCase() {
+    return TestInstancePerClassNestedExample.class;
+  }
+
+  private static class CustomSoftAssertions extends AbstractSoftAssertions
+      implements SoftAssertionsProvider {
+    public IntegerAssert expectThat(int value) {
+      return proxy(IntegerAssert.class, Integer.class, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> ProxyableListAssert<T> expectThat(List<? extends T> actual) {
+      return proxy(ProxyableListAssert.class, List.class, actual);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+
+  @ExtendWith(SoftAssertionsExtension.class)
+  @TestMethodOrder(OrderAnnotation.class)
+  private static abstract class AbstractCustomSoftAssertionsExample {
+
+    @Test
+    @Order(1)
+    void multipleFailures(CustomSoftAssertions softly) {
+      softly.expectThat(1).isEqualTo(0);
+      softly.expectThat(2).isEqualTo(2);
+      softly.expectThat(3).isEqualTo(4);
+    }
+
+    @Test
+    @Order(2)
+    void allAssertionsShouldPass(CustomSoftAssertions softly) {
+      softly.expectThat(1).isEqualTo(1);
+      softly.expectThat(Arrays.asList(1, 2)).containsOnly(1, 2);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, 1, 2", "1, 2, 3" })
+    @Order(3)
+    void parameterizedTest(int a, int b, int sum, CustomSoftAssertions softly) {
+      softly.expectThat(a + b).as("sum").isEqualTo(sum);
+      softly.expectThat(a).as("operand 1 is equal to operand 2").isEqualTo(b);
+    }
+  }
+
+  @TestInstance(PER_METHOD)
+  @Disabled("Executed via the JUnit Platform Test Kit")
+  static class TestInstancePerMethodExample extends AbstractCustomSoftAssertionsExample {
+  }
+
+  @TestInstance(PER_CLASS)
+  @Disabled
+  static class TestInstancePerClassExample extends AbstractCustomSoftAssertionsExample {
+  }
+
+  @TestInstance(PER_METHOD)
+  @Disabled("Executed via the JUnit Platform Test Kit")
+  static class TestInstancePerMethodNestedExample extends AbstractCustomSoftAssertionsExample {
+
+    @Nested
+    @Disabled("Executed via the JUnit Platform Test Kit")
+    class InnerExample extends AbstractCustomSoftAssertionsExample {
+    }
+  }
+
+  @TestInstance(PER_CLASS)
+  @Disabled("Executed via the JUnit Platform Test Kit")
+  static class TestInstancePerClassNestedExample extends AbstractCustomSoftAssertionsExample {
+
+    @Nested
+    @Disabled("Executed via the JUnit Platform Test Kit")
+    class InnerExample extends AbstractCustomSoftAssertionsExample {
+    }
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
@@ -36,8 +36,9 @@ import org.junit.jupiter.params.provider.CsvSource;
  * @author Sam Brannen
  * @since 3.13
  * @see BDDSoftAssertionsExtensionIntegrationTest
+ * @see CustomSoftAssertionsExtensionIntegrationTest
  */
-@DisplayName("JUnit Jupiter Soft Assertions extension integration tests")
+@DisplayName("JUnit Jupiter Soft Assertions extension integration tests (standard)")
 class SoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 
 	@Override


### PR DESCRIPTION
Note that this PR depends on #1817.

With this implementation, any class that:
* is concrete implementation of the `SoftAssertion` interface
* has a default constructor
...can be injected as a parameter.

This mechanism has been retro-fitted to `SoftAssertions` and `BDDSoftAssertions`, and will also support any other soft assertion implementations anyone might conjure up (either within AssertJ or users of AssertJ). 

#### Check List:
* Fixes #1819
* Unit tests : YES 
* Javadoc with a code example (on API only) : Some - will ensure that this is complete if the PR is accepted.