### PR TITLE
filteredOn function

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2380,7 +2380,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   /**
    * Filter the iterable under test keeping only elements for which the result of the {@code function} is equal to {@code expectedValue}.
    * <p>
-   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * It allows to filter elements in more safe way than by using {@link #filteredOn(String, Object)}, as it
    * doesn't utilize introspection.
    * <p>
    *

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2376,6 +2376,43 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     Iterable<? extends ELEMENT> filteredIterable = filter.being(condition).get();
     return newAbstractIterableAssert(filteredIterable).withAssertionState(myself);
   }
+  
+  /**
+   * Filter the iterable under test keeping only elements for which the result of the {@code function} is equal to {@code expectedValue}.
+   * <p>
+   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * doesn't utilize introspection.
+   * <p>
+   *
+   * As an example, let's check all employees 800 years old (yes, special employees):
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
+   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   * Employee noname = new Employee(4L, null, 50);
+   *
+   * List&lt;Employee&gt; employees = newArrayList(yoda, luke, obiwan, noname);
+   *
+   * assertThat(employees).filteredOn(Employee::getAge, 800)
+   *                      .containsOnly(yoda, obiwan);
+   *
+   * assertThat(employees).filteredOn(e -&gt; e.getName(), null)
+   *                      .containsOnly(noname);</code></pre>
+   *
+   * If you need more complex filter, use {@link #filteredOn(Predicate)} or {@link #filteredOn(Condition)}.
+   *
+   * @param <T> result type of the filter function
+   * @param function the filter function
+   * @param expectedValue the expected value of the filter function
+   * @return a new assertion object with the filtered iterable under test
+   * @throws IllegalArgumentException if the given function is {@code null}.
+   * @since 3.17.0
+   */
+  @CheckReturnValue
+  public <T> SELF filteredOn(Function<? super ELEMENT, T> function, T expectedValue) {
+    checkArgument(function != null, "The filter function should not be null");
+    return filteredOn(element -> java.util.Objects.equals(function.apply(element), expectedValue));
+  }
+
 
   /**
    * Filter the iterable under test keeping only elements matching the given assertions specified with a {@link Consumer}.

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -2755,6 +2755,42 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
+   * Filter the array under test into a list composed of the elements for which the result of the {@code function} is equal to {@code expectedValue}.
+   * <p>
+   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * doesn't utilize introspection.
+   * <p>
+   *
+   * As an example, let's check all employees 800 years old (yes, special employees):
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
+   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   * Employee noname = new Employee(4L, null, 50);
+   *
+   * Employee[] employees = new Employee[] { yoda, luke, obiwan, noname };
+   *
+   * assertThat(employees).filteredOn(Employee::getAge, 800)
+   *                      .containsOnly(yoda, obiwan);
+   *
+   * assertThat(employees).filteredOn(e -&gt; e.getName(), null)
+   *                      .containsOnly(noname);</code></pre>
+   *
+   * If you need more complex filter, use {@link #filteredOn(Predicate)} or {@link #filteredOn(Condition)}.
+   *
+   * @param <T> result type of the filter function
+   * @param function the filter function
+   * @param expectedValue the expected value of the filter function
+   * @return a new assertion object with the filtered list under test
+   * @throws IllegalArgumentException if the given function is {@code null}.
+   * @since 3.17.0
+   */
+  @CheckReturnValue
+  public <T> SELF filteredOn(Function<? super ELEMENT, T> function, T expectedValue) {
+    checkArgument(function != null, "The filter function should not be null");
+    return filteredOn(element -> java.util.Objects.equals(function.apply(element), expectedValue));
+  }
+
+  /**
    * Filter the array under test keeping only elements matching the given assertions specified with a {@link Consumer}.
    * <p>
    * Example : check old employees whose age &gt; 100:

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -2757,7 +2757,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   /**
    * Filter the array under test into a list composed of the elements for which the result of the {@code function} is equal to {@code expectedValue}.
    * <p>
-   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * It allows to filter elements in more safe way than by using {@link #filteredOn(String, Object)}, as it
    * doesn't utilize introspection.
    * <p>
    *

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -2872,7 +2872,7 @@ public class AtomicReferenceArrayAssert<T>
   /**
    * Filter the array under test into a list composed of the elements for which the result of the {@code function} is equal to {@code expectedValue}.
    * <p>
-   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * It allows to filter elements in more safe way than by using {@link #filteredOn(String, Object)}, as it
    * doesn't utilize introspection.
    * <p>
    *

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.api;
 
+import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.filter.Filters.filter;
 import static org.assertj.core.description.Description.mostRelevantDescription;
@@ -26,6 +27,7 @@ import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.isArray;
 import static org.assertj.core.util.IterableUtil.toArray;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.lang.reflect.Array;
@@ -2785,8 +2787,8 @@ public class AtomicReferenceArrayAssert<T>
    *                                .filteredOn("name", not("Boromir"))
    *                                .containsOnly(aragorn);</code></pre>
    *
-   * If you need more complex filter, use {@link #filteredOn(Condition)} and provide a {@link Condition} to specify the
-   * filter to apply.
+   * If you need more complex filter, use {@link #filteredOn(Condition)} or {@link #filteredOn(Predicate)} and 
+   * provide a {@link Condition} or {@link Predicate} to specify the filter to apply.
    *
    * @param propertyOrFieldName the name of the property or field to read
    * @param filterOperator the filter operator to apply
@@ -2839,6 +2841,68 @@ public class AtomicReferenceArrayAssert<T>
   public AtomicReferenceArrayAssert<T> filteredOn(Condition<? super T> condition) {
     Iterable<? extends T> filteredIterable = filter(array).being(condition).get();
     return new AtomicReferenceArrayAssert<>(new AtomicReferenceArray<>(toArray(filteredIterable)));
+  }
+
+  /**
+   * Filter the array under test into a list composed of the elements matching the given {@link Predicate},
+   * allowing to perform assertions on the filtered list.
+   * <p>
+   * Example : check old employees whose age &gt; 100:
+   *
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
+   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   *
+   * AtomicReferenceArray&lt;Employee&gt; employees = new AtomicReferenceArray&lt;&gt;(new Employee[]{ yoda, luke, obiwan, noname });
+   *
+   * assertThat(employees).filteredOn(employee -&gt; employee.getAge() &gt; 100)
+   *                      .containsOnly(yoda, obiwan);</code></pre>
+   *
+   * @param predicate the filter predicate
+   * @return a new assertion object with the filtered array under test
+   * @throws IllegalArgumentException if the given predicate is {@code null}.
+   * @since 3.16.0
+   */
+  public AtomicReferenceArrayAssert<T> filteredOn(Predicate<? super T> predicate) {
+    checkArgument(predicate != null, "The filter predicate should not be null");
+    List<T> filteredList = stream(array).filter(predicate).collect(toList());
+    return new AtomicReferenceArrayAssert<>(new AtomicReferenceArray<>(toArray(filteredList)));
+  }
+
+  /**
+   * Filter the array under test into a list composed of the elements for which the result of the {@code function} is equal to {@code expectedValue}.
+   * <p>
+   * It allows to filter elements in more safe way than by using {@link #filterOn(String, Object)}, as it
+   * doesn't utilize introspection.
+   * <p>
+   *
+   * As an example, let's check all employees 800 years old (yes, special employees):
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
+   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   * Employee noname = new Employee(4L, null, 50);
+   *
+   * AtomicReferenceArray&lt;Employee&gt; employees = new AtomicReferenceArray&lt;&gt;(new Employee[]{ yoda, luke, obiwan, noname });
+   *
+   * assertThat(employees).filteredOn(Employee::getAge, 800)
+   *                      .containsOnly(yoda, obiwan);
+   *
+   * assertThat(employees).filteredOn(e -&gt; e.getName(), null)
+   *                      .containsOnly(noname);</code></pre>
+   *
+   * If you need more complex filter, use {@link #filteredOn(Predicate)} or {@link #filteredOn(Condition)}.
+   *
+   * @param <U> result type of the filter function
+   * @param function the filter function
+   * @param expectedValue the expected value of the filter function
+   * @return a new assertion object with the filtered array under test
+   * @throws IllegalArgumentException if the given function is {@code null}.
+   * @since 3.17.0
+   */
+  @CheckReturnValue
+  public <U> AtomicReferenceArrayAssert<T> filteredOn(Function<? super T, U> function, U expectedValue) {
+    checkArgument(function != null, "The filter function should not be null");
+    return filteredOn(element -> java.util.Objects.equals(function.apply(element), expectedValue));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_Test.java
@@ -72,7 +72,7 @@ public class AtomicReferenceArrayAssert_filteredOn_Test extends AtomicReferenceA
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, 800))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, 800))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_condition_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_condition_Test.java
@@ -49,8 +49,10 @@ public class AtomicReferenceArrayAssert_filteredOn_condition_Test extends Atomic
 
   @Test
   public void should_fail_if_given_condition_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null))
-                                        .withMessage("The filter condition should not be null");
+    assertThatIllegalArgumentException().isThrownBy(() -> {
+      Condition<Employee> condition = null;
+      assertThat(employees).filteredOn(condition);
+    }).withMessage("The filter condition should not be null");
   }
 
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_function_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_function_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.Name.lastNameComparator;
+import static org.assertj.core.test.Name.name;
+
+import java.util.function.Function;
+
+import org.assertj.core.api.IterableAssert;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AtomicReferenceArrayAssert filteredOn function")
+class AtomicReferenceArrayAssert_filteredOn_function_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
+
+  @Test
+  void should_pass_filter_object_array_under_test_on_function() {
+    assertThat(employees).filteredOn(Employee::getAge, 800).containsOnly(yoda, obiwan);
+  }
+
+  @Test
+  void should_pass_filter_object_array_under_test_on_function_expected_value_is_null() {
+    assertThat(employees).filteredOn(Employee::getName, null).containsOnly(noname);
+  }
+
+  @Test
+  void should_fail_if_given_function_is_null() {
+    // GIVEN
+    Function<? super Employee, String> function = null;
+    // WHEN/THEN
+    assertThatIllegalArgumentException()
+                                        .isThrownBy(() -> assertThat(employees).filteredOn(function, "Yoda"))
+                                        .withMessage("The filter function should not be null");
+  }
+
+  @Test
+  void should_pass_keep_assertion_state() {
+    // GIVEN
+    Iterable<Name> names = asList(name("Manu", "Ginobili"), name("Magic", "Johnson"));
+    // WHEN
+    IterableAssert<Name> assertion = assertThat(names).as("test description")
+                                                      .withFailMessage("error message")
+                                                      .withRepresentation(UNICODE_REPRESENTATION)
+                                                      .usingElementComparator(lastNameComparator)
+                                                      .filteredOn(Name::getFirst, "Manu")
+                                                      .containsExactly(name("Whoever", "Ginobili"));
+    // THEN
+    assertThat(assertion.descriptionText()).isEqualTo("test description");
+    assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_in_Test.java
@@ -71,7 +71,7 @@ public class AtomicReferenceArrayAssert_filteredOn_in_Test extends AtomicReferen
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, in(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, in(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_notIn_Test.java
@@ -74,7 +74,7 @@ public class AtomicReferenceArrayAssert_filteredOn_notIn_Test extends AtomicRefe
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, notIn(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, notIn(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_not_Test.java
@@ -71,7 +71,7 @@ public class AtomicReferenceArrayAssert_filteredOn_not_Test extends AtomicRefere
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, not(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, not(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_predicate_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_predicate_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.function.Predicate;
+
+import org.assertj.core.test.Employee;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AtomicReferenceArrayAssert filteredOn predicate")
+class AtomicReferenceArrayAssert_filteredOn_predicate_Test extends AtomicReferenceArrayAssert_filtered_baseTest {
+
+  @Test
+  void should_filter_iterable_under_test_on_predicate() {
+    assertThat(employees).filteredOn(employee -> employee.getAge() > 100).containsOnly(yoda, obiwan);
+  }
+
+  @Test
+  void should_fail_if_given_predicate_is_null() {
+    assertThatIllegalArgumentException().isThrownBy(() -> {
+      Predicate<? super Employee> predicate = null;
+      assertThat(employees).filteredOn(predicate);
+    }).withMessage("The filter predicate should not be null");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_Test.java
@@ -98,7 +98,7 @@ public class IterableAssert_filteredOn_Test extends IterableAssert_filtered_base
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, 800))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, 800))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_function_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_function_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.Name.lastNameComparator;
+import static org.assertj.core.test.Name.name;
+import static org.assertj.core.util.Sets.newHashSet;
+
+import java.util.function.Function;
+
+import org.assertj.core.api.IterableAssert;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IterableAssert filteredOn function")
+class IterableAssert_filteredOn_function_Test extends IterableAssert_filtered_baseTest {
+
+  @Test
+  void should_pass_filter_iterable_under_test_on_function() {
+    assertThat(employees).filteredOn(Employee::getAge, 800).containsOnly(yoda, obiwan);
+    assertThat(newHashSet(employees)).filteredOn(Employee::getAge, 800).containsOnly(yoda, obiwan);
+  }
+
+  @Test
+  void should_pass_filter_iterable_under_test_on_function_expected_value_is_null() {
+    assertThat(employees).filteredOn(Employee::getName, null).containsOnly(noname);
+  }
+
+  @Test
+  void should_fail_if_given_function_is_null() {
+    // GIVEN
+    Function<? super Employee, String> function = null;
+    // WHEN/THEN
+    assertThatIllegalArgumentException()
+                                        .isThrownBy(() -> assertThat(employees).filteredOn(function, "Yoda"))
+                                        .withMessage("The filter function should not be null");
+  }
+
+  @Test
+  void should_pass_keep_assertion_state() {
+    // GIVEN
+    Iterable<Name> names = asList(name("Manu", "Ginobili"), name("Magic", "Johnson"));
+    // WHEN
+    IterableAssert<Name> assertion = assertThat(names).as("test description")
+                                                      .withFailMessage("error message")
+                                                      .withRepresentation(UNICODE_REPRESENTATION)
+                                                      .usingElementComparator(lastNameComparator)
+                                                      .filteredOn(Name::getFirst, "Manu")
+                                                      .containsExactly(name("Whoever", "Ginobili"));
+    // THEN
+    assertThat(assertion.descriptionText()).isEqualTo("test description");
+    assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_in_Test.java
@@ -80,7 +80,7 @@ public class IterableAssert_filteredOn_in_Test extends IterableAssert_filtered_b
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, in(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, in(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_notIn_Test.java
@@ -80,7 +80,7 @@ public class IterableAssert_filteredOn_notIn_Test extends IterableAssert_filtere
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, notIn(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, notIn(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_filteredOn_not_Test.java
@@ -83,7 +83,7 @@ public class IterableAssert_filteredOn_not_Test extends IterableAssert_filtered_
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, not(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, not(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/list/ListAssert_filteredOn_function_with_navigation_Test.java
+++ b/src/test/java/org/assertj/core/api/list/ListAssert_filteredOn_function_with_navigation_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.list;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.data.TolkienCharacter;
+import org.assertj.core.data.TolkienCharacterAssert;
+import org.assertj.core.data.TolkienCharacterAssertFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ListAssert filteredOn function with navigation")
+class ListAssert_filteredOn_function_with_navigation_Test extends ListAssert_filteredOn_BaseTest {
+
+  @Test
+  void should_pass_honor_AssertFactory_strongly_typed_navigation_assertions() {
+    // GIVEN
+    Iterable<TolkienCharacter> hobbits = hobbits();
+    TolkienCharacterAssertFactory tolkienCharacterAssertFactory = new TolkienCharacterAssertFactory();
+    // WHEN/THEN
+    assertThat(hobbits, tolkienCharacterAssertFactory).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                      .first()
+                                                      .hasAge(33);
+    assertThat(hobbits, tolkienCharacterAssertFactory).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                      .last()
+                                                      .hasAge(33);
+    assertThat(hobbits, tolkienCharacterAssertFactory).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                      .element(0)
+                                                      .hasAge(33);
+  }
+
+  @Test
+  void should_pass_honor_class_based_strongly_typed_navigation_assertions() {
+    // GIVEN
+    Iterable<TolkienCharacter> hobbits = hobbits();
+    // WHEN/THEN
+    assertThat(hobbits, TolkienCharacterAssert.class).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                     .first()
+                                                     .hasAge(33);
+    assertThat(hobbits, TolkienCharacterAssert.class).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                     .last()
+                                                     .hasAge(33);
+    assertThat(hobbits, TolkienCharacterAssert.class).filteredOn(TolkienCharacter::getName, "Frodo")
+                                                     .element(0)
+                                                     .hasAge(33);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_Test.java
@@ -72,7 +72,7 @@ public class ObjectArrayAssert_filteredOn_Test extends ObjectArrayAssert_filtere
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, 800))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, 800))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_function_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_function_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.test.Name.lastNameComparator;
+import static org.assertj.core.test.Name.name;
+
+import java.util.function.Function;
+
+import org.assertj.core.api.IterableAssert;
+import org.assertj.core.test.Employee;
+import org.assertj.core.test.Name;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ObjectArrayAssert filteredOn function")
+class ObjectArrayAssert_filteredOn_function_Test extends ObjectArrayAssert_filtered_baseTest {
+
+  @Test
+  void should_pass_filter_object_array_under_test_on_function() {
+    assertThat(employees).filteredOn(Employee::getAge, 800).containsOnly(yoda, obiwan);
+  }
+
+  @Test
+  void should_pass_filter_object_array_under_test_on_function_expected_value_is_null() {
+    assertThat(employees).filteredOn(Employee::getName, null).containsOnly(noname);
+  }
+
+  @Test
+  void should_fail_if_given_function_is_null() {
+    // GIVEN
+    Function<? super Employee, String> function = null;
+    // WHEN/THEN
+    assertThatIllegalArgumentException()
+                                        .isThrownBy(() -> assertThat(employees).filteredOn(function, "Yoda"))
+                                        .withMessage("The filter function should not be null");
+  }
+
+  @Test
+  void should_pass_keep_assertion_state() {
+    // GIVEN
+    Iterable<Name> names = asList(name("Manu", "Ginobili"), name("Magic", "Johnson"));
+    // WHEN
+    IterableAssert<Name> assertion = assertThat(names).as("test description")
+                                                      .withFailMessage("error message")
+                                                      .withRepresentation(UNICODE_REPRESENTATION)
+                                                      .usingElementComparator(lastNameComparator)
+                                                      .filteredOn(Name::getFirst, "Manu")
+                                                      .containsExactly(name("Whoever", "Ginobili"));
+    // THEN
+    assertThat(assertion.descriptionText()).isEqualTo("test description");
+    assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_in_Test.java
@@ -71,7 +71,7 @@ public class ObjectArrayAssert_filteredOn_in_Test extends ObjectArrayAssert_filt
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, in(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, in(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_notIn_Test.java
@@ -74,7 +74,7 @@ public class ObjectArrayAssert_filteredOn_notIn_Test extends ObjectArrayAssert_f
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, notIn(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, notIn(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_filteredOn_not_Test.java
@@ -71,7 +71,7 @@ public class ObjectArrayAssert_filteredOn_not_Test extends ObjectArrayAssert_fil
 
   @Test
   public void should_fail_if_given_property_or_field_name_is_null() {
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn(null, not(800)))
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(employees).filteredOn((String)null, not(800)))
                                         .withMessage("The property/field name to filter on should not be null or empty");
   }
 


### PR DESCRIPTION
Implementation for `filteredOn(Function<? super ELEMENT, T>, T)` for `AbstractIterableAssert`, `AbstractObjectArrayAssert`, and `AtomicReferenceArrayAssert`.

#### TODO:
* Also add `filteredOn(Function, FilterOperator)`.

#### Questions: 
* The filteredOn implementation is currently located directly in `AbstractIterableAssert` etc. 
Should the implementation be moved to `org.assertj.core.api.filter.Filters` (i.e., in a public method `having(Function, String)`)?

#### Check List:
* Fixes #1620
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


