### PR TITLE
Add decodedAsBase64 to AbstractStringAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Base64;
 import java.util.Comparator;
 
 import org.assertj.core.internal.Comparables;
@@ -222,7 +223,7 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
    * Verifies that the actual value is a valid Base64 encoded string.
    * <p>
    * Examples:
-   * <pre><code class='java'> // assertions succeeds
+   * <pre><code class='java'> // assertion succeeds
    * assertThat(&quot;QXNzZXJ0Sg==&quot;).isValidBase64();
    *
    * // assertion succeeds even without padding as it is optional by specification
@@ -240,6 +241,31 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
   public SELF isValidBase64() {
     strings.assertIsValidBase64(info, actual);
     return myself;
+  }
+
+  /**
+   * Decodes the actual value as a Base64 encoded string, the decoded bytes becoming the new array under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat(&quot;QXNzZXJ0Sg==&quot;).decodedAsBase64().containsExactly("AssertJ".getBytes());
+   *
+   * // assertion succeeds even without padding as it is optional by specification
+   * assertThat(&quot;QXNzZXJ0Sg&quot;).decodedAsBase64().containsExactly("AssertJ".getBytes());
+   *
+   * // assertion fails as it has invalid Base64 characters
+   * assertThat(&quot;inv@lid&quot;).decodedAsBase64();</code></pre>
+   *
+   * @return a new {@link ByteArrayAssert} instance whose array under test is the result of the decoding.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not a valid Base64 encoded string.
+   *
+   * @since 3.16.0
+   */
+  @CheckReturnValue
+  public AbstractByteArrayAssert<?> decodedAsBase64() {
+    strings.assertIsValidBase64(info, actual);
+    return new ByteArrayAssert(Base64.getDecoder().decode(actual)).withAssertionState(myself);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -41,6 +41,7 @@ class SoftProxies {
 
   private static final Junction<MethodDescription> METHODS_CHANGING_THE_OBJECT_UNDER_TEST = methodsNamed("asInstanceOf").or(named("asList"))
                                                                                                                         .or(named("asString"))
+                                                                                                                        .or(named("decodedAsBase64"))
                                                                                                                         .or(named("extracting"))
                                                                                                                         .or(named("extractingByKey"))
                                                                                                                         .or(named("extractingByKeys"))

--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -104,7 +104,7 @@ public class ShouldBeEqual implements AssertionErrorFactory {
    * org.junit.ComparisonFailure that highlights the difference(s) between the expected and actual objects.
    * </p>
    * <p>
-   *   If opentest4j is on the classpath then {@code org.opentest4j.AssertionFailedError} would be used.
+   * If opentest4j is on the classpath then {@code org.opentest4j.AssertionFailedError} would be used.
    * </p>
    * {@link AssertionError} stack trace won't show AssertJ related elements if {@link Failures} is configured to filter
    * them (see {@link Failures#setRemoveAssertJRelatedElementsFromStackTrace(boolean)}).

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -1926,6 +1927,33 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
                                       .hasMessageContaining("888");
     assertThat(errorsCollected.get(3)).hasMessage("[get()] error message");
     assertThat(errorsCollected.get(4)).hasMessage("[get(as(STRING))] error message");
+  }
+
+  @Test
+  void string_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
+    // GIVEN
+    String base64String = "QXNzZXJ0Sg==";
+    // WHEN
+    softly.assertThat(base64String)
+          .as("decodedAsBase64()")
+          .overridingErrorMessage("error message 1")
+          .decodedAsBase64()
+          .isEmpty();
+    // THEN
+    then(softly.errorsCollected()).extracting(Throwable::getMessage)
+                                  .containsExactly("[decodedAsBase64()] error message 1");
+  }
+
+  @Test
+  void should_work_with_string() {
+    // GIVEN
+    String base64String = "QXNzZXJ0Sg==";
+    // WHEN
+    softly.assertThat(base64String)
+          .decodedAsBase64()
+          .containsExactly("AssertJ".getBytes());
+    // THEN
+    softly.assertAll();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/string_/StringAssert_decodedAsBase64_Test.java
+++ b/src/test/java/org/assertj/core/api/string_/StringAssert_decodedAsBase64_Test.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractByteArrayAssert;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link StringAssert#decodedAsBase64()}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("StringAssert decodedAsBase64")
+class StringAssert_decodedAsBase64_Test extends StringAssertBaseTest implements NavigationMethodBaseTest<StringAssert> {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    assertions.decodedAsBase64();
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertIsValidBase64(getInfo(assertions), getActual(assertions));
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Override
+  public StringAssert getAssertion() {
+    return assertions;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(StringAssert assertion) {
+    return assertion.decodedAsBase64();
+  }
+
+  @Test
+  void should_return_byte_array_assertion() {
+    // WHEN
+    AbstractAssert<?, ?> result = assertions.decodedAsBase64();
+    // THEN
+    then(result).isInstanceOf(AbstractByteArrayAssert.class);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #1805
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


