### PR TITLE
Add encodedAsBase64 to AbstractByteArrayAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Hexadecimals.toHexString;
 
+import java.util.Base64;
 import java.util.Comparator;
 
 import org.assertj.core.data.Index;
@@ -914,7 +915,8 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
   }
 
   /**
-   * Converts the actual byte array under test to an hexadecimal String and returns assertions for the computed String allowing String specific assertions from this call.
+   * Converts the actual byte array under test to an hexadecimal String and returns assertions for the computed String
+   * allowing String specific assertions from this call.
    * <p>
    * The Hex String representation is in upper case.
    * <p>
@@ -939,4 +941,23 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
     objects.assertNotNull(info, actual);
     return assertThat(toHexString(actual));
   }
+
+  /**
+   * Encodes the actual array into a Base64 string, the encoded string becoming the new object under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat("AssertJ".getBytes()).encodedAsBase64().isEqualTo(&quot;QXNzZXJ0Sg==&quot;);</code></pre>
+   *
+   * @return a new {@link StringAssert} instance whose string under test is the result of the encoding.
+   * @throws AssertionError if the actual value is {@code null}.
+   *
+   * @since 3.16.0
+   */
+  @CheckReturnValue
+  public AbstractStringAssert<?> encodedAsBase64() {
+    objects.assertNotNull(info, actual);
+    return new StringAssert(Base64.getEncoder().encodeToString(actual)).withAssertionState(myself);
+  }
+
 }

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -43,6 +43,7 @@ class SoftProxies {
                                                                                                                         .or(named("asString"))
                                                                                                                         .or(named("asHexString"))
                                                                                                                         .or(named("decodedAsBase64"))
+                                                                                                                        .or(named("encodedAsBase64"))
                                                                                                                         .or(named("extracting"))
                                                                                                                         .or(named("extractingByKey"))
                                                                                                                         .or(named("extractingByKeys"))

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1945,6 +1945,21 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   @Test
+  void byte_array_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
+    // GIVEN
+    byte[] byteArray = "AssertJ".getBytes();
+    // WHEN
+    softly.assertThat(byteArray)
+          .as("encodedAsBase64()")
+          .overridingErrorMessage("error message 1")
+          .encodedAsBase64()
+          .isEmpty();
+    // THEN
+    then(softly.errorsCollected()).extracting(Throwable::getMessage)
+                                  .containsExactly("[encodedAsBase64()] error message 1");
+  }
+
+  @Test
   void should_work_with_string() {
     // GIVEN
     String base64String = "QXNzZXJ0Sg==";
@@ -1952,6 +1967,18 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(base64String)
           .decodedAsBase64()
           .containsExactly("AssertJ".getBytes());
+    // THEN
+    softly.assertAll();
+  }
+
+  @Test
+  void should_work_with_byte_array() {
+    // GIVEN
+    byte[] byteArray = "AssertJ".getBytes();
+    // WHEN
+    softly.assertThat(byteArray)
+          .encodedAsBase64()
+          .isEqualTo("QXNzZXJ0Sg==");
     // THEN
     softly.assertAll();
   }

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_encodedAsBase64_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_encodedAsBase64_Test.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.bytearray;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.ByteArrayAssert;
+import org.assertj.core.api.ByteArrayAssertBaseTest;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ByteArrayAssert#encodedAsBase64()}</code>.
+ *
+ * @author Stefano Cordio
+ */
+@DisplayName("ByteArrayAssert encodedAsBase64")
+class ByteArrayAssert_encodedAsBase64_Test extends ByteArrayAssertBaseTest implements NavigationMethodBaseTest<ByteArrayAssert> {
+
+  @Override
+  protected ByteArrayAssert invoke_api_method() {
+    assertions.encodedAsBase64();
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotNull(getInfo(assertions), getActual(assertions));
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Override
+  public ByteArrayAssert getAssertion() {
+    return assertions;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(ByteArrayAssert assertion) {
+    return assertion.encodedAsBase64();
+  }
+
+  @Test
+  void should_return_string_assertion() {
+    // WHEN
+    AbstractAssert<?, ?> result = assertions.encodedAsBase64();
+    // THEN
+    then(result).isInstanceOf(AbstractStringAssert.class);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Related to #1805
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


