### PR TITLE
In the event that an iterable is only singly-passable, ie can only be…

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -338,7 +338,7 @@ public class Iterables {
 
   private void assertIterableContainsGivenValues(Iterable<?> actual, Object[] values, AssertionInfo info) {
     Set<Object> notFound = stream(values).filter(value -> !iterableContains(actual, value))
-                                         .collect(toCollection(LinkedHashSet::new));
+      .collect(toCollection(LinkedHashSet::new));
     if (notFound.isEmpty())
       return;
     throw failures.failure(info, shouldContain(actual, values, notFound, comparisonStrategy));
@@ -387,8 +387,8 @@ public class Iterables {
 
     if (!unexpectedValues.isEmpty() || !missingValues.isEmpty()) {
       throw failures.failure(info, shouldContainOnly(actual, expectedValues,
-                                                     missingValues, unexpectedValues,
-                                                     comparisonStrategy));
+        missingValues, unexpectedValues,
+        comparisonStrategy));
     }
   }
 
@@ -568,7 +568,7 @@ public class Iterables {
     assertNotNull(info, actual);
     checkIterableIsNotNull(values);
     List<Object> extra = stream(actual).filter(actualElement -> !iterableContains(values, actualElement))
-                                       .collect(toList());
+      .collect(toList());
     if (extra.size() > 0) throw failures.failure(info, shouldBeSubsetOf(actual, values, extra, comparisonStrategy));
   }
 
@@ -1079,12 +1079,11 @@ public class Iterables {
     assertNotNull(info, actual);
 
     List<Object> actualAsList = newArrayList(actual);
-    List<Object> copyOfActual = newArrayList(actualAsList);
     IterableDiff diff = diff(actualAsList, asList(values), comparisonStrategy);
     if (!diff.differencesFound()) {
       // actual and values have the same elements but are they in the same order ?
       int i = 0;
-      for (Object elementFromActual : copyOfActual) {
+      for (Object elementFromActual : actualAsList) {
         if (!areEqual(elementFromActual, values[i])) {
           throw failures.failure(info, elementsDifferAtIndex(elementFromActual, values[i], i, comparisonStrategy));
         }
@@ -1093,8 +1092,8 @@ public class Iterables {
       return;
     }
     throw failures.failure(info,
-                           shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
-                                                comparisonStrategy));
+      shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
+        comparisonStrategy));
   }
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {
@@ -1102,9 +1101,9 @@ public class Iterables {
     requireNonNull(requirements, "The Consumer<T> expressing the assertions requirements must not be null");
 
     List<UnsatisfiedRequirement> unsatisfiedRequirements = stream(actual).map(element -> failsRequirements(requirements, element))
-                                                                         .filter(Optional::isPresent)
-                                                                         .map(Optional::get)
-                                                                         .collect(toList());
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .collect(toList());
     if (!unsatisfiedRequirements.isEmpty())
       throw failures.failure(info, elementsShouldSatisfy(actual, unsatisfiedRequirements, info));
   }
@@ -1129,10 +1128,10 @@ public class Iterables {
     Iterator<OTHER_ELEMENT> otherIterator = other.iterator();
 
     List<ZipSatisfyError> errors = stream(actual).map(actualElement -> failsZipRequirements(actualElement, otherIterator.next(),
-                                                                                            zipRequirements))
-                                                 .filter(Optional::isPresent)
-                                                 .map(Optional::get)
-                                                 .collect(toList());
+      zipRequirements))
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .collect(toList());
     if (!errors.isEmpty()) throw failures.failure(info, zippedElementsShouldSatisfy(info, actual, other, errors));
   }
 
@@ -1169,8 +1168,8 @@ public class Iterables {
 
     if (!nonMatches.isEmpty()) {
       throw failures.failure(info, elementsShouldMatch(actual,
-                                                       nonMatches.size() == 1 ? nonMatches.get(0) : nonMatches,
-                                                       predicateDescription));
+        nonMatches.size() == 1 ? nonMatches.get(0) : nonMatches,
+        predicateDescription));
     }
   }
 
@@ -1178,9 +1177,9 @@ public class Iterables {
     assertNotNull(info, actual);
     requireNonNull(restrictions, "The Consumer<T> expressing the restrictions must not be null");
     List<E> erroneousElements = stream(actual).map(element -> failsRestrictions(element, restrictions))
-                                              .filter(Optional::isPresent)
-                                              .map(Optional::get)
-                                              .collect(toList());
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .collect(toList());
     if (erroneousElements.size() > 0) throw failures.failure(info, noElementsShouldSatisfy(actual, erroneousElements));
   }
 
@@ -1200,10 +1199,10 @@ public class Iterables {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
     stream(actual).filter(predicate)
-                  .findFirst()
-                  .orElseGet(() -> {
-                    throw failures.failure(info, anyElementShouldMatch(actual, predicateDescription));
-                  });
+      .findFirst()
+      .orElseGet(() -> {
+        throw failures.failure(info, anyElementShouldMatch(actual, predicateDescription));
+      });
   }
 
   public <E> void assertNoneMatch(AssertionInfo info, Iterable<? extends E> actual, Predicate<? super E> predicate,
@@ -1211,11 +1210,11 @@ public class Iterables {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
     stream(actual).filter(predicate)
-                  .findFirst()
-                  .ifPresent(e -> {
-                    throw failures.failure(info, noElementsShouldMatch(actual, e,
-                                                                       predicateDescription));
-                  });
+      .findFirst()
+      .ifPresent(e -> {
+        throw failures.failure(info, noElementsShouldMatch(actual, e,
+          predicateDescription));
+      });
   }
 
   /**
@@ -1256,7 +1255,7 @@ public class Iterables {
     if (notExpected.isEmpty() && notFound.isEmpty()) return;
 
     throw failures.failure(info,
-                           shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+      shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
   }
 
   void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1079,11 +1079,12 @@ public class Iterables {
     assertNotNull(info, actual);
 
     List<Object> actualAsList = newArrayList(actual);
+    List<Object> copyOfActual = newArrayList(actualAsList);
     IterableDiff diff = diff(actualAsList, asList(values), comparisonStrategy);
     if (!diff.differencesFound()) {
       // actual and values have the same elements but are they in the same order ?
       int i = 0;
-      for (Object elementFromActual : actualAsList) {
+      for (Object elementFromActual : copyOfActual) {
         if (!areEqual(elementFromActual, values[i])) {
           throw failures.failure(info, elementsDifferAtIndex(elementFromActual, values[i], i, comparisonStrategy));
         }

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -12,24 +12,6 @@
  */
 package org.assertj.core.internal;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.Condition;
-import org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirement;
-import org.assertj.core.error.ZippedElementsShouldSatisfy.ZipSatisfyError;
-import org.assertj.core.presentation.PredicateDescription;
-import org.assertj.core.util.VisibleForTesting;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
@@ -97,6 +79,24 @@ import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Streams.stream;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Condition;
+import org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirement;
+import org.assertj.core.error.ZippedElementsShouldSatisfy.ZipSatisfyError;
+import org.assertj.core.presentation.PredicateDescription;
+import org.assertj.core.util.VisibleForTesting;
 
 /**
  * Reusable assertions for <code>{@link Iterable}</code>s.

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -12,6 +12,24 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Condition;
+import org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirement;
+import org.assertj.core.error.ZippedElementsShouldSatisfy.ZipSatisfyError;
+import org.assertj.core.presentation.PredicateDescription;
+import org.assertj.core.util.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
@@ -79,24 +97,6 @@ import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Streams.stream;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.Condition;
-import org.assertj.core.error.ElementsShouldSatisfy.UnsatisfiedRequirement;
-import org.assertj.core.error.ZippedElementsShouldSatisfy.ZipSatisfyError;
-import org.assertj.core.presentation.PredicateDescription;
-import org.assertj.core.util.VisibleForTesting;
 
 /**
  * Reusable assertions for <code>{@link Iterable}</code>s.
@@ -1083,7 +1083,7 @@ public class Iterables {
     if (!diff.differencesFound()) {
       // actual and values have the same elements but are they in the same order ?
       int i = 0;
-      for (Object elementFromActual : actual) {
+      for (Object elementFromActual : actualAsList) {
         if (!areEqual(elementFromActual, values[i])) {
           throw failures.failure(info, elementsDifferAtIndex(elementFromActual, values[i], i, comparisonStrategy));
         }

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -338,7 +338,7 @@ public class Iterables {
 
   private void assertIterableContainsGivenValues(Iterable<?> actual, Object[] values, AssertionInfo info) {
     Set<Object> notFound = stream(values).filter(value -> !iterableContains(actual, value))
-      .collect(toCollection(LinkedHashSet::new));
+                                         .collect(toCollection(LinkedHashSet::new));
     if (notFound.isEmpty())
       return;
     throw failures.failure(info, shouldContain(actual, values, notFound, comparisonStrategy));
@@ -387,8 +387,8 @@ public class Iterables {
 
     if (!unexpectedValues.isEmpty() || !missingValues.isEmpty()) {
       throw failures.failure(info, shouldContainOnly(actual, expectedValues,
-        missingValues, unexpectedValues,
-        comparisonStrategy));
+                                                     missingValues, unexpectedValues,
+                                                     comparisonStrategy));
     }
   }
 
@@ -568,7 +568,7 @@ public class Iterables {
     assertNotNull(info, actual);
     checkIterableIsNotNull(values);
     List<Object> extra = stream(actual).filter(actualElement -> !iterableContains(values, actualElement))
-      .collect(toList());
+                                       .collect(toList());
     if (extra.size() > 0) throw failures.failure(info, shouldBeSubsetOf(actual, values, extra, comparisonStrategy));
   }
 
@@ -1092,8 +1092,8 @@ public class Iterables {
       return;
     }
     throw failures.failure(info,
-      shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
-        comparisonStrategy));
+                           shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
+                                                comparisonStrategy));
   }
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {
@@ -1101,9 +1101,9 @@ public class Iterables {
     requireNonNull(requirements, "The Consumer<T> expressing the assertions requirements must not be null");
 
     List<UnsatisfiedRequirement> unsatisfiedRequirements = stream(actual).map(element -> failsRequirements(requirements, element))
-      .filter(Optional::isPresent)
-      .map(Optional::get)
-      .collect(toList());
+                                                                         .filter(Optional::isPresent)
+                                                                         .map(Optional::get)
+                                                                         .collect(toList());
     if (!unsatisfiedRequirements.isEmpty())
       throw failures.failure(info, elementsShouldSatisfy(actual, unsatisfiedRequirements, info));
   }
@@ -1128,10 +1128,10 @@ public class Iterables {
     Iterator<OTHER_ELEMENT> otherIterator = other.iterator();
 
     List<ZipSatisfyError> errors = stream(actual).map(actualElement -> failsZipRequirements(actualElement, otherIterator.next(),
-      zipRequirements))
-      .filter(Optional::isPresent)
-      .map(Optional::get)
-      .collect(toList());
+                                                                                            zipRequirements))
+                                                 .filter(Optional::isPresent)
+                                                 .map(Optional::get)
+                                                 .collect(toList());
     if (!errors.isEmpty()) throw failures.failure(info, zippedElementsShouldSatisfy(info, actual, other, errors));
   }
 
@@ -1168,8 +1168,8 @@ public class Iterables {
 
     if (!nonMatches.isEmpty()) {
       throw failures.failure(info, elementsShouldMatch(actual,
-        nonMatches.size() == 1 ? nonMatches.get(0) : nonMatches,
-        predicateDescription));
+                                                       nonMatches.size() == 1 ? nonMatches.get(0) : nonMatches,
+                                                       predicateDescription));
     }
   }
 
@@ -1177,9 +1177,9 @@ public class Iterables {
     assertNotNull(info, actual);
     requireNonNull(restrictions, "The Consumer<T> expressing the restrictions must not be null");
     List<E> erroneousElements = stream(actual).map(element -> failsRestrictions(element, restrictions))
-      .filter(Optional::isPresent)
-      .map(Optional::get)
-      .collect(toList());
+                                              .filter(Optional::isPresent)
+                                              .map(Optional::get)
+                                              .collect(toList());
     if (erroneousElements.size() > 0) throw failures.failure(info, noElementsShouldSatisfy(actual, erroneousElements));
   }
 
@@ -1199,10 +1199,10 @@ public class Iterables {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
     stream(actual).filter(predicate)
-      .findFirst()
-      .orElseGet(() -> {
-        throw failures.failure(info, anyElementShouldMatch(actual, predicateDescription));
-      });
+                  .findFirst()
+                  .orElseGet(() -> {
+                    throw failures.failure(info, anyElementShouldMatch(actual, predicateDescription));
+                  });
   }
 
   public <E> void assertNoneMatch(AssertionInfo info, Iterable<? extends E> actual, Predicate<? super E> predicate,
@@ -1210,11 +1210,11 @@ public class Iterables {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
     stream(actual).filter(predicate)
-      .findFirst()
-      .ifPresent(e -> {
-        throw failures.failure(info, noElementsShouldMatch(actual, e,
-          predicateDescription));
-      });
+                  .findFirst()
+                  .ifPresent(e -> {
+                    throw failures.failure(info, noElementsShouldMatch(actual, e,
+                                                                       predicateDescription));
+                  });
   }
 
   /**
@@ -1255,7 +1255,7 @@ public class Iterables {
     if (notExpected.isEmpty() && notFound.isEmpty()) return;
 
     throw failures.failure(info,
-      shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+                           shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
   }
 
   void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -112,7 +112,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
-    Object[] expected = {"Luke", "Yoda", "Han"};
+    Object[] expected = { "Luke", "Yoda", "Han" };
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
@@ -125,7 +125,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order() {
     AssertionInfo info = someInfo();
-    Object[] expected = {"Luke", "Leia", "Yoda"};
+    Object[] expected = { "Luke", "Leia", "Yoda" };
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
@@ -137,7 +137,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
-    Object[] expected = {"Luke", "Leia"};
+    Object[] expected = { "Luke", "Leia" };
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
@@ -159,7 +159,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    Object[] expected = {"Luke", "Yoda", "Han"};
+    Object[] expected = { "Luke", "Yoda", "Han" };
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 
@@ -172,7 +172,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    Object[] expected = {"Luke", "Leia", "Yoda"};
+    Object[] expected = { "Luke", "Leia", "Yoda" };
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 
@@ -184,7 +184,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
-    Object[] expected = {"LUKE", "Leia"};
+    Object[] expected = { "LUKE", "Leia" };
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -12,6 +12,14 @@
  */
 package org.assertj.core.internal.iterables;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Iterables;
+import org.assertj.core.internal.IterablesBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -28,13 +36,6 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Iterables;
-import org.assertj.core.internal.IterablesBaseTest;
-import org.junit.jupiter.api.Test;
-
 /**
  * Tests for <code>{@link Iterables#assertContainsExactly(AssertionInfo, Iterable, Object[])}</code>.
  *
@@ -45,6 +46,37 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_pass_if_actual_contains_exactly_given_values() {
     iterables.assertContainsExactly(someInfo(), actual, array("Luke", "Yoda", "Leia"));
+  }
+
+  @Test
+  public void should_pass_if_nonrestartable_actual_contains_exactly_given_values() {
+    iterables.assertContainsExactly(someInfo(), createSinglyIterable(actual), array("Luke", "Yoda", "Leia"));
+  }
+
+  private Iterable<String> createSinglyIterable(final List<String> values) {
+    return new Iterable<String>() {
+      private boolean isIteratorCreated = false;
+
+      @Override
+      public Iterator<String> iterator() {
+        if (isIteratorCreated)
+          throw new IllegalArgumentException("Cannot create two iterators on a singly-iterable sequence");
+        isIteratorCreated = true;
+        return new Iterator<String>() {
+          private final Iterator<String> l_it = values.iterator();
+
+          @Override
+          public boolean hasNext() {
+            return l_it.hasNext();
+          }
+
+          @Override
+          public String next() {
+            return l_it.next();
+          }
+        };
+      }
+    };
   }
 
   @Test
@@ -68,19 +100,19 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_throw_error_if_array_of_values_to_look_for_is_null() {
     assertThatNullPointerException().isThrownBy(() -> iterables.assertContainsExactly(someInfo(), emptyList(), null))
-                                    .withMessage(valuesToLookForIsNull());
+      .withMessage(valuesToLookForIsNull());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsExactly(someInfo(), null, array("Yoda")))
-                                                   .withMessage(actualIsNull());
+      .withMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly() {
     AssertionInfo info = someInfo();
-    Object[] expected = { "Luke", "Yoda", "Han" };
+    Object[] expected = {"Luke", "Yoda", "Han"};
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
@@ -93,7 +125,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order() {
     AssertionInfo info = someInfo();
-    Object[] expected = { "Luke", "Leia", "Yoda" };
+    Object[] expected = {"Luke", "Leia", "Yoda"};
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
@@ -105,13 +137,13 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_all_given_values_but_size_differ() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
-    Object[] expected = { "Luke", "Leia" };
+    Object[] expected = {"Luke", "Leia"};
 
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(), newArrayList("Luke")));
+      newArrayList(), newArrayList("Luke")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -121,26 +153,26 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_pass_if_actual_contains_given_values_exactly_according_to_custom_comparison_strategy() {
     iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(someInfo(), actual,
-                                                                         array("LUKE", "YODA", "Leia"));
+      array("LUKE", "YODA", "Leia"));
   }
 
   @Test
   public void should_fail_if_actual_does_not_contain_given_values_exactly_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    Object[] expected = { "Luke", "Yoda", "Han" };
+    Object[] expected = {"Luke", "Yoda", "Han"};
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList("Han"), newArrayList("Leia"),
-                                                        comparisonStrategy));
+      newArrayList("Han"), newArrayList("Leia"),
+      comparisonStrategy));
   }
 
   @Test
   public void should_fail_if_actual_contains_all_given_values_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    Object[] expected = { "Luke", "Leia", "Yoda" };
+    Object[] expected = {"Luke", "Leia", "Yoda"};
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 
@@ -152,14 +184,14 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   public void should_fail_if_actual_contains_all_given_values_but_size_differ_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual = newArrayList("Luke", "Leia", "Luke");
-    Object[] expected = { "LUKE", "Leia" };
+    Object[] expected = {"LUKE", "Leia"};
 
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(), newArrayList("Luke"),
-                                                        comparisonStrategy));
+      newArrayList(), newArrayList("Luke"),
+      comparisonStrategy));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -29,6 +29,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Iterator;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Iterables;

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -12,13 +12,6 @@
  */
 package org.assertj.core.internal.iterables;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Iterables;
-import org.assertj.core.internal.IterablesBaseTest;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -34,6 +27,13 @@ import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Iterables;
+import org.assertj.core.internal.IterablesBaseTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link Iterables#assertContainsExactly(AssertionInfo, Iterable, Object[])}</code>.

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -63,16 +63,16 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
           throw new IllegalArgumentException("Cannot create two iterators on a singly-iterable sequence");
         isIteratorCreated = true;
         return new Iterator<String>() {
-          private final Iterator<String> l_it = values.iterator();
+          private final Iterator<String> listIterator = values.iterator();
 
           @Override
           public boolean hasNext() {
-            return l_it.hasNext();
+            return listIterator.hasNext();
           }
 
           @Override
           public String next() {
-            return l_it.next();
+            return listIterator.next();
           }
         };
       }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -17,7 +17,6 @@ import org.assertj.core.internal.Iterables;
 import org.assertj.core.internal.IterablesBaseTest;
 import org.junit.jupiter.api.Test;
 
-import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -100,13 +99,13 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_throw_error_if_array_of_values_to_look_for_is_null() {
     assertThatNullPointerException().isThrownBy(() -> iterables.assertContainsExactly(someInfo(), emptyList(), null))
-      .withMessage(valuesToLookForIsNull());
+                                    .withMessage(valuesToLookForIsNull());
   }
 
   @Test
   public void should_fail_if_actual_is_null() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsExactly(someInfo(), null, array("Yoda")))
-      .withMessage(actualIsNull());
+                                                   .withMessage(actualIsNull());
   }
 
   @Test
@@ -143,7 +142,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-      newArrayList(), newArrayList("Luke")));
+                                                        newArrayList(), newArrayList("Luke")));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -153,7 +152,7 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   public void should_pass_if_actual_contains_given_values_exactly_according_to_custom_comparison_strategy() {
     iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(someInfo(), actual,
-      array("LUKE", "YODA", "Leia"));
+                                                                         array("LUKE", "YODA", "Leia"));
   }
 
   @Test
@@ -165,8 +164,8 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-      newArrayList("Han"), newArrayList("Leia"),
-      comparisonStrategy));
+                                                        newArrayList("Han"), newArrayList("Leia"),
+                                                        comparisonStrategy));
   }
 
   @Test
@@ -190,8 +189,8 @@ public class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-      newArrayList(), newArrayList("Luke"),
-      comparisonStrategy));
+                                                        newArrayList(), newArrayList("Luke"),
+                                                        comparisonStrategy));
   }
 
 }


### PR DESCRIPTION
… read once (and is destroyed after reading) then the assertion was failing because the iterable was first read into a list and secondly parsed for equal order. Instead read the copied list as the original iterable may have been destroyed.

#### Check List:
* Fixes #??? -- of course :D :D Change 'actual' to 'actualAsList' in Iterables.java and add a test
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


