### PR TITLE
fix ShouldContain/ShouldContainOnly use a more specific name in error message (with tests failing)

### DIFF
--- a/failed_test.log
+++ b/failed_test.log
@@ -1,0 +1,8722 @@
+[INFO] Scanning for projects...
+[INFO] Inspecting build with total of 1 modules...
+[INFO] Installing Nexus Staging features:
+[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
+[INFO] 
+[INFO] ----------------------< org.assertj:assertj-core >----------------------
+[INFO] Building AssertJ fluent assertions 3.16.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ assertj-core ---
+[INFO] 
+[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-dependency-rules) @ assertj-core ---
+[INFO] 
+[INFO] --- license-maven-plugin:3.0:format (default) @ assertj-core ---
+[INFO] Updating license headers...
+[INFO] 
+[INFO] --- jacoco-maven-plugin:0.8.5:prepare-agent (prepare-agent) @ assertj-core ---
+[INFO] argLine set to -javaagent:/Users/yiwu/.m2/repository/org/jacoco/org.jacoco.agent/0.8.5/org.jacoco.agent-0.8.5-runtime.jar=destfile=/Users/yiwu/Documents/Senior/SE/project/assertj-core/target/jacoco.exec,excludes=**/*hamcrest*/**
+[INFO] 
+[INFO] --- yuicompressor-maven-plugin:1.5.1:compress (default) @ assertj-core ---
+[INFO] nothing to do, /Users/yiwu/Documents/Senior/SE/project/assertj-core/target/javadoc-stylesheet/assertj-javadoc-min.css is younger than original, use 'force' option or clean your target
+[INFO] nb warnings: 0, nb errors: 0
+[INFO] 
+[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ assertj-core ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /Users/yiwu/Documents/Senior/SE/project/assertj-core/src/main/resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ assertj-core ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.8.1:compile (jdk9) @ assertj-core ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ assertj-core ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 19 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ assertj-core ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ assertj-core ---
+[INFO] 
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running org.assertj.core.configuration.Configuration_apply_Test
+Applying configuration org.assertj.core.test.ConfigurationForTests
+- representation .................................. = StandardRepresentation
+- comparingPrivateFieldsEnabled ................... = true
+- extractingPrivateFieldsEnabled .................. = true
+- bareNamePropertyExtractionEnabled ............... = true
+- lenientDateParsingEnabled ....................... = false
+- additional date formats ......................... = []
+- maxLengthForSingleLineDescription ............... = 80
+- maxElementsForPrinting .......................... = 1000
+- removeAssertJRelatedElementsFromStackTraceEnabled = false
+
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.054 s - in org.assertj.core.configuration.Configuration_apply_Test
+[INFO] Running org.assertj.core.configuration.Configuration_describe_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.configuration.Configuration_describe_Test
+[INFO] Running org.assertj.core.test.TypeCanonizerTest
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s - in org.assertj.core.test.TypeCanonizerTest
+[INFO] Running org.assertj.core.util.Preconditions_checkNotNullOrEmpty_String_String_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.Preconditions_checkNotNullOrEmpty_String_String_Test
+[INFO] Running org.assertj.core.util.DoubleComparatorTest
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 s - in org.assertj.core.util.DoubleComparatorTest
+[INFO] Running org.assertj.core.util.Files_contentOf_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.util.Files_contentOf_Test
+[INFO] Running org.assertj.core.util.Arrays_array_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.Arrays_array_Test
+[INFO] Running org.assertj.core.util.Files_currentFolder_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.assertj.core.util.Files_currentFolder_Test
+[INFO] Running org.assertj.core.util.ArrayWrapperList_wrap_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.ArrayWrapperList_wrap_Test
+[INFO] Running org.assertj.core.util.Closeables_closeQuietly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.assertj.core.util.Closeables_closeQuietly_Test
+[INFO] Running org.assertj.core.util.Throwables_getRootCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Throwables_getRootCause_Test
+[INFO] Running org.assertj.core.util.Sets_newHashSet_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Sets_newHashSet_Iterable_Test
+[INFO] Running org.assertj.core.util.Strings_quoteString_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Strings_quoteString_Test
+[INFO] Running org.assertj.core.util.BigDecimalComparatorTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.BigDecimalComparatorTest
+[INFO] Running org.assertj.core.util.DateUtil_millisecondOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_millisecondOf_Test
+[INFO] Running org.assertj.core.util.DateUtil_secondOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.DateUtil_secondOf_Test
+[INFO] Running org.assertj.core.util.DateUtil_hourOfDayOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.DateUtil_hourOfDayOf_Test
+[INFO] Running org.assertj.core.util.Files_temporaryFolder_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.util.Files_temporaryFolder_Test
+[INFO] Running org.assertj.core.util.Objects_hashCodeFor_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Objects_hashCodeFor_Test
+[INFO] Running org.assertj.core.util.Strings_append_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Strings_append_Test
+[INFO] Running org.assertj.core.util.Strings_isEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Strings_isEmpty_Test
+[INFO] Running org.assertj.core.util.Lists_newArrayList_withVarArgs_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Lists_newArrayList_withVarArgs_Test
+[INFO] Running org.assertj.core.util.Hexadecimals_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Hexadecimals_Test
+[INFO] Running org.assertj.core.util.URLs_linesOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.URLs_linesOf_Test
+[INFO] Running org.assertj.core.util.Files_fileNamesIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.058 s - in org.assertj.core.util.Files_fileNamesIn_Test
+[INFO] Running org.assertj.core.util.DateUtil_format_with_date_time_format_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.util.DateUtil_format_with_date_time_format_Test
+[INFO] Running org.assertj.core.util.Files_newFolder_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.util.Files_newFolder_Test
+[INFO] Running org.assertj.core.util.DateUtil_monthOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_monthOf_Test
+[INFO] Running org.assertj.core.util.Preconditions_checkNotNull_GenericObject_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Preconditions_checkNotNull_GenericObject_Test
+[INFO] Running org.assertj.core.util.DateUtil_parse_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_parse_Test
+[INFO] Running org.assertj.core.util.Lists_newArrayList_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Lists_newArrayList_Test
+[INFO] Running org.assertj.core.util.Introspection_getProperty_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.Introspection_getProperty_Test
+[INFO] Running org.assertj.core.util.DateUtil_toCalendar_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.DateUtil_toCalendar_Test
+[INFO] Running org.assertj.core.util.Strings_join_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Strings_join_Test
+[INFO] Running org.assertj.core.util.Streams_stream_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Streams_stream_Test
+[INFO] Running org.assertj.core.util.Files_newTemporaryFolder_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.util.Files_newTemporaryFolder_Test
+[INFO] Running org.assertj.core.util.IterableUtil_nonNullElementsIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.IterableUtil_nonNullElementsIn_Test
+[INFO] Running org.assertj.core.util.Strings_concat_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Strings_concat_Test
+[INFO] Running org.assertj.core.util.Strings_quoteObject_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Strings_quoteObject_Test
+[INFO] Running org.assertj.core.util.Preconditions_checkNotNull_GenericObject_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Preconditions_checkNotNull_GenericObject_String_Test
+[INFO] Running org.assertj.core.util.DateUtil_timeDifference_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_timeDifference_Test
+[INFO] Running org.assertj.core.util.Objects_areEqual_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Objects_areEqual_Test
+[INFO] Running org.assertj.core.util.diff.myers.SnakeTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.diff.myers.SnakeTest
+[INFO] Running org.assertj.core.util.diff.ChangeDeltaTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.util.diff.ChangeDeltaTest
+[INFO] Running org.assertj.core.util.diff.DiffTest
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.util.diff.DiffTest
+[INFO] Running org.assertj.core.util.diff.InsertDeltaTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.diff.InsertDeltaTest
+[INFO] Running org.assertj.core.util.diff.DeleteDeltaTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.diff.DeleteDeltaTest
+[INFO] Running org.assertj.core.util.diff.Delta_equals_hashCode_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.diff.Delta_equals_hashCode_Test
+[INFO] Running org.assertj.core.util.diff.GenerateUnifiedDiffTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.assertj.core.util.diff.GenerateUnifiedDiffTest
+[INFO] Running org.assertj.core.util.diff.ChunkTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.util.diff.ChunkTest
+[INFO] Running org.assertj.core.util.diff.PatchTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.diff.PatchTest
+[INFO] Running org.assertj.core.util.Arrays_asList_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.util.Arrays_asList_Test
+[INFO] Running org.assertj.core.util.DateUtil_dayOfWeekOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_dayOfWeekOf_Test
+[INFO] Running org.assertj.core.util.Files_linesOf_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.Files_linesOf_Test
+[INFO] Running org.assertj.core.util.IterableUtil_isNullOrEmpty_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.IterableUtil_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.util.Objects_castIfBelongsToType_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Objects_castIfBelongsToType_Test
+[INFO] Running org.assertj.core.util.introspection.PropertyOrFieldSupport_getValueOf_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in org.assertj.core.util.introspection.PropertyOrFieldSupport_getValueOf_Test
+[INFO] Running org.assertj.core.util.introspection.FieldSupport_isAllowedToReadField_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.introspection.FieldSupport_isAllowedToReadField_Test
+[INFO] Running org.assertj.core.util.introspection.PropertySupport_publicGetterExistsFor_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.introspection.PropertySupport_publicGetterExistsFor_Test
+[INFO] Running org.assertj.core.util.introspection.FieldSupport_fieldValues_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.util.introspection.FieldSupport_fieldValues_Test
+[INFO] Running org.assertj.core.util.introspection.PropertyOrFieldSupport_getSimpleValue_with_Map_input_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.util.introspection.PropertyOrFieldSupport_getSimpleValue_with_Map_input_Test
+[INFO] Running org.assertj.core.util.introspection.MethodSupport_methodResultFor_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.introspection.MethodSupport_methodResultFor_Test
+[INFO] Running org.assertj.core.util.introspection.PropertySupport_propertyValues_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.introspection.PropertySupport_propertyValues_Test
+[INFO] Running org.assertj.core.util.Lists_emptyList_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Lists_emptyList_Test
+[INFO] Running org.assertj.core.util.DateUtil_minuteOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_minuteOf_Test
+[INFO] Running org.assertj.core.util.DateUtil_yearOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.DateUtil_yearOf_Test
+[INFO] Running org.assertj.core.util.Arrays_isNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Arrays_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.util.xml.XmlStringPrettyFormatter_prettyFormat_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s - in org.assertj.core.util.xml.XmlStringPrettyFormatter_prettyFormat_Test
+[INFO] Running org.assertj.core.util.DateUtil_truncateTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.DateUtil_truncateTime_Test
+[INFO] Running org.assertj.core.util.Preconditions_checkNotNullOrEmpty_String_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Preconditions_checkNotNullOrEmpty_String_Test
+[INFO] Running org.assertj.core.util.Arrays_isArray_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Arrays_isArray_Test
+[INFO] Running org.assertj.core.util.DateUtil_formatTimeDifference_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.DateUtil_formatTimeDifference_Test
+[INFO] Running org.assertj.core.util.Files_newFile_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in org.assertj.core.util.Files_newFile_Test
+[INFO] Running org.assertj.core.util.Sets_newHashSet_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.Sets_newHashSet_Test
+[INFO] Running org.assertj.core.util.ArrayWrapperList_size_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.util.ArrayWrapperList_size_Test
+[INFO] Running org.assertj.core.util.Preconditions_checkArgument_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Preconditions_checkArgument_Test
+[INFO] Running org.assertj.core.util.Sets_newLinkedHashSet_GenericArray_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Sets_newLinkedHashSet_GenericArray_Test
+[INFO] Running org.assertj.core.util.Throwables_appendCurrentThreadStackTraceToThrowable_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.util.Throwables_appendCurrentThreadStackTraceToThrowable_Test
+[INFO] Running org.assertj.core.util.Lists_newArrayList_withIterator_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Lists_newArrayList_withIterator_Test
+[INFO] Running org.assertj.core.util.IterableUtil_sizeOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.util.IterableUtil_sizeOf_Test
+[INFO] Running org.assertj.core.util.URLs_contentOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.URLs_contentOf_Test
+[INFO] Running org.assertj.core.util.Arrays_asObjectArray_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.util.Arrays_asObjectArray_Test
+[INFO] Running org.assertj.core.util.ArrayWrapperList_get_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.ArrayWrapperList_get_Test
+[INFO] Running org.assertj.core.util.Throwables_removeAssertJElementFromStackTrace_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Throwables_removeAssertJElementFromStackTrace_Test
+[INFO] Running org.assertj.core.util.DateUtil_format_with_date_time_with_ms_format_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_format_with_date_time_with_ms_format_Test
+[INFO] Running org.assertj.core.util.DateUtil_dayOfMonthOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_dayOfMonthOf_Test
+[INFO] Running org.assertj.core.util.Arrays_hasOnlyNullElements_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Arrays_hasOnlyNullElements_Test
+[INFO] Running org.assertj.core.util.DateUtil_parse_date_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_parse_date_Test
+[INFO] Running org.assertj.core.util.Throwables_getStackTrace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.679 s - in org.assertj.core.util.Throwables_getStackTrace_Test
+[INFO] Running org.assertj.core.util.Files_temporaryFolderPath_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.Files_temporaryFolderPath_Test
+[INFO] Running org.assertj.core.util.FloatComparatorTest
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.util.FloatComparatorTest
+[INFO] Running org.assertj.core.util.Sets_newLinkedHashSet_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Sets_newLinkedHashSet_Test
+[INFO] Running org.assertj.core.util.Preconditions_checkNotNullOrEmpty_GenericArray_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Preconditions_checkNotNullOrEmpty_GenericArray_Test
+[INFO] Running org.assertj.core.util.Files_newTemporaryFile_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.util.Files_newTemporaryFile_Test
+[INFO] Running org.assertj.core.util.IterableUtil_toArray_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.IterableUtil_toArray_Test
+[INFO] Running org.assertj.core.util.Objects_namesOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.util.Objects_namesOf_Test
+[INFO] Running org.assertj.core.util.Files_delete_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.util.Files_delete_Test
+[INFO] Running org.assertj.core.util.NearlyEqualsTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in org.assertj.core.util.NearlyEqualsTest
+[INFO] Running org.assertj.core.util.Arrays_nonNullElementsIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Arrays_nonNullElementsIn_Test
+[INFO] Running org.assertj.core.util.DateUtil_parse_date_time_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.DateUtil_parse_date_time_Test
+[INFO] Running org.assertj.core.util.Lists_newArrayList_withIterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.util.Lists_newArrayList_withIterable_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsStrictlyBetween_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertNotEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertNotEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertEqual_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotCloseTo_Test
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsCloseTo_Test
+[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertGreaterThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bigintegers.BigIntegers_assertIsPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigintegers.BigIntegers_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doubles.Doubles_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotCloseTo_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.doubles.Doubles_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_NaN_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_NaN_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.doubles.Doubles_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.doubles.Doubles_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsZero_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.doubles.Doubles_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNaN_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_assertIsNaN_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsCloseToPercentage_Test
+[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.assertj.core.internal.doubles.Doubles_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doubles.Doubles_assertEqual_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.internal.doubles.Doubles_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsStrictlyBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.doubles.Doubles_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNegative_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.doubles.Doubles_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doubles.Doubles_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.doubles.Doubles_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsNotNaN_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doubles.Doubles_assertIsNotNaN_Test
+[INFO] Running org.assertj.core.internal.doubles.Doubles_assertIsPositive_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doubles.Doubles_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_key_and_condition_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_key_and_condition_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContains_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.maps.Maps_assertContains_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertDoesNotContainKeys_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.maps.Maps_assertDoesNotContainKeys_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsAnyOf_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.maps.Maps_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertNoneSatisfy_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.maps.Maps_assertNoneSatisfy_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasEntrySatisfyingCondition_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.maps.Maps_assertHasEntrySatisfyingCondition_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasEntrySatisfyingConsumer_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.maps.Maps_assertHasEntrySatisfyingConsumer_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertDoesNotContainKey_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertDoesNotContainKey_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasKeySatisfying_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.maps.Maps_assertHasKeySatisfying_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsExactly_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.maps.Maps_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Map_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSameSizeAs_with_Map_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_key_and_value_conditions_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsKeys_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.maps.Maps_assertContainsKeys_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertDoesNotContainValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.maps.Maps_assertDoesNotContainValue_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertContainsValue_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsOnlyKeys_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.maps.Maps_assertContainsOnlyKeys_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasValueSatisfying_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasValueSatisfying_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.maps.Maps_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsKey_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.maps.Maps_assertContainsKey_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertDoesNotContain_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.maps.Maps_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsOnly_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.maps.Maps_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertAllSatisfyingConsumer_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.maps.Maps_assertAllSatisfyingConsumer_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertAnySatisfyingConsumer_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s - in org.assertj.core.internal.maps.Maps_assertAnySatisfyingConsumer_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_entry_condition_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.maps.Maps_assertHasEntrySatisfying_with_entry_condition_Test
+[INFO] Running org.assertj.core.internal.maps.Maps_assertContainsValues_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.maps.Maps_assertContainsValues_Test
+[INFO] Running org.assertj.core.internal.failures.Failures_failure_with_ErrorMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.internal.failures.Failures_failure_with_ErrorMessage_Test
+[INFO] Running org.assertj.core.internal.failures.Failures_failure_with_AssertionErrorFactory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.failures.Failures_failure_with_AssertionErrorFactory_Test
+[INFO] Running org.assertj.core.internal.TypeComparators_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.TypeComparators_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_iterableContains_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_iterableContains_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.139 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsExactly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.doublearrays.DoubleArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.doublearrays.DoubleArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_isGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_isGreaterThan_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotBlank_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.strings.Strings_assertNotBlank_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsPattern_Pattern_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.strings.Strings_assertContainsPattern_Pattern_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotEqualsIgnoringCase_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.strings.Strings_assertNotEqualsIgnoringCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertStartsWith_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.strings.Strings_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSizeBetween_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEqualsIgnoringCase_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.strings.Strings_assertEqualsIgnoringCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsXmlEqualCase_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.assertj.core.internal.strings.Strings_assertIsXmlEqualCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_CharSequence_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_CharSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsSubsequence_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertContainsSubsequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsValidBase64_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertIsValidBase64_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotContainOnlyWhitespaces_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.strings.Strings_assertDoesNotContainOnlyWhitespaces_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotContainAnyWhitespaces_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.strings.Strings_assertDoesNotContainAnyWhitespaces_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.strings.Strings_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEqualsIgnoringWhitespace_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.strings.Strings_assertEqualsIgnoringWhitespace_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.strings.Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotContainPattern_CharSequence_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.strings.Strings_assertDoesNotContainPattern_CharSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContains_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.strings.Strings_assertContains_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertBlank_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.strings.Strings_assertBlank_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotMatch_CharSequence_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.strings.Strings_assertDoesNotMatch_CharSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNullOrEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotEndWith_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.strings.Strings_assertDoesNotEndWith_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.strings.Strings_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertJavaBlank_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in org.assertj.core.internal.strings.Strings_assertJavaBlank_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsLowerCase_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertIsLowerCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotEqualsNormalizingWhitespace_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.strings.Strings_assertNotEqualsNormalizingWhitespace_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsEqualToIgnoringNewLines_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.strings.Strings_assertIsEqualToIgnoringNewLines_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsOnlyWhitespaces_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.strings.Strings_assertContainsOnlyWhitespaces_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsOnlyDigits_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertContainsOnlyDigits_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsUpperCase_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertIsUpperCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotJavaBlank_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.strings.Strings_assertNotJavaBlank_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsIgnoringCase_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.strings.Strings_assertContainsIgnoringCase_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsSubstringOf_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.strings.Strings_assertIsSubstringOf_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertMatches_Pattern_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.strings.Strings_assertMatches_Pattern_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsWhitespaces_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.strings.Strings_assertContainsWhitespaces_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsPattern_CharSequence_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.strings.Strings_assertContainsPattern_CharSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotContainPattern_Pattern_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.strings.Strings_assertDoesNotContainPattern_Pattern_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotEqualsIgnoringWhitespace_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s - in org.assertj.core.internal.strings.Strings_assertNotEqualsIgnoringWhitespace_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsOnlyOnce_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.strings.Strings_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEndsWith_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.strings.Strings_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertMatches_CharSequence_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.strings.Strings_assertMatches_CharSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSizeLessThan_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.strings.Strings_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.strings.Strings_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSize_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.strings.Strings_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotStartWith_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.strings.Strings_assertDoesNotStartWith_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertNotEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertEqualsNormalizingWhitespace_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.strings.Strings_assertEqualsNormalizingWhitespace_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertContainsSequence_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.strings.Strings_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertIsEqualToNormalizingNewlines_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.strings.Strings_assertIsEqualToNormalizingNewlines_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertDoesNotMatch_Pattern_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.strings.Strings_assertDoesNotMatch_Pattern_Test
+[INFO] Running org.assertj.core.internal.strings.Strings_assertHasLinesCount_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.strings.Strings_assertHasLinesCount_Test
+[INFO] Running org.assertj.core.internal.RecursiveFieldByFieldComparator_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.RecursiveFieldByFieldComparator_toString_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInTheFuture_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.dates.Dates_assertIsInTheFuture_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsBefore_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.dates.Dates_assertIsBefore_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameSecondWindowAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.dates.Dates_assertIsInSameSecondWindowAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasMonth_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.dates.Dates_assertHasMonth_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsBetween_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.assertj.core.internal.dates.Dates_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsNotBetween_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.assertj.core.internal.dates.Dates_assertIsNotBetween_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasYear_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertHasYear_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameMinuteAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertIsInSameMinuteAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasHourOfDay_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.dates.Dates_assertHasHourOfDay_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasSecond_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.dates.Dates_assertHasSecond_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsEqualWithPrecision_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.dates.Dates_assertIsEqualWithPrecision_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameSecondAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.dates.Dates_assertIsInSameSecondAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsBeforeYear_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.dates.Dates_assertIsBeforeYear_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsBeforeOrEqualTo_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.dates.Dates_assertIsBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasMillisecond_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertHasMillisecond_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameMinuteWindowAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.dates.Dates_assertIsInSameMinuteWindowAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsCloseTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.dates.Dates_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasTime_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.dates.Dates_assertHasTime_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameHourWindowAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.dates.Dates_assertIsInSameHourWindowAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsToday_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertIsToday_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameMonthAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertIsInSameMonthAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasDayOfMonth_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.dates.Dates_assertHasDayOfMonth_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasMinute_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.dates.Dates_assertHasMinute_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameYearAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertIsInSameYearAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsAfter_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.dates.Dates_assertIsAfter_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameHourAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.dates.Dates_assertIsInSameHourAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsAfterOrEqualTo_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.dates.Dates_assertIsAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInSameDayAs_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.dates.Dates_assertIsInSameDayAs_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsAfterYear_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.dates.Dates_assertIsAfterYear_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertIsInThePast_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.dates.Dates_assertIsInThePast_Test
+[INFO] Running org.assertj.core.internal.dates.Dates_assertHasDayOfWeek_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.dates.Dates_assertHasDayOfWeek_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.047 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsSequence_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveNot_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveNot_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasOnlyElementsOfType_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasOnlyElementsOfType_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainSubsequence_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainSubsequence_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSorted_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertEndsWith_Test
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveAtMost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveAtMost_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHave_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHave_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSubsetOf_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSubsetOf_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsAll_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsAll_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainSequence_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainSequence_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasOnlyElementsOfTypes_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasOnlyElementsOfTypes_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertStartsWith_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertAreAtLeast_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertAreAtLeast_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertEndsWithFirstAndRest_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertEndsWithFirstAndRest_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnlyNulls_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsOnlyNulls_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainAnyElementsOf_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainAnyElementsOf_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasAtLeastOneElementOfType_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasAtLeastOneElementOfType_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertAre_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertAre_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveAtLeast_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveAtLeast_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertAreAtMost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertAreAtMost_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainNull_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContainNull_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoNotHave_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoNotHave_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertAreExactly_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertAreExactly_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContains_at_Index_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContain_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotHaveAnyElementsOfTypes_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertDoesNotHaveAnyElementsOfTypes_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsNull_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsNull_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsSubsequence_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertContainsSubsequence_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveExactly_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertHaveExactly_Test
+[INFO] Running org.assertj.core.internal.objectarrays.ObjectArrays_assertAreNot_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objectarrays.ObjectArrays_assertAreNot_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_duplicatesFrom_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.StandardComparisonStrategy_duplicatesFrom_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_areEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_areEqual_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.shortarrays.ShortArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_iterableContains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_iterableContains_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContains_at_Index_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotContain_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsExactly_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertStartsWith_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertIsSorted_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertEndsWith_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsOnly_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsSequence_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.booleanarrays.BooleanArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleanarrays.BooleanArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsStrictlyBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytes.Bytes_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNotCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.assertj.core.internal.bytes.Bytes_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bytes.Bytes_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in org.assertj.core.internal.bytes.Bytes_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytes.Bytes_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytes.Bytes_assertEqual_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytes.Bytes_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsZero_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytes.Bytes_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bytes.Bytes_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNotNegative_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytes.Bytes_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNotZero_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytes.Bytes_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.bytes.Bytes_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNotPositive_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bytes.Bytes_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytes.Bytes_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bytes.Bytes_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsOne_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytes.Bytes_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytes.Bytes_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsNegative_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytes.Bytes_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.bytes.Bytes_assertIsPositive_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytes.Bytes_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.Digests_digestDiff_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.062 s - in org.assertj.core.internal.Digests_digestDiff_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.lists.Lists_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_satisfies_at_index_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.lists.Lists_satisfies_at_index_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_assertHas_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.lists.Lists_assertHas_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_assertDoesNotContain_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.lists.Lists_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.lists.Lists_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.lists.List_assertIs_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.lists.List_assertIs_Test
+[INFO] Running org.assertj.core.internal.lists.Lists_assertContains_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.lists.Lists_assertContains_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floatarrays.FloatArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsNotInterface_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertIsNotInterface_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasNoSuperclass_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.classes.Classes_assertHasNoSuperclass_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsPublic_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertIsPublic_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsAnnotation_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertIsAnnotation_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertContainsAnnotation_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.classes.Classes_assertContainsAnnotation_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasMethods_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.classes.Classes_assertHasMethods_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasSuperclass_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.classes.Classes_assertHasSuperclass_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsFinal_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsFinal_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsNotFinal_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertIsNotFinal_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsAssignableFrom_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertIsAssignableFrom_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasOnlyPublicFields_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.classes.Classes_assertHasOnlyPublicFields_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsPackagePrivate_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsPackagePrivate_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsAbstract_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsAbstract_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasOnlyDeclaredFields_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.classes.Classes_assertHasOnlyDeclaredFields_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsInterface_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsInterface_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasDeclaredMethods_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertHasDeclaredMethods_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasPublicFields_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.classes.Classes_assertHasPublicFields_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasPublicMethods_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertHasPublicMethods_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsProtected_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsProtected_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertIsNotAnnotation_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.classes.Classes_assertIsNotAnnotation_Test
+[INFO] Running org.assertj.core.internal.classes.Classes_assertHasDeclaredFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.classes.Classes_assertHasDeclaredFields_Test
+[INFO] Running org.assertj.core.internal.spliterator.Spliterators_assertHasOnlyCharacteristics_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.spliterator.Spliterators_assertHasOnlyCharacteristics_Test
+[INFO] Running org.assertj.core.internal.spliterator.Spliterators_assertHasCharacteristics_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.spliterator.Spliterators_assertHasCharacteristics_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.floats.Floats_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotCloseTo_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.floats.Floats_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.floats.Floats_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floats.Floats_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsCloseToPercentage_Test
+[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.floats.Floats_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNegative_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.floats.Floats_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsPositive_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floats.Floats_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsZero_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.floats.Floats_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.floats.Floats_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotNaN_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsNotNaN_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNaN_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertIsNaN_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsStrictlyBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.floats.Floats_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.floats.Floats_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_NaN_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.floats.Floats_NaN_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.floats.Floats_assertEqual_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.floats.Floats_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.floats.Floats_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.floats.Floats_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.floats.Floats_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.integers.Integers_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.integers.Integers_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsStrictlyBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.integers.Integers_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.integers.Integers_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in org.assertj.core.internal.integers.Integers_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.integers.Integers_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.integers.Integers_assertEqual_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.integers.Integers_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.integers.Integers_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.integers.Integers_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNotCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.internal.integers.Integers_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.integers.Integers_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.integers.Integers_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.integers.Integers_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.integers.Integers_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.integers.Integers_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsPositive_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.integers.Integers_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsNegative_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.integers.Integers_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.integers.Integers_assertIsCloseTo_Test
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.internal.integers.Integers_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.intarrays.IntArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsExactly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.intarrays.IntArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.intarrays.IntArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.intarrays.IntArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.intarrays.IntArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in org.assertj.core.internal.intarrays.IntArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.intarrays.IntArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.intarrays.IntArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.intarrays.IntArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.intarrays.IntArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_isGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s - in org.assertj.core.internal.StandardComparisonStrategy_isGreaterThan_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_toString_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_toString_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAnyMatch_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.iterables.Iterables_assertAnyMatch_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContains_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.iterables.Iterables_assertContains_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAreExactly_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.iterables.Iterables_assertAreExactly_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSize_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasOnlyOneElementSatisfying_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertHasOnlyOneElementSatisfying_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.iterables.Iterables_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAreNot_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertAreNot_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotHaveDuplicates_Test
+Time elapsed in ms for assertDoesNotHaveDuplicates : 155
+Time elapsed in ms for assertDoesNotHaveDuplicates with custom comparison strategy : 211
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.545 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAre_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertAre_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertStartsWith_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.iterables.Iterables_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAreAtLeast_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertAreAtLeast_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertNoneSatisfy_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.iterables.Iterables_assertNoneSatisfy_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.iterables.Iterables_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertNullOrEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.iterables.Iterables_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsAnyOf_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsAll_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertContainsAll_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsSubsequence_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.iterables.Iterables_assertContainsSubsequence_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertNoneMatch_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertNoneMatch_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotContain_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHave_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertHave_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotContainAnyElementsOf_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotContainAnyElementsOf_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsExactly_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.iterables.Iterables_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertNotEmpty_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertIsSubsetOf_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.iterables.Iterables_assertIsSubsetOf_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAllMatch_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertAllMatch_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAllSatisfy_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertAllSatisfy_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.iterables.Iterables_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHaveAtLeast_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertHaveAtLeast_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAreAtMost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertAreAtMost_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotContainSequence_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotContainSequence_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertAnySatisfy_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.internal.iterables.Iterables_assertAnySatisfy_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoNotHave_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertDoNotHave_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotContainNull_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotContainNull_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsNull_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.iterables.Iterables_assertContainsNull_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsOnlyNulls_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.iterables.Iterables_assertContainsOnlyNulls_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertEndsWith_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.iterables.Iterables_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHaveExactly_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.iterables.Iterables_assertHaveExactly_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertZipSatisfy_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.iterables.Iterables_assertZipSatisfy_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertDoesNotContainSubsequence_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.iterables.Iterables_assertDoesNotContainSubsequence_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHaveAtMost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.iterables.Iterables_assertHaveAtMost_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertEndsWithFirstAndRest_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.iterables.Iterables_assertEndsWithFirstAndRest_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.iterables.Iterables_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.iterables.Iterables_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.iterables.Iterables_assertContainsSequence_Test
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.iterables.Iterables_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.ExtendedByTypesComparator_compareTo_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.ExtendedByTypesComparator_compareTo_Test
+[INFO] Running org.assertj.core.internal.booleans.Booleans_assertEqual_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleans.Booleans_assertEqual_Test
+[INFO] Running org.assertj.core.internal.booleans.Booleans_assertNotEqual_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.booleans.Booleans_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsExecutable_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.134 s - in org.assertj.core.internal.paths.Paths_assertIsExecutable_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertNotExists_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertNotExists_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsDirectoryNotContaining_Predicate_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s - in org.assertj.core.internal.paths.Paths_assertIsDirectoryNotContaining_Predicate_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsNormalized_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertIsNormalized_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasNoParent_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertHasNoParent_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasDigest_AlgorithmString_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s - in org.assertj.core.internal.paths.Paths_assertHasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasParent_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.paths.Paths_assertHasParent_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasSameBinaryContentAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s - in org.assertj.core.internal.paths.Paths_assertHasSameBinaryContentAs_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsCanonical_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertIsCanonical_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsDirectory_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertIsDirectory_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsSymbolicLink_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.paths.Paths_assertIsSymbolicLink_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertExistsNoFollowLinks_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertExistsNoFollowLinks_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.paths.Paths_assertHasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsRelative_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertIsRelative_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsNotEmptyDirectory_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.paths.Paths_assertIsNotEmptyDirectory_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s - in org.assertj.core.internal.paths.Paths_assertIsDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertStartsWithRaw_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.paths.Paths_assertStartsWithRaw_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasNoParentRaw_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.paths.Paths_assertHasNoParentRaw_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasBinaryContent_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.paths.Paths_assertHasBinaryContent_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasDigest_DigestBytes_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.paths.Paths_assertHasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasSameContentAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s - in org.assertj.core.internal.paths.Paths_assertHasSameContentAs_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertStartsWith_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.paths.Paths_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsReadable_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertIsReadable_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertEndsWithRaw_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertEndsWithRaw_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertEndsWith_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasDigest_DigestString_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.paths.Paths_assertHasDigest_DigestString_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasFileName_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.096 s - in org.assertj.core.internal.paths.Paths_assertHasFileName_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s - in org.assertj.core.internal.paths.Paths_assertIsDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsWritable_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertIsWritable_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasContent_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.paths.Paths_assertHasContent_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsDirectoryContaining_Predicate_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in org.assertj.core.internal.paths.Paths_assertIsDirectoryContaining_Predicate_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertExists_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.paths.Paths_assertExists_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertHasParentRaw_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.paths.Paths_assertHasParentRaw_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsAbsolute_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertIsAbsolute_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsRegularFile_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.paths.Paths_assertIsRegularFile_Test
+[INFO] Running org.assertj.core.internal.paths.Paths_assertIsEmptyDirectory_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.paths.Paths_assertIsEmptyDirectory_Test
+[INFO] Running org.assertj.core.internal.Arrays_containsAnyOf_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.Arrays_containsAnyOf_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_stringEndsWith_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_stringEndsWith_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertSame_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objects.Objects_assertSame_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsIn_with_array_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertIsIn_with_array_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsInstanceOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objects.Objects_assertIsInstanceOf_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotOfClassIn_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertIsNotOfClassIn_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsOfClassIn_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertIsOfClassIn_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsEqualToIgnoringGivenFields_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.assertj.core.internal.objects.Objects_assertIsEqualToIgnoringGivenFields_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertHasToString_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.objects.Objects_assertHasToString_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertHasSameClassAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertHasSameClassAs_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotInstanceOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertIsNotInstanceOf_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertDoesNotHaveNotSameClassAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertDoesNotHaveNotSameClassAs_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertNotEqual_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertNotNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objects.Objects_assertNotNull_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotIn_with_array_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objects.Objects_assertIsNotIn_with_array_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertHasAllNullFieldsOrPropertiesExcept_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.objects.Objects_assertHasAllNullFieldsOrPropertiesExcept_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertEqual_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.objects.Objects_assertEqual_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotExactlyInstanceOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertIsNotExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotInstanceOfAny_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertIsNotInstanceOfAny_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsIn_with_Iterable_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.objects.Objects_assertIsIn_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsEqualToComparingOnlyGivenFields_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.objects.Objects_assertIsEqualToComparingOnlyGivenFields_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertNotSame_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertNotSame_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsNotIn_with_Iterable_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertIsNotIn_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertHasSameHashCodeAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.objects.Objects_assertHasSameHashCodeAs_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsExactlyInstanceOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.objects.Objects_assertIsExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objects.Objects_assertNull_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertNotNull_with_label_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.objects.Objects_assertNotNull_with_label_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsEqualToComparingFieldByFieldRecursive_Test
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.115 s - in org.assertj.core.internal.objects.Objects_assertIsEqualToComparingFieldByFieldRecursive_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsInstanceOfAny_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.objects.Objects_assertIsInstanceOfAny_Test
+[INFO] Running org.assertj.core.internal.objects.Objects_assertIsEqualToIgnoringNullFields_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.assertj.core.internal.objects.Objects_assertIsEqualToIgnoringNullFields_Test
+[INFO] Running org.assertj.core.internal.IgnoringFieldsComparator_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.IgnoringFieldsComparator_toString_Test
+[INFO] Running org.assertj.core.internal.OnFieldsComparator_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.OnFieldsComparator_toString_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_iterableRemove_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_iterableRemove_Test
+[INFO] Running org.assertj.core.internal.FieldByFieldComparator_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.FieldByFieldComparator_toString_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringContains_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactly_with_Integer_Arguments_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactly_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnlyOnce_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnly_with_Integer_Arguments_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnly_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsSequence_with_Integer_Arguments_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsSequence_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsExactlyInAnyOrder_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotContain_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContains_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContains_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertStartsWith_with_Integer_Arguments_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertStartsWith_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContains_with_Integer_Arguments_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContains_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertEndsWith_with_Integer_Arguments_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertEndsWith_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bytearrays.ByteArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_isGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_isGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.OffsetDateTimeByInstantComparatorTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.OffsetDateTimeByInstantComparatorTest
+[INFO] Running org.assertj.core.internal.ExtendedByTypesComparator_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ExtendedByTypesComparator_toString_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_iterableRemove_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.StandardComparisonStrategy_iterableRemove_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_isLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_isLessThan_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_stringContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_stringContains_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_areEqual_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.StandardComparisonStrategy_areEqual_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_arrayContains_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_arrayContains_Test
+[INFO] Running org.assertj.core.internal.IterableDiff_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.IterableDiff_Test
+[INFO] Running org.assertj.core.internal.IgnoringFieldsComparator_compareTo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.IgnoringFieldsComparator_compareTo_Test
+[INFO] Running org.assertj.core.internal.OnFieldsComparator_creation_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.OnFieldsComparator_creation_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_DigestBytes_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_AlgorithmString_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertSameContentAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.inputstreams.InputStreams_assertSameContentAs_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_DigestString_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_DigestString_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.inputstreams.InputStreams_assertHasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.internal.inputstreams.InputStreams_assertHasContent_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.inputstreams.InputStreams_assertHasContent_Test
+[INFO] Running org.assertj.core.internal.inputstreams.BinaryDiff_diff_InputStream_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.inputstreams.BinaryDiff_diff_InputStream_Test
+[INFO] Running org.assertj.core.internal.inputstreams.Diff_diff_InputStream_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.inputstreams.Diff_diff_InputStream_Test
+[INFO] Running org.assertj.core.internal.inputstreams.Diff_diff_InputStream_String_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.inputstreams.Diff_diff_InputStream_String_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringEndsWith_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringEndsWith_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertEqual_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.shorts.Shorts_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNotCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s - in org.assertj.core.internal.shorts.Shorts_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsCloseTo_Test
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s - in org.assertj.core.internal.shorts.Shorts_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.shorts.Shorts_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsPositive_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shorts.Shorts_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.shorts.Shorts_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsStrictlyBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.shorts.Shorts_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNegative_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.shorts.Shorts_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.shorts.Shorts_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.shorts.Shorts_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.shorts.Shorts_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.shorts.Shorts_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.shorts.Shorts_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.shorts.Shorts_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasUserInfo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.urls.Urls_assertHasUserInfo_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasPath_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.urls.Uris_assertHasPath_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasQuery_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.urls.Uris_assertHasQuery_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasAuthority_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.urls.Urls_assertHasAuthority_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasHost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Urls_assertHasHost_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasScheme_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Uris_assertHasScheme_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasNoParameter_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.internal.urls.Uris_assertHasNoParameter_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasHost_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Uris_assertHasHost_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasPath_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.urls.Urls_assertHasPath_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasParameter_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.urls.Urls_assertHasParameter_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasFragment_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.urls.Uris_assertHasFragment_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasUserInfo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.urls.Uris_assertHasUserInfo_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasParameter_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s - in org.assertj.core.internal.urls.Uris_assertHasParameter_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasPort_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Uris_assertHasPort_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_assertHasAuthority_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.urls.Uris_assertHasAuthority_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasPort_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.urls.Urls_assertHasPort_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasProtocol_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Urls_assertHasProtocol_Test
+[INFO] Running org.assertj.core.internal.urls.Uris_getParameters_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.urls.Uris_getParameters_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasAnchor_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.urls.Urls_assertHasAnchor_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasNoParameter_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.urls.Urls_assertHasNoParameter_Test
+[INFO] Running org.assertj.core.internal.urls.Urls_assertHasQuery_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.urls.Urls_assertHasQuery_Test
+[INFO] Running org.assertj.core.internal.ChronoZonedDateTimeByInstantComparatorTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.ChronoZonedDateTimeByInstantComparatorTest
+[INFO] Running org.assertj.core.internal.conditions.Conditions_assertHas_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.conditions.Conditions_assertHas_Test
+[INFO] Running org.assertj.core.internal.conditions.Conditions_assertDoesNotHave_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.conditions.Conditions_assertDoesNotHave_Test
+[INFO] Running org.assertj.core.internal.conditions.Conditions_assertIs_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.conditions.Conditions_assertIs_Test
+[INFO] Running org.assertj.core.internal.conditions.Conditions_assertIsNot_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.conditions.Conditions_assertIsNot_Test
+[INFO] Running org.assertj.core.internal.conditions.Conditions_assertIsNotNull_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.conditions.Conditions_assertIsNotNull_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsNotEmptyFile_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.058 s - in org.assertj.core.internal.files.Files_assertIsNotEmptyFile_Test
+[INFO] Running org.assertj.core.internal.files.BinaryDiff_diff_File_byteArray_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.files.BinaryDiff_diff_File_byteArray_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsDirectoryContaining_Predicate_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s - in org.assertj.core.internal.files.Files_assertIsDirectoryContaining_Predicate_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s - in org.assertj.core.internal.files.Files_assertIsDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertSameContentAs_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.files.Files_assertSameContentAs_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsRelative_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertIsRelative_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasDigest_DigestString_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.files.Files_assertHasDigest_DigestString_Test
+[INFO] Running org.assertj.core.internal.files.Diff_diff_File_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.files.Diff_diff_File_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasBinaryContent_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.files.Files_assertHasBinaryContent_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasParent_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.files.Files_assertHasParent_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertCanWrite_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertCanWrite_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsEmptyFile_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.files.Files_assertIsEmptyFile_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasExtension_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.files.Files_assertHasExtension_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasName_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.files.Files_assertHasName_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s - in org.assertj.core.internal.files.Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsAbsolute_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertIsAbsolute_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsDirectory_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertIsDirectory_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsFile_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.files.Files_assertIsFile_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsDirectoryNotContaining_Predicate_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.assertj.core.internal.files.Files_assertIsDirectoryNotContaining_Predicate_Test
+[INFO] Running org.assertj.core.internal.files.File_assertHasSize_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.files.File_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.files.Files_assertHasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasDigest_DigestBytes_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.files.Files_assertHasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasSameBinaryContentAs_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in org.assertj.core.internal.files.Files_assertHasSameBinaryContentAs_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasContent_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.files.Files_assertHasContent_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertCanRead_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertCanRead_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsEmptyDirectory_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.files.Files_assertIsEmptyDirectory_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasNoParent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertHasNoParent_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertExists_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertExists_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertDoesNotExist_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.files.Files_assertDoesNotExist_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertIsNotEmptyDirectory_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.files.Files_assertIsNotEmptyDirectory_Test
+[INFO] Running org.assertj.core.internal.files.Files_assertHasDigest_AlgorithmString_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.internal.files.Files_assertHasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.internal.files.Diff_diff_File_String_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.files.Diff_diff_File_String_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_isLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_isLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.TypeComparators_hasComparator_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.TypeComparators_hasComparator_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_isLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_isLessThan_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_stringStartsWith_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_stringStartsWith_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.longarrays.LongArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.longarrays.LongArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longarrays.LongArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.longarrays.LongArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.longarrays.LongArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.longarrays.LongArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longarrays.LongArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.longarrays.LongArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.longarrays.LongArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.longarrays.LongArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNegative_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.longs.Longs_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsPositive_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in org.assertj.core.internal.longs.Longs_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longs.Longs_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsCloseTo_Test
+[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.assertj.core.internal.longs.Longs_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.longs.Longs_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.longs.Longs_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.internal.longs.Longs_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertIsNotCloseTo_Test
+[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in org.assertj.core.internal.longs.Longs_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.longs.Longs_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.longs.Longs_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.longs.Longs_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.longs.Longs_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.longs.Longs_assertEqual_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_isLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.StandardComparisonStrategy_isLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.Digests_toHex_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.Digests_toHex_Test
+[INFO] Running org.assertj.core.internal.FieldByFieldComparator_compareTo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.FieldByFieldComparator_compareTo_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsAnyOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsAnyOf_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsSequence_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsSequence_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertNotEmpty_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSizeGreaterThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsOnlyOnce_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsOnlyOnce_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertEndsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.chararrays.CharArrays_assertEndsWith_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertIsSorted_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.chararrays.CharArrays_assertIsSorted_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.chararrays.CharArrays_assertDoesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsOnly_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsOnly_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsExactly_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsExactly_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContains_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.chararrays.CharArrays_assertContains_at_Index_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSize_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSize_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertDoesNotContain_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.chararrays.CharArrays_assertDoesNotContain_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertNullOrEmpty_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertDoesNotContain_at_Index_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertDoesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertIsSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContains_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.assertj.core.internal.chararrays.CharArrays_assertContainsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertStartsWith_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.chararrays.CharArrays_assertStartsWith_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSizeLessThan_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSizeLessThan_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.chararrays.CharArrays_assertEmpty_Test
+[INFO] Running org.assertj.core.internal.chararrays.CharArrays_assertHasSizeBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.chararrays.CharArrays_assertHasSizeBetween_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertLowerCase_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.characters.Characters_assertLowerCase_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.characters.Characters_assertEqual_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.characters.Characters_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.characters.Characters_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.characters.Characters_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.characters.Characters_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.characters.Characters_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.characters.Characters_assertUpperCase_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.characters.Characters_assertUpperCase_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertEqual_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertLessThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsBetween_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsBetween_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotCloseToPercentage_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertGreaterThan_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotZero_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsCloseTo_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsCloseTo_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotCloseTo_Test
+[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotCloseTo_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertNotEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertNotEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsOne_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsOne_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsZero_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsZero_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsPositive_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotPositive_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotPositive_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsStrictlyBetween_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertNotEqual_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertNotEqual_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNegative_Test
+[INFO] Running org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotNegative_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.bigdecimals.BigDecimals_assertIsNotNegative_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_arrayContains_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.StandardComparisonStrategy_arrayContains_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringStartsWith_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_stringStartsWith_Test
+[INFO] Running org.assertj.core.internal.ComparatorBasedComparisonStrategy_duplicatesFrom_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.ComparatorBasedComparisonStrategy_duplicatesFrom_Test
+[INFO] Running org.assertj.core.internal.RecursiveFieldByFieldComparator_compareTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.RecursiveFieldByFieldComparator_compareTo_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasNoCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.throwables.Throwables_assertHasNoCause_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageContaining_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageContaining_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasSuppressedException_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.throwables.Throwables_assertHasSuppressedException_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasNoSuppressedExceptions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.throwables.Throwables_assertHasNoSuppressedExceptions_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasCauseExactlyInstanceOf_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.throwables.Throwables_assertHasCauseExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageNotContaining_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageNotContaining_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageNotContainingAny_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageNotContainingAny_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageStartingWith_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageStartingWith_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasRootCauseMessage_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.throwables.Throwables_assertHasRootCauseMessage_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasRootCause_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.internal.throwables.Throwables_assertHasRootCause_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessage_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessage_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasCauseReference_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.internal.throwables.Throwables_assertHasCauseReference_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageMatching_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageMatching_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasCauseInstanceOf_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.throwables.Throwables_assertHasCauseInstanceOf_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasRootCauseExactlyInstanceOf_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.throwables.Throwables_assertHasRootCauseExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageEnding_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageEnding_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasStackTraceContaining_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.throwables.Throwables_assertHasStackTraceContaining_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasRootCauseInstanceOf_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.throwables.Throwables_assertHasRootCauseInstanceOf_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageContainingAll_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageContainingAll_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasCause_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.internal.throwables.Throwables_assertHasCause_Test
+[INFO] Running org.assertj.core.internal.throwables.Throwables_assertHasMessageFindingMatch_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.throwables.Throwables_assertHasMessageFindingMatch_Test
+[INFO] Running org.assertj.core.internal.Digests_fromHex_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.internal.Digests_fromHex_Test
+[INFO] Running org.assertj.core.internal.StandardComparisonStrategy_isGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.StandardComparisonStrategy_isGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.ChronoLocalDateTimeComparatorTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.internal.ChronoLocalDateTimeComparatorTest
+[INFO] Running org.assertj.core.internal.DeepDifference_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.339 s - in org.assertj.core.internal.DeepDifference_Test
+[INFO] Running org.assertj.core.internal.Arrays_assertContains_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.internal.Arrays_assertContains_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertLessThanOrEqualTo_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.comparables.Comparables_assertLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.comparables.Comparables_assertEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertGreaterThanOrEqualTo_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.comparables.Comparables_assertGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_isBetween_Test
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.internal.comparables.Comparables_isBetween_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertNotEqualByComparison_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.internal.comparables.Comparables_assertNotEqualByComparison_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertLessThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.comparables.Comparables_assertLessThan_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_isStrictlyBetween_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.internal.comparables.Comparables_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.internal.comparables.Comparables_assertGreaterThan_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.comparables.Comparables_assertGreaterThan_Test
+[INFO] Running org.assertj.core.internal.OnFieldsComparator_compare_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.internal.OnFieldsComparator_compare_Test
+[INFO] Running org.assertj.core.navigation.ClassBasedNavigableIterable_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.navigation.ClassBasedNavigableIterable_Test
+[INFO] Running org.assertj.core.navigation.ClassBasedNavigableList_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.navigation.ClassBasedNavigableList_Test
+[INFO] Running org.assertj.core.navigation.FactoryBasedNavigableIterableAssert_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.navigation.FactoryBasedNavigableIterableAssert_Test
+[INFO] Running org.assertj.core.navigation.ClassBasedNavigableList_withDefault_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.navigation.ClassBasedNavigableList_withDefault_Test
+[INFO] Running org.assertj.core.navigation.ClassBasedNavigableList_withString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.navigation.ClassBasedNavigableList_withString_Test
+[INFO] Running org.assertj.core.navigation.FactoryBasedNavigableList_withString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.navigation.FactoryBasedNavigableList_withString_Test
+[INFO] Running org.assertj.core.navigation.FactoryBasedNavigableListAssert_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.navigation.FactoryBasedNavigableListAssert_Test
+[INFO] Running org.assertj.core.extractor.ToStringExtractorTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.extractor.ToStringExtractorTest
+[INFO] Running org.assertj.core.extractor.ByNameMultipleExtractorTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.extractor.ByNameMultipleExtractorTest
+[INFO] Running org.assertj.core.extractor.ByNameSingleExtractorTest
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.extractor.ByNameSingleExtractorTest
+[INFO] Running org.assertj.core.groups.Properties_ofType_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.groups.Properties_ofType_Test
+[INFO] Running org.assertj.core.groups.FieldsOrPropertiesExtractor_extract_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.groups.FieldsOrPropertiesExtractor_extract_Test
+[INFO] Running org.assertj.core.groups.FieldsOrPropertiesExtractor_assertNotNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.groups.FieldsOrPropertiesExtractor_assertNotNull_Test
+[INFO] Running org.assertj.core.groups.FieldsOrPropertiesExtractor_extract_tuples_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.groups.FieldsOrPropertiesExtractor_extract_tuples_Test
+[INFO] Running org.assertj.core.groups.Properties_from_with_array_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s - in org.assertj.core.groups.Properties_from_with_array_Test
+[INFO] Running org.assertj.core.groups.Properties_extractProperty_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.groups.Properties_extractProperty_Test
+[INFO] Running org.assertj.core.groups.Properties_from_with_Collection_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.groups.Properties_from_with_Collection_Test
+[INFO] Running org.assertj.core.matcher.AssertionMatcher_matches_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.matcher.AssertionMatcher_matches_Test
+[INFO] Running org.assertj.core.condition.AllOf_allOf_with_Collection_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AllOf_allOf_with_Collection_Test
+[INFO] Running org.assertj.core.condition.AllOf_matches_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AllOf_matches_Test
+[INFO] Running org.assertj.core.condition.Join_constructor_with_Collection_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.condition.Join_constructor_with_Collection_Test
+[INFO] Running org.assertj.core.condition.AnyOf_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.condition.AnyOf_toString_Test
+[INFO] Running org.assertj.core.condition.ConditionBuiltWithPredicateTest
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.condition.ConditionBuiltWithPredicateTest
+[INFO] Running org.assertj.core.condition.AllOf_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AllOf_toString_Test
+[INFO] Running org.assertj.core.condition.Not_matches_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.Not_matches_Test
+[INFO] Running org.assertj.core.condition.AnyOf_anyOf_with_Collection_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AnyOf_anyOf_with_Collection_Test
+[INFO] Running org.assertj.core.condition.AllOf_allOf_with_array_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AllOf_allOf_with_array_Test
+[INFO] Running org.assertj.core.condition.Multiple_combined_conditions_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.Multiple_combined_conditions_Test
+[INFO] Running org.assertj.core.condition.DoesNotHave_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.DoesNotHave_toString_Test
+[INFO] Running org.assertj.core.condition.Join_constructor_with_array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.Join_constructor_with_array_Test
+[INFO] Running org.assertj.core.condition.AnyOf_anyOf_with_array_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.condition.AnyOf_anyOf_with_array_Test
+[INFO] Running org.assertj.core.condition.AnyOf_matches_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.AnyOf_matches_Test
+[INFO] Running org.assertj.core.condition.Not_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.Not_toString_Test
+[INFO] Running org.assertj.core.condition.DoesNotHave_matches_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.condition.DoesNotHave_matches_Test
+[INFO] Running org.assertj.core.condition.MatchPredicateTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.condition.MatchPredicateTest
+[INFO] Running org.assertj.core.condition.DoesNotHave_with_condition_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.condition.DoesNotHave_with_condition_Test
+[INFO] Running org.assertj.core.condition.Not_with_condition_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.condition.Not_with_condition_Test
+[INFO] Running org.assertj.core.description.Description_mostRelevantDescription_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.Description_mostRelevantDescription_Test
+[INFO] Running org.assertj.core.description.EmptyTextDescription_emptyText_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.description.EmptyTextDescription_emptyText_Test
+[INFO] Running org.assertj.core.description.TextDescription_value_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.TextDescription_value_Test
+[INFO] Running org.assertj.core.description.TextDescription_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.description.TextDescription_toString_Test
+[INFO] Running org.assertj.core.description.Description_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.Description_toString_Test
+[INFO] Running org.assertj.core.description.JoinDescription_value_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.JoinDescription_value_Test
+[INFO] Running org.assertj.core.description.TextDescription_constructor_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.description.TextDescription_constructor_Test
+[INFO] Running org.assertj.core.description.JoinDescription_constructor_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.JoinDescription_constructor_Test
+[INFO] Running org.assertj.core.description.TextDescription_equals_hashCode_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.description.TextDescription_equals_hashCode_Test
+[INFO] Running org.assertj.core.api.Assertions_tuple_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_tuple_Test
+[INFO] Running org.assertj.core.api.JUnitSoftAssertionsFailureTest
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.403 s <<< FAILURE! - in org.assertj.core.api.JUnitSoftAssertionsFailureTest
+[ERROR] should_report_all_errors  Time elapsed: 0.403 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting:
+ <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to start with:
+ <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+
+	at org.assertj.core.api.JUnitSoftAssertionsFailureTest.should_report_all_errors(JUnitSoftAssertionsFailureTest.java:46)
+
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Float_Test
+[INFO] Running org.assertj.core.api.BDDSoftAssertionsTest
+[ERROR] Tests run: 48, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 3.816 s <<< FAILURE! - in org.assertj.core.api.BDDSoftAssertionsTest
+[ERROR] should_be_able_to_catch_exceptions_thrown_by_all_proxied_methods  Time elapsed: 2.371 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting:
+ <"java.lang.AssertionError: 
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+">
+to contain:
+ <"
+Expecting:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find:
+ <[MapEntry[key="1", value="2"]]>
+"> 
+	at org.assertj.core.api.BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_all_proxied_methods(BDDSoftAssertionsTest.java:346)
+
+[ERROR] should_be_able_to_catch_exceptions_thrown_by_map_assertions  Time elapsed: 0.003 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting throwable message:
+  <"
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+">
+to contain:
+  <"Expecting:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find:
+ <[MapEntry[key="1", value="2"]]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Maps.assertContains(Maps.java:356)
+	at org.assertj.core.api.AbstractMapAssert.contains(AbstractMapAssert.java:516)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains$accessor$uIXUkEB0(Unknown Source)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7$AssertJ$SoftProxies$m0a0ZXYZ.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains(Unknown Source)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains(Unknown Source)
+	at org.assertj.core.api.BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_map_assertions(BDDSoftAssertionsTest.java:193)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_map_assertions(BDDSoftAssertionsTest.java:197)
+
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_built_from_lambda_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_built_from_lambda_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageEndingWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageEndingWith_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasCauseReference_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasCauseReference_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessage_with_String_format_syntax_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessage_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseInstanceOf_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_getRootCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_getRootCause_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageContaining_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageContaining_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageEndingWith_with_String_format_syntax_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageEndingWith_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageFindingMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageFindingMatch_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasStackTraceContaining_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasStackTraceContaining_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageContaining_with_String_format_syntax_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageContaining_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_getCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_getCause_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageContainingAll_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageContainingAll_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasRootCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasRootCause_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseMessage_with_String_format_syntax_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseMessage_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ExpectThrowableAssert_isThrownBy_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ExpectThrowableAssert_isThrownBy_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseMessage_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasNoCause_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasNoCause_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageStartingWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageStartingWith_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableTypeAssert_description_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableTypeAssert_description_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessage_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasSuppressedException_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasSuppressedException_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageNotContaining_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageNotContaining_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasCauseInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasCauseInstanceOf_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageMatchingRegex_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageMatchingRegex_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_built_with_then_method_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_built_with_then_method_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasNoSuppressedExceptions_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasNoSuppressedExceptions_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_built_from_ThrowingCallable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_built_from_ThrowingCallable_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasCauseExactlyInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasCauseExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseExactlyInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasRootCauseExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageStartingWith_with_String_format_syntax_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageStartingWith_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasStackTraceContaining_with_String_format_syntax_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasStackTraceContaining_with_String_format_syntax_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.throwable.ThrowableAssert_hasCause_Test
+[INFO] Running org.assertj.core.api.throwable.ThrowableAssert_hasMessageNotContainingAny_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.throwable.ThrowableAssert_hasMessageNotContainingAny_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_CharSequence_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_CharSequence_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isEqualTo_double_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.097 s - in org.assertj.core.api.double_.DoubleAssert_isEqualTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isEqualTo_DoubleWrapper_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.double_.DoubleAssert_isEqualTo_DoubleWrapper_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isCloseTo_DoubleObject_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.double_.DoubleAssert_isCloseTo_DoubleObject_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isLessThanOrEqualTo_DoubleWrapper_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isLessThanOrEqualTo_DoubleWrapper_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isLessThan_double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isLessThan_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotEqualTo_double_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.double_.DoubleAssert_isNotEqualTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isCloseTo_double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isCloseTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isOne_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.api.double_.DoubleAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isGreaterThanOrEqualTo_DoubleWrapper_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isGreaterThanOrEqualTo_DoubleWrapper_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotCloseTo_double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isNotCloseTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isLessThanOrEqualTo_double_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.double_.DoubleAssert_isLessThanOrEqualTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isZero_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isZero_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isEqualTo_with_offset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isEqualTo_with_offset_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotZero_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isBetween_Doubles_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isBetween_Doubles_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotNaN_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isNotNaN_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isGreaterThan_double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isGreaterThan_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isGreaterThanOrEqualTo_double_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isGreaterThanOrEqualTo_double_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isEqualTo_double_with_offset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isEqualTo_double_with_offset_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNotCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isNaN_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.double_.DoubleAssert_isNaN_Test
+[INFO] Running org.assertj.core.api.double_.DoubleAssert_isStrictlyBetween_Doubles_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.double_.DoubleAssert_isStrictlyBetween_Doubles_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_IntPredicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_IntPredicate_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Byte_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Throwable_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Throwable_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_URI_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_URI_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_FloatArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_FloatArray_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_OptionalDouble_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_OptionalDouble_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThatObject_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThatObject_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_StringBuilder_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_StringBuilder_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_byte_Test
+[INFO] Running org.assertj.core.api.predicate.PredicateAssert_accepts_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.083 s - in org.assertj.core.api.predicate.PredicateAssert_accepts_Test
+[INFO] Running org.assertj.core.api.predicate.PredicateAssert_rejectsAllTest
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.predicate.PredicateAssert_rejectsAllTest
+[INFO] Running org.assertj.core.api.predicate.PredicateAssert_rejects_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.api.predicate.PredicateAssert_rejects_Test
+[INFO] Running org.assertj.core.api.predicate.PredicateAssert_acceptsAll_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.predicate.PredicateAssert_acceptsAll_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 s - in org.assertj.core.api.string_.StringAssert_isLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.string_.StringAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.string_.StringAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_usingCustomComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.string_.StringAssert_usingCustomComparator_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isValidBase64_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.string_.StringAssert_isValidBase64_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.string_.StringAssert_isGreaterThan_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.string_.StringAssert_isLessThan_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.string_.StringAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.string_.StringAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.string_.StringAssert_isGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.JUnitBDDSoftAssertionsFailureTest
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in org.assertj.core.api.JUnitBDDSoftAssertionsFailureTest
+[ERROR] should_report_all_errors  Time elapsed: 0 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting:
+ <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to start with:
+ <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+
+	at org.assertj.core.api.JUnitBDDSoftAssertionsFailureTest.should_report_all_errors(JUnitBDDSoftAssertionsFailureTest.java:46)
+
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Boolean_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Boolean_Test
+[INFO] Running org.assertj.core.api.Java6Assertions_fail_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Java6Assertions_fail_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_DoublePredicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_DoublePredicate_Test
+[INFO] Running org.assertj.core.api.InstanceOfAssertFactoriesTest
+[INFO] Tests run: 91, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s - in org.assertj.core.api.InstanceOfAssertFactoriesTest
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsExactlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsExactlyElementsOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainAnyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_flatExtracting_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.assertj.core.api.iterable.IterableAssert_flatExtracting_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doNotHave_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_doNotHave_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainSequence_List_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_first_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_first_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_isSubsetOf_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_isSubsetOf_with_Array_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_allSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_allSatisfy_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSameElementsAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSameElementsAs_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_isNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsOnlyNulls_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsOnlyNulls_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_size_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_size_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_in_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_in_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_haveAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_haveAtLeast_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_isSubsetOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_isSubsetOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_element_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_element_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_areAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_areAtLeastOne_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_extractingResultOf_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_extractingResultOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_SortedSet_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_SortedSet_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainSubsequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainSubsequence_List_Test
+[INFO] Running org.assertj.core.api.iterable.SetAssert_raw_set_assertions_chained_after_superclass_method_Test
+[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.SetAssert_raw_set_assertions_chained_after_superclass_method_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOnNull_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_filteredOnNull_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_haveAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_haveAtMost_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsSequence_List_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_extracting_with_SortedSet_Test
+[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in org.assertj.core.api.iterable.IterableAssert_extracting_with_SortedSet_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_condition_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_condition_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsAnyElementsOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_contains_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_zipSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_zipSatisfy_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_haveAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_haveAtLeastOne_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_anyMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_anyMatch_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsSubsequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsSubsequence_List_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_haveExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_haveExactly_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_extracting_Test
+[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in org.assertj.core.api.iterable.IterableAssert_extracting_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_notIn_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_notIn_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_areAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_areAtMost_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_anySatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_anySatisfy_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasAtLeastOneElementOfType_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasAtLeastOneElementOfType_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainSubsequence_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSameSizeAs_with_Array_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_predicate_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_predicate_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_consumer_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_consumer_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.iterable.Iterable_generics_with_varargs_Test
+[WARNING] Tests run: 4, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.Iterable_generics_with_varargs_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_extractingResultOf_with_SortedSet_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.iterable.IterableAssert_extractingResultOf_with_SortedSet_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_element_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_element_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_last_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_last_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test
+[ERROR] Tests run: 12, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.024 s <<< FAILURE! - in org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test
+[ERROR] should_only_use_comparator_on_fields_element_but_not_the_element_itself  Time elapsed: 0.007 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+but was:
+  <"
+Expecting ArrayList:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertIterableContainsGivenValues(Iterables.java:344)
+	at org.assertj.core.internal.Iterables.assertContains(Iterables.java:336)
+	at org.assertj.core.api.AbstractIterableAssert.contains(AbstractIterableAssert.java:346)
+	at org.assertj.core.api.ListAssert.contains(ListAssert.java:251)
+	at org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test.lambda$should_only_use_comparator_on_fields_element_but_not_the_element_itself$0(IterableAssert_usingComparatorForType_Test.java:109)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test.should_only_use_comparator_on_fields_element_but_not_the_element_itself(IterableAssert_usingComparatorForType_Test.java:105)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test.should_only_use_comparator_on_fields_element_but_not_the_element_itself(IterableAssert_usingComparatorForType_Test.java:110)
+
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasOnlyElementsOfType_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasOnlyElementsOfType_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_usingElementComparatorOnFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_usingElementComparatorOnFields_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_multiple_extractors_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_multiple_extractors_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_are_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_are_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_noneMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_noneMatch_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_areExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_areExactly_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_allMatch_with_description_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_allMatch_with_description_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_hasOnlyElementsOfTypes_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_hasOnlyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainNull_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_last_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_last_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_allMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_allMatch_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_filteredOn_not_Test
+[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_filteredOn_not_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_noneSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_noneSatisfy_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_first_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_first_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsNull_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_doesNotContainSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_doesNotContainSequence_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsOnlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsOnlyElementsOf_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_String_parameter_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_flatExtracting_with_String_parameter_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_areAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_areAtLeast_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_usingFieldByFieldElementComparator_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.iterable.IterableAssert_usingFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_have_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_have_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_should_honor_SortedSet_comparator_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.iterable.IterableAssert_should_honor_SortedSet_comparator_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_areNot_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_areNot_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsAll_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterable.IterableAssert_containsAll_Test
+[INFO] Running org.assertj.core.api.iterable.IterableAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.iterable.IterableAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_inBinary_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.Assertions_assertThat_inBinary_Test
+[INFO] Running org.assertj.core.api.ComparableAssertion_should_be_flexible_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.ComparableAssertion_should_be_flexible_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_boolean_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_boolean_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Stream_startsWith_Test
+[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.004 s - in org.assertj.core.api.Assertions_assertThat_with_Stream_startsWith_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_inUnicode_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_inUnicode_Test
+[INFO] Running org.assertj.core.api.Assertions_fail_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_fail_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test
+[ERROR] Tests run: 19, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.012 s <<< FAILURE! - in org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test
+[ERROR] should_assert_bytes_contains_in_hexadecimal  Time elapsed: 0.003 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting message to be:
+  <"
+Expecting:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find:
+ <[0x01]>
+">
+but was:
+  <"
+Expecting array byte[]:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find the following byte:
+ <[0x01]>
+">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array byte[]:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find the following byte:
+ <[0x01]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ByteArrays.assertContains(ByteArrays.java:199)
+	at org.assertj.core.api.AbstractByteArrayAssert.contains(AbstractByteArrayAssert.java:214)
+	at org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test.lambda$should_assert_bytes_contains_in_hexadecimal$3(Assertions_assertThat_inHexadecimal_Test.java:55)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test.should_assert_bytes_contains_in_hexadecimal(Assertions_assertThat_inHexadecimal_Test.java:54)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test.should_assert_bytes_contains_in_hexadecimal(Assertions_assertThat_inHexadecimal_Test.java:56)
+
+[INFO] Running org.assertj.core.api.Assertions_sync_with_BDDAssumptions_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in org.assertj.core.api.Assertions_sync_with_BDDAssumptions_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isPresent_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValueCloseToOffset_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValueCloseToOffset_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isNotPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_isNotPresent_Test
+[INFO] Running org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValueCloseToPercentage_Test
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.api.optionaldouble.OptionalDoubleAssert_hasValueCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_IntStream_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.api.Assertions_assertThat_with_IntStream_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fail_withMessage_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.fail.Fail_fail_withMessage_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fest_elements_stack_trace_filtering_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.fail.Fail_fest_elements_stack_trace_filtering_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fail_because_exception_was_not_thrown_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.fail.Fail_fail_because_exception_was_not_thrown_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fail_withMessage_and_parameters_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.fail.Fail_fail_withMessage_and_parameters_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fail_withMessageAndCause_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.fail.Fail_fail_withMessageAndCause_Test
+[INFO] Running org.assertj.core.api.fail.Fail_fail_because_exception_should_have_thrown_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.fail.Fail_fail_because_exception_should_have_thrown_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotIn_errors_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotIn_errors_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBefore_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isAfter_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotEqualTo_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotIn_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isIn_errors_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isIn_errors_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isIn_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isIn_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_defaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_defaultComparator_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.zoneddatetime.ZonedDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Running org.assertj.core.api.TemporalAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.TemporalAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_AssertDelegateTarget_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_AssertDelegateTarget_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_usingCharset_default_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in org.assertj.core.api.file.FileAssert_usingCharset_default_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_usingCharset_null_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_usingCharset_null_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasDigest_AlgorithmString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasParentWithNullStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasParentWithNullStringParameter_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isEmptyFile_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isEmptyFile_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasSameTextualContentAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasSameTextualContentAs_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasSameBinaryContentAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasSameBinaryContentAs_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isDirectoryNotContaining_Predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isDirectoryNotContaining_Predicate_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isRelative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isRelative_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_usingCharset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_usingCharset_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_canWrite_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_canWrite_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasSameContentAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasSameContentAs_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasExtension_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasExtension_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasBinaryContent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasBinaryContent_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_canRead_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_canRead_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_usingCharset_String_invalid_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_usingCharset_String_invalid_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isFile_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isFile_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isAbsolute_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isAbsolute_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasName_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasName_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasDigest_DigestString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasDigest_DigestString_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_isDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasContent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasContent_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isNotEmptyFile_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isNotEmptyFile_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_doesNotExist_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_doesNotExist_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasParent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasParent_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasNoParent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasNoParent_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isEmptyDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isEmptyDirectory_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasParentWithStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.file.FileAssert_hasParentWithStringParameter_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_hasDigest_DigestBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_hasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isNotEmptyDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isNotEmptyDirectory_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_exists_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_exists_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_usingCharset_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_usingCharset_String_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isDirectoryContaining_Predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isDirectoryContaining_Predicate_Test
+[INFO] Running org.assertj.core.api.file.FileAssert_isDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.file.FileAssert_isDirectory_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_ByteArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_ByteArray_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_String_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_URL_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_URL_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_asList_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_asList_Test
+[INFO] Running org.assertj.core.api.array.AbstractEnumerableAssert_hasSameSizeAs_with_Array_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.array.AbstractEnumerableAssert_hasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_StringBuffer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_StringBuffer_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotEqualTo_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.api.byte_.ByteAssert_isNotEqualTo_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isCloseTo_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isCloseTo_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isOne_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotCloseToPercentage_primitive_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isNotCloseToPercentage_primitive_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isCloseToPercentage_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isCloseToPercentage_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.byte_.ByteAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isEqualTo_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isEqualTo_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isLessThan_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isLessThan_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotCloseTo_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isNotCloseTo_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isZero_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotCloseTo_primitive_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isNotCloseTo_primitive_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isCloseToPercentage_primitive_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isCloseToPercentage_primitive_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotCloseToPercentage_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isNotCloseToPercentage_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isLessThanOrEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isLessThanOrEqualTo_long_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isGreaterThan_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isGreaterThan_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.byte_.ByteAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isGreaterThanOrEqualTo_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isGreaterThanOrEqualTo_byte_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.byte_.ByteAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isBetween_Bytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isBetween_Bytes_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isStrictlyBetween_Bytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isStrictlyBetween_Bytes_Test
+[INFO] Running org.assertj.core.api.byte_.ByteAssert_isCloseTo_primitive_byte_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.byte_.ByteAssert_isCloseTo_primitive_byte_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Class_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Class_Test
+[INFO] Running org.assertj.core.api.HamcrestConditionTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.HamcrestConditionTest
+[INFO] Running org.assertj.core.api.junit.jupiter.SoftAssertionsExtensionIntegrationTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.05 s - in org.assertj.core.api.junit.jupiter.SoftAssertionsExtensionIntegrationTest
+[INFO] Running org.assertj.core.api.junit.jupiter.SoftAssertionsExtensionUnitTest
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in org.assertj.core.api.junit.jupiter.SoftAssertionsExtensionUnitTest
+[INFO] Running org.assertj.core.api.junit.jupiter.CustomSoftAssertionsExtensionIntegrationTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s - in org.assertj.core.api.junit.jupiter.CustomSoftAssertionsExtensionIntegrationTest
+[INFO] Running org.assertj.core.api.junit.jupiter.BDDSoftAssertionsExtensionIntegrationTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in org.assertj.core.api.junit.jupiter.BDDSoftAssertionsExtensionIntegrationTest
+[INFO] Running org.assertj.core.api.ByteAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.ByteAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isInterface_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.assertj.core.api.classes.ClassAssert_isInterface_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isProtected_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isProtected_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasDeclaredMethods_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasDeclaredMethods_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isFinal_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isFinal_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasAnnotations_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasAnnotations_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isNotFinal_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isNotFinal_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isAbstract_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isAbstract_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasSuperclass_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasSuperclass_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasExactlyDeclaredFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_hasExactlyDeclaredFields_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isNotAnnotation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isNotAnnotation_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isNotInterface_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_isNotInterface_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasNoSuperclass_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_hasNoSuperclass_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isAnnotation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_isAnnotation_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasFields_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasDeclaredFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.classes.ClassAssert_hasDeclaredFields_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasAnnotation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasAnnotation_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasPublicMethods_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasPublicMethods_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isPackagePrivate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isPackagePrivate_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isAssignableFrom_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.classes.ClassAssert_isAssignableFrom_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_isPublic_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_isPublic_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasOnlyFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasOnlyFields_Test
+[INFO] Running org.assertj.core.api.classes.ClassAssert_hasMethods_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.classes.ClassAssert_hasMethods_Test
+[INFO] Running org.assertj.core.api.Condition_as_String_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_as_String_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isIn_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isNotEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isBefore_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isAfter_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isAfterOrEqual_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_isAfterOrEqual_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_IsBeforeOrEqualTo_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.instant.InstantAssert_IsBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.instant.InstantAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.instant.InstantAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.spliterator.SpliteratorAssert_hasOnlyCharacteristics_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.spliterator.SpliteratorAssert_hasOnlyCharacteristics_Test
+[INFO] Running org.assertj.core.api.spliterator.SpliteratorAssert_hasCharacteristics_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.spliterator.SpliteratorAssert_hasCharacteristics_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_predicate_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyElementsOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_flatExtracting_Test
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_flatExtracting_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_in_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_in_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_areAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_areAtLeastOne_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_allSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_allSatisfy_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_have_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_have_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_noneSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_noneSatisfy_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isSubsetOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isSubsetOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyElementsOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSequence_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsAnyElementsOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsSequence_List_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyElementsOfTypes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsAll_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsAll_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsSubSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsSubSequence_List_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_anyMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_anyMatch_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtMost_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtLeastOne_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_zipSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_zipSatisfy_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_areNot_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_areNot_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_extractingResultOf_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_extractingResultOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_noneMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_noneMatch_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_extracting_Test
+[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_extracting_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_flatExtracting_with_String_parameter_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_flatExtracting_with_String_parameter_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingComparatorForType_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingComparatorForType_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isSubsetOf_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isSubsetOf_with_Array_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSubsequence_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainsSubsequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainsSubsequence_List_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsSubSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsSubSequence_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOnAssertions_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOnAssertions_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparatorOnFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparatorOnFields_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_areAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_areAtMost_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_haveExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_haveExactly_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_allMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_allMatch_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainNull_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_are_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_are_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasAtLeastOneElementOfType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasAtLeastOneElementOfType_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_areExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_areExactly_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_allMatch_with_description_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_allMatch_with_description_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsNull_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_condition_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_condition_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyNulls_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_containsOnlyNulls_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingFieldByFieldElementComparator_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doNothave_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doNothave_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_not_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_not_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainAnyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_haveAtLeast_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyElementsOfType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasOnlyElementsOfType_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameElementsAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameElementsAs_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_notIn_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_filteredOn_notIn_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_areAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_areAtLeast_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.objectarray.ObjectArrayAssert_doesNotContainSequence_List_Test
+[INFO] Running org.assertj.core.api.Assertions_sync_with_InstanceOfAssertFactories_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.assertj.core.api.Assertions_sync_with_InstanceOfAssertFactories_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Map_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Map_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isLowerCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in org.assertj.core.api.character.CharacterAssert_isLowerCase_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isLessThan_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isLessThan_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isLessThanOrEqualTo_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isLessThanOrEqualTo_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isEqualTo_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isEqualTo_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isGreaterThan_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.character.CharacterAssert_isGreaterThan_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isNotEqualTo_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isNotEqualTo_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.character.CharacterAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isGreaterThanOrEqualTo_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isGreaterThanOrEqualTo_char_Test
+[INFO] Running org.assertj.core.api.character.CharacterAssert_isUpperCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.character.CharacterAssert_isUpperCase_Test
+[INFO] Running org.assertj.core.api.InstanceOfAssertFactoryTest
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 s - in org.assertj.core.api.InstanceOfAssertFactoryTest
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_ObjectArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_ObjectArray_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Comparable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Comparable_Test
+[INFO] Running org.assertj.core.api.optionallong.OptionalLongAssert_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionallong.OptionalLongAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.optionallong.OptionalLongAssert_isNotPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionallong.OptionalLongAssert_isNotPresent_Test
+[INFO] Running org.assertj.core.api.optionallong.OptionalLongAssert_isEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionallong.OptionalLongAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.optionallong.OptionalLongAssert_isNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionallong.OptionalLongAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.optionallong.OptionalLongAssert_isPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionallong.OptionalLongAssert_isPresent_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_IntArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_IntArray_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isGreaterThanOrEqualTo_FloatWrapper_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s - in org.assertj.core.api.float_.FloatAssert_isGreaterThanOrEqualTo_FloatWrapper_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isCloseTo_float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isCloseTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isEqualTo_float_with_offset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isEqualTo_float_with_offset_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isLessThanOrEqualTo_float_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.float_.FloatAssert_isLessThanOrEqualTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isGreaterThan_float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isGreaterThan_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isStrictlyBetween_Floats_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isStrictlyBetween_Floats_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isLessThanOrEqualTo_FloatWrapper_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isLessThanOrEqualTo_FloatWrapper_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isOne_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotEqualTo_float_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.float_.FloatAssert_isNotEqualTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isGreaterThanOrEqualTo_float_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.api.float_.FloatAssert_isGreaterThanOrEqualTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isEqualTo_FloatWrapper_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.float_.FloatAssert_isEqualTo_FloatWrapper_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotCloseTo_float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNotCloseTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isBetween_Floats_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isBetween_Floats_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotZero_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isEqualTo_float_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.float_.FloatAssert_isEqualTo_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isEqualTo_with_offset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isEqualTo_with_offset_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNotNaN_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNotNaN_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isNaN_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.float_.FloatAssert_isNaN_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isLessThan_float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isLessThan_float_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.float_.FloatAssert_isZero_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.float_.FloatAssert_isZero_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_isFalse_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in org.assertj.core.api.boolean_.BooleanAssert_isFalse_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.boolean_.BooleanAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_isNotEqualTo_boolean_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.boolean_.BooleanAssert_isNotEqualTo_boolean_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.boolean_.BooleanAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_isEqualTo_boolean_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.boolean_.BooleanAssert_isEqualTo_boolean_Test
+[INFO] Running org.assertj.core.api.boolean_.BooleanAssert_isTrue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.boolean_.BooleanAssert_isTrue_Test
+[INFO] Running org.assertj.core.api.Condition_constructor_with_predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_constructor_with_predicate_Test
+[INFO] Running org.assertj.core.api.Condition_describedAs_Description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_describedAs_Description_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.assertj.core.api.path.PathAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isSymbolicLink_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isSymbolicLink_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_endsWithRaw_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_endsWithRaw_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isRelative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isRelative_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasDigest_DigestString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_hasDigest_DigestString_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasNoParentRaw_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasNoParentRaw_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_usingCharset_null_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_usingCharset_null_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_usingCharset_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_usingCharset_String_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isDirectoryContaining_Predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_isDirectoryContaining_Predicate_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasParent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasParent_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isNormalized_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isNormalized_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_exists_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_exists_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_doesNotExist_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_doesNotExist_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isNotEmptyDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_isNotEmptyDirectory_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasBinaryContent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_hasBinaryContent_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_startsWithRaw_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_startsWithRaw_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_existsNoFollowLinks_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_existsNoFollowLinks_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasFileName_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_hasFileName_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasSameContentAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasSameContentAs_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isDirectory_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isDirectoryContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isCanonical_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isCanonical_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isAbsolute_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isAbsolute_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_usingCharset_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_usingCharset_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isDirectoryNotContaining_Predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isDirectoryNotContaining_Predicate_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_usingCharset_default_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_usingCharset_default_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasNoParent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasNoParent_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasContent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_hasContent_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasSameTextualContentAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasSameTextualContentAs_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasParentRaw_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_hasParentRaw_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isRegularFile_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isRegularFile_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasDigest_AlgorithmString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isEmptyDirectory_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.path.PathAssert_isEmptyDirectory_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_hasDigest_DigestBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_hasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isDirectoryNotContaining_SyntaxAndPattern_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_usingCharset_String_invalid_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_usingCharset_String_invalid_Test
+[INFO] Running org.assertj.core.api.path.PathAssert_isReadable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.path.PathAssert_isReadable_Test
+[INFO] Running org.assertj.core.api.SoftAssertions_combined_with_asInstanceOf_Test
+[INFO] Tests run: 73, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.298 s - in org.assertj.core.api.SoftAssertions_combined_with_asInstanceOf_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_BigInteger_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_BigInteger_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_List_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_List_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_float_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_float_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isAfterYear_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in org.assertj.core.api.date.DateAssert_isAfterYear_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isNotBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isNotBetween_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_hasTime_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isBetween_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInTheFuture_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isInTheFuture_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameSecondAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameSecondAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInThePast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isInThePast_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isEqualToIgnoringMillis_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_isEqualToIgnoringMillis_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasMillisecond_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasMillisecond_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameMinuteWindowAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isInSameMinuteWindowAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isToday_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isToday_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasSameTimeAsDateInString_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_hasSameTimeAsDateInString_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasMonth_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasMonth_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_with_string_based_date_representation_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.api.date.DateAssert_with_string_based_date_representation_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isBetweenSpecifyingBoundariesInclusion_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isBetweenSpecifyingBoundariesInclusion_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isBeforeYear_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_isBeforeYear_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasSecond_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_hasSecond_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameSecondWindowAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_isInSameSecondWindowAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasHourOfDay_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasHourOfDay_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isBefore_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameMinuteAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isInSameMinuteAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isAfter_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameMonthAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameMonthAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isNotEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasDayOfMonth_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasDayOfMonth_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isCloseTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_isCloseTo_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_setLenientDateParsing_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_setLenientDateParsing_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameYearAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameYearAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isNotIn_with_vararg_param_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isNotIn_with_vararg_param_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isIn_with_collection_param_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isIn_with_collection_param_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameHourAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameHourAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasYear_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_hasYear_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasMinute_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasMinute_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isEqualToIgnoringHours_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_isEqualToIgnoringHours_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isIn_with_vararg_param_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isIn_with_vararg_param_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasDayOfWeek_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_hasDayOfWeek_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasSameTimeAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_hasSameTimeAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameHourWindowAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameHourWindowAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isNotIn_with_collection_param_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isNotIn_with_collection_param_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_hasSameTimeAsOtherDate_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_hasSameTimeAsOtherDate_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.date.DateAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isInSameDayAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.date.DateAssert_isInSameDayAs_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isNotBetweenSpecifyingBoundariesInclusion_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isNotBetweenSpecifyingBoundariesInclusion_Test
+[INFO] Running org.assertj.core.api.date.DateAssert_isEqualToIgnoringMinutes_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.date.DateAssert_isEqualToIgnoringMinutes_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThatCode_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThatCode_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_OffsetDateTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_OffsetDateTime_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Stream_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.assertj.core.api.Assertions_assertThat_with_Stream_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.04 s - in org.assertj.core.api.integer_.IntegerAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isZero_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isLessThan_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isLessThan_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isGreaterThanOrEqualTo_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isGreaterThanOrEqualTo_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isEqualTo_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isEqualTo_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isLessThanOrEqualTo_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isLessThanOrEqualTo_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isStrictlyBetween_Integers_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isStrictlyBetween_Integers_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotCloseToPercentage_integer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isNotCloseToPercentage_integer_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isOne_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isCloseTo_integer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isCloseTo_integer_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isGreaterThan_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isGreaterThan_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotCloseTo_integer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isNotCloseTo_integer_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isNotEqualTo_int_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isNotEqualTo_int_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isEqualTo_long_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isCloseToPercentage_integer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.integer_.IntegerAssert_isCloseToPercentage_integer_Test
+[INFO] Running org.assertj.core.api.integer_.IntegerAssert_isBetween_Integers_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.integer_.IntegerAssert_isBetween_Integers_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsExactly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.assertj.core.api.longarray.LongArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longarray.LongArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.longarray.LongArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longarray.LongArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_DoubleStream_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_DoubleStream_Test
+[INFO] Running org.assertj.core.api.Assertions_catchThrowableOfType_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_catchThrowableOfType_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in org.assertj.core.api.floatarray.FloatArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_contains_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsOnly_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_doesNotContain_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsSequence_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_startsWith_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_endsWith_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsExactly_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.floatarray.FloatArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.api.intarray.IntArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsExactly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intarray.IntArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.intarray.IntArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.intarray.IntArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValueDequeTest
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.DualValueDequeTest
+[INFO] Running org.assertj.core.api.recursive.comparison.FieldLocation_compareTo_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.FieldLocation_compareTo_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreCollectionOrder_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_enumValues_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.DualValue_enumValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_optionals_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_optionals_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.436 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_fluent_API_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_fluent_API_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_hasCustomComparators_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_hasCustomComparators_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_fieldComparators_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_fieldComparators_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_arrayValues_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.DualValue_arrayValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_optionalValues_Test
+[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.api.recursive.comparison.DualValue_optionalValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_comparatorByType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_comparatorByType_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_hasNoNullValues_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.DualValue_hasNoNullValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreOverriddenEqualsOf_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreOverriddenEqualsOf_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_isJavaType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.DualValue_isJavaType_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.092 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.FieldComparators_registerComparator_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.FieldComparators_registerComparator_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_withTypeComparators_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_withTypeComparators_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.ComparisonDifference_multiLineDescription_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.recursive.comparison.ComparisonDifference_multiLineDescription_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_iterables_Test
+[INFO] Tests run: 48, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.129 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_iterables_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_iterableValues_Test
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.recursive.comparison.DualValue_iterableValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_multiLineDescription_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_multiLineDescription_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_maps_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.08 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_maps_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_iterables_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_iterables_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_arrays_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_arrays_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.FieldLocation_from_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.FieldLocation_from_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_assumptions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.212 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_assumptions_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_constructor_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.DualValue_constructor_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.ComparisonDifference_compareTo_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.ComparisonDifference_compareTo_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_maps_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_maps_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.FieldLocation_matches_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.FieldLocation_matches_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_bddSoftAssertions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_bddSoftAssertions_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.922 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreFields_Test
+[INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_shouldIgnoreFields_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_getFieldName_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.recursive.comparison.DualValue_getFieldName_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_softAssertions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_softAssertions_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_getActualNonIgnoreFields_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration_getActualNonIgnoreFields_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringFields_Test
+[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.446 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringFields_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_mapValues_Test
+[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.recursive.comparison.DualValue_mapValues_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_object_arrays_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_for_object_arrays_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.292 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_optional_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_with_optional_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_withFieldComparators_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.081 s - in org.assertj.core.api.recursive.comparison.RecursiveComparisonAssert_isEqualTo_withFieldComparators_Test
+[INFO] Running org.assertj.core.api.recursive.comparison.DualValue_hasNoContainerValues_Test
+[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.recursive.comparison.DualValue_hasNoContainerValues_Test
+[INFO] Running org.assertj.core.api.Assertions_linesOf_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_linesOf_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_LongPredicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_LongPredicate_Test
+[INFO] Running org.assertj.core.api.WritableAssertionInfo_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.WritableAssertionInfo_toString_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringTimezone_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringTimezone_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_hasSameHourAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_hasSameHourAs_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isIn_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isNotEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isAfter_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isBefore_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsettime.OffsetTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Running org.assertj.core.api.Tuple_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.207 s - in org.assertj.core.api.Tuple_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.037 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isZero_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isOne_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isEqualToWithStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isEqualToWithStringParameter_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotCloseTo_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotEqualByComparingToWithStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNotEqualByComparingToWithStringParameter_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isEqualByComparingToWithStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isEqualByComparingToWithStringParameter_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.bigdecimal.BigDecimalAssert_isCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bigdecimal.BigDecimalAssert_isCloseTo_Test
+[INFO] Running org.assertj.core.api.AbstractTemporalAssert_isCloseTo_Test
+[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in org.assertj.core.api.AbstractTemporalAssert_isCloseTo_Test
+[INFO] Running org.assertj.core.api.Condition_constructor_with_description_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Condition_constructor_with_description_Test
+[INFO] Running org.assertj.core.api.SoftAssertionErrorTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.SoftAssertionErrorTest
+[INFO] Running org.assertj.core.api.Condition_default_constructor_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_default_constructor_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.localtime.LocalTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isNotEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isIn_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isAfter_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_hasSameHourAs_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_hasSameHourAs_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isBefore_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localtime.LocalTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localtime.LocalTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localtime.LocalTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.WritableAssertionInfo_descriptionText_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.WritableAssertionInfo_descriptionText_Test
+[INFO] Running org.assertj.core.api.doublepredicate.DoublePredicateAssert_accepts_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublepredicate.DoublePredicateAssert_accepts_Test
+[INFO] Running org.assertj.core.api.doublepredicate.DoublePredicateAssert_rejects_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublepredicate.DoublePredicateAssert_rejects_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsExactly_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsSequence_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsSequence_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsOnly_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsOnly_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsOnlyOnce_with_Integer_Arguments_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsOnlyOnce_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsExactly_with_Integer_Arguments_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsExactly_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsExactlyInAnyOrder_with_integers_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsExactlyInAnyOrder_with_integers_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_contains_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_contains_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_contains_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_contains_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_startsWith_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.bytearray.ByteArrayAssert_startsWith_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsAnyOf_with_int_argument_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsAnyOf_with_int_argument_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_endsWith_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_endsWith_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.bytearray.ByteArrayAssert_containsSubsequence_with_Integer_Arguments_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.bytearray.ByteArrayAssert_containsSubsequence_with_Integer_Arguments_Test
+[INFO] Running org.assertj.core.api.ThrowableAssertAlternative_havingRootCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.ThrowableAssertAlternative_havingRootCause_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_File_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_File_Test
+[INFO] Running org.assertj.core.api.Assertions_as_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_as_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_LongArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_LongArray_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_ShortArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_ShortArray_Test
+[INFO] Running org.assertj.core.api.AutoCloseableSoftAssertionsTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.AutoCloseableSoftAssertionsTest
+[INFO] Running org.assertj.core.api.Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.assertj.core.api.Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicLongArray_assertions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.AtomicLongArray_assertions_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasArray_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasArray_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integerarray.AtomicIntegerArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicIntegerFieldUpdater_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.AtomicIntegerFieldUpdater_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtLeast_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtLeastOne_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyElementsOfTypes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allSatisfy_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_in_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_in_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doNothave_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doNothave_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allMatch_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_extractingResultOf_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_extractingResultOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyElementsOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSequence_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainAnyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSubsequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSubsequence_List_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSubsetOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSubsetOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSequence_List_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyElementsOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveExactly_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areNot_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areNot_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingRecursiveFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainSubsequence_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameSizeAs_with_Arrays_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameSizeAs_with_Arrays_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasAtLeastOneElementOfType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasAtLeastOneElementOfType_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_not_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_not_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSubSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSubSequence_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test
+[ERROR] Tests run: 12, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.003 s <<< FAILURE! - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test
+[ERROR] should_fail_because_of_comparator_set_last  Time elapsed: 0.001 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}">
+but was:
+  <"
+Expecting array Object[]:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find the following elements:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array Object[]:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find the following elements:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ObjectArrays.assertContains(ObjectArrays.java:236)
+	at org.assertj.core.api.AtomicReferenceArrayAssert.contains(AtomicReferenceArrayAssert.java:459)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.lambda$should_fail_because_of_comparator_set_last$1(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:178)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_fail_because_of_comparator_set_last(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:173)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_fail_because_of_comparator_set_last(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:179)
+
+[ERROR] should_not_use_comparator_on_fields_level_for_elements  Time elapsed: 0.001 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+but was:
+  <"
+Expecting array Object[]:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array Object[]:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ObjectArrays.assertContains(ObjectArrays.java:236)
+	at org.assertj.core.api.AtomicReferenceArrayAssert.contains(AtomicReferenceArrayAssert.java:459)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.lambda$should_not_use_comparator_on_fields_level_for_elements$0(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:126)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_not_use_comparator_on_fields_level_for_elements(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:123)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_not_use_comparator_on_fields_level_for_elements(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:127)
+
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtMost_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyElementsOfType_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyElementsOfType_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_anySatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_anySatisfy_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtMost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtMost_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_condition_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_condition_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_are_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_are_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotHaveAnyElementsOfTypes_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_extracting_Test
+[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_extracting_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingFieldByFieldElementComparator_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allMatch_with_description_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_allMatch_with_description_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_anyMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_anyMatch_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsNull_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_flatExtracting_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_flatExtracting_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSubSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSubSequence_List_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_notIn_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_notIn_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSequence_List_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsSequence_List_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasOnlyOneElementSatisfying_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAnyElementsOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAnyElementsOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_have_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_have_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_filteredOn_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areExactly_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_noneMatch_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_noneMatch_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSubsetOf_with_Array_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_isSubsetOf_with_Array_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_flatExtracting_with_String_parameter_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_flatExtracting_with_String_parameter_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAll_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsAll_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtLeastOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_haveAtLeastOne_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsExactlyInAnyOrderElementsOf_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameElementsAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_hasSameElementsAs_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtLeast_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_areAtLeast_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyNulls_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_containsOnlyNulls_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparatorOnFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingElementComparatorOnFields_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_doesNotContainNull_Test
+[INFO] Running org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_noneSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_noneSatisfy_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicMarkableReferenceAssert_hasValue_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.AtomicMarkableReferenceAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_info_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_info_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isFalse_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isFalse_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isNull_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isNull_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isTrue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_isTrue_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_customRepresentation_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_customRepresentation_Test
+[INFO] Running org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_overridingErrorMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.boolean_.AtomicBooleanAssert_overridingErrorMessage_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasArray_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasArray_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.longarray.AtomicLongArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicLongFieldUpdater_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.AtomicLongFieldUpdater_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicReferenceFieldUpdater_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.AtomicReferenceFieldUpdater_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.AtomicStampedReferenceAssert_hasValue_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.AtomicStampedReferenceAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNonPositiveValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNonPositiveValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueBetween_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueGreaterThan_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasPositiveValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasPositiveValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_overridingErrorMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_overridingErrorMessage_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_info_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_info_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueCloseTo_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueLessThan_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_isNull_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_isNull_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNegativeValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNegativeValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueCloseTo_withinPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasValueCloseTo_withinPercentage_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_doesNotHaveValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_doesNotHaveValue_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_customRepresentation_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_customRepresentation_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_customComparator_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_customComparator_Test
+[INFO] Running org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNonNegativeValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.integer.AtomicIntegerAssert_hasNonNegativeValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_isNull_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_isNull_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasPositiveValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasPositiveValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_customRepresentation_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_customRepresentation_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueGreaterThan_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueBetween_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNonPositiveValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNonPositiveValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_info_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_info_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueLessThan_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNonNegativeValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNonNegativeValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_customComparator_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_customComparator_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueCloseTo_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_overridingErrorMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_overridingErrorMessage_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueCloseTo_withinPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasValueCloseTo_withinPercentage_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNegativeValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_hasNegativeValue_Test
+[INFO] Running org.assertj.core.api.atomic.long_.AtomicLongAssert_doesNotHaveValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.long_.AtomicLongAssert_doesNotHaveValue_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_customRepresentation_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_customRepresentation_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_customComparator_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_customComparator_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_doesNotHaveValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_doesNotHaveValue_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_hasValue_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_isNull_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_isNull_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_overridingErrorMessage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_overridingErrorMessage_Test
+[INFO] Running org.assertj.core.api.atomic.reference.AtomicReferenceAssert_info_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.atomic.reference.AtomicReferenceAssert_info_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringWhitespace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringWhitespace_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToIgnoringWhitespace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToIgnoringWhitespace_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainOnlyWhitespaces_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainOnlyWhitespaces_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotMatch_CharSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotMatch_CharSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasLineCount_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasLineCount_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotStartWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotStartWith_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsPattern_Pattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsPattern_Pattern_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotBlank_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotBlank_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsIgnoringCase_CharSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsIgnoringCase_CharSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_contains_several_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_contains_several_String_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyDigits_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyDigits_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isXmlEqualToContentOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isXmlEqualToContentOf_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainAnyWhitespaces_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainAnyWhitespaces_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToNormalizingWhitespace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToNormalizingWhitespace_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotMatch_Pattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotMatch_Pattern_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isXmlEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isXmlEqualTo_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_matches_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_matches_String_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_contains_CharSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_contains_CharSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToNormalizingWhitespace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToNormalizingWhitespace_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_contains_several_String_as_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_contains_several_String_as_Iterable_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isJavaBlank_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isJavaBlank_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainPattern_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainPattern_String_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_CharSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_CharSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isLowerCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isLowerCase_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_Array_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isUpperCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isUpperCase_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isBlank_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isBlank_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainPattern_Pattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContainPattern_Pattern_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotEndWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotEndWith_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isSubstringOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isSubstringOf_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_CharSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSameSizeAs_with_CharSequence_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_several_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_several_String_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsWhitespaces_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsWhitespaces_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsSubsequence_with_var_args_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsSubsequence_with_var_args_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_several_String_as_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_doesNotContain_several_String_as_Iterable_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyWhitespaces_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsOnlyWhitespaces_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToIgnoringCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotEqualToIgnoringCase_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToNormalizingPunctuationAndWhitespace_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToNormalizingPunctuationAndWhitespace_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringCase_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringCase_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_matches_Pattern_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_matches_Pattern_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_usingCustomComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_usingCustomComparator_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsSequence_with_var_args_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsSequence_with_var_args_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotJavaBlank_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotJavaBlank_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_containsPattern_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_containsPattern_String_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.charsequence.CharSequenceAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringNewLines_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.charsequence.CharSequenceAssert_isEqualToIgnoringNewLines_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasPath_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasPath_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasAuthority_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasAuthority_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasParameter_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasParameter_String_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasUserInfo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasUserInfo_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoAnchor_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasNoAnchor_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoParameter_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasNoParameter_String_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasQuery_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasQuery_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoQuery_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasNoQuery_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasHost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasHost_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasAnchor_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasAnchor_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoParameter_String_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasNoParameter_String_String_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoUserInfo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasNoUserInfo_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasNoPort_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.url.UrlAssert_hasNoPort_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasPort_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasPort_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasProtocol_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasProtocol_Test
+[INFO] Running org.assertj.core.api.url.UrlAssert_hasParameter_String_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.url.UrlAssert_hasParameter_String_String_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsOnly_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsOnly_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsExactly_with_Integer_Argument_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsExactly_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_contains_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_contains_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsSequence_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsSequence_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_at_Index_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsExactly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_endsWith_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_endsWith_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_startsWith_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_startsWith_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsSubsequence_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsSubsequence_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsExactlyInAnyOrder_with_Integer_Argument_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsExactlyInAnyOrder_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_contains_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_contains_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsOnlyOnce_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsOnlyOnce_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.shortarray.ShortArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.shortarray.ShortArrayAssert_containsAnyOf_with_Integer_Argument_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.shortarray.ShortArrayAssert_containsAnyOf_with_Integer_Argument_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Object_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Object_Test
+[INFO] Running org.assertj.core.api.SoftAssertions_check_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.SoftAssertions_check_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_BigDecimal_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_BigDecimal_Test
+[INFO] Running org.assertj.core.api.SoftAssertions_assertAlso_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.SoftAssertions_assertAlso_Test
+[INFO] Running org.assertj.core.api.Assertions_from_with_Function_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_from_with_Function_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_isNotPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optional.OptionalAssert_isNotPresent_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_get_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_get_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_containsInstanceOf_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_containsInstanceOf_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_containsSame_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_containsSame_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_map_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_map_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_contains_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optional.OptionalAssert_contains_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_isPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_isPresent_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_contains_usingValueComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_contains_usingValueComparator_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_get_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optional.OptionalAssert_get_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_hasValueSatisfying_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_hasValueSatisfying_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_flatMap_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optional.OptionalAssert_flatMap_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_contains_usingFieldByFieldValueComparator_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_contains_usingFieldByFieldValueComparator_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_isNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optional.OptionalAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_hasValueSatisfying_Condition_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_hasValueSatisfying_Condition_Test
+[INFO] Running org.assertj.core.api.optional.OptionalAssert_isEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optional.OptionalAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.TemporalAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.TemporalAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_defaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_defaultComparator_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isCloseToUtcNow_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isCloseToUtcNow_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringTimezone_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringTimezone_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAtSameInstantAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAtSameInstantAs_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isNotEqualTo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualTo_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isIn_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBefore_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAfter_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.offsetdatetime.OffsetDateTimeAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.SoftAssertionsTest
+[INFO] Tests run: 59, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.SoftAssertionsTest
+[INFO] Running org.assertj.core.api.iterator.IteratorAssert_isExhausted_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterator.IteratorAssert_isExhausted_Test
+[INFO] Running org.assertj.core.api.iterator.IteratorAssert_hasNext_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.iterator.IteratorAssert_hasNext_Test
+[INFO] Running org.assertj.core.api.Java6JUnitBDDSoftAssertionsFailureTest
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.assertj.core.api.Java6JUnitBDDSoftAssertionsFailureTest
+[ERROR] should_report_all_errors  Time elapsed: 0.001 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting throwable message:
+  <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to contain:
+  <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertContainsOnly(Iterables.java:389)
+	at org.assertj.core.api.AbstractIterableAssert.containsOnly(AbstractIterableAssert.java:355)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly$accessor$1t1lhf1U(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP$AssertJ$SoftProxies$WgiSCk3M.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.Java6JUnitBDDSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitBDDSoftAssertionsFailureTest.java:36)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.Java6JUnitBDDSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitBDDSoftAssertionsFailureTest.java:44)
+
+[INFO] Running org.assertj.core.api.map.MapAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsOnly_with_Java_Util_MapEntry_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsOnly_with_Java_Util_MapEntry_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsOnlyKeys_with_Iterable_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsOnlyKeys_with_Iterable_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_key_and_condition_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_key_and_condition_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsOnly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasEntrySatisfyingCondition_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasEntrySatisfyingCondition_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_noneSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_noneSatisfy_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContainKeys_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_doesNotContainKeys_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_flatExtracting_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_flatExtracting_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContainEntry_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_doesNotContainEntry_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_extractingFromEntries_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_extractingFromEntries_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsOnlyKeys_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsOnlyKeys_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsExactlyEntriesOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsExactlyEntriesOf_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsKeys_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsKeys_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsValue_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Array_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Array_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContainValue_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_doesNotContainValue_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_anySatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_anySatisfy_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_extracting_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_extracting_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContain_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsOnlyKeys_with_Path_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsOnlyKeys_with_Path_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsValues_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsValues_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsEntry_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsEntry_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsExactly_with_Java_Util_MapEntry_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsExactly_with_Java_Util_MapEntry_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasKeySatisfying_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasKeySatisfying_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsExactly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsKey_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsKey_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_extractingByKey_with_Key_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_extractingByKey_with_Key_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_key_and_value_conditions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_key_and_value_conditions_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsAllEntries_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsAllEntries_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_contains_with_Java_Util_MapEntry_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_contains_with_Java_Util_MapEntry_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_size_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_size_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsExactlyInAnyOrderEntriesOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_containsExactlyInAnyOrderEntriesOf_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasEntrySatisfyingConsumer_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasEntrySatisfyingConsumer_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContainKey_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_doesNotContainKey_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_raw_map_assertions_chained_after_base_assertions_Test
+[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_raw_map_assertions_chained_after_base_assertions_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasValueSatisfying_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasValueSatisfying_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Map_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasSameSizeAs_with_Map_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_allSatisfy_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_allSatisfy_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_extractingByKeys_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_extractingByKeys_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_contains_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_contains_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_containsAnyOf_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_condition_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_hasEntrySatisfying_with_condition_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.map.MapAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.map.MapAssert_doesNotContain_with_Java_Util_MapEntry_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.map.MapAssert_doesNotContain_with_Java_Util_MapEntry_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotCloseTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.short_.ShortAssert_isNotCloseTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isGreaterThan_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isGreaterThan_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.short_.ShortAssert_isZero_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isCloseToPercentage_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isCloseToPercentage_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isGreaterThanOrEqualTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isGreaterThanOrEqualTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isBetween_Shorts_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isBetween_Shorts_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isEqualTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isEqualTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isStrictlyBetween_Shorts_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isStrictlyBetween_Shorts_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotCloseToPercentage_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isNotCloseToPercentage_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.short_.ShortAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isCloseTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.short_.ShortAssert_isCloseTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isLessThan_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isLessThan_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.short_.ShortAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotEqualTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isNotEqualTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isOne_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isLessThanOrEqualTo_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isLessThanOrEqualTo_short_Test
+[INFO] Running org.assertj.core.api.short_.ShortAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.short_.ShortAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_BooleanArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_BooleanArray_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.106 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_succeedsWithin_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_succeedsWithin_Test
+[INFO] Running org.assertj.core.api.assumptions.Optional_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.06 s - in org.assertj.core.api.assumptions.Optional_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Iterable_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.169 s - in org.assertj.core.api.assumptions.Iterable_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_involving_iterable_navigation_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_involving_iterable_navigation_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_various_types_Test
+[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.144 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_various_types_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_filteredOn_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_filteredOn_Test
+[INFO] Running org.assertj.core.api.assumptions.ObjectArray_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 66, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s - in org.assertj.core.api.assumptions.ObjectArray_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_Stream_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_Stream_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_extracting_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_extracting_Test
+[INFO] Running org.assertj.core.api.assumptions.Map_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s - in org.assertj.core.api.assumptions.Map_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Class_final_method_assertions_in_assumptions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Class_final_method_assertions_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_Object_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_Object_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_Atomics_Test
+[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.688 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_Atomics_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_various_java_8_types_Test
+[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.635 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_various_java_8_types_Test
+[INFO] Running org.assertj.core.api.assumptions.Predicate_final_method_assertions_in_assumptions_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Predicate_final_method_assertions_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_Numbers_Test
+[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.711 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_Numbers_Test
+[INFO] Running org.assertj.core.api.assumptions.Object_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.assertj.core.api.assumptions.Object_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.assumptions.BDDAssumptionsTest
+[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.078 s - in org.assertj.core.api.assumptions.BDDAssumptionsTest
+[INFO] Running org.assertj.core.api.assumptions.Assumptions_assumeThat_with_asInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.assumptions.Assumptions_assumeThat_with_asInstanceOf_Test
+[INFO] Running org.assertj.core.api.assumptions.List_special_assertion_methods_in_assumptions_Test
+[INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.04 s - in org.assertj.core.api.assumptions.List_special_assertion_methods_in_assumptions_Test
+[INFO] Running org.assertj.core.api.Assertions_withinPercentage_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_withinPercentage_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_asString_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_asString_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.assertj.core.api.chararray.CharArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_containsExactly_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.chararray.CharArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.chararray.CharArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.chararray.CharArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Iterator_Test
+[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Iterator_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_extracting_with_Function_Array_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_extracting_with_Function_Array_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasSameHashCodeAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_hasSameHashCodeAs_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasAllNullFieldsOrProperties_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_hasAllNullFieldsOrProperties_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_extracting_Test
+[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_extracting_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasFieldOrPropertyWithValue_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_hasFieldOrPropertyWithValue_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_flatExtracting_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_flatExtracting_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_extracting_with_Function_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_extracting_with_Function_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasNoNullFieldsOrProperties_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_hasNoNullFieldsOrProperties_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasAllNullFieldsOrPropertiesExcept_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_hasAllNullFieldsOrPropertiesExcept_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_hasFieldOrProperty_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_hasFieldOrProperty_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_isEqualToComparingOnlyGivenFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_isEqualToComparingOnlyGivenFields_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_isEqualToIgnoringNullFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_isEqualToIgnoringNullFields_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_returns_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.object.ObjectAssert_returns_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_isEqualsToComparingFields_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_isEqualsToComparingFields_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.object.ObjectAssert_isEqualToIgnoringGivenFields_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.object.ObjectAssert_isEqualToIgnoringGivenFields_Test
+[INFO] Running org.assertj.core.api.intpredicate.IntPredicateAssert_rejects_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intpredicate.IntPredicateAssert_rejects_Test
+[INFO] Running org.assertj.core.api.intpredicate.IntPredicateAssert_accepts_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.intpredicate.IntPredicateAssert_accepts_Test
+[INFO] Running org.assertj.core.api.AutoCloseableBDDSoftAssertionsTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.AutoCloseableBDDSoftAssertionsTest
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_array_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_array_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotNull_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotNull_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_doesNotHave_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_doesNotHave_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isInstanceOfAny_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isInstanceOfAny_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_overridingErrorMessage_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_overridingErrorMessage_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isOfAnyClassIn_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isOfAnyClassIn_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_hasTheSameClassAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_hasTheSameClassAs_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_equal_hashCode_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_equal_hashCode_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_as_with_description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_as_with_description_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_doesNotHaveTheSameClassAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_doesNotHaveTheSameClassAs_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_get_writable_info_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_get_writable_info_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_withRepresentation_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_withRepresentation_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isIn_with_vararg_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isIn_with_vararg_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_as_with_text_description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_as_with_text_description_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_has_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_has_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_satisfies_with_Condition_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_satisfies_with_Condition_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_hasToString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_hasToString_Test
+[INFO] Running org.assertj.core.api.abstract_.SoftAssertionsErrorsCollectedTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.SoftAssertionsErrorsCollectedTest
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_is_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_is_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isInstanceOf_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_extracting_with_String_and_AssertFactory_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_extracting_with_String_and_AssertFactory_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_satisfies_with_Consumer_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_satisfies_with_Consumer_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_failWithMessage_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.assertj.core.api.abstract_.AbstractAssert_failWithMessage_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_Iterable_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isInstanceOfSatisfying_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.assertj.core.api.abstract_.AbstractAssert_isInstanceOfSatisfying_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotSameAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotSameAs_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotInstanceOf_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_withFailMessage_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.062 s - in org.assertj.core.api.abstract_.AbstractAssert_withFailMessage_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_vararg_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotIn_with_vararg_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isSameAs_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isSameAs_Test
+[INFO] Running org.assertj.core.api.abstract_.SoftAssertionsMultipleProjectsTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 s - in org.assertj.core.api.abstract_.SoftAssertionsMultipleProjectsTest
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isExactlyInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotInstanceOfAny_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotInstanceOfAny_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_describedAs_with_text_description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_describedAs_with_text_description_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotExactlyInstanceOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotExactlyInstanceOf_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isIn_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isIn_with_Iterable_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_satisfiesAnyOf_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_satisfiesAnyOf_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_extracting_with_Function_and_AssertFactory_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_extracting_with_Function_and_AssertFactory_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isIn_with_array_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isIn_with_array_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNot_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.abstract_.AbstractAssert_isNot_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNotOfAnyClassIn_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isNotOfAnyClassIn_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_isNull_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_isNull_Test
+[INFO] Running org.assertj.core.api.abstract_.AbstractAssert_describedAs_with_description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.abstract_.AbstractAssert_describedAs_with_description_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_DigestString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_DigestString_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_AlgorithmBytes_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasContent_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasContent_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_DigestBytes_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_DigestBytes_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_AlgorithmString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasDigest_AlgorithmString_Test
+[INFO] Running org.assertj.core.api.inputstream.InputStreamAssert_hasSameContentAs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.inputstream.InputStreamAssert_hasSameContentAs_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsExactly_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_startsWith_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_contains_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsOnly_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_endsWith_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_containsSequence_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotContain_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.doublearray.DoubleArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.doublearray.DoubleArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Predicate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Predicate_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_filteredOn_with_navigation_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_consumer_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_filteredOn_consumer_with_navigation_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_usingElementComparatorOnFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_usingElementComparatorOnFields_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_usingElementComparatorIgnoringFields_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_condition_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_filteredOn_condition_with_navigation_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_usingFieldByFieldElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_usingFieldByFieldElementComparator_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_raw_list_assertions_chained_after_superclass_method_Test
+[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_raw_list_assertions_chained_after_superclass_method_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_is_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_is_at_Index_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_satisfies_at_index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_satisfies_at_index_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_predicate_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_filteredOn_predicate_with_navigation_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_assertionState_propagation_with_extracting_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_assertionState_propagation_with_extracting_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_null_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.list.ListAssert_filteredOn_null_with_navigation_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_has_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_has_at_Index_Test
+[INFO] Running org.assertj.core.api.list.ListAssert_filteredOn_using_filterOperator_with_navigation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.list.ListAssert_filteredOn_using_filterOperator_with_navigation_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_InputStream_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_InputStream_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Long_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Character_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Character_Test
+[INFO] Running org.assertj.core.api.Condition_constructor_with_text_description_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_constructor_with_text_description_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_OffsetTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_OffsetTime_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThatExceptionOfType_Test
+[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThatExceptionOfType_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_long_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_long_Test
+[INFO] Running org.assertj.core.api.ThrowableAssertAlternative_havingCause_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.ThrowableAssertAlternative_havingCause_Test
+[INFO] Running org.assertj.core.api.Java6JUnitSoftAssertionsFailureTest
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.assertj.core.api.Java6JUnitSoftAssertionsFailureTest
+[ERROR] should_report_all_errors  Time elapsed: 0.001 s  <<< FAILURE!
+java.lang.AssertionError: 
+
+Expecting throwable message:
+  <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to contain:
+  <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertContainsOnly(Iterables.java:389)
+	at org.assertj.core.api.AbstractIterableAssert.containsOnly(AbstractIterableAssert.java:355)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly$accessor$1t1lhf1U(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP$AssertJ$SoftProxies$WgiSCk3M.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.Java6JUnitSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitSoftAssertionsFailureTest.java:36)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.api.Java6JUnitSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitSoftAssertionsFailureTest.java:44)
+
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_char_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_char_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_LocalDate_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_LocalDate_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdate.LocalDateAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isIn_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isBefore_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdate.LocalDateAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isToday_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdate.LocalDateAssert_isToday_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdate.LocalDateAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isNotEqualTo_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.localdate.LocalDateAssert_isAfter_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdate.LocalDateAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.GenericComparableAssert_isLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_canCallObjectAssertMethod_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_canCallObjectAssertMethod_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isNotEqualByComparingTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.GenericComparableAssert_isNotEqualByComparingTo_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.GenericComparableAssert_isLessThan_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isEqualByComparingTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.comparable.GenericComparableAssert_isEqualByComparingTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isGreaterThan_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.GenericComparableAssert_isGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isEqualByComparingTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isEqualByComparingTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isLessThan_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.comparable.AbstractComparableAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.comparable.GenericComparableAssert_isGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.GenericComparableAssert_isGreaterThan_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isNotEqualByComparingTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isNotEqualByComparingTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.comparable.AbstractComparableAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.comparable.AbstractComparableAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.Condition_describedAs_String_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Condition_describedAs_String_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_short_Test
+[INFO] Running org.assertj.core.api.Condition_description_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Condition_description_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_int_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_int_Test
+[INFO] Running org.assertj.core.api.Java6Assertions_assertThat_with_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Java6Assertions_assertThat_with_String_Test
+[INFO] Running org.assertj.core.api.Assertions_useRepresentation_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_useRepresentation_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_OptionalLong_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_OptionalLong_Test
+[INFO] Running org.assertj.core.api.optionalint.OptionalIntAssert_isEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionalint.OptionalIntAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.optionalint.OptionalIntAssert_hasValue_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionalint.OptionalIntAssert_hasValue_Test
+[INFO] Running org.assertj.core.api.optionalint.OptionalIntAssert_isPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionalint.OptionalIntAssert_isPresent_Test
+[INFO] Running org.assertj.core.api.optionalint.OptionalIntAssert_isNotPresent_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.optionalint.OptionalIntAssert_isNotPresent_Test
+[INFO] Running org.assertj.core.api.optionalint.OptionalIntAssert_isNotEmpty_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.optionalint.OptionalIntAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_AssertProvider_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_AssertProvider_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Optional_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Optional_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isStrictlyBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBefore_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBefore_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringMinutes_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualTo_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringSeconds_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_defaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_defaultComparator_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBeforeOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isNotEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isNotEqualTo_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringNanoseconds_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isBetween_with_String_parameters_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isAfterOrEqualTo_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isCloseToUtcNow_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isCloseToUtcNow_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isAfter_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isAfter_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isEqualToIgnoringHours_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isIn_Test
+[INFO] Running org.assertj.core.api.localdatetime.LocalDateTimeAssert_isNotIn_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.localdatetime.LocalDateTimeAssert_isNotIn_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Iterable_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_LocalDateTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_LocalDateTime_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isBetween_Longs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isBetween_Longs_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotCloseToPercentage_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isNotCloseToPercentage_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isLessThan_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isLessThan_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotCloseTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isNotCloseTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isGreaterThanOrEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isGreaterThanOrEqualTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isCloseToPercentage_primitive_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isCloseToPercentage_primitive_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isOne_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isOne_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isCloseTo_primitive_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isCloseTo_primitive_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isNotEqualTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isLessThanOrEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isLessThanOrEqualTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isCloseTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isCloseTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isCloseToPercentage_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isCloseToPercentage_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isZero_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotCloseToPercentage_primitive_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isNotCloseToPercentage_primitive_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNotCloseTo_primitive_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isNotCloseTo_primitive_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isEqualTo_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.long_.LongAssert_isEqualTo_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isGreaterThan_long_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isGreaterThan_long_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.long_.LongAssert_isStrictlyBetween_Longs_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.long_.LongAssert_isStrictlyBetween_Longs_Test
+[INFO] Running org.assertj.core.api.WithAssertions_delegation_Test
+[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.WithAssertions_delegation_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_CompletionStage_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_CompletionStage_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_common_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.filter.Filter_with_common_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_equals_to_given_value_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_with_property_equals_to_given_value_Test
+[INFO] Running org.assertj.core.api.filter.Filter_being_condition_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_being_condition_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_in_given_values_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_with_property_in_given_values_Test
+[INFO] Running org.assertj.core.api.filter.Filter_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.filter.Filter_create_Test
+[INFO] Running org.assertj.core.api.filter.Filter_on_different_properties_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_on_different_properties_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_not_in_given_values_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_with_property_not_in_given_values_Test
+[INFO] Running org.assertj.core.api.filter.Filter_having_condition_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.filter.Filter_having_condition_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_not_equals_to_given_value_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_with_property_not_equals_to_given_value_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_equals_to_null_value_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.filter.Filter_with_property_equals_to_null_value_Test
+[INFO] Running org.assertj.core.api.filter.Filter_with_property_equals_to_given_value_short_version_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.filter.Filter_with_property_equals_to_given_value_short_version_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithLongParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithLongParameter_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNotNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNotNegative_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isStrictlyBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isStrictlyBetween_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isBetween_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNotPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNotPositive_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNotCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNotCloseTo_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithIntParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithIntParameter_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNotZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNotZero_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isZero_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isCloseTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isCloseTo_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isNotCloseToPercentage_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isNotCloseToPercentage_Test
+[INFO] Running org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithStringParameter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.biginteger.BigIntegerAssert_isEqualToWithStringParameter_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_CharArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_CharArray_Test
+[INFO] Running org.assertj.core.api.longpredicate.LongPredicateAssert_rejects_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.longpredicate.LongPredicateAssert_rejects_Test
+[INFO] Running org.assertj.core.api.longpredicate.LongPredicateAssert_accepts_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.longpredicate.LongPredicateAssert_accepts_Test
+[INFO] Running org.assertj.core.api.AbstractAssert_usingRecursiveComparison_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.AbstractAssert_usingRecursiveComparison_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Integer_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Integer_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_DoubleArray_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_DoubleArray_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoParameter_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasNoParameter_String_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasQuery_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasQuery_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoParameter_String_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasNoParameter_String_String_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasHost_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasHost_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoFragment_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasNoFragment_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoPort_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasNoPort_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasScheme_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasScheme_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoQuery_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasNoQuery_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoUserInfo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasNoUserInfo_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasFragment_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasFragment_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasPath_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasPath_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasUserInfo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasUserInfo_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasAuthority_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasAuthority_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasPort_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasPort_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasParameter_String_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.uri.UriAssert_hasParameter_String_String_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasNoParameters_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasNoParameters_Test
+[INFO] Running org.assertj.core.api.uri.UriAssert_hasParameter_String_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.uri.UriAssert_hasParameter_String_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasNanos_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.duration.DurationAssert_hasNanos_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_isNegative_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.duration.DurationAssert_isNegative_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_isPositive_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.duration.DurationAssert_isPositive_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasHours_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.duration.DurationAssert_hasHours_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasDays_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.duration.DurationAssert_hasDays_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasMinutes_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.duration.DurationAssert_hasMinutes_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasSeconds_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.duration.DurationAssert_hasSeconds_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_hasMillis_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.duration.DurationAssert_hasMillis_Test
+[INFO] Running org.assertj.core.api.duration.DurationAssert_isZero_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.duration.DurationAssert_isZero_Test
+[INFO] Running org.assertj.core.api.Condition_as_Description_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Condition_as_Description_Test
+[INFO] Running org.assertj.core.api.Assertions_sync_with_Assumptions_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_sync_with_Assumptions_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isDone_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_isDone_Test
+[INFO] Running org.assertj.core.api.future.FutureAssert_isDone_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.FutureAssert_isDone_Test
+[INFO] Running org.assertj.core.api.future.FutureAssert_isNotDone_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.FutureAssert_isNotDone_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isCompletedExceptionally_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_isCompletedExceptionally_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_hasFailed_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_hasFailed_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_succeedsWithin_duration_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_succeedsWithin_duration_Test
+[INFO] Running org.assertj.core.api.future.FutureAssert_isCancelled_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.FutureAssert_isCancelled_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isCompletedWithValue_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_isCompletedWithValue_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isCompletedWithValueMatching_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_isCompletedWithValueMatching_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isCompleted_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_isCompleted_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_hasFailedWithThrowableThat_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_hasFailedWithThrowableThat_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isNotDone_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_isNotDone_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isNotCancelled_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_isNotCancelled_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isNotCompletedExceptionally_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_isNotCompletedExceptionally_Test
+[INFO] Running org.assertj.core.api.future.FutureAssert_isNotCancelled_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.FutureAssert_isNotCancelled_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isCancelled_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_isCancelled_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_succeedsWithin_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.api.future.CompletableFutureAssert_succeedsWithin_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_hasNotFailed_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.future.CompletableFutureAssert_hasNotFailed_Test
+[INFO] Running org.assertj.core.api.future.CompletableFutureAssert_isNotCompleted_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.future.CompletableFutureAssert_isNotCompleted_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Short_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_Short_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_OptionalInt_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_OptionalInt_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_ZonedDateTime_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_ZonedDateTime_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_isEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_isEmpty_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsOnlyOnce_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsOnlyOnce_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeBetween_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeBetween_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeLessThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_endsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_endsWith_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_isNotEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_isNotEmpty_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsExactly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsExactly_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeGreaterThanOrEqualTo_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_usingElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_usingElementComparator_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_isSorted_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_isSorted_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotHaveDuplicates_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_contains_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_contains_at_Index_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsSubsequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsSubsequence_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsSequence_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsSequence_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotContain_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotContain_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsAnyOf_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsAnyOf_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_usingComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_usingComparator_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_isNullOrEmpty_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_isNullOrEmpty_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotContain_at_Index_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_doesNotContain_at_Index_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_startsWith_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_startsWith_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsExactlyInAnyOrder_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSameSizeAs_with_Iterable_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_containsOnly_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_containsOnly_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_isSortedAccordingToComparator_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_usingDefaultElementComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_usingDefaultElementComparator_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_contains_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_contains_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_usingDefaultComparator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_usingDefaultComparator_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeLessThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeLessThan_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSize_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSize_Test
+[INFO] Running org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeGreaterThan_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.booleanarray.BooleanArrayAssert_hasSizeGreaterThan_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_primitive_double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_primitive_double_Test
+[INFO] Running org.assertj.core.api.Assertions_avoid_ambiguous_reference_compilation_error_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_avoid_ambiguous_reference_compilation_error_Test
+[INFO] Running org.assertj.core.api.BDDAssertions_then_Test
+[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.BDDAssertions_then_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Double_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Double_Test
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_LongStream_Test
+[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Assertions_assertThat_with_LongStream_Test
+[INFO] Running org.assertj.core.api.Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 s - in org.assertj.core.api.Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test
+[INFO] Running org.assertj.core.perf.ContainsOnlyPerfTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.281 s - in org.assertj.core.perf.ContainsOnlyPerfTest
+[INFO] Running org.assertj.core.perf.TypeComparatorsPerfTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s - in org.assertj.core.perf.TypeComparatorsPerfTest
+[INFO] Running org.assertj.core.perf.SoftAssertionsPerfTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s - in org.assertj.core.perf.SoftAssertionsPerfTest
+[INFO] Running org.assertj.core.data.MapEntry_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.MapEntry_toString_Test
+[INFO] Running org.assertj.core.data.Percentage_withPercentage_with_Double_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Percentage_withPercentage_with_Double_Test
+[INFO] Running org.assertj.core.data.Percentage_withPercentage_with_Long_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Percentage_withPercentage_with_Long_Test
+[INFO] Running org.assertj.core.data.Index_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Index_toString_Test
+[INFO] Running org.assertj.core.data.Offset_equals_hashCode_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Offset_equals_hashCode_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_Integer_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Offset_built_with_Integer_Test
+[INFO] Running org.assertj.core.data.Offset_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Offset_toString_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_BigInteger_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Offset_built_with_BigInteger_Test
+[INFO] Running org.assertj.core.data.Percentage_withPercentage_with_Integer_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Percentage_withPercentage_with_Integer_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_Double_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Offset_built_with_Double_Test
+[INFO] Running org.assertj.core.data.Index_equals_hashCode_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Index_equals_hashCode_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_Long_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Offset_built_with_Long_Test
+[INFO] Running org.assertj.core.data.Percentage_equals_hashCode_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Percentage_equals_hashCode_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_BigDecimal_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Offset_built_with_BigDecimal_Test
+[INFO] Running org.assertj.core.data.Percentage_toString_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Percentage_toString_Test
+[INFO] Running org.assertj.core.data.MapEntry_equals_hashCode_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.MapEntry_equals_hashCode_Test
+[INFO] Running org.assertj.core.data.Offset_built_with_Float_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.data.Offset_built_with_Float_Test
+[INFO] Running org.assertj.core.data.Index_atIndex_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.data.Index_atIndex_Test
+[INFO] Running org.assertj.core.error.ShouldHaveCause_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveCause_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeNull_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeNull_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainPattern_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainPattern_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveToString_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveToString_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveRootCause_create_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.assertj.core.error.ShouldHaveRootCause_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeGreaterOrEqual_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeGreaterOrEqual_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainExactlyInAnyOrder_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainExactlyInAnyOrder_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSize_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSize_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveFields_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveFields_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeRelativePath_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeRelativePath_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotHaveAnyElementsOfTypes_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotHaveAnyElementsOfTypes_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSubsetOf_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSubsetOf_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeExactlyInstance_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeExactlyInstance_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotHaveThrown_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotHaveThrown_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameHourWindow_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeInSameHourWindow_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainKeys_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainKeys_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringWhitespace_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualIgnoringWhitespace_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_equals_hashCode_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqual_equals_hashCode_Test
+[INFO] Running org.assertj.core.error.BasicErrorMessageFactory_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.BasicErrorMessageFactory_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveComparableElementsAccordingToComparator_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveComparableElementsAccordingToComparator_create_Test
+[INFO] Running org.assertj.core.error.BasicErrorMessageFactory_unquotedString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.BasicErrorMessageFactory_unquotedString_Test
+[INFO] Running org.assertj.core.error.ShouldMatch_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldMatch_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldNotHave_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldNotHave_create_Test
+[INFO] Running org.assertj.core.error.ShouldMatchPattern_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldMatchPattern_create_Test
+[INFO] Running org.assertj.core.error.AssertionErrorCreator_multipleAssertionsError_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.AssertionErrorCreator_multipleAssertionsError_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameSizeAs_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveSameSizeAs_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualComparingOnlyGivenFields_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualComparingOnlyGivenFields_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameYear_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeInSameYear_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeCanonicalPath_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeCanonicalPath_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainAtIndex_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainAtIndex_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainValue_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotContainValue_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringSeconds_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualIgnoringSeconds_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainOnlyNulls_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainOnlyNulls_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainValues_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainValues_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainSubsequence_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainSubsequence_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameTime_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveSameTime_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldNotBe_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldNotBe_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameHashCode_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSameHashCode_create_Test
+[INFO] Running org.assertj.core.error.ShouldExist_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldExist_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveNoParent_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveNoParent_create_Test
+[INFO] Running org.assertj.core.error.BasicErrorMessageFactory_toString_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.BasicErrorMessageFactory_toString_Test
+[INFO] Running org.assertj.core.error.ElementsShouldBeAtLeast_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldBeAtLeast_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveReference_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveReference_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainPattern_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotContainPattern_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEqualIgnoringCase_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeEqualIgnoringCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainSubsequenceOfCharSequence_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainSubsequenceOfCharSequence_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContain_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotContain_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotExist_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotExist_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainExactly_create_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainExactly_create_Test
+[INFO] Running org.assertj.core.error.Optional_ShouldBeEmpty_create_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.Optional_ShouldBeEmpty_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringMinutes_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualIgnoringMinutes_create_Test
+[INFO] Running org.assertj.core.error.ShouldAccept_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldAccept_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainOnly_create_Test
+[ERROR] Tests run: 6, Failures: 6, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.assertj.core.error.ShouldContainOnly_create_Test
+[ERROR] should_not_display_elements_not_found_when_there_are_none_with_custom_comparison_strategy  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_not_display_elements_not_found_when_there_are_none_with_custom_comparison_strategy(ShouldContainOnly_create_Test.java:155)
+
+[ERROR] should_not_display_unexpected_elements_when_there_are_none  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_not_display_unexpected_elements_when_there_are_none(ShouldContainOnly_create_Test.java:95)
+
+[ERROR] should_not_display_unexpected_elements_when_there_are_none_with_custom_comparison_strategy  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_not_display_unexpected_elements_when_there_are_none_with_custom_comparison_strategy(ShouldContainOnly_create_Test.java:115)
+
+[ERROR] should_create_error_message  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_create_error_message(ShouldContainOnly_create_Test.java:51)
+
+[ERROR] should_create_error_message_with_custom_comparison_strategy  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_create_error_message_with_custom_comparison_strategy(ShouldContainOnly_create_Test.java:73)
+
+[ERROR] should_not_display_elements_not_found_when_there_are_none  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+">
+but was not.
+	at org.assertj.core.error.ShouldContainOnly_create_Test.should_not_display_elements_not_found_when_there_are_none(ShouldContainOnly_create_Test.java:135)
+
+[INFO] Running org.assertj.core.error.ShouldBeAssignableFrom_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeAssignableFrom_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSame_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSame_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_newAssertionError_without_JUnit_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqual_newAssertionError_without_JUnit_Test
+[INFO] Running org.assertj.core.error.AnyElementsShouldMatch_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.AnyElementsShouldMatch_create_Test
+[INFO] Running org.assertj.core.error.ShouldOnlyHaveFields_create_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldOnlyHaveFields_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeMarkedCase_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeMarkedCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameDay_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeInSameDay_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSubstringOf_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSubstringOf_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainString_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotContainString_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldHaveExactly_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ElementsShouldHaveExactly_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSymbolicLink_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSymbolicLink_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeBefore_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeBefore_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameClass_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSameClass_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameSecondWindow_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeInSameSecondWindow_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldBeAtMost_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldBeAtMost_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringCase_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualIgnoringCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldStartWithPath_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldStartWithPath_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeRegularFile_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeRegularFile_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveAllNullFields_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveAllNullFields_create_Test
+[INFO] Running org.assertj.core.error.OptionalDouble_ShouldHaveValueCloseToPercentage_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.OptionalDouble_ShouldHaveValueCloseToPercentage_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualWithTimePrecision_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualWithTimePrecision_create_Test
+[INFO] Running org.assertj.core.error.AssertionErrorCreator_multipleSoftAssertionsError_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.AssertionErrorCreator_multipleSoftAssertionsError_Test
+[INFO] Running org.assertj.core.error.ShouldBeBetween_create_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeBetween_create_Test
+[INFO] Running org.assertj.core.error.Optional_ShouldBePresent_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.Optional_ShouldBePresent_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeAfter_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAfter_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainAtIndex_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotContainAtIndex_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeExhausted_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeExhausted_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotMatch_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotMatch_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveOnlyElementsOfType_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveOnlyElementsOfType_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainEntry_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainEntry_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainsOnlyOnce_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainsOnlyOnce_create_Test
+[INFO] Running org.assertj.core.error.ShouldHave_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHave_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeUpperCase_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeUpperCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringNewlines_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualIgnoringNewlines_create_Test
+[INFO] Running org.assertj.core.error.ShouldContain_create_Test
+[ERROR] Tests run: 8, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in org.assertj.core.error.ShouldContain_create_Test
+[ERROR] should_create_error_message_differentiating_long_from_integer_in_arrays  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <[5L, 7L]>
+to contain:
+ <[5, 7]>
+but could not find the following elements:
+ <[5, 7]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <[5L, 7L]>
+to contain:
+ <[5, 7]>
+but could not find:
+ <[5, 7]>
+">
+but was not.
+	at org.assertj.core.error.ShouldContain_create_Test.should_create_error_message_differentiating_long_from_integer_in_arrays(ShouldContain_create_Test.java:101)
+
+[ERROR] should_create_error_message_with_custom_comparison_strategy  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <["Yoda"]>
+to contain:
+ <["Luke", "Yoda"]>
+but could not find the following elements:
+ <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <["Yoda"]>
+to contain:
+ <["Luke", "Yoda"]>
+but could not find:
+ <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+	at org.assertj.core.error.ShouldContain_create_Test.should_create_error_message_with_custom_comparison_strategy(ShouldContain_create_Test.java:67)
+
+[ERROR] should_create_error_message_differentiating_double_from_float  Time elapsed: 0 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <[5.0, 7.0]>
+to contain:
+ <[5.0f, 7.0f]>
+but could not find the following elements:
+ <[5.0f, 7.0f]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <[5.0, 7.0]>
+to contain:
+ <[5.0f, 7.0f]>
+but could not find:
+ <[5.0f, 7.0f]>
+">
+but was not.
+	at org.assertj.core.error.ShouldContain_create_Test.should_create_error_message_differentiating_double_from_float(ShouldContain_create_Test.java:118)
+
+[INFO] Running org.assertj.core.error.ShouldNotBeBetween_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeBetween_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEqual_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeEqual_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEqualNormalizingWhitespace_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotBeEqualNormalizingWhitespace_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeLess_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeLess_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeNormalized_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeNormalized_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test
+[INFO] Running org.assertj.core.error.ShouldNotHave_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotHave_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInstanceOfAny_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeInstanceOfAny_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveValue_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveValue_create_Test
+[INFO] Running org.assertj.core.error.AssertionErrorCreator_assertionError_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.AssertionErrorCreator_assertionError_Test
+[INFO] Running org.assertj.core.error.ShouldHaveMessage_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveMessage_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeFile_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeFile_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeBeforeOrEqualTo_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeBeforeOrEqualTo_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainsAnyOf_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainsAnyOf_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainString_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainString_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotHaveSameClass_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotHaveSameClass_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainThrowable_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainThrowable_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeValidBase64_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeValidBase64_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualWithinPercentage_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualWithinPercentage_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEmpty_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEmpty_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldHaveAtLeast_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldHaveAtLeast_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeExactlyInstance_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeExactlyInstance_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringNanos_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualIgnoringNanos_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameHourAs_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveSameHourAs_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveName_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveName_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainKey_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotContainKey_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeInstanceOfAny_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeInstanceOfAny_create_Test
+[INFO] Running org.assertj.core.error.AssertionErrorCreator_tryThrowingMultipleFailuresError_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.AssertionErrorCreator_tryThrowingMultipleFailuresError_Test
+[INFO] Running org.assertj.core.error.ClassModifierShouldBe_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ClassModifierShouldBe_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainOnlyWhitespaces_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainOnlyWhitespaces_create_Test
+[INFO] Running org.assertj.core.error.ShouldEndWith_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldEndWith_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringGivenFields_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualIgnoringGivenFields_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveNoSuperclass_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveNoSuperclass_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldZipSatisfy_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ElementsShouldZipSatisfy_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainOnlyDigits_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainOnlyDigits_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeDirectory_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeDirectory_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSizeLessThan_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSizeLessThan_create_Test
+[INFO] Running org.assertj.core.error.ShouldSatisfy_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldSatisfy_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeOfClassIn_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeOfClassIn_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeInstance_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeInstance_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveParent_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveParent_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotEndWith_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotEndWith_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeMarkedCase_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeMarkedCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqual_Test
+[INFO] Running org.assertj.core.error.ShouldBeExecutable_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeExecutable_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEmpty_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeEmpty_create_Test
+[INFO] Running org.assertj.core.error.BasicErrorMessageFactory_equals_hashCode_Test
+[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.BasicErrorMessageFactory_equals_hashCode_Test
+[INFO] Running org.assertj.core.error.ShouldHaveTime_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveTime_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameMinuteWindow_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeInSameMinuteWindow_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeOfClassIn_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeOfClassIn_Test
+[INFO] Running org.assertj.core.error.Optional_ShouldContain_create_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.Optional_ShouldContain_create_Test
+[INFO] Running org.assertj.core.error.ShouldOnlyHaveElementsOfTypes_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldOnlyHaveElementsOfTypes_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeReadable_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeReadable_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeIn_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeIn_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInSameMonth_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeInSameMonth_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSameContent_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSameContent_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainKeys_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotContainKeys_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveMessageMatchingRegex_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveMessageMatchingRegex_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeIn_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeIn_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeAbsolutePath_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAbsolutePath_create_Test
+[INFO] Running org.assertj.core.error.NoElementsShouldMatch_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.NoElementsShouldMatch_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeGreater_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeGreater_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldBe_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldBe_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEmptyDirectory_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEmptyDirectory_create_Test
+[INFO] Running org.assertj.core.error.MessageFormatter_format_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.MessageFormatter_format_Test
+[INFO] Running org.assertj.core.error.ElementsShouldHave_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldHave_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldSatisfy_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldSatisfy_create_Test
+[INFO] Running org.assertj.core.error.OptionalShouldContainInstanceOf_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.OptionalShouldContainInstanceOf_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBe_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBe_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualNormalizingWhitespace_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualNormalizingWhitespace_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveMessageFindingMatchRegex_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveMessageFindingMatchRegex_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveAnnotations_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveAnnotations_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainKey_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainKey_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualByComparingFieldByFieldRecursively_create_Test
+[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualByComparingFieldByFieldRecursively_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainSequenceOfCharSequence_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainSequenceOfCharSequence_create_Test
+[INFO] Running org.assertj.core.error.ShouldEndWithPath_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldEndWithPath_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSorted_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSorted_create_Test
+[INFO] Running org.assertj.core.error.OptionalDouble_ShouldHaveValueCloseToOffset_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.OptionalDouble_ShouldHaveValueCloseToOffset_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveDateField_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveDateField_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_assertj_elements_stack_trace_filtering_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqual_assertj_elements_stack_trace_filtering_Test
+[INFO] Running org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test
+[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test
+[ERROR] should_include_errors_count_and_clearly_separate_error_messages  Time elapsed: 0.001 s  <<< FAILURE!
+org.opentest4j.AssertionFailedError: 
+
+Expecting message to be:
+  <"
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+">
+but was:
+  <"
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+">
+
+Throwable that failed the check:
+
+org.assertj.core.error.AssertJMultipleFailuresError: 
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+	at jdk.internal.reflect.GeneratedConstructorAccessor162.newInstance(Unknown Source)
+	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
+	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
+	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
+	at org.assertj.core.error.ConstructorInvoker.newInstance(ConstructorInvoker.java:28)
+	at org.assertj.core.error.AssertionErrorCreator.tryBuildingMultipleFailuresError(AssertionErrorCreator.java:113)
+	at org.assertj.core.error.AssertionErrorCreator.tryBuildingMultipleFailuresError(AssertionErrorCreator.java:98)
+	at org.assertj.core.error.AssertionErrorCreator.multipleSoftAssertionsError(AssertionErrorCreator.java:74)
+	at org.assertj.core.api.AbstractSoftAssertions.assertAll(AbstractSoftAssertions.java:37)
+	at org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test.lambda$should_include_errors_count_and_clearly_separate_error_messages$0(AssertJMultipleFailuresError_getMessage_Test.java:49)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableAssert.catchThrowableOfType(ThrowableAssert.java:72)
+	at org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType(AssertionsForClassTypes.java:792)
+	at org.assertj.core.api.Assertions.catchThrowableOfType(Assertions.java:1222)
+	at org.assertj.core.util.AssertionsUtil.expectAssertionError(AssertionsUtil.java:34)
+	at org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test.should_include_errors_count_and_clearly_separate_error_messages(AssertJMultipleFailuresError_getMessage_Test.java:49)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+	at org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test.should_include_errors_count_and_clearly_separate_error_messages(AssertJMultipleFailuresError_getMessage_Test.java:51)
+
+[INFO] Running org.assertj.core.error.ShouldBeAfterOrEqualTo_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAfterOrEqualTo_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_newAssertionError_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqual_newAssertionError_Test
+[INFO] Running org.assertj.core.error.ShouldBeSameGenericBetweenIterableAndCondition_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeSameGenericBetweenIterableAndCondition_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringTimezone_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualIgnoringTimezone_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveStamp_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveStamp_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveExtension_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveExtension_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveContent_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveContent_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainValue_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainValue_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveMethods_create_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveMethods_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeCloseTo_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeCloseTo_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSizeGreaterThan_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveSizeGreaterThan_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotHaveDuplicates_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotHaveDuplicates_create_Test
+[INFO] Running org.assertj.core.error.NoElementsShouldSatisfy_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.NoElementsShouldSatisfy_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualWithinOffset_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqualWithinOffset_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveParameter_create_Test
+[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveParameter_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHavePort_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHavePort_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveHost_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveHost_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveQuery_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.uri.ShouldHaveQuery_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHavePath_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHavePath_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveScheme_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveScheme_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveAnchor_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveAnchor_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveUserInfo_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveUserInfo_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveFragment_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.uri.ShouldHaveFragment_create_Test
+[INFO] Running org.assertj.core.error.uri.ShouldHaveAuthority_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.uri.ShouldHaveAuthority_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveAtIndex_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveAtIndex_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotContainOnlyWhitespaces_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotContainOnlyWhitespaces_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveNext_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveNext_create_Test
+[INFO] Running org.assertj.core.error.ShouldBe_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBe_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainsStringOnlyOnce_create_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldContainsStringOnlyOnce_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldHaveAtMost_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldHaveAtMost_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldBeCompletedWithin_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.future.ShouldBeCompletedWithin_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldHaveCompletedExceptionally_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldHaveCompletedExceptionally_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldNotBeCancelled_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldNotBeCancelled_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldNotBeCompleted_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldNotBeCompleted_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldNotBeDone_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldNotBeDone_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldNotHaveCompletedExceptionally_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.future.ShouldNotHaveCompletedExceptionally_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldNotHaveFailed_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldNotHaveFailed_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldBeDone_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldBeDone_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldBeCompleted_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldBeCompleted_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldHaveFailed_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldHaveFailed_create_Test
+[INFO] Running org.assertj.core.error.future.ShouldBeCancelled_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.future.ShouldBeCancelled_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeNullOrEmpty_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeNullOrEmpty_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveDigest_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveDigest_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotStartWith_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotStartWith_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldMatch_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ElementsShouldMatch_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotMatchPattern_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotMatchPattern_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveAtLeastOneElementOfType_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveAtLeastOneElementOfType_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeWritable_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeWritable_create_Test
+[INFO] Running org.assertj.core.error.ShouldStartWith_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldStartWith_create_Test
+[INFO] Running org.assertj.core.error.ElementsShouldBeExactly_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ElementsShouldBeExactly_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeLowerCase_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeLowerCase_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSuperclass_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSuperclass_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotAccept_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldNotAccept_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeSame_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeSame_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeInstance_create_Test
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeInstance_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeAtSameInstant_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAtSameInstant_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveCauseReference_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveCauseReference_create_Test
+[INFO] Running org.assertj.core.error.ShouldHaveSuppressedException_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldHaveSuppressedException_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqualIgnoringNewlineDifference_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldBeEqualIgnoringNewlineDifference_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeSortedAccordingToComparator_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeSortedAccordingToComparator_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainSequence_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainSequence_create_Test
+[INFO] Running org.assertj.core.error.ShouldBeAtIndex_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAtIndex_create_Test
+[INFO] Running org.assertj.core.error.DescriptionFormatter_format_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.DescriptionFormatter_format_Test
+[INFO] Running org.assertj.core.error.ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test
+[INFO] Running org.assertj.core.error.ShouldBeAbstract_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldBeAbstract_create_Test
+[INFO] Running org.assertj.core.error.ShouldContainOnlyKeys_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldContainOnlyKeys_create_Test
+[INFO] Running org.assertj.core.error.ShouldNotBeEqualWithinOffset_create_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ShouldNotBeEqualWithinOffset_create_Test
+[INFO] Running org.assertj.core.error.ConstructorInvoker_newInstance_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.error.ConstructorInvoker_newInstance_Test
+[INFO] Running org.assertj.core.error.ShouldHaveComparableElements_create_Test
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.error.ShouldHaveComparableElements_create_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_map_format_Test
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.StandardRepresentation_map_format_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_custom_formatter_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.presentation.StandardRepresentation_custom_formatter_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_array_format_Test
+[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.StandardRepresentation_array_format_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_format_CompletableFuture_Test
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.StandardRepresentation_format_CompletableFuture_Test
+[INFO] Running org.assertj.core.presentation.NumberGrouping_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.NumberGrouping_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_iterable_format_Test
+[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.StandardRepresentation_iterable_format_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_toStringOf_Test
+[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.presentation.StandardRepresentation_toStringOf_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_unambiguousToStringOf_Test
+[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.presentation.StandardRepresentation_unambiguousToStringOf_Test
+[INFO] Running org.assertj.core.presentation.StandardRepresentation_static_setters_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.presentation.StandardRepresentation_static_setters_Test
+[INFO] Running org.example.test.AutoClosableSoftAssertionsLineNumberTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.test.AutoClosableSoftAssertionsLineNumberTest
+[INFO] Running org.example.test.SoftAssertionsLineNumberTest
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.test.SoftAssertionsLineNumberTest
+[INFO] Running org.example.test.BDDSoftAssertionsLineNumberTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.test.BDDSoftAssertionsLineNumberTest
+[INFO] Running org.example.test.CustomSoftAssertionsLineNumberTest
+[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s - in org.example.test.CustomSoftAssertionsLineNumberTest
+[INFO] Running org.example.custom.SoftAssertionsErrorDescriptionTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.custom.SoftAssertionsErrorDescriptionTest
+[INFO] Running org.example.custom.CustomAsserts_filter_stacktrace_Test
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.example.custom.CustomAsserts_filter_stacktrace_Test
+[INFO] Running org.assertj.core.api.string_.StringAssert_isEqualTo_Test
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.string_.StringAssert_isEqualTo_Test
+[INFO] Running org.assertj.core.api.JUnitSoftAssertionsSuccessTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.JUnitSoftAssertionsSuccessTest
+[INFO] Running org.assertj.core.api.JUnitBDDSoftAssertionsSuccessTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.JUnitBDDSoftAssertionsSuccessTest
+[INFO] Running org.assertj.core.api.Assertions_assertThat_with_Spliterator_Test
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Assertions_assertThat_with_Spliterator_Test
+[INFO] Running org.assertj.core.api.Java6JUnitSoftAssertionsSuccessTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.assertj.core.api.Java6JUnitSoftAssertionsSuccessTest
+[INFO] Running org.assertj.core.api.Java6JUnitBDDSoftAssertionsSuccessTest
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.assertj.core.api.Java6JUnitBDDSoftAssertionsSuccessTest
+[INFO] 
+[INFO] Results:
+[INFO] 
+[ERROR] Failures: 
+[ERROR]   Assertions_assertThat_inHexadecimal_Test.should_assert_bytes_contains_in_hexadecimal:56 
+Expecting message to be:
+  <"
+Expecting:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find:
+ <[0x01]>
+">
+but was:
+  <"
+Expecting array byte[]:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find the following byte:
+ <[0x01]>
+">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array byte[]:
+ <[0x02, 0x03]>
+to contain:
+ <[0x01]>
+but could not find the following byte:
+ <[0x01]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ByteArrays.assertContains(ByteArrays.java:199)
+	at org.assertj.core.api.AbstractByteArrayAssert.contains(AbstractByteArrayAssert.java:214)
+	at org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test.lambda$should_assert_bytes_contains_in_hexadecimal$3(Assertions_assertThat_inHexadecimal_Test.java:55)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.Assertions_assertThat_inHexadecimal_Test.should_assert_bytes_contains_in_hexadecimal(Assertions_assertThat_inHexadecimal_Test.java:54)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_all_proxied_methods:346 
+Expecting:
+ <"java.lang.AssertionError: 
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+">
+to contain:
+ <"
+Expecting:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find:
+ <[MapEntry[key="1", value="2"]]>
+"> 
+[ERROR]   BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_map_assertions:197 
+Expecting throwable message:
+  <"
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+">
+to contain:
+  <"Expecting:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find:
+ <[MapEntry[key="1", value="2"]]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting LinkedHashMap:
+ <{"54"="55"}>
+to contain:
+ <[MapEntry[key="1", value="2"]]>
+but could not find the following map entries:
+ <[MapEntry[key="1", value="2"]]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Maps.assertContains(Maps.java:356)
+	at org.assertj.core.api.AbstractMapAssert.contains(AbstractMapAssert.java:516)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains$accessor$uIXUkEB0(Unknown Source)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7$AssertJ$SoftProxies$m0a0ZXYZ.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains(Unknown Source)
+	at org.assertj.core.api.ProxyableMapAssert$ByteBuddy$K8oyOrr7.contains(Unknown Source)
+	at org.assertj.core.api.BDDSoftAssertionsTest.should_be_able_to_catch_exceptions_thrown_by_map_assertions(BDDSoftAssertionsTest.java:193)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   JUnitBDDSoftAssertionsFailureTest.should_report_all_errors:46 
+Expecting:
+ <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to start with:
+ <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+
+[ERROR]   JUnitSoftAssertionsFailureTest.should_report_all_errors:46 
+Expecting:
+ <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to start with:
+ <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+
+[ERROR]   Java6JUnitBDDSoftAssertionsFailureTest.should_report_all_errors:44 
+Expecting throwable message:
+  <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to contain:
+  <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertContainsOnly(Iterables.java:389)
+	at org.assertj.core.api.AbstractIterableAssert.containsOnly(AbstractIterableAssert.java:355)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly$accessor$1t1lhf1U(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP$AssertJ$SoftProxies$WgiSCk3M.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.Java6JUnitBDDSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitBDDSoftAssertionsFailureTest.java:36)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   Java6JUnitSoftAssertionsFailureTest.should_report_all_errors:44 
+Expecting throwable message:
+  <"
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+to contain:
+  <"
+Expecting:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+">
+but did not.
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+  <[1, 2]>
+to contain only:
+  <[1, 3]>
+elements not found:
+  <[3]>
+and elements not expected:
+  <[2]>
+
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertContainsOnly(Iterables.java:389)
+	at org.assertj.core.api.AbstractIterableAssert.containsOnly(AbstractIterableAssert.java:355)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly$accessor$1t1lhf1U(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP$AssertJ$SoftProxies$WgiSCk3M.call(Unknown Source)
+	at org.assertj.core.api.ErrorCollector.intercept(ErrorCollector.java:58)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.ProxyableListAssert$ByteBuddy$zaEO6tuP.containsOnly(Unknown Source)
+	at org.assertj.core.api.Java6JUnitSoftAssertionsFailureTest.should_report_all_errors(Java6JUnitSoftAssertionsFailureTest.java:36)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   AtomicReferenceArrayAssert_usingComparatorForType_Test.should_fail_because_of_comparator_set_last:179 
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}">
+but was:
+  <"
+Expecting array Object[]:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find the following elements:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array Object[]:
+ <[Yoda the Jedi, Yoda the Jedi]>
+to contain:
+ <[Luke the Jedi, Luke the Jedi]>
+but could not find the following elements:
+ <[Luke the Jedi]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> org.assertj.core.test.NeverEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ObjectArrays.assertContains(ObjectArrays.java:236)
+	at org.assertj.core.api.AtomicReferenceArrayAssert.contains(AtomicReferenceArrayAssert.java:459)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.lambda$should_fail_because_of_comparator_set_last$1(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:178)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_fail_because_of_comparator_set_last(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:173)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   AtomicReferenceArrayAssert_usingComparatorForType_Test.should_not_use_comparator_on_fields_level_for_elements:127 
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+but was:
+  <"
+Expecting array Object[]:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting array Object[]:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Arrays.assertContains(Arrays.java:205)
+	at org.assertj.core.internal.ObjectArrays.assertContains(ObjectArrays.java:236)
+	at org.assertj.core.api.AtomicReferenceArrayAssert.contains(AtomicReferenceArrayAssert.java:459)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.lambda$should_not_use_comparator_on_fields_level_for_elements$0(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:126)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.atomic.referencearray.AtomicReferenceArrayAssert_usingComparatorForType_Test.should_not_use_comparator_on_fields_level_for_elements(AtomicReferenceArrayAssert_usingComparatorForType_Test.java:123)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   IterableAssert_usingComparatorForType_Test.should_only_use_comparator_on_fields_element_but_not_the_element_itself:110 
+Expecting message to be:
+  <"
+Expecting:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+but was:
+  <"
+Expecting ArrayList:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}">
+
+Throwable that failed the check:
+
+java.lang.AssertionError: 
+Expecting ArrayList:
+ <[Yoda the Jedi, "some"]>
+to contain:
+ <[Luke the Jedi, "any"]>
+but could not find the following elements:
+ <["any"]>
+when comparing values using field/property by field/property comparator on all fields/properties except ["name"]
+Comparators used:
+- for elements fields (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6], String -> AlwaysEqualComparator}
+- for elements (by type): {Double -> DoubleComparator[precision=1.0E-15], Float -> FloatComparator[precision=1.0E-6]}
+	at org.assertj.core.internal.Failures.failure(Failures.java:125)
+	at org.assertj.core.internal.Iterables.assertIterableContainsGivenValues(Iterables.java:344)
+	at org.assertj.core.internal.Iterables.assertContains(Iterables.java:336)
+	at org.assertj.core.api.AbstractIterableAssert.contains(AbstractIterableAssert.java:346)
+	at org.assertj.core.api.ListAssert.contains(ListAssert.java:251)
+	at org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test.lambda$should_only_use_comparator_on_fields_element_but_not_the_element_itself$0(IterableAssert_usingComparatorForType_Test.java:109)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:58)
+	at org.assertj.core.api.iterable.IterableAssert_usingComparatorForType_Test.should_only_use_comparator_on_fields_element_but_not_the_element_itself(IterableAssert_usingComparatorForType_Test.java:105)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   AssertJMultipleFailuresError_getMessage_Test.should_include_errors_count_and_clearly_separate_error_messages:51 
+Expecting message to be:
+  <"
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+">
+but was:
+  <"
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+">
+
+Throwable that failed the check:
+
+org.assertj.core.error.AssertJMultipleFailuresError: 
+Multiple Failures (10 failures)
+-- failure 1 --
+Expecting empty but was:<[""]>
+-- failure 2 --
+[isEmpty list] 
+Expecting empty but was:<["a", "b", "c"]>
+-- failure 3 --
+Expecting empty but was:<"abc">
+-- failure 4 --
+[isEmpty string] 
+Expecting empty but was:<"abc">
+-- failure 5 --
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 6 --
+[isEqualTo] 
+Expecting:
+ <"abc">
+to be equal to:
+ <"bcd">
+but was not.
+-- failure 7 --
+[contains] 
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 8 --
+[contains] 
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+-- failure 9 --
+Expecting ArrayList:
+ <["a", "b", "c"]>
+to contain:
+ <["e"]>
+but could not find the following elements:
+ <["e"]>
+
+-- failure 10 --
+Expecting
+ <["a", "b", "c"]>
+not to contain
+ <["a"]>
+but found
+ <["a"]>
+
+	at jdk.internal.reflect.GeneratedConstructorAccessor162.newInstance(Unknown Source)
+	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
+	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
+	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
+	at org.assertj.core.error.ConstructorInvoker.newInstance(ConstructorInvoker.java:28)
+	at org.assertj.core.error.AssertionErrorCreator.tryBuildingMultipleFailuresError(AssertionErrorCreator.java:113)
+	at org.assertj.core.error.AssertionErrorCreator.tryBuildingMultipleFailuresError(AssertionErrorCreator.java:98)
+	at org.assertj.core.error.AssertionErrorCreator.multipleSoftAssertionsError(AssertionErrorCreator.java:74)
+	at org.assertj.core.api.AbstractSoftAssertions.assertAll(AbstractSoftAssertions.java:37)
+	at org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test.lambda$should_include_errors_count_and_clearly_separate_error_messages$0(AssertJMultipleFailuresError_getMessage_Test.java:49)
+	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
+	at org.assertj.core.api.ThrowableAssert.catchThrowableOfType(ThrowableAssert.java:72)
+	at org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType(AssertionsForClassTypes.java:792)
+	at org.assertj.core.api.Assertions.catchThrowableOfType(Assertions.java:1222)
+	at org.assertj.core.util.AssertionsUtil.expectAssertionError(AssertionsUtil.java:34)
+	at org.assertj.core.error.AssertJMultipleFailuresError_getMessage_Test.should_include_errors_count_and_clearly_separate_error_messages(AssertJMultipleFailuresError_getMessage_Test.java:49)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
+	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
+	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
+	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
+
+[ERROR]   ShouldContainOnly_create_Test.should_create_error_message:51 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+">
+but was not.
+[ERROR]   ShouldContainOnly_create_Test.should_create_error_message_with_custom_comparison_strategy:73 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Han"]>
+to contain only:
+  <["Luke", "Yoda"]>
+elements not found:
+  <["Luke"]>
+and elements not expected:
+  <["Han"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+[ERROR]   ShouldContainOnly_create_Test.should_not_display_elements_not_found_when_there_are_none:135 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+">
+but was not.
+[ERROR]   ShouldContainOnly_create_Test.should_not_display_elements_not_found_when_there_are_none_with_custom_comparison_strategy:155 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda", "Leia"]>
+to contain only:
+  <["Yoda"]>
+but the following elements were unexpected:
+  <["Leia"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+[ERROR]   ShouldContainOnly_create_Test.should_not_display_unexpected_elements_when_there_are_none:95 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+">
+but was not.
+[ERROR]   ShouldContainOnly_create_Test.should_not_display_unexpected_elements_when_there_are_none_with_custom_comparison_strategy:115 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+  <["Yoda"]>
+to contain only:
+  <["Luke", "Yoda"]>
+but could not find the following elements:
+  <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+[ERROR]   ShouldContain_create_Test.should_create_error_message_differentiating_double_from_float:118 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <[5.0, 7.0]>
+to contain:
+ <[5.0f, 7.0f]>
+but could not find the following elements:
+ <[5.0f, 7.0f]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <[5.0, 7.0]>
+to contain:
+ <[5.0f, 7.0f]>
+but could not find:
+ <[5.0f, 7.0f]>
+">
+but was not.
+[ERROR]   ShouldContain_create_Test.should_create_error_message_differentiating_long_from_integer_in_arrays:101 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <[5L, 7L]>
+to contain:
+ <[5, 7]>
+but could not find the following elements:
+ <[5, 7]>
+">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <[5L, 7L]>
+to contain:
+ <[5, 7]>
+but could not find:
+ <[5, 7]>
+">
+but was not.
+[ERROR]   ShouldContain_create_Test.should_create_error_message_with_custom_comparison_strategy:67 
+Expecting:
+ <"[Test] 
+Expecting ArrayList:
+ <["Yoda"]>
+to contain:
+ <["Luke", "Yoda"]>
+but could not find the following elements:
+ <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+to be equal to:
+ <"[Test] 
+Expecting:
+ <["Yoda"]>
+to contain:
+ <["Luke", "Yoda"]>
+but could not find:
+ <["Luke"]>
+when comparing values using CaseInsensitiveStringComparator">
+but was not.
+[INFO] 
+[ERROR] Tests run: 14242, Failures: 20, Errors: 0, Skipped: 9
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  40.727 s
+[INFO] Finished at: 2020-04-11T21:37:52+08:00
+[INFO] ------------------------------------------------------------------------
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project assertj-core: There are test failures.
+[ERROR] 
+[ERROR] Please refer to /Users/yiwu/Documents/Senior/SE/project/assertj-core/target/surefire-reports for the individual test results.
+[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
+[ERROR] -> [Help 1]
+[ERROR] 
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR] 
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

--- a/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
+++ b/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
@@ -22,6 +22,7 @@ import static org.assertj.core.util.Objects.hashCodeFor;
 import static org.assertj.core.util.Strings.quote;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.presentation.Representation;
@@ -161,4 +162,31 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
                   CONFIGURATION_PROVIDER.representation().toStringOf(arguments));
   }
 
+  /**
+   * Return the specific name that will be used in the error message.
+   *
+   * @param actual the object that is being verified .
+   * @return an String array of length two. The first string is the object (class) name, the second string is the element name.
+   */
+  public static String[] getSpecificName(Object actual) {
+    String name = actual.getClass().getSimpleName();
+    String[] s = { "", "elements" };
+    StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
+    if (stElements[5].getClassName().contains("Spliterators")) {
+      s[0] = "spliterator characteristics";
+      s[1] = "characteristics";
+    } else if (actual instanceof Map) {
+      s[0] = name;
+      s[1] = "map entries";
+    } else if (actual.getClass().isArray()) {
+      s[0] = "array " + name;
+      if(actual.getClass().getComponentType().isPrimitive()){
+        s[1] = name.substring(0, name.length() - 2);
+      };// get "float" from "float[]"
+    } else {
+      s[0] = name;
+    }
+    s[0] = " " + s[0];
+    return s;
+  }
 }

--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -41,7 +41,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContain(Object actual, Object expected, Object notFound,
                                                   ComparisonStrategy comparisonStrategy) {
-    return new ShouldContain(actual, expected, notFound, comparisonStrategy);
+    String[] name = getSpecificName(actual);
+    return new ShouldContain(actual, expected, notFound, comparisonStrategy, name);
   }
 
   /**
@@ -63,8 +64,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
     return new ShouldContain(actual, directoryContent, filterDescription);
   }
 
-  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting:%n <%s>%nto contain:%n <%s>%nbut could not find:%n <%s>%n%s", actual, expected, notFound,
+  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy, String[] name) {
+    super("%nExpecting" + name[0] + ":%n <%s>%nto contain:%n <%s>%nbut could not find the following "+name[1]+":%n <%s>%n%s", actual, expected, notFound,
           comparisonStrategy);
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldContainOnly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnly.java
@@ -42,11 +42,12 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Iterable<?> notFound,
                                                       Iterable<?> notExpected, ComparisonStrategy comparisonStrategy) {
+    String[] name = getSpecificName(actual);
     if (isNullOrEmpty(notExpected))
-      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy);
+      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy, name);
     if (isNullOrEmpty(notFound))
-      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy);
-    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy);
+      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy, name);
+    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy, name);
   }
 
   /**
@@ -64,28 +65,28 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFound, Iterable<?> notExpected,
-                            ComparisonStrategy comparisonStrategy) {
+                            ComparisonStrategy comparisonStrategy, String[] name) {
     super("%n" +
-          "Expecting:%n" +
+          "Expecting" + name[0] + ":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" +
-          "elements not found:%n" +
+          name[1] + " not found:%n" +
           "  <%s>%n" +
-          "and elements not expected:%n" +
+          "and " + name[1] + " not expected:%n" +
           "  <%s>%n%s", actual,
           expected, notFound, notExpected, comparisonStrategy);
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFoundOrNotExpected, ErrorType errorType,
-                            ComparisonStrategy comparisonStrategy) {
+                            ComparisonStrategy comparisonStrategy, String[] name) {
     // @format:off
     super("%n" +
-          "Expecting:%n" +
+          "Expecting"+name[0]+":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" + (errorType == NOT_FOUND_ONLY ?
-          "but could not find the following elements:%n" : "but the following elements were unexpected:%n") +
+          "but could not find the following "+name[1]+":%n" : "but the following "+name[1]+" were unexpected:%n") +
           "  <%s>%n%s",
           actual, expected, notFoundOrNotExpected, comparisonStrategy);
     // @format:on

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_inHexadecimal_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_inHexadecimal_Test.java
@@ -53,11 +53,11 @@ public class Assertions_assertThat_inHexadecimal_Test {
   public void should_assert_bytes_contains_in_hexadecimal() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(new byte[] { 2, 3 }).inHexadecimal()
                                                                                                     .contains(new byte[] { 1 }))
-                                                   .withMessage(format("%nExpecting:%n" +
+                                                   .withMessage(format("%nExpecting array byte[]:%n" +
                                                                        " <[0x02, 0x03]>%n"
                                                                        + "to contain:%n" +
                                                                        " <[0x01]>%n" +
-                                                                       "but could not find:%n" +
+                                                                       "but could not find the following byte:%n" +
                                                                        " <[0x01]>%n"));
   }
 

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -206,11 +206,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errors = softly.errorsCollected();
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting:%n"
+    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting LinkedHashMap:%n"
                                                             + " <{\"54\"=\"55\"}>%n"
                                                             + "to contain:%n"
                                                             + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                                            + "but could not find:%n"
+                                                            + "but could not find the following map entries:%n"
                                                             + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
     assertThat(errors.get(1)).hasMessageStartingWith(format("%nExpecting empty but was:<{\"54\"=\"55\"}>"));
   }
@@ -395,11 +395,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                                  + "  <\"something was good\">%n"
                                                  + "but was:%n"
                                                  + "  <\"something was wrong\">"));
-      assertThat(errors.get(39)).contains(format("%nExpecting:%n"
+      assertThat(errors.get(39)).contains(format("%nExpecting LinkedHashMap:%n"
                                                  + " <{\"54\"=\"55\"}>%n"
                                                  + "to contain:%n"
                                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                                 + "but could not find:%n"
+                                                 + "but could not find the following map entries:%n"
                                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
 
       assertThat(errors.get(40)).contains(format("%nExpecting:%n <12:00>%nto be equal to:%n <13:00>%nbut was not."));

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingComparatorForType_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingComparatorForType_Test.java
@@ -152,11 +152,11 @@ public class IterableAssert_usingComparatorForType_Test extends IterableAssertBa
                                         .usingComparatorForElementFieldsWithType(NEVER_EQUALS_STRING, String.class)
                                         .usingFieldByFieldElementComparator()
                                         .contains(other, other);
-    }).withMessage(format("%nExpecting:%n"
+    }).withMessage(format("%nExpecting ArrayList:%n"
                           + " <[Yoda the Jedi, Yoda the Jedi]>%n"
                           + "to contain:%n"
                           + " <[Luke the Jedi, Luke the Jedi]>%n"
-                          + "but could not find:%n"
+                          + "but could not find the following elements:%n"
                           + " <[Luke the Jedi]>%n"
                           + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                           + "Comparators used:%n"

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_usingComparatorForType_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_usingComparatorForType_Test.java
@@ -119,11 +119,11 @@ public class ObjectArrayAssert_usingComparatorForType_Test extends ObjectArrayAs
                                                                                                                                String.class)
                                                                                       .usingFieldByFieldElementComparator()
                                                                                       .contains(other, "any"))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Comparable[]:%n"
                                                                        + " <[Yoda the Jedi, \"some\"]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, \"any\"]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[\"any\"]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"
@@ -171,11 +171,11 @@ public class ObjectArrayAssert_usingComparatorForType_Test extends ObjectArrayAs
                                                                                                                                String.class)
                                                                                       .usingFieldByFieldElementComparator()
                                                                                       .contains(other, other))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Jedi[]:%n"
                                                                        + " <[Yoda the Jedi, Yoda the Jedi]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, Luke the Jedi]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[Luke the Jedi]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"

--- a/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
@@ -48,11 +48,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting ArrayList:%n" +
                                    " <[\"Yoda\"]>%n" +
                                    "to contain:%n" +
                                    " <[\"Luke\", \"Yoda\"]>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <[\"Luke\"]>%n"));
   }
 
@@ -82,11 +82,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting Long:%n" +
                                    " <5L>%n" +
                                    "to contain:%n" +
                                    " <5>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <5>%n" +
                                    ""));
   }

--- a/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
+++ b/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
@@ -29,6 +29,7 @@ import org.assertj.core.internal.SpliteratorsBaseTest;
 import org.assertj.core.test.StringSpliterator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.ls.LSOutput;
 
 /**
  * Tests for <code>{@link SpliteratorAssert#hasCharacteristics(int...)}</code>.
@@ -77,12 +78,18 @@ public class Spliterators_assertHasCharacteristics_Test extends SpliteratorsBase
     // GIVEN
     Spliterator<?> actual = createSpliterator(SORTED);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasCharacteristics(INFO, actual, DISTINCT));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasCharacteristics(INFO, actual, DISTINCT));
     // THEN
-    verify(failures).failure(INFO, shouldContain(singleton("SORTED"), array("DISTINCT"), singleton("DISTINCT")));
+    assertThat(error).hasMessage("\nExpecting spliterator characteristics:\n"
+                                 + " <[\"SORTED\"]>\n"
+                                 + "to contain:\n"
+                                 + " <[\"DISTINCT\"]>\n"
+                                 + "but could not find the following characteristics:\n"
+                                 + " <[\"DISTINCT\"]>\n");
   }
 
   private Spliterator<?> createSpliterator(int characteristics) {
     return new StringSpliterator(characteristics);
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
+++ b/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
@@ -72,12 +72,14 @@ public class Spliterators_assertHasOnlyCharacteristics_Test extends Spliterators
     // GIVEN
     Spliterator<?> actual = createSpliterator(Spliterator.SORTED | DISTINCT);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT));
     // THEN
-    verify(failures).failure(INFO, shouldContainOnly(newHashSet("DISTINCT", "SORTED"),
-                                                     array("DISTINCT"),
-                                                     emptyList(),
-                                                     list("SORTED")));
+    assertThat(error).hasMessage("\nExpecting spliterator characteristics:\n"
+                                 + "  <[\"DISTINCT\", \"SORTED\"]>\n"
+                                 + "to contain only:\n"
+                                 + "  <[\"DISTINCT\"]>\n"
+                                 + "but the following characteristics were unexpected:\n"
+                                 + "  <[\"SORTED\"]>\n");
   }
 
   @Test
@@ -85,12 +87,16 @@ public class Spliterators_assertHasOnlyCharacteristics_Test extends Spliterators
     // GIVEN
     Spliterator<?> actual = createSpliterator(SORTED | ORDERED);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT, SORTED));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT, SORTED));
     // THEN
-    verify(failures).failure(INFO, shouldContainOnly(newHashSet("SORTED", "ORDERED"),
-                                                     array("DISTINCT", "SORTED"),
-                                                     list("DISTINCT"),
-                                                     list("ORDERED")));
+    assertThat(error).hasMessage("\nExpecting spliterator characteristics:\n"
+                                 + "  <[\"ORDERED\", \"SORTED\"]>\n"
+                                 + "to contain only:\n"
+                                 + "  <[\"DISTINCT\", \"SORTED\"]>\n"
+                                 + "characteristics not found:\n"
+                                 + "  <[\"DISTINCT\"]>\n"
+                                 + "and characteristics not expected:\n"
+                                 + "  <[\"ORDERED\"]>\n");
   }
 
   private static Spliterator<?> createSpliterator(int characteristics) {


### PR DESCRIPTION
#### Check List:
* Fixes #1645 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA

I implemented  ``getSpecificName()``  in ``BasicErrorMessageFactory`` class and called it in the ``ShouldContain`` and ``ShouldContainOnly`` class.

Changing the error message content caused a few existing tests to fail. I corrected some of them by replacing with the more specific messages. This pull request currently has 20 failing tests (in the failed_tests.log). 

If this implementation is ok, I'd like to refactor the remaing failing tests.

