### PR TITLE
Fix issue #1796 / add a method isEqualToWithSortedQueryParameters

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -419,11 +419,10 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
   }
 
   /**
-   * Verifies that the URL {@code actual} and URL {@code expected} are actually equivalent after <b>their parameters are sorted</b>.
+   * Verifies that the URL {@code expected} is equivalent to URL actual after <b>their parameters are sorted</b>.
    * <p>
    * Example:
    * <pre><code class='java'> URL expected = new URL("http://localhost?a=b&c=d");
-   *       URL actual2 = new URL("http://example.com?a=b&c=e");
    *
    * // this assertion succeeds ...
    * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://localhost?c=d&a=b"));

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -418,6 +418,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
     return myself;
   }
 
+
   /**
    * Verifies that the URL {@code url1} and URL {@code url2} are actually equivalent after <b>their parameters are sorted</b>.
    * <p>

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -431,7 +431,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&amp;c=e"));
    *
    * //... and this case fails as even their domains are different.
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example2.com?amp;a=b&c=d"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example2.com?amp;a=b&amp;c=d"));
    * </code></pre>
    *
    * @param expected the expected URL of the actual {@code URL}.

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -422,16 +422,16 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * Verifies that the URL {@code expected} is equivalent to URL actual after <b>their parameters are sorted</b>.
    * <p>
    * Example:
-   * <pre><code class='java'> URL expected = new URL("http://localhost?a=b&c=d");
+   * <pre><code class='java'> URL expected = new URL("http://example.com?a=b&c=d");
    *
    * // this assertion succeeds ...
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://localhost?c=d&a=b"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?c=d&a=b"));
    *
    * // ... but these cases fail as their parameters do not match.
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://localhost?a=b&c=e"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&c=e"));
    *
    * //... and this case fails as even their domains are different.
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&c=d"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example2.com?a=b&c=d"));
    * </code></pre>
    *
    * @param expected the expected URL of the actual {@code URL}.

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -419,7 +419,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
   }
 
   /**
-   * Verifies that the URL {@code url1} and URL {@code url2} are actually equivalent after <b>their parameters are sorted</b>.
+   * Verifies that the URL {@code actual} and URL {@code expected} are actually equivalent after <b>their parameters are sorted</b>.
    * <p>
    * Example:
    * <pre><code class='java'> URL expected = new URL("http://localhost?a=b&c=d");

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -441,7 +441,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the actual {@code CharSequence} does not contain all the given strings <b>in the given order</b>.
    * 
-   * @since 3.15.0
+   * @since 3.16.0
    */
   public SELF isEqualToWithSortedQueryParameters(URL expected) {
     urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -422,16 +422,16 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * Verifies that the URL {@code expected} is equivalent to URL actual after <b>their parameters are sorted</b>.
    * <p>
    * Example:
-   * <pre><code class='java'> URL expected = new URL("http://example.com?a=b&c=d");
+   * <pre><code class='java'> URL expected = new URL("http://example.com?a=b&amp;c=d");
    *
    * // this assertion succeeds ...
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?c=d&a=b"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?c=d&amp;a=b"));
    *
    * // ... but these cases fail as their parameters do not match.
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&c=e"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&amp;c=e"));
    *
    * //... and this case fails as even their domains are different.
-   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example2.com?a=b&c=d"));
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example2.com?amp;a=b&c=d"));
    * </code></pre>
    *
    * @param expected the expected URL of the actual {@code URL}.

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -418,7 +418,6 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
     return myself;
   }
 
-
   /**
    * Verifies that the URL {@code url1} and URL {@code url2} are actually equivalent after <b>their parameters are sorted</b>.
    * <p>
@@ -442,6 +441,8 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * @throws IllegalArgumentException if the given values is empty.
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the actual {@code CharSequence} does not contain all the given strings <b>in the given order</b>.
+   * 
+   * @since 3.15.0
    */
   public SELF isEqualToWithSortedQueryParameters(URL expected) {
     urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -417,4 +417,33 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
     urls.assertHasNoParameter(info, actual, name, value);
     return myself;
   }
+
+  /**
+   * Verifies that the URL {@code url1} and URL {@code url2} are actually equivalent after <b>their parameters are sorted</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'> URL expected = new URL("http://localhost?a=b&c=d");
+   *       URL actual2 = new URL("http://example.com?a=b&c=e");
+   *
+   * // this assertion succeeds ...
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://localhost?c=d&a=b"));
+   *
+   * // ... but these cases fail as their parameters do not match.
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://localhost?a=b&c=e"));
+   *
+   * //... and this case fails as even their domains are different.
+   * assertThat(expected).isEqualToWithSortedQueryParameters(new URL("http://example.com?a=b&c=d"));
+   * </code></pre>
+   *
+   * @param expected the expected URL of the actual {@code URL}.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given values is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not contain all the given strings <b>in the given order</b>.
+   */
+  public SELF isEqualToWithSortedQueryParameters(URL expected) {
+    urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
@@ -18,7 +18,7 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
 public class ShouldBeEqualToWithSortedQueryParameters extends BasicErrorMessageFactory {
-  private static final String SHOULD_BE_EQUAL_TO_WITH_SORTED_QUERY_PARAMETERS = "%nExpecting URL to be:%n  <%s>%nbut actually is:%n  <%s>";
+  private static final String SHOULD_BE_EQUAL_TO_WITH_SORTED_QUERY_PARAMETERS = "%nExpecting URL to be:%n  <%s>%nbut was:%n  <%s>%n after sorting parameters";
 
   public static ErrorMessageFactory shouldBeEqualToWithSortedQueryParameters(URL actual, URL expected) {
     return new ShouldBeEqualToWithSortedQueryParameters(actual, expected);

--- a/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error.uri;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import java.net.URL;
+
+public class ShouldBeEqualToWithSortedQueryParameters extends BasicErrorMessageFactory {
+  private static final String SHOULD_BE_EQUAL_TO_WITH_SORTED_QUERY_PARAMETERS = "%nExpecting URL to be:%n  <%s>%nbut actually is:%n  <%s>";
+
+  public static ErrorMessageFactory shouldBeEqualToWithSortedQueryParameters(URL actual, URL expected) {
+    return new ShouldBeEqualToWithSortedQueryParameters(actual, expected);
+  }
+
+  private ShouldBeEqualToWithSortedQueryParameters(URL actual, URL expected) {
+    super(SHOULD_BE_EQUAL_TO_WITH_SORTED_QUERY_PARAMETERS, expected.toString(), actual.toString());
+  }
+}

--- a/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters.java
@@ -12,10 +12,10 @@
  */
 package org.assertj.core.error.uri;
 
+import java.net.URL;
+
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
-
-import java.net.URL;
 
 public class ShouldBeEqualToWithSortedQueryParameters extends BasicErrorMessageFactory {
   private static final String SHOULD_BE_EQUAL_TO_WITH_SORTED_QUERY_PARAMETERS = "%nExpecting URL to be:%n  <%s>%nbut actually is:%n  <%s>";

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -12,12 +12,20 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
-import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
-import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
-import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
+import static org.assertj.core.error.uri.ShouldHaveParameter.*;
 import static org.assertj.core.error.uri.ShouldHavePath.shouldHavePath;
 import static org.assertj.core.error.uri.ShouldHavePort.shouldHavePort;
 import static org.assertj.core.error.uri.ShouldHaveProtocol.shouldHaveProtocol;
@@ -26,14 +34,6 @@ import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.internal.Comparables.assertNotNull;
 import static org.assertj.core.internal.Uris.getParameters;
 import static org.assertj.core.util.Preconditions.checkArgument;
-
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.VisibleForTesting;
 
 public class Urls {
 
@@ -46,7 +46,8 @@ public class Urls {
     return INSTANCE;
   }
 
-  Urls() {}
+  Urls() {
+  }
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
     assertNotNull(info, actual);
@@ -138,4 +139,22 @@ public class Urls {
     }
   }
 
+  public void assertIsEqualToWithSortedQueryParameters(AssertionInfo info, URL actual, URL expected) {
+    assertNotNull(info, actual);
+    String expected_nonquery = expected.toString().substring(0, expected.toString().length() - expected.getQuery().length());
+    String actual_nonquery = actual.toString().substring(0, actual.toString().length() - actual.getQuery().length());
+
+    if (!expected_nonquery.equals(actual_nonquery))
+      throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+    if (expected.getQuery() == null || actual.getQuery() == null)
+      if (expected.getQuery() == null && actual.getQuery() == null)
+        return;
+      else throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+    String[] expected_query_params = expected.getQuery().split("&");
+    String[] actual_query_params = actual.getQuery().split("&");
+    java.util.Arrays.sort(expected_query_params);
+    java.util.Arrays.sort(actual_query_params);
+    if (!java.util.Arrays.toString(expected_query_params).equals(Arrays.toString(actual_query_params)))
+      throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
 }

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -27,7 +27,6 @@ import static org.assertj.core.internal.Uris.getParameters;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,6 +46,15 @@ public class Urls {
   }
 
   Urls() {}
+
+  static String extractNonQueryPart(URL url) {
+    return url.toString().substring(0, url.toString().length()
+                                       - (url.getQuery() == null ? 0
+                                           : url.getQuery().length())
+                                       - (url.getRef() == null ? 0
+                                           : url.getRef().length() + 1))
+           + " " + (url.getRef() == null ? "" : url.getRef());
+  }
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
     assertNotNull(info, actual);
@@ -140,19 +148,14 @@ public class Urls {
 
   public void assertIsEqualToWithSortedQueryParameters(AssertionInfo info, URL actual, URL expected) {
     assertNotNull(info, actual);
-    if (expected.getQuery() == null || actual.getQuery() == null)
-      if (expected.getQuery() == null && actual.getQuery() == null)
-        return;
-      else throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
-    String expected_non_query = expected.toString().substring(0, expected.toString().length() - expected.getQuery().length());
-    String actual_non_query = actual.toString().substring(0, actual.toString().length() - actual.getQuery().length());
-    if (!expected_non_query.equals(actual_non_query))
+    if (!extractNonQueryPart(expected).equals(extractNonQueryPart(actual)))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
-    String[] expected_query_params = expected.getQuery().split("&");
-    String[] actual_query_params = actual.getQuery().split("&");
-    java.util.Arrays.sort(expected_query_params);
-    java.util.Arrays.sort(actual_query_params);
-    if (!java.util.Arrays.toString(expected_query_params).equals(Arrays.toString(actual_query_params)))
+
+    String[] expectedQueryParams = (expected.getQuery() == null ? "" : expected.getQuery()).split("&");
+    String[] actualQueryParams = (actual.getQuery() == null ? "" : actual.getQuery()).split("&");
+    java.util.Arrays.sort(expectedQueryParams);
+    java.util.Arrays.sort(actualQueryParams);
+    if (!Objects.deepEquals(expectedQueryParams, actualQueryParams))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
   }
 }

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -12,15 +12,6 @@
  */
 package org.assertj.core.internal;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.VisibleForTesting;
-
-import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
@@ -35,6 +26,15 @@ import static org.assertj.core.internal.Comparables.assertNotNull;
 import static org.assertj.core.internal.Uris.getParameters;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+
 public class Urls {
 
   private static final Urls INSTANCE = new Urls();
@@ -46,8 +46,7 @@ public class Urls {
     return INSTANCE;
   }
 
-  Urls() {
-  }
+  Urls() {}
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
     assertNotNull(info, actual);

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -27,6 +27,7 @@ import static org.assertj.core.internal.Uris.getParameters;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,13 +48,8 @@ public class Urls {
 
   Urls() {}
 
-  static String extractNonQueryPart(URL url) {
-    return url.toString().substring(0, url.toString().length()
-                                       - (url.getQuery() == null ? 0
-                                           : url.getQuery().length())
-                                       - (url.getRef() == null ? 0
-                                           : url.getRef().length() + 1))
-           + " " + (url.getRef() == null ? "" : url.getRef());
+  private static String[] extractQueryParams(URL url) {
+    return (url.getQuery() == null ? "" : url.getQuery()).split("&");
   }
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
@@ -148,13 +144,18 @@ public class Urls {
 
   public void assertIsEqualToWithSortedQueryParameters(AssertionInfo info, URL actual, URL expected) {
     assertNotNull(info, actual);
-    if (!extractNonQueryPart(expected).equals(extractNonQueryPart(actual)))
+    String expectedQuery = expected.getQuery() == null ? "" : expected.getQuery();
+    String actualQuery = actual.getQuery() == null ? "" : actual.getQuery();
+    String expectedNonQueryPart = expected.toString().replace(expectedQuery, " ");
+    String actualNonQueryPart = actual.toString().replace(actualQuery, " ");
+
+    if (!expectedNonQueryPart.equals(actualNonQueryPart))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
 
-    String[] expectedQueryParams = (expected.getQuery() == null ? "" : expected.getQuery()).split("&");
-    String[] actualQueryParams = (actual.getQuery() == null ? "" : actual.getQuery()).split("&");
-    java.util.Arrays.sort(expectedQueryParams);
-    java.util.Arrays.sort(actualQueryParams);
+    String[] expectedQueryParams = extractQueryParams(expected);
+    String[] actualQueryParams = extractQueryParams(actual);
+    Arrays.sort(expectedQueryParams);
+    Arrays.sort(actualQueryParams);
     if (!Objects.deepEquals(expectedQueryParams, actualQueryParams))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
   }

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -140,14 +140,14 @@ public class Urls {
 
   public void assertIsEqualToWithSortedQueryParameters(AssertionInfo info, URL actual, URL expected) {
     assertNotNull(info, actual);
-    String expected_nonquery = expected.toString().substring(0, expected.toString().length() - expected.getQuery().length());
-    String actual_nonquery = actual.toString().substring(0, actual.toString().length() - actual.getQuery().length());
-    if (!expected_nonquery.equals(actual_nonquery))
-      throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
     if (expected.getQuery() == null || actual.getQuery() == null)
       if (expected.getQuery() == null && actual.getQuery() == null)
         return;
       else throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+    String expected_non_query = expected.toString().substring(0, expected.toString().length() - expected.getQuery().length());
+    String actual_non_query = actual.toString().substring(0, actual.toString().length() - actual.getQuery().length());
+    if (!expected_non_query.equals(actual_non_query))
+      throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
     String[] expected_query_params = expected.getQuery().split("&");
     String[] actual_query_params = actual.getQuery().split("&");
     java.util.Arrays.sort(expected_query_params);

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -48,8 +48,15 @@ public class Urls {
 
   Urls() {}
 
-  private static String[] extractQueryParams(URL url) {
-    return (url.getQuery() == null ? "" : url.getQuery()).split("&");
+  private static String extractNonQueryParams(URL url) {
+    String queryPart = url.getQuery() == null ? "" : url.getQuery();
+    return url.toString().replace(queryPart, " ");
+  }
+
+  private static String[] extractSortedQueryParams(URL url) {
+    String[] queryParams = (url.getQuery() == null ? "" : url.getQuery()).split("&");
+    Arrays.sort(queryParams);
+    return queryParams;
   }
 
   public void assertHasProtocol(final AssertionInfo info, final URL actual, final String protocol) {
@@ -144,19 +151,10 @@ public class Urls {
 
   public void assertIsEqualToWithSortedQueryParameters(AssertionInfo info, URL actual, URL expected) {
     assertNotNull(info, actual);
-    String expectedQuery = expected.getQuery() == null ? "" : expected.getQuery();
-    String actualQuery = actual.getQuery() == null ? "" : actual.getQuery();
-    String expectedNonQueryPart = expected.toString().replace(expectedQuery, " ");
-    String actualNonQueryPart = actual.toString().replace(actualQuery, " ");
-
-    if (!expectedNonQueryPart.equals(actualNonQueryPart))
+    if (!extractNonQueryParams(expected).equals(extractNonQueryParams(actual)))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
 
-    String[] expectedQueryParams = extractQueryParams(expected);
-    String[] actualQueryParams = extractQueryParams(actual);
-    Arrays.sort(expectedQueryParams);
-    Arrays.sort(actualQueryParams);
-    if (!Objects.deepEquals(expectedQueryParams, actualQueryParams))
+    if (!Objects.deepEquals(extractSortedQueryParams(expected), extractSortedQueryParams(actual)))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
   }
 }

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -143,7 +143,6 @@ public class Urls {
     assertNotNull(info, actual);
     String expected_nonquery = expected.toString().substring(0, expected.toString().length() - expected.getQuery().length());
     String actual_nonquery = actual.toString().substring(0, actual.toString().length() - actual.getQuery().length());
-
     if (!expected_nonquery.equals(actual_nonquery))
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
     if (expected.getQuery() == null || actual.getQuery() == null)

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -13,19 +13,53 @@
 package org.assertj.core.api.url;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
 
 /**
  * Test for <code>{@link org.assertj.core.api.UrlAssert#isEqualToWithSortedQueryParameters(URL)} </code>.
  */
-class UrlAssert_isEqualToWithSortedQueryParameters_Test {
+
+@DisplayName("UrlAssert isEqualToWithSortedQueryParameters")
+public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
+
   @Test
-  private void should_be_equal_to_if_only_query_parameters_orders_are_different() throws MalformedURLException {
-    assertThat(new URL("https://example.com/path/to/page?color=purple&name=ferret"))
-                                                                                    .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
+  public void should_pass_if_only_query_parameters_orders_are_different() throws MalformedURLException {
+    // GIVEN
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
+    URL expected = new URL("https://example.com/path/to/page?name=ferret&color=purple");
+    // WHEN/THEN
+    assertThat(actual).isEqualToWithSortedQueryParameters(expected);
   }
+
+  @Test
+  public void should_fail_if_domains_are_different() throws MalformedURLException {
+    // GIVEN
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
+    URL expected = new URL("https://example2.com/path/to/page?color=purple&name=ferret");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualToWithSortedQueryParameters(expected));
+    // THEN
+    then(assertionError).hasMessage("%nExpecting URL to be:%n  <\"%s\">%nbut actually is:%n  <\"%s\">", expected.toString(),
+                                    actual.toString());
+  }
+
+  @Test
+  public void should_fail_if_sorted_query_parameters_are_different() throws MalformedURLException {
+    // GIVEN
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
+    URL expected = new URL("https://example.com/path/to/page?color=purple");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualToWithSortedQueryParameters(expected));
+    // THEN
+    then(assertionError).hasMessage("%nExpecting URL to be:%n  <\"%s\">%nbut actually is:%n  <\"%s\">", expected.toString(),
+                                    actual.toString());
+  }
+
 }

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -22,16 +22,10 @@ import org.junit.Test;
 /**
  * Test for <code>{@link org.assertj.core.api.UrlAssert#isEqualToWithSortedQueryParameters(URL)} </code>.
  */
-public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
+class UrlAssert_isEqualToWithSortedQueryParameters_Test {
   @Test
-  public void should_be_equal_to_if_only_query_parameters_orders_are_different() throws MalformedURLException {
+  private void should_be_equal_to_if_only_query_parameters_orders_are_different() throws MalformedURLException {
     assertThat(new URL("https://example.com/path/to/page?color=purple&name=ferret"))
                                                                                     .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
-  }
-
-  @Test
-  public void should_not_be_equal_to_if_domains_are_different() throws MalformedURLException {
-    assertThat(new URL("https://example.com/path/to/page?color=purple"))
-      .isEqualToWithSortedQueryParameters(new URL("https://example2.com/path/to/page?color=purple&name=ferret"));
   }
 }

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -12,12 +12,12 @@
  */
 package org.assertj.core.api.url;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 /**
  * Test for <code>{@link org.assertj.core.api.UrlAssert#isEqualToWithSortedQueryParameters(URL)} </code>.
@@ -26,6 +26,6 @@ public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
   @Test
   public void should_be_equal_to_if_only_query_parameters_are_different() throws MalformedURLException {
     assertThat(new URL("https://example.com/path/to/page?color=purple&name=ferret"))
-      .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
+                                                                                    .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
   }
 }

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for <code>{@link org.assertj.core.api.UrlAssert#isEqualToWithSortedQueryParameters(URL)} </code>.
+ */
+public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
+  @Test
+  public void should_be_equal_to_if_only_query_parameters_are_different() throws MalformedURLException {
+    assertThat(new URL("https://example.com/path/to/page?color=purple&name=ferret"))
+      .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -12,14 +12,13 @@
  */
 package org.assertj.core.api.url;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.verify;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
 import org.junit.jupiter.api.DisplayName;
 
 /**
@@ -27,39 +26,19 @@ import org.junit.jupiter.api.DisplayName;
  */
 
 @DisplayName("UrlAssert isEqualToWithSortedQueryParameters")
-public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
+public class UrlAssert_isEqualToWithSortedQueryParameters_Test extends UrlAssertBaseTest {
+  private URL expected = new URL("http://example.com?a=b&c=d#hello");
 
-  @Test
-  public void should_pass_if_only_query_parameters_orders_are_different() throws MalformedURLException {
-    // GIVEN
-    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
-    URL expected = new URL("https://example.com/path/to/page?name=ferret&color=purple");
-    // WHEN/THEN
-    assertThat(actual).isEqualToWithSortedQueryParameters(expected);
+  public UrlAssert_isEqualToWithSortedQueryParameters_Test() throws MalformedURLException {}
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.isEqualToWithSortedQueryParameters(expected);
   }
 
-  @Test
-  public void should_fail_if_domains_are_different() throws MalformedURLException {
-    // GIVEN
-    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
-    URL expected = new URL("https://example2.com/path/to/page?color=purple&name=ferret");
-    // WHEN
-    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualToWithSortedQueryParameters(expected));
-    // THEN
-    then(assertionError).hasMessage("%nExpecting URL to be:%n  <\"%s\">%nbut actually is:%n  <\"%s\">", expected.toString(),
-                                    actual.toString());
-  }
-
-  @Test
-  public void should_fail_if_sorted_query_parameters_are_different() throws MalformedURLException {
-    // GIVEN
-    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
-    URL expected = new URL("https://example.com/path/to/page?color=purple");
-    // WHEN
-    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualToWithSortedQueryParameters(expected));
-    // THEN
-    then(assertionError).hasMessage("%nExpecting URL to be:%n  <\"%s\">%nbut actually is:%n  <\"%s\">", expected.toString(),
-                                    actual.toString());
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertIsEqualToWithSortedQueryParameters(getInfo(assertions), getActual(assertions), expected);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_isEqualToWithSortedQueryParameters_Test.java
@@ -24,8 +24,14 @@ import org.junit.Test;
  */
 public class UrlAssert_isEqualToWithSortedQueryParameters_Test {
   @Test
-  public void should_be_equal_to_if_only_query_parameters_are_different() throws MalformedURLException {
+  public void should_be_equal_to_if_only_query_parameters_orders_are_different() throws MalformedURLException {
     assertThat(new URL("https://example.com/path/to/page?color=purple&name=ferret"))
                                                                                     .isEqualToWithSortedQueryParameters(new URL("https://example.com/path/to/page?name=ferret&color=purple"));
+  }
+
+  @Test
+  public void should_not_be_equal_to_if_domains_are_different() throws MalformedURLException {
+    assertThat(new URL("https://example.com/path/to/page?color=purple"))
+      .isEqualToWithSortedQueryParameters(new URL("https://example2.com/path/to/page?color=purple&name=ferret"));
   }
 }

--- a/src/test/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters_create_Test.java
+++ b/src/test/java/org/assertj/core/error/uri/ShouldBeEqualToWithSortedQueryParameters_create_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error.uri;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+public class ShouldBeEqualToWithSortedQueryParameters_create_Test {
+
+  @Test
+  public void should_create_error_message_for_sorted_query_parameters_are_different() throws MalformedURLException {
+    // GIVEN
+    URL expected = new URL("https://example.com/path/to/page?color=purple");
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret");
+    // WHEN
+    String error = shouldBeEqualToWithSortedQueryParameters(actual, expected).create(new TestDescription("TEST"));
+    // THEN
+    then(error).isEqualTo(format("[TEST] %n" +
+                                 "Expecting URL to be:%n" +
+                                 "  <\"https://example.com/path/to/page?color=purple\">%n" +
+                                 "but was:%n" +
+                                 "  <\"https://example.com/path/to/page?color=purple&name=ferret\">%n" +
+                                 " after sorting parameters"));
+  }
+
+  @Test
+  public void should_create_error_message_for_non_query_parts_are_different() throws MalformedURLException {
+    // GIVEN
+    URL expected = new URL("https://example.com/path/to/page?color=purple&name=ferret");
+    URL actual = new URL("https://example2.com/path/to/page?color=purple&name=ferret");
+    // WHEN
+    String error = shouldBeEqualToWithSortedQueryParameters(actual, expected).create(new TestDescription("TEST"));
+    // THEN
+    then(error).isEqualTo(format("[TEST] %n" +
+                                 "Expecting URL to be:%n" +
+                                 "  <\"https://example.com/path/to/page?color=purple&name=ferret\">%n" +
+                                 "but was:%n" +
+                                 "  <\"https://example2.com/path/to/page?color=purple&name=ferret\">%n" +
+                                 " after sorting parameters"));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for
- * <code>{@link org.assertj.core.internal.Urls#assertIsEqualToWithSortedQueryParameters(AssertionInfo, URL, URL)} (org.assertj.core.api.AssertionInfo, java.net.URL, String)}  </code>
+ * <code>{@link org.assertj.core.internal.Urls#assertIsEqualToWithSortedQueryParameters(AssertionInfo, URL, URL)} (org.assertj.core.api.AssertionInfo, java.net.URL, java.net.URL)}  </code>
  * .
  *
  * @author SUN Ting

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for
- * <code>{@link org.assertj.core.internal.Urls#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URL, String)}  </code>
+ * <code>{@link org.assertj.core.internal.Urls#assertIsEqualToWithSortedQueryParameters(AssertionInfo, URL, URL)} (org.assertj.core.api.AssertionInfo, java.net.URL, String)}  </code>
  * .
  *
  * @author SUN Ting
@@ -43,14 +43,16 @@ public class Urls_assertIsEqualToWithSortedQueryParameters_Test extends UrlsBase
   }
 
   @Test
-  public void should_pass_if_both_expected_and_actual_have_query_and_they_are_literally_equivalent() throws MalformedURLException {
+  public void should_pass_if_both_expected_and_actual_have_query_and_they_are_literally_equivalent()
+    throws MalformedURLException {
     URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
     URL expected = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
     urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
   }
 
   @Test
-  public void should_pass_if_both_expected_and_actual_have_no_query_and_they_are_literally_equivalent() throws MalformedURLException {
+  public void should_pass_if_both_expected_and_actual_have_no_query_and_they_are_literally_equivalent()
+    throws MalformedURLException {
     URL actual = new URL("https://example.com/path/to/page#hello");
     URL expected = new URL("https://example.com/path/to/page#hello");
     urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.UrlsBaseTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Urls#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URL, String)}  </code>
+ * .
+ *
+ * @author SUN Ting
+ */
+
+public class Urls_assertIsEqualToWithSortedQueryParameters_Test extends UrlsBaseTest {
+
+  @Test
+  public void should_pass_if_only_query_parameters_orders_are_different() throws MalformedURLException {
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
+    URL expected = new URL("https://example.com/path/to/page?name=ferret&color=purple#hello");
+    urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_both_expected_and_actual_have_query_and_they_are_literally_equivalent() throws MalformedURLException {
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
+    URL expected = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
+    urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
+  }
+
+  @Test
+  public void should_pass_if_both_expected_and_actual_have_no_query_and_they_are_literally_equivalent() throws MalformedURLException {
+    URL actual = new URL("https://example.com/path/to/page#hello");
+    URL expected = new URL("https://example.com/path/to/page#hello");
+    urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
+  }
+
+  @Test
+  public void should_fail_if_sorted_query_parameters_are_different() throws MalformedURLException {
+    AssertionInfo info = someInfo();
+    URL actual = new URL("https://example.com/path/to/page?color=purple&name=ferret#hello");
+    URL expected = new URL("https://example.com/path/to/page?color=red&name=jackson#hello");
+
+    Throwable error = catchThrowable(() -> urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+
+  @Test
+  public void should_fail_if_domains_are_different() throws MalformedURLException {
+    AssertionInfo info = someInfo();
+    URL actual = new URL("https://example.com/path/to/page?color=red&name=jackson#hello");
+    URL expected = new URL("https://example2.com/path/to/page?color=red&name=jackson#hello");
+
+    Throwable error = catchThrowable(() -> urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+
+  @Test
+  public void should_fail_if_fragments_are_different() throws MalformedURLException {
+    AssertionInfo info = someInfo();
+    URL actual = new URL("https://example.com/path/to/page?color=red&name=jackson#hello");
+    URL expected = new URL("https://example.com/path/to/page?color=red&name=jackson#world");
+
+    Throwable error = catchThrowable(() -> urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+
+  @Test
+  public void should_fail_if_actual_has_no_query_and_expected_has_query() throws MalformedURLException {
+    AssertionInfo info = someInfo();
+    URL actual = new URL("https://example.com/path/to/page#hello");
+    URL expected = new URL("https://example.com/path/to/page?color=red&name=jackson#hello");
+
+    Throwable error = catchThrowable(() -> urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+
+  @Test
+  public void should_fail_if_actual_has_query_and_expected_has_no_query() throws MalformedURLException {
+    AssertionInfo info = someInfo();
+    URL actual = new URL("https://example.com/path/to/page?color=red&name=jackson#hello");
+    URL expected = new URL("https://example.com/path/to/page#hello");
+
+    Throwable error = catchThrowable(() -> urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+}


### PR DESCRIPTION
#### Check List:

* Fixes #1796 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


This part is designed for URL. And after fully finish it, I think I can copy it to URI.

To compare actual and expected, we can separately compare non-query parts and query parts, or assemble non-query parts and sorted querys into new URLs and then compare them. Personally, I choose the former one.