### PR TITLE
make two test cases more reasonable.

### DIFF
--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasQuery_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasQuery_Test.java
@@ -47,7 +47,7 @@ public class Uris_assertHasQuery_Test extends UrisBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> uris.assertHasQuery(info, null, "http://www.helloworld.org/index.html?type=test"))
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> uris.assertHasQuery(info, null, "type=test"))
                                                    .withMessage(actualIsNull());
   }
 

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasQuery_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasQuery_Test.java
@@ -48,7 +48,7 @@ public class Urls_assertHasQuery_Test extends UrlsBaseTest {
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> urls.assertHasQuery(info, null, "http://www.helloworld.org/index.html?type=test"))
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> urls.assertHasQuery(info, null, "type=test"))
                                                    .withMessage(actualIsNull());
   }
 


### PR DESCRIPTION
#### Check List:
* Fixes the tests of `Urls_assertHasQuery_Test` and `Uris_assertHasQuery_Test`
* Unit tests : yes
* Javadoc with a code example (on API only) : NA

The third argument of `assertHasQuery` should be the expected query part, rather than the whole expected URL.  