### PR TITLE
Explicitly set Javadoc locale to English

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <!-- Explicitly set Javadoc locale to English -->
+          <locale>en_US</locale>
           <!-- needed to fix javadoc on java 11+ https://github.com/joel-costigliola/assertj-core/issues/1403 -->
           <source>8</source>
           <!-- (1) CSS file location -->


### PR DESCRIPTION
This ensures that the html tag always contains language "en" and therefore does not default to the local used locale.

In order to verify that it works I've change the value to `de_DE` locally and the html tag did contain the de one afterwards.

#### Check List:
* Fixes #1825
* Unit tests : YES / NO / **NA**
* Javadoc with a code example (on API only) : YES / NO / **NA**


