### PR TITLE
Fix issue #1289 by adding the annotation @deprecated to method temporaryFolder

### DIFF
--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -82,7 +82,10 @@ public class Files {
    * 
    * @return the system's temporary directory.
    * @throws RuntimeException if this method cannot find or create the system's temporary directory.
+   *
+   * @deprecated For JUnit4, use TemporaryFolder and @Rule; for JUnit5, use TempDirectory extension and @TempDir instead.
    */
+  @Deprecated
   public static File temporaryFolder() {
     File temp = new File(temporaryFolderPath());
     if (!temp.isDirectory()) {

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -83,7 +83,7 @@ public class Files {
    * @return the system's temporary directory.
    * @throws RuntimeException if this method cannot find or create the system's temporary directory.
    *
-   * @deprecated For JUnit4, use TemporaryFolder and @Rule; for JUnit5, use TempDirectory extension and @TempDir instead.
+   * @deprecated Use either {@link org.junit.jupiter.api.io.TempDir} or {@link org.junit.rules.TemporaryFolder}
    */
   @Deprecated
   public static File temporaryFolder() {


### PR DESCRIPTION
#### Check List:
* Fixes #1289
* Unit tests : YES
* Javadoc with a code example (on API only) : NA

The annotation @deprecated is added before the method  `File temporaryFolder()`. Also, the alternatives in JUnit4+JUnit5 are added in javadoc part of the method.