### PR TITLE
Fix ShouldContain/ShouldContainOnly use a more specific name in error message

### DIFF
--- a/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
+++ b/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
@@ -22,6 +22,7 @@ import static org.assertj.core.util.Objects.hashCodeFor;
 import static org.assertj.core.util.Strings.quote;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.presentation.Representation;
@@ -161,4 +162,31 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
                   CONFIGURATION_PROVIDER.representation().toStringOf(arguments));
   }
 
+  /**
+   * Return the specific name that will be used in the error message.
+   *
+   * @param actual the object that is being verified .
+   * @return an String array of length two. The first string is the object (class) name, the second string is the element name.
+   */
+  public static String[] getSpecificName(Object actual) {
+    String name = actual.getClass().getSimpleName();
+    String[] s = { "", "elements" };
+    StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
+    if (stElements[5].getClassName().contains("Spliterators")) {
+      s[0] = "spliterator characteristics";
+      s[1] = "characteristics";
+    } else if (actual instanceof Map) {
+      s[0] = name;
+      s[1] = "map entries";
+    } else if (actual.getClass().isArray()) {
+      s[0] = "array " + name;
+      if(actual.getClass().getComponentType().isPrimitive()){
+        s[1] = name.substring(0, name.length() - 2);
+      };// get "float" from "float[]"
+    } else {
+      s[0] = name;
+    }
+    s[0] = " " + s[0];
+    return s;
+  }
 }

--- a/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
+++ b/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
@@ -22,7 +22,6 @@ import static org.assertj.core.util.Objects.hashCodeFor;
 import static org.assertj.core.util.Strings.quote;
 
 import java.util.Arrays;
-import java.util.Map;
 
 import org.assertj.core.description.Description;
 import org.assertj.core.presentation.Representation;
@@ -30,7 +29,7 @@ import org.assertj.core.util.VisibleForTesting;
 
 /**
  * A factory of error messages typically shown when an assertion fails.
- * 
+ *
  * @author Alex Ruiz
  */
 public class BasicErrorMessageFactory implements ErrorMessageFactory {
@@ -94,7 +93,7 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
 
   /**
    * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   * 
+   *
    * @param format the format string.
    * @param arguments arguments referenced by the format specifiers in the format string.
    */
@@ -123,7 +122,7 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
 
   /**
    * Return a string who will be unquoted in message format (without '')
-   * 
+   *
    * @param string the string who will be unquoted.
    * @return an unquoted string in message format.
    */
@@ -162,31 +161,4 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
                   CONFIGURATION_PROVIDER.representation().toStringOf(arguments));
   }
 
-  /**
-   * Return the specific name that will be used in the error message.
-   *
-   * @param actual the object that is being verified .
-   * @return an String array of length two. The first string is the object (class) name, the second string is the element name.
-   */
-  public static String[] getSpecificName(Object actual) {
-    String name = actual.getClass().getSimpleName();
-    String[] s = { "", "elements" };
-    StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
-    if (stElements[5].getClassName().contains("Spliterators")) {
-      s[0] = "spliterator characteristics";
-      s[1] = "characteristics";
-    } else if (actual instanceof Map) {
-      s[0] = name;
-      s[1] = "map entries";
-    } else if (actual.getClass().isArray()) {
-      s[0] = "array " + name;
-      if(actual.getClass().getComponentType().isPrimitive()){
-        s[1] = name.substring(0, name.length() - 2);
-      };// get "float" from "float[]"
-    } else {
-      s[0] = name;
-    }
-    s[0] = " " + s[0];
-    return s;
-  }
 }

--- a/src/main/java/org/assertj/core/error/GroupTypeDescription.java
+++ b/src/main/java/org/assertj/core/error/GroupTypeDescription.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.Map;
+
+/**
+ * Generates a description for the type of a group of elements. The description is used in the error message.
+ *
+ */
+public class GroupTypeDescription {
+  private String groupTypeName;
+  private String elementTypeName;
+
+  public GroupTypeDescription(String groupTypeName, String elementTypeName) {
+    this.groupTypeName = groupTypeName;
+    this.elementTypeName = elementTypeName;
+  }
+
+  public String getElementTypeName() {
+    return elementTypeName;
+  }
+
+  public String getGroupTypeName() {
+    return groupTypeName;
+  }
+
+  /**
+   * Creates a new <code>{@link GroupTypeDescription}</code> for a group of elements.
+   *
+   * @param actual the group of elements.
+   * @return the created GroupTypeDescription object
+   */
+  public static GroupTypeDescription getGroupTypeDescription(Object actual) {
+
+    Class<?> c = actual.getClass();
+    if (Thread.currentThread().getStackTrace()[5].getClassName().contains("Spliterators"))
+      return new GroupTypeDescription("spliterator characteristics", "characteristics");
+
+    if (actual instanceof Map)
+      return new GroupTypeDescription("map", "map entries");
+
+    if (c.isArray() && c.getComponentType().isPrimitive())
+      return new GroupTypeDescription("array " + c.getSimpleName(), c.getComponentType().getSimpleName());
+    if (c.isArray())
+      return new GroupTypeDescription("array " + c.getSimpleName(), "elements");
+
+    return new GroupTypeDescription(c.getSimpleName(), "elements");
+  }
+}

--- a/src/main/java/org/assertj/core/error/GroupTypeDescription.java
+++ b/src/main/java/org/assertj/core/error/GroupTypeDescription.java
@@ -19,6 +19,7 @@ import java.util.Map;
  *
  */
 public class GroupTypeDescription {
+  private static final int SPLITERATORS_CLASS_STACK_TRACE_NUM = 5;
   private String groupTypeName;
   private String elementTypeName;
 
@@ -44,14 +45,15 @@ public class GroupTypeDescription {
   public static GroupTypeDescription getGroupTypeDescription(Object actual) {
 
     Class<?> c = actual.getClass();
-    if (Thread.currentThread().getStackTrace()[5].getClassName().contains("Spliterators"))
+    if (Thread.currentThread().getStackTrace()[SPLITERATORS_CLASS_STACK_TRACE_NUM].getClassName().contains("Spliterators"))
       return new GroupTypeDescription("spliterator characteristics", "characteristics");
 
     if (actual instanceof Map)
       return new GroupTypeDescription("map", "map entries");
 
-    if (c.isArray() && c.getComponentType().isPrimitive())
+    if (c.isArray() && c.getComponentType().isPrimitive() || actual instanceof String[])
       return new GroupTypeDescription("array " + c.getSimpleName(), c.getComponentType().getSimpleName());
+
     if (c.isArray())
       return new GroupTypeDescription("array " + c.getSimpleName(), "elements");
 

--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -41,7 +41,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContain(Object actual, Object expected, Object notFound,
                                                   ComparisonStrategy comparisonStrategy) {
-    return new ShouldContain(actual, expected, notFound, comparisonStrategy);
+    String[] name = getSpecificName(actual);
+    return new ShouldContain(actual, expected, notFound, comparisonStrategy, name);
   }
 
   /**
@@ -63,8 +64,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
     return new ShouldContain(actual, directoryContent, filterDescription);
   }
 
-  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting:%n <%s>%nto contain:%n <%s>%nbut could not find:%n <%s>%n%s", actual, expected, notFound,
+  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy, String[] name) {
+    super("%nExpecting" + name[0] + ":%n <%s>%nto contain:%n <%s>%nbut could not find the following "+name[1]+":%n <%s>%n%s", actual, expected, notFound,
           comparisonStrategy);
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
-
+import static org.assertj.core.error.GroupTypeDescription.getGroupTypeDescription;
 import static org.assertj.core.util.Strings.escapePercent;
 
 /**
@@ -41,7 +41,7 @@ public class ShouldContain extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContain(Object actual, Object expected, Object notFound,
                                                   ComparisonStrategy comparisonStrategy) {
-    GroupTypeDescription groupTypeDescription = GroupTypeDescription.getGroupTypeDescription(actual);
+    GroupTypeDescription groupTypeDescription = getGroupTypeDescription(actual);
     return new ShouldContain(actual, expected, notFound, comparisonStrategy, groupTypeDescription);
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -41,8 +41,8 @@ public class ShouldContain extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContain(Object actual, Object expected, Object notFound,
                                                   ComparisonStrategy comparisonStrategy) {
-    String[] name = getSpecificName(actual);
-    return new ShouldContain(actual, expected, notFound, comparisonStrategy, name);
+    GroupTypeDescription groupTypeDescription = GroupTypeDescription.getGroupTypeDescription(actual);
+    return new ShouldContain(actual, expected, notFound, comparisonStrategy, groupTypeDescription);
   }
 
   /**
@@ -64,8 +64,11 @@ public class ShouldContain extends BasicErrorMessageFactory {
     return new ShouldContain(actual, directoryContent, filterDescription);
   }
 
-  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy, String[] name) {
-    super("%nExpecting" + name[0] + ":%n <%s>%nto contain:%n <%s>%nbut could not find the following "+name[1]+":%n <%s>%n%s", actual, expected, notFound,
+  private ShouldContain(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy,
+                        GroupTypeDescription groupTypeDescription) {
+    super("%nExpecting " + groupTypeDescription.getGroupTypeName()
+          + ":%n <%s>%nto contain:%n <%s>%nbut could not find the following " + groupTypeDescription.getElementTypeName()
+          + ":%n <%s>%n%s", actual, expected, notFound,
           comparisonStrategy);
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldContainOnly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnly.java
@@ -42,11 +42,12 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Iterable<?> notFound,
                                                       Iterable<?> notExpected, ComparisonStrategy comparisonStrategy) {
+    String[] name = getSpecificName(actual);
     if (isNullOrEmpty(notExpected))
-      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy);
+      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy, name);
     if (isNullOrEmpty(notFound))
-      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy);
-    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy);
+      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy, name);
+    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy, name);
   }
 
   /**
@@ -64,28 +65,28 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFound, Iterable<?> notExpected,
-                            ComparisonStrategy comparisonStrategy) {
+                            ComparisonStrategy comparisonStrategy, String[] name) {
     super("%n" +
-          "Expecting:%n" +
+          "Expecting" + name[0] + ":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" +
-          "elements not found:%n" +
+          name[1] + " not found:%n" +
           "  <%s>%n" +
-          "and elements not expected:%n" +
+          "and " + name[1] + " not expected:%n" +
           "  <%s>%n%s", actual,
           expected, notFound, notExpected, comparisonStrategy);
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFoundOrNotExpected, ErrorType errorType,
-                            ComparisonStrategy comparisonStrategy) {
+                            ComparisonStrategy comparisonStrategy, String[] name) {
     // @format:off
     super("%n" +
-          "Expecting:%n" +
+          "Expecting"+name[0]+":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" + (errorType == NOT_FOUND_ONLY ?
-          "but could not find the following elements:%n" : "but the following elements were unexpected:%n") +
+          "but could not find the following "+name[1]+":%n" : "but the following "+name[1]+" were unexpected:%n") +
           "  <%s>%n%s",
           actual, expected, notFoundOrNotExpected, comparisonStrategy);
     // @format:on

--- a/src/main/java/org/assertj/core/error/ShouldContainOnly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnly.java
@@ -14,6 +14,7 @@ package org.assertj.core.error;
 
 import static org.assertj.core.error.ShouldContainOnly.ErrorType.NOT_EXPECTED_ONLY;
 import static org.assertj.core.error.ShouldContainOnly.ErrorType.NOT_FOUND_ONLY;
+import static org.assertj.core.error.GroupTypeDescription.getGroupTypeDescription;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 
 import org.assertj.core.internal.ComparisonStrategy;
@@ -42,12 +43,12 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Iterable<?> notFound,
                                                       Iterable<?> notExpected, ComparisonStrategy comparisonStrategy) {
-    String[] name = getSpecificName(actual);
+    GroupTypeDescription groupTypeDescription = getGroupTypeDescription(actual);
     if (isNullOrEmpty(notExpected))
-      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy, name);
+      return new ShouldContainOnly(actual, expected, notFound, NOT_FOUND_ONLY, comparisonStrategy, groupTypeDescription);
     if (isNullOrEmpty(notFound))
-      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy, name);
-    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy, name);
+      return new ShouldContainOnly(actual, expected, notExpected, NOT_EXPECTED_ONLY, comparisonStrategy, groupTypeDescription);
+    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy, groupTypeDescription);
   }
 
   /**
@@ -65,28 +66,28 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFound, Iterable<?> notExpected,
-                            ComparisonStrategy comparisonStrategy, String[] name) {
+                            ComparisonStrategy comparisonStrategy, GroupTypeDescription groupTypeDescription) {
     super("%n" +
-          "Expecting" + name[0] + ":%n" +
+          "Expecting " + groupTypeDescription.getGroupTypeName() + ":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" +
-          name[1] + " not found:%n" +
+          groupTypeDescription.getElementTypeName() + " not found:%n" +
           "  <%s>%n" +
-          "and " + name[1] + " not expected:%n" +
+          "and " + groupTypeDescription.getElementTypeName() + " not expected:%n" +
           "  <%s>%n%s", actual,
           expected, notFound, notExpected, comparisonStrategy);
   }
 
   private ShouldContainOnly(Object actual, Object expected, Iterable<?> notFoundOrNotExpected, ErrorType errorType,
-                            ComparisonStrategy comparisonStrategy, String[] name) {
+                            ComparisonStrategy comparisonStrategy, GroupTypeDescription groupTypeDescription) {
     // @format:off
     super("%n" +
-          "Expecting"+name[0]+":%n" +
+          "Expecting "+groupTypeDescription.getGroupTypeName()+":%n" +
           "  <%s>%n" +
           "to contain only:%n" +
           "  <%s>%n" + (errorType == NOT_FOUND_ONLY ?
-          "but could not find the following "+name[1]+":%n" : "but the following "+name[1]+" were unexpected:%n") +
+          "but could not find the following "+groupTypeDescription.getElementTypeName()+":%n" : "but the following "+groupTypeDescription.getElementTypeName()+" were unexpected:%n") +
           "  <%s>%n%s",
           actual, expected, notFoundOrNotExpected, comparisonStrategy);
     // @format:on

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_inHexadecimal_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_inHexadecimal_Test.java
@@ -53,11 +53,11 @@ public class Assertions_assertThat_inHexadecimal_Test {
   public void should_assert_bytes_contains_in_hexadecimal() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(new byte[] { 2, 3 }).inHexadecimal()
                                                                                                     .contains(new byte[] { 1 }))
-                                                   .withMessage(format("%nExpecting:%n" +
+                                                   .withMessage(format("%nExpecting array byte[]:%n" +
                                                                        " <[0x02, 0x03]>%n"
                                                                        + "to contain:%n" +
                                                                        " <[0x01]>%n" +
-                                                                       "but could not find:%n" +
+                                                                       "but could not find the following byte:%n" +
                                                                        " <[0x01]>%n"));
   }
 

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -194,11 +194,11 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errors = softly.errorsCollected();
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0)).hasMessageContaining(format("Expecting:%n"
+    assertThat(errors.get(0)).hasMessageContaining(format("Expecting LinkedHashMap:%n"
                                                           + " <{\"54\"=\"55\"}>%n"
                                                           + "to contain:%n"
                                                           + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                                          + "but could not find:%n"
+                                                          + "but could not find the following map entries:%n"
                                                           + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
     assertThat(errors.get(1)).hasMessageContaining(format("Expecting empty but was:<{\"54\"=\"55\"}>"));
 
@@ -343,11 +343,11 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
                                                + "  <\"something was good\">%n"
                                                + "but was:%n"
                                                + "  <\"something was wrong\">"));
-    assertThat(errors.get(39)).contains(format("%nExpecting:%n"
+    assertThat(errors.get(39)).contains(format("%nExpecting LinkedHashMap:%n"
                                                + " <{\"54\"=\"55\"}>%n"
                                                + "to contain:%n"
                                                + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                               + "but could not find:%n"
+                                               + "but could not find the following map entries:%n"
                                                + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
     assertThat(errors.get(40)).contains(format("%nExpecting:%n <12:00>%nto be equal to:%n <13:00>%nbut was not."));
     assertThat(errors.get(41)).contains(format("%nExpecting:%n <12:00Z>%nto be equal to:%n <13:00Z>%nbut was not."));

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -194,7 +194,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errors = softly.errorsCollected();
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0)).hasMessageContaining(format("Expecting LinkedHashMap:%n"
+    assertThat(errors.get(0)).hasMessageContaining(format("Expecting map:%n"
                                                           + " <{\"54\"=\"55\"}>%n"
                                                           + "to contain:%n"
                                                           + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
@@ -343,7 +343,7 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
                                                + "  <\"something was good\">%n"
                                                + "but was:%n"
                                                + "  <\"something was wrong\">"));
-    assertThat(errors.get(39)).contains(format("%nExpecting LinkedHashMap:%n"
+    assertThat(errors.get(39)).contains(format("%nExpecting map:%n"
                                                + " <{\"54\"=\"55\"}>%n"
                                                + "to contain:%n"
                                                + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"

--- a/src/test/java/org/assertj/core/api/JUnitBDDSoftAssertionsFailureTest.java
+++ b/src/test/java/org/assertj/core/api/JUnitBDDSoftAssertionsFailureTest.java
@@ -44,7 +44,7 @@ public class JUnitBDDSoftAssertionsFailureTest {
     assertThat(failures).hasSize(2);
     assertThat(failures.get(0)).hasMessageStartingWith(format("%nExpecting:%n <1>%nto be equal to:%n <2>%nbut was not."));
     assertThat(failures.get(1)).hasMessageStartingWith(format("%n" +
-                                                              "Expecting:%n" +
+                                                              "Expecting ArrayList:%n" +
                                                               "  <[1, 2]>%n" +
                                                               "to contain only:%n" +
                                                               "  <[1, 3]>%n" +

--- a/src/test/java/org/assertj/core/api/JUnitSoftAssertionsFailureTest.java
+++ b/src/test/java/org/assertj/core/api/JUnitSoftAssertionsFailureTest.java
@@ -44,7 +44,7 @@ public class JUnitSoftAssertionsFailureTest {
     assertThat(failures).hasSize(2);
     assertThat(failures.get(0)).hasMessageStartingWith(format("%nExpecting:%n <1>%nto be equal to:%n <2>%nbut was not."));
     assertThat(failures.get(1)).hasMessageStartingWith(format("%n" +
-                                                              "Expecting:%n" +
+                                                              "Expecting ArrayList:%n" +
                                                               "  <[1, 2]>%n" +
                                                               "to contain only:%n" +
                                                               "  <[1, 3]>%n" +

--- a/src/test/java/org/assertj/core/api/Java6JUnitBDDSoftAssertionsFailureTest.java
+++ b/src/test/java/org/assertj/core/api/Java6JUnitBDDSoftAssertionsFailureTest.java
@@ -42,7 +42,7 @@ public class Java6JUnitBDDSoftAssertionsFailureTest {
       assertThat(failures).hasSize(2);
       assertThat(failures.get(0)).hasMessageContaining(format("%nExpecting:%n <1>%nto be equal to:%n <2>%nbut was not."));
       assertThat(failures.get(1)).hasMessageContaining(format("%n" +
-                                                              "Expecting:%n" +
+                                                              "Expecting ArrayList:%n" +
                                                               "  <[1, 2]>%n" +
                                                               "to contain only:%n" +
                                                               "  <[1, 3]>%n" +

--- a/src/test/java/org/assertj/core/api/Java6JUnitSoftAssertionsFailureTest.java
+++ b/src/test/java/org/assertj/core/api/Java6JUnitSoftAssertionsFailureTest.java
@@ -42,7 +42,7 @@ public class Java6JUnitSoftAssertionsFailureTest {
       assertThat(failures).hasSize(2);
       assertThat(failures.get(0)).hasMessageContaining(format("%nExpecting:%n <1>%nto be equal to:%n <2>%nbut was not."));
       assertThat(failures.get(1)).hasMessageContaining(format("%n" +
-                                                              "Expecting:%n" +
+                                                              "Expecting ArrayList:%n" +
                                                               "  <[1, 2]>%n" +
                                                               "to contain only:%n" +
                                                               "  <[1, 3]>%n" +

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -207,11 +207,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errors = softly.errorsCollected();
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting:%n"
+    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting LinkedHashMap:%n"
                                                             + " <{\"54\"=\"55\"}>%n"
                                                             + "to contain:%n"
                                                             + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                                            + "but could not find:%n"
+                                                            + "but could not find the following map entries:%n"
                                                             + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
     assertThat(errors.get(1)).hasMessageStartingWith(format("%nExpecting empty but was:<{\"54\"=\"55\"}>"));
   }
@@ -396,11 +396,11 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                                  + "  <\"something was good\">%n"
                                                  + "but was:%n"
                                                  + "  <\"something was wrong\">"));
-      assertThat(errors.get(39)).contains(format("%nExpecting:%n"
+      assertThat(errors.get(39)).contains(format("%nExpecting LinkedHashMap:%n"
                                                  + " <{\"54\"=\"55\"}>%n"
                                                  + "to contain:%n"
                                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
-                                                 + "but could not find:%n"
+                                                 + "but could not find the following map entries:%n"
                                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"));
 
       assertThat(errors.get(40)).contains(format("%nExpecting:%n <12:00>%nto be equal to:%n <13:00>%nbut was not."));

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -207,7 +207,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     // THEN
     List<Throwable> errors = softly.errorsCollected();
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting LinkedHashMap:%n"
+    assertThat(errors.get(0)).hasMessageStartingWith(format("%nExpecting map:%n"
                                                             + " <{\"54\"=\"55\"}>%n"
                                                             + "to contain:%n"
                                                             + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"
@@ -396,7 +396,7 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                                  + "  <\"something was good\">%n"
                                                  + "but was:%n"
                                                  + "  <\"something was wrong\">"));
-      assertThat(errors.get(39)).contains(format("%nExpecting LinkedHashMap:%n"
+      assertThat(errors.get(39)).contains(format("%nExpecting map:%n"
                                                  + " <{\"54\"=\"55\"}>%n"
                                                  + "to contain:%n"
                                                  + " <[MapEntry[key=\"1\", value=\"2\"]]>%n"

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingComparatorForType_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_usingComparatorForType_Test.java
@@ -124,11 +124,11 @@ public class AtomicReferenceArrayAssert_usingComparatorForType_Test extends Atom
                                                                                                                                      String.class)
                                                                                             .usingFieldByFieldElementComparator()
                                                                                             .contains(other, "any"))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Object[]:%n"
                                                                        + " <[Yoda the Jedi, \"some\"]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, \"any\"]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[\"any\"]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"
@@ -176,11 +176,11 @@ public class AtomicReferenceArrayAssert_usingComparatorForType_Test extends Atom
                                                                                                                                      String.class)
                                                                                             .usingFieldByFieldElementComparator()
                                                                                             .contains(other, other))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Object[]:%n"
                                                                        + " <[Yoda the Jedi, Yoda the Jedi]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, Luke the Jedi]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[Luke the Jedi]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingComparatorForType_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_usingComparatorForType_Test.java
@@ -107,11 +107,11 @@ public class IterableAssert_usingComparatorForType_Test extends IterableAssertBa
                                                                                                                                         String.class)
                                                                                                .usingElementComparatorIgnoringFields("name")
                                                                                                .contains(other, "any"))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting ArrayList:%n"
                                                                        + " <[Yoda the Jedi, \"some\"]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, \"any\"]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[\"any\"]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties except [\"name\"]%n"
                                                                        + "Comparators used:%n"
@@ -152,11 +152,11 @@ public class IterableAssert_usingComparatorForType_Test extends IterableAssertBa
                                         .usingComparatorForElementFieldsWithType(NEVER_EQUALS_STRING, String.class)
                                         .usingFieldByFieldElementComparator()
                                         .contains(other, other);
-    }).withMessage(format("%nExpecting:%n"
+    }).withMessage(format("%nExpecting ArrayList:%n"
                           + " <[Yoda the Jedi, Yoda the Jedi]>%n"
                           + "to contain:%n"
                           + " <[Luke the Jedi, Luke the Jedi]>%n"
-                          + "but could not find:%n"
+                          + "but could not find the following elements:%n"
                           + " <[Luke the Jedi]>%n"
                           + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                           + "Comparators used:%n"

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_usingComparatorForType_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_usingComparatorForType_Test.java
@@ -119,11 +119,11 @@ public class ObjectArrayAssert_usingComparatorForType_Test extends ObjectArrayAs
                                                                                                                                String.class)
                                                                                       .usingFieldByFieldElementComparator()
                                                                                       .contains(other, "any"))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Comparable[]:%n"
                                                                        + " <[Yoda the Jedi, \"some\"]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, \"any\"]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[\"any\"]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"
@@ -171,11 +171,11 @@ public class ObjectArrayAssert_usingComparatorForType_Test extends ObjectArrayAs
                                                                                                                                String.class)
                                                                                       .usingFieldByFieldElementComparator()
                                                                                       .contains(other, other))
-                                                   .withMessage(format("%nExpecting:%n"
+                                                   .withMessage(format("%nExpecting array Jedi[]:%n"
                                                                        + " <[Yoda the Jedi, Yoda the Jedi]>%n"
                                                                        + "to contain:%n"
                                                                        + " <[Luke the Jedi, Luke the Jedi]>%n"
-                                                                       + "but could not find:%n"
+                                                                       + "but could not find the following elements:%n"
                                                                        + " <[Luke the Jedi]>%n"
                                                                        + "when comparing values using field/property by field/property comparator on all fields/properties%n"
                                                                        + "Comparators used:%n"

--- a/src/test/java/org/assertj/core/error/AssertJMultipleFailuresError_getMessage_Test.java
+++ b/src/test/java/org/assertj/core/error/AssertJMultipleFailuresError_getMessage_Test.java
@@ -74,11 +74,11 @@ public class AssertJMultipleFailuresError_getMessage_Test {
                                   "but was not.%n" +
                                   "-- failure 7 --%n" +
                                   "[contains] %n" +
-                                  "Expecting:%n" +
+                                  "Expecting ArrayList:%n" +
                                   " <[\"a\", \"b\", \"c\"]>%n" +
                                   "to contain:%n" +
                                   " <[\"e\"]>%n" +
-                                  "but could not find:%n" +
+                                  "but could not find the following elements:%n" +
                                   " <[\"e\"]>%n" +
                                   "%n" +
                                   "-- failure 8 --%n" +
@@ -91,11 +91,11 @@ public class AssertJMultipleFailuresError_getMessage_Test {
                                   " <[\"a\"]>%n" +
                                   "%n" +
                                   "-- failure 9 --%n" +
-                                  "Expecting:%n" +
+                                  "Expecting ArrayList:%n" +
                                   " <[\"a\", \"b\", \"c\"]>%n" +
                                   "to contain:%n" +
                                   " <[\"e\"]>%n" +
-                                  "but could not find:%n" +
+                                  "but could not find the following elements:%n" +
                                   " <[\"e\"]>%n" +
                                   "%n" +
                                   "-- failure 10 --%n" +

--- a/src/test/java/org/assertj/core/error/GroupTypeDescription_getGroupTypeDescription_Test.java
+++ b/src/test/java/org/assertj/core/error/GroupTypeDescription_getGroupTypeDescription_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.test.Jedi;
+import org.junit.jupiter.params.provider.Arguments;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.error.GroupTypeDescription.getGroupTypeDescription;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+class GroupTypeDescription_getGroupTypeDescription_Test {
+
+  @ParameterizedTest
+  @MethodSource("argumentsStreamProvider")
+  void getGroupTypeDescription_test(Object obj, String groupTypeName, String elementTypeName) {
+    GroupTypeDescription description = getGroupTypeDescription(obj);
+    assertThat(description.getGroupTypeName()).isEqualTo(groupTypeName);
+    assertThat(description.getElementTypeName()).isEqualTo(elementTypeName);
+
+  }
+
+  private static Stream<Arguments> argumentsStreamProvider() {
+    return Stream.of(Arguments.of(mapOf(entry("1", 2d)), "map", "map entries"),
+                     Arguments.of(new int[] { 1, 2 }, "array int[]", "int"),
+                     Arguments.of(new double[] { 1, 2 }, "array double[]", "double"),
+                     Arguments.of(new float[] { 1f, 2f }, "array float[]", "float"),
+                     Arguments.of(new byte[] { 1, 2 }, "array byte[]", "byte"),
+                     Arguments.of(new long[] { 1L, 2L }, "array long[]", "long"),
+                     Arguments.of(new boolean[] { true }, "array boolean[]", "boolean"),
+                     Arguments.of(new char[] { 1, 2 }, "array char[]", "char"),
+                     Arguments.of(new short[] { 1, 2 }, "array short[]", "short"),
+                     Arguments.of(new String[] { "a", "c" }, "array String[]", "String"),
+                     Arguments.of(new Object[] { "a", "c" }, "array Object[]", "elements"),
+                     Arguments.of(new Jedi[] { new Jedi("Yoda", "green") }, "array Jedi[]", "elements"),
+                     Arguments.of(list(1, 2), "ArrayList", "elements"),
+                     Arguments.of(newLinkedHashSet(1, 2), "LinkedHashSet", "elements")
+
+    );
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
@@ -15,15 +15,23 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
+import org.assertj.core.test.Jedi;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 
+import org.assertj.core.data.MapEntry;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.test.Maps;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
 
@@ -161,4 +169,293 @@ public class ShouldContainOnly_create_Test {
                                    + "  <[\"Leia\"]>%n"
                                    + "when comparing values using CaseInsensitiveStringComparator"));
   }
+
+  @Test
+  public void should_create_error_message_unexpected_for_map() {
+    // GIVEN
+    Map<String, String> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
+    MapEntry<String, String>[] expected = array(entry("name", "Yoda"));
+    ErrorMessageFactory factory = shouldContainOnly(map,
+                                                    expected,
+                                                    emptySet(),
+                                                    set(entry("color", "green")));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting map:%n"
+                                   + "  <{\"color\"=\"green\", \"name\"=\"Yoda\"}>%n"
+                                   + "to contain only:%n"
+                                   + "  <[MapEntry[key=\"name\", value=\"Yoda\"]]>%n"
+                                   + "but the following map entries were unexpected:%n"
+                                   + "  <[MapEntry[key=\"color\", value=\"green\"]]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_for_map() {
+    // GIVEN
+    Map<String, String> map = mapOf(entry("name", "Yoda"));
+    MapEntry<String, String>[] expected = array(entry("name", "Yoda"), entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainOnly(map,
+                                                    expected,
+                                                    set(entry("color", "green")),
+                                                    emptySet());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting map:%n"
+                                   + "  <{\"name\"=\"Yoda\"}>%n"
+                                   + "to contain only:%n"
+                                   + "  <[MapEntry[key=\"name\", value=\"Yoda\"], MapEntry[key=\"color\", value=\"green\"]]>%n"
+                                   + "but could not find the following map entries:%n"
+                                   + "  <[MapEntry[key=\"color\", value=\"green\"]]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_and_unexpected_for_map() {
+    // GIVEN
+    Map<String, String> map = mapOf(entry("name", "Yoda"));
+    MapEntry<String, String>[] expected = array(entry("color", "green"));
+    ErrorMessageFactory factory = shouldContainOnly(map,
+                                                    expected,
+                                                    set(entry("color", "green")),
+                                                    set(entry("name", "Yoda")));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting map:%n"
+                                   + "  <{\"name\"=\"Yoda\"}>%n"
+                                   + "to contain only:%n"
+                                   + "  <[MapEntry[key=\"color\", value=\"green\"]]>%n"
+                                   + "map entries not found:%n"
+                                   + "  <[MapEntry[key=\"color\", value=\"green\"]]>%n"
+                                   + "and map entries not expected:%n"
+                                   + "  <[MapEntry[key=\"name\", value=\"Yoda\"]]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_unexpected_for_float_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new float[] { 6f, 8f, 7f },
+                                                    new float[] { 6f, 8f },
+                                                    emptySet(),
+                                                    newLinkedHashSet(7f));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array float[]:%n"
+                                   + "  <[6.0f, 8.0f, 7.0f]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[6.0f, 8.0f]>%n"
+                                   + "but the following float were unexpected:%n"
+                                   + "  <[7.0f]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_for_char_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new char[] { 'a' },
+                                                    new char[] { 'a', 'b' },
+                                                    newLinkedHashSet('b'),
+                                                    emptySet());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array char[]:%n"
+                                   + "  <['a']>%n"
+                                   + "to contain only:%n"
+                                   + "  <['a', 'b']>%n"
+                                   + "but could not find the following char:%n"
+                                   + "  <['b']>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_and_unexpected_for_long_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new long[] { 5L, 6L },
+                                                    new long[] { 3L, 6L },
+                                                    newLinkedHashSet(3L),
+                                                    newLinkedHashSet(5L));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array long[]:%n"
+                                   + "  <[5L, 6L]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[3L, 6L]>%n"
+                                   + "long not found:%n"
+                                   + "  <[3L]>%n"
+                                   + "and long not expected:%n"
+                                   + "  <[5L]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_unexpected_for_boolean_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new boolean[] { true, false },
+                                                    new boolean[] { false },
+                                                    emptySet(),
+                                                    newLinkedHashSet(true));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array boolean[]:%n"
+                                   + "  <[true, false]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[false]>%n"
+                                   + "but the following boolean were unexpected:%n"
+                                   + "  <[true]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_for_double_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new double[] { 1.0 },
+                                                    new double[] { 1.0, 2.0 },
+                                                    newLinkedHashSet(2.0),
+                                                    emptySet());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array double[]:%n"
+                                   + "  <[1.0]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[1.0, 2.0]>%n"
+                                   + "but could not find the following double:%n"
+                                   + "  <[2.0]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_and_unexpected_for_short_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new short[] { 5, 6 },
+                                                    new short[] { 3, 6 },
+                                                    newLinkedHashSet((short) 3),
+                                                    newLinkedHashSet((short) 5));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array short[]:%n"
+                                   + "  <[5, 6]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[3, 6]>%n"
+                                   + "short not found:%n"
+                                   + "  <[3]>%n"
+                                   + "and short not expected:%n"
+                                   + "  <[5]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_unexpected_for_int_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new int[] { 1, 2 },
+                                                    new int[] { 2 },
+                                                    emptySet(),
+                                                    newLinkedHashSet(1));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array int[]:%n"
+                                   + "  <[1, 2]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[2]>%n"
+                                   + "but the following int were unexpected:%n"
+                                   + "  <[1]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_for_byte_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new byte[] { 1 },
+                                                    new byte[] { 1, 2 },
+                                                    newLinkedHashSet((byte) 2),
+                                                    emptySet());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array byte[]:%n"
+                                   + "  <[1]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[1, 2]>%n"
+                                   + "but could not find the following byte:%n"
+                                   + "  <[2]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_unexpected_for_String_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(new String[] { "1", "2" },
+                                                    new String[] { "2" },
+                                                    emptySet(),
+                                                    newLinkedHashSet("1"));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array String[]:%n"
+                                   + "  <[\"1\", \"2\"]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[\"2\"]>%n"
+                                   + "but the following String were unexpected:%n"
+                                   + "  <[\"1\"]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_for_set() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnly(newLinkedHashSet(1),
+                                                    newLinkedHashSet(1, 2),
+                                                    newLinkedHashSet(2),
+                                                    emptySet());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting LinkedHashSet:%n"
+                                   + "  <[1]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[1, 2]>%n"
+                                   + "but could not find the following elements:%n"
+                                   + "  <[2]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_not_found_and_unexpected_for_custom_object() {
+    // GIVEN
+    Jedi actual = new Jedi("Yoda", "green");
+    Jedi expected = new Jedi("Luke", "blue");
+    ErrorMessageFactory factory = shouldContainOnly(array(actual),
+                                                    array(expected),
+                                                    newLinkedHashSet(expected),
+                                                    newLinkedHashSet(actual));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array Jedi[]:%n"
+                                   + "  <[Yoda the Jedi]>%n"
+                                   + "to contain only:%n"
+                                   + "  <[Luke the Jedi]>%n"
+                                   + "elements not found:%n"
+                                   + "  <[Luke the Jedi]>%n"
+                                   + "and elements not expected:%n"
+                                   + "  <[Yoda the Jedi]>%n"));
+  }
+
+  private static <K, V> HashSet<MapEntry<K, V>> set(MapEntry<K, V> entry) {
+    HashSet<MapEntry<K, V>> set = new HashSet<>();
+    set.add(entry);
+    return set;
+  }
+
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
@@ -49,7 +49,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\", \"Han\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Luke\", \"Yoda\"]>%n"
@@ -71,7 +71,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\", \"Han\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Luke\", \"Yoda\"]>%n"
@@ -93,7 +93,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Luke\", \"Yoda\"]>%n"
@@ -113,7 +113,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Luke\", \"Yoda\"]>%n"
@@ -133,7 +133,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\", \"Leia\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Yoda\"]>%n"
@@ -153,7 +153,7 @@ public class ShouldContainOnly_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting:%n"
+                                   + "Expecting ArrayList:%n"
                                    + "  <[\"Yoda\", \"Leia\"]>%n"
                                    + "to contain only:%n"
                                    + "  <[\"Yoda\"]>%n"

--- a/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
@@ -16,16 +16,22 @@ import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContain.directoryShouldContain;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Map;
 
+import org.assertj.core.data.MapEntry;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.test.Jedi;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +129,185 @@ public class ShouldContain_create_Test {
                                    "but could not find the following elements:%n" +
                                    " <[5.0f, 7.0f]>%n" +
                                    ""));
+  }
+
+  @Test
+  public void should_create_error_message_for_map() {
+    // GIVEN
+    Map<String, Double> map = mapOf(MapEntry.entry("1", 2d));
+    ErrorMessageFactory factory = shouldContain(map, MapEntry.entry("3", 4d), MapEntry.entry("3", 4d));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting map:%n"
+                                   + " <{\"1\"=2.0}>%n"
+                                   + "to contain:%n"
+                                   + " <MapEntry[key=\"3\", value=4.0]>%n"
+                                   + "but could not find the following map entries:%n"
+                                   + " <MapEntry[key=\"3\", value=4.0]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_byte_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new byte[] { 2, 3 }, new byte[] { 4 }, new byte[] { 4 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array byte[]:%n"
+                                   + " <[2, 3]>%n"
+                                   + "to contain:%n"
+                                   + " <[4]>%n"
+                                   + "but could not find the following byte:%n"
+                                   + " <[4]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_float_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new float[] { 2f, 3f }, new float[] { 4f }, new float[] { 4f });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array float[]:%n"
+                                   + " <[2.0f, 3.0f]>%n"
+                                   + "to contain:%n"
+                                   + " <[4.0f]>%n"
+                                   + "but could not find the following float:%n"
+                                   + " <[4.0f]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_int_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new int[] { 2, 3 }, new int[] { 4 }, new int[] { 4 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array int[]:%n"
+                                   + " <[2, 3]>%n"
+                                   + "to contain:%n"
+                                   + " <[4]>%n"
+                                   + "but could not find the following int:%n"
+                                   + " <[4]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_char_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new char[] { 'a', 'b' }, new char[] { 'c', 'd' }, new char[] { 'c', 'd' });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array char[]:%n"
+                                   + " <['a', 'b']>%n"
+                                   + "to contain:%n"
+                                   + " <['c', 'd']>%n"
+                                   + "but could not find the following char:%n"
+                                   + " <['c', 'd']>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_long_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new long[] { 6L, 8L }, new long[] { 10L, 9L }, new long[] { 10L, 9L });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array long[]:%n"
+                                   + " <[6L, 8L]>%n"
+                                   + "to contain:%n"
+                                   + " <[10L, 9L]>%n"
+                                   + "but could not find the following long:%n"
+                                   + " <[10L, 9L]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_double_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new double[] { 6, 8 }, new double[] { 10, 9 }, new double[] { 10, 9 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array double[]:%n"
+                                   + " <[6.0, 8.0]>%n"
+                                   + "to contain:%n"
+                                   + " <[10.0, 9.0]>%n"
+                                   + "but could not find the following double:%n"
+                                   + " <[10.0, 9.0]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_boolean_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new boolean[] { true }, new boolean[] { true, false }, new boolean[] { false });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array boolean[]:%n"
+                                   + " <[true]>%n"
+                                   + "to contain:%n"
+                                   + " <[true, false]>%n"
+                                   + "but could not find the following boolean:%n"
+                                   + " <[false]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_short_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new short[] { 6, 8 }, new short[] { 10, 9 }, new short[] { 10, 9 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array short[]:%n"
+                                   + " <[6, 8]>%n"
+                                   + "to contain:%n"
+                                   + " <[10, 9]>%n"
+                                   + "but could not find the following short:%n"
+                                   + " <[10, 9]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_String_array() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(new String[] { "a"}, new String[] { "b" }, new String[] { "b" });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array String[]:%n"
+                                   + " <[\"a\"]>%n"
+                                   + "to contain:%n"
+                                   + " <[\"b\"]>%n"
+                                   + "but could not find the following String:%n"
+                                   + " <[\"b\"]>%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_custom_class_array() {
+    Jedi actual = new Jedi("Yoda", "green");
+    Jedi expected =new Jedi("Luke", "blue");
+    // GIVEN
+    ErrorMessageFactory factory = shouldContain(array(actual), array(expected), array(expected));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting array Jedi[]:%n"
+                                   + " <[Yoda the Jedi]>%n"
+                                   + "to contain:%n"
+                                   + " <[Luke the Jedi]>%n"
+                                   + "but could not find the following elements:%n"
+                                   + " <[Luke the Jedi]>%n"));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
@@ -48,11 +48,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting ArrayList:%n" +
                                    " <[\"Yoda\"]>%n" +
                                    "to contain:%n" +
                                    " <[\"Luke\", \"Yoda\"]>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <[\"Luke\"]>%n"));
   }
 
@@ -65,11 +65,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting ArrayList:%n" +
                                    " <[\"Yoda\"]>%n" +
                                    "to contain:%n" +
                                    " <[\"Luke\", \"Yoda\"]>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <[\"Luke\"]>%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
@@ -82,11 +82,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting Long:%n" +
                                    " <5L>%n" +
                                    "to contain:%n" +
                                    " <5>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <5>%n" +
                                    ""));
   }
@@ -99,11 +99,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting ArrayList:%n" +
                                    " <[5L, 7L]>%n" +
                                    "to contain:%n" +
                                    " <[5, 7]>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <[5, 7]>%n" +
                                    ""));
   }
@@ -116,11 +116,11 @@ public class ShouldContain_create_Test {
     String message = factory.create(new TextDescription("Test"));
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting:%n" +
+                                   "Expecting ArrayList:%n" +
                                    " <[5.0, 7.0]>%n" +
                                    "to contain:%n" +
                                    " <[5.0f, 7.0f]>%n" +
-                                   "but could not find:%n" +
+                                   "but could not find the following elements:%n" +
                                    " <[5.0f, 7.0f]>%n" +
                                    ""));
   }

--- a/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
+++ b/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
@@ -11,7 +11,7 @@
  * Copyright 2012-2020 the original author or authors.
  */
 package org.assertj.core.internal.spliterator;
-
+import static java.lang.String.format;
 import static java.util.Collections.singleton;
 import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.SORTED;
@@ -29,6 +29,7 @@ import org.assertj.core.internal.SpliteratorsBaseTest;
 import org.assertj.core.test.StringSpliterator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.ls.LSOutput;
 
 /**
  * Tests for <code>{@link SpliteratorAssert#hasCharacteristics(int...)}</code>.
@@ -77,12 +78,18 @@ public class Spliterators_assertHasCharacteristics_Test extends SpliteratorsBase
     // GIVEN
     Spliterator<?> actual = createSpliterator(SORTED);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasCharacteristics(INFO, actual, DISTINCT));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasCharacteristics(INFO, actual, DISTINCT));
     // THEN
-    verify(failures).failure(INFO, shouldContain(singleton("SORTED"), array("DISTINCT"), singleton("DISTINCT")));
+    assertThat(error).hasMessage(format("%nExpecting spliterator characteristics:%n"
+                                 + " <[\"SORTED\"]>%n"
+                                 + "to contain:%n"
+                                 + " <[\"DISTINCT\"]>%n"
+                                 + "but could not find the following characteristics:%n"
+                                 + " <[\"DISTINCT\"]>%n"));
   }
 
   private Spliterator<?> createSpliterator(int characteristics) {
     return new StringSpliterator(characteristics);
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
+++ b/src/test/java/org/assertj/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.spliterator;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.ORDERED;
@@ -72,12 +73,14 @@ public class Spliterators_assertHasOnlyCharacteristics_Test extends Spliterators
     // GIVEN
     Spliterator<?> actual = createSpliterator(Spliterator.SORTED | DISTINCT);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT));
     // THEN
-    verify(failures).failure(INFO, shouldContainOnly(newHashSet("DISTINCT", "SORTED"),
-                                                     array("DISTINCT"),
-                                                     emptyList(),
-                                                     list("SORTED")));
+    assertThat(error).hasMessage(format("%nExpecting spliterator characteristics:%n"
+                                 + "  <[\"DISTINCT\", \"SORTED\"]>%n"
+                                 + "to contain only:%n"
+                                 + "  <[\"DISTINCT\"]>%n"
+                                 + "but the following characteristics were unexpected:%n"
+                                 + "  <[\"SORTED\"]>%n"));
   }
 
   @Test
@@ -85,12 +88,16 @@ public class Spliterators_assertHasOnlyCharacteristics_Test extends Spliterators
     // GIVEN
     Spliterator<?> actual = createSpliterator(SORTED | ORDERED);
     // WHEN
-    expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT, SORTED));
+    AssertionError error = expectAssertionError(() -> spliterators.assertHasOnlyCharacteristics(INFO, actual, DISTINCT, SORTED));
     // THEN
-    verify(failures).failure(INFO, shouldContainOnly(newHashSet("SORTED", "ORDERED"),
-                                                     array("DISTINCT", "SORTED"),
-                                                     list("DISTINCT"),
-                                                     list("ORDERED")));
+    assertThat(error).hasMessage(format("%nExpecting spliterator characteristics:%n"
+                                 + "  <[\"ORDERED\", \"SORTED\"]>%n"
+                                 + "to contain only:%n"
+                                 + "  <[\"DISTINCT\", \"SORTED\"]>%n"
+                                 + "characteristics not found:%n"
+                                 + "  <[\"DISTINCT\"]>%n"
+                                 + "and characteristics not expected:%n"
+                                 + "  <[\"ORDERED\"]>%n"));
   }
 
   private static Spliterator<?> createSpliterator(int characteristics) {


### PR DESCRIPTION
#### Check List:
* Fixes #1645 
* Unit tests : YES
* Javadoc with a code example (on API only) :  NA

I implemented ``getSpecificName()`` in ``BasicErrorMessageFactory`` class and called it in the ``ShouldContain`` and ``ShouldContainOnly`` class.

Changing the error message content caused a few existing tests to fail. So I corrected them by replacing with the more specific message.

Please let me know If you have any feedback.