### PR TITLE
Add doesNotContainIgnoringCase to CharSequence Asserts

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -871,13 +871,11 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * <p>
    * Example :
    * <pre><code class='java'> // assertion will pass
-   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;pippin&quot;)
-   *                    .doesNotContainIgnoringCase(&quot;Merry&quot;, &quot;sam&quot;);
+   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;pippin&quot;).doesNotContainIgnoringCase(&quot;Merry&quot;, &quot;sam&quot;);
    *
    *
    * // assertion will fail
-   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;Fro&quot;, &quot;Gimli&quot;, &quot;Legolas&quot;)
-   *                    .doesNotContainIgnoringCase(&quot;fro&quot;);
+   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;Fro&quot;, &quot;Gimli&quot;, &quot;Legolas&quot;).doesNotContainIgnoringCase(&quot;fro&quot;);
    * </code></pre>
    *
    * @param values the CharSequences to search for.
@@ -893,7 +891,6 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
     strings.assertDoesNotContainIgnoringCase(info, actual, values);
     return myself;
   }
-  
 
   /**
    * Verifies that the actual {@code CharSequence} does not contain the given regular expression.

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -867,6 +867,35 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} does not contain any of the given values, ignoring case considerations.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;pippin&quot;)
+   *                    .doesNotContainIgnoringCase(&quot;Merry&quot;, &quot;sam&quot;);
+   *
+   *
+   * // assertion will fail
+   * assertThat(&quot;Frodo&quot;).doesNotContainIgnoringCase(&quot;Fro&quot;, &quot;Gimli&quot;, &quot;Legolas&quot;)
+   *                    .doesNotContainIgnoringCase(&quot;fro&quot;);
+   * </code></pre>
+   *
+   * @param values the CharSequences to search for.
+   * @return {@code this} assertion object.
+   * 
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws NullPointerException if any one of the given values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} contains any one of the given values, ignoring case considerations.
+   */
+  public SELF doesNotContainIgnoringCase(CharSequence... values) {
+    strings.assertDoesNotContainIgnoringCase(info, actual, values);
+    return myself;
+  }
+  
+
+  /**
    * Verifies that the actual {@code CharSequence} does not contain the given regular expression.
    * <p>
    * Example :

--- a/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
@@ -82,4 +82,34 @@ public class ShouldNotContainCharSequence extends BasicErrorMessageFactory {
                                             actual, values, found, comparisonStrategy);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldContainCharSequence}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param sequence the sequence of values expected to be in {@code actual}, ignoring case
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainIgnoringCase(CharSequence actual, CharSequence sequence) {
+    return new ShouldNotContainCharSequence("%n" +
+                                            "Expecting:%n" +
+                                            " <%s>%n" +
+                                            "not to contain (ignoring case):%n" +
+                                            " <%s>%n" +
+                                            "%s",
+                                            actual, sequence, StandardComparisonStrategy.instance());
+  }
+
+  public static ErrorMessageFactory shouldNotContainIgnoringCase(CharSequence actual, CharSequence[] sequences,
+                                                                 Set<CharSequence> foundSequences) {
+    return new ShouldNotContainCharSequence("%n" +
+                                            "Expecting:%n" +
+                                            " <%s>%n" +
+                                            "not to contain (ignoring case):%n" +
+                                            " <%s>%n" +
+                                            "but found:%n" +
+                                            " <%s>%n" +
+                                            "%s",
+                                            actual, sequences, foundSequences, StandardComparisonStrategy.instance());
+  }
+
 }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -515,7 +515,6 @@ public class Strings {
       throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
   }
 
-  
   /**
    * Verifies that the given {@code CharSequence} does not contain any one of the given values, ignoring case considerations.
    *
@@ -532,21 +531,18 @@ public class Strings {
   public void assertDoesNotContainIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence... values) {
     doCommonCheckForCharSequence(info, actual, values);
 
-    Set<CharSequence> foundSequences = new LinkedHashSet<>();
-    for (CharSequence sequence : values) {
-      if (actual.toString().toLowerCase().contains(sequence.toString().toLowerCase()))
-        foundSequences.add(sequence);
-    }
-    
-    if (foundSequences.isEmpty()) 
-      return;
-    
-    if (foundSequences.size() == 1 && values.length == 1) {
+    String actualLowerCase = actual.toString().toLowerCase();
+    Set<CharSequence> foundValues = stream(values).filter(value -> actualLowerCase.contains(value.toString().toLowerCase()))
+                                                  .collect(toCollection(LinkedHashSet::new));
+
+    if (foundValues.isEmpty()) return;
+
+    if (foundValues.size() == 1 && values.length == 1) {
       throw failures.failure(info, shouldNotContainIgnoringCase(actual, values[0]));
     }
-    throw failures.failure(info, shouldNotContainIgnoringCase(actual, values, foundSequences));
+    throw failures.failure(info, shouldNotContainIgnoringCase(actual, values, foundValues));
   }
-  
+
   /**
    * Verifies that the given {@code CharSequence} does not contain any one of the given values.
    *

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -54,6 +54,7 @@ import static org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace.shouldNo
 import static org.assertj.core.error.ShouldNotBeEqualNormalizingWhitespace.shouldNotBeEqualNormalizingWhitespace;
 import static org.assertj.core.error.ShouldNotContainAnyWhitespaces.shouldNotContainAnyWhitespaces;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContainIgnoringCase;
 import static org.assertj.core.error.ShouldNotContainOnlyWhitespaces.shouldNotContainOnlyWhitespaces;
 import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
 import static org.assertj.core.error.ShouldNotEndWith.shouldNotEndWith;
@@ -514,6 +515,38 @@ public class Strings {
       throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
   }
 
+  
+  /**
+   * Verifies that the given {@code CharSequence} does not contain any one of the given values, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param values the sequences to search for.
+   * 
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws NullPointerException if any one of the given values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} contains any one of the given values, ignoring case considerations.
+   */
+  public void assertDoesNotContainIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence... values) {
+    doCommonCheckForCharSequence(info, actual, values);
+
+    Set<CharSequence> foundSequences = new LinkedHashSet<>();
+    for (CharSequence sequence : values) {
+      if (actual.toString().toLowerCase().contains(sequence.toString().toLowerCase()))
+        foundSequences.add(sequence);
+    }
+    
+    if (foundSequences.isEmpty()) 
+      return;
+    
+    if (foundSequences.size() == 1 && values.length == 1) {
+      throw failures.failure(info, shouldNotContainIgnoringCase(actual, values[0]));
+    }
+    throw failures.failure(info, shouldNotContainIgnoringCase(actual, values, foundSequences));
+  }
+  
   /**
    * Verifies that the given {@code CharSequence} does not contain any one of the given values.
    *

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+import org.assertj.core.util.Arrays;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotContainIgnoringCase(CharSequence...)}</code>.
+ * 
+ * @author Brummolix
+ */
+public class CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainIgnoringCase("od", "do");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainIgnoringCase(getInfo(assertions), getActual(assertions), Arrays.array("od", "do"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test.java
@@ -14,8 +14,8 @@ package org.assertj.core.api.charsequence;
 
 import org.assertj.core.api.CharSequenceAssert;
 import org.assertj.core.api.CharSequenceAssertBaseTest;
-import org.assertj.core.util.Arrays;
 
+import static org.assertj.core.util.Arrays.array;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -32,6 +32,6 @@ public class CharSequenceAssert_doesNotContainIgnoringCase_CharSequence_Test ext
 
   @Override
   protected void verify_internal_effects() {
-    verify(strings).assertDoesNotContainIgnoringCase(getInfo(assertions), getActual(assertions), Arrays.array("od", "do"));
+    verify(strings).assertDoesNotContainIgnoringCase(getInfo(assertions), getActual(assertions), array("od", "do"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContainIgnoringCase;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Arrays.array;
 import static org.mockito.internal.util.collections.Sets.newSet;
@@ -23,10 +24,8 @@ import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.core.util.Arrays;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.util.collections.Sets;
 
 /**
  * Tests for <code>{@link ShouldNotContainCharSequence#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
@@ -101,9 +100,7 @@ public class ShouldNotContainString_create_Test {
   @Test
   public void should_create_error_message_for_ignoring_case_with_multiple_findings() {
     // GIVEN
-    ErrorMessageFactory factory = ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
-                                                                                            Arrays.array("OD", "da", "Luke"),
-                                                                                            Sets.newSet("OD", "da"));
+    ErrorMessageFactory factory = shouldNotContainIgnoringCase("Yoda", array("OD", "da", "Luke"), newSet("OD", "da"));
     // WHEN
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN

--- a/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContainString_create_Test.java
@@ -23,8 +23,10 @@ import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.Arrays;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.util.collections.Sets;
 
 /**
  * Tests for <code>{@link ShouldNotContainCharSequence#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
@@ -81,4 +83,37 @@ public class ShouldNotContainString_create_Test {
                                    "but found:%n" +
                                    " <[\"ya\"]>%n"));
   }
+
+  @Test
+  public void should_create_error_message_for_ignoring_case() {
+    // GIVEN
+    ErrorMessageFactory factory = ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda", "OD");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting:%n" +
+                                   " <\"Yoda\">%n" +
+                                   "not to contain (ignoring case):%n" +
+                                   " <\"OD\">%n"));
+  }
+
+  @Test
+  public void should_create_error_message_for_ignoring_case_with_multiple_findings() {
+    // GIVEN
+    ErrorMessageFactory factory = ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
+                                                                                            Arrays.array("OD", "da", "Luke"),
+                                                                                            Sets.newSet("OD", "da"));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting:%n" +
+                                   " <\"Yoda\">%n" +
+                                   "not to contain (ignoring case):%n" +
+                                   " <[\"OD\", \"da\", \"Luke\"]>%n" +
+                                   "but found:%n" +
+                                   " <[\"OD\", \"da\"]>%n"));
+  }
+
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.error.ShouldNotContainCharSequence;
+import org.assertj.core.internal.ErrorMessages;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.util.collections.Sets;
+
+/**
+ * Tests for <code>{@link Strings#assertDoesNotContainIgnoringCase(AssertionInfo, CharSequence, CharSequence...)}</code>.
+ * 
+ * @author Brummolix
+ */
+public class Strings_assertDoesNotContainIgnoringCase_Test extends StringsBaseTest {
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_sequence_ignoring_case() {
+    strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda", "no");
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contain_sequences_ignoring_case() {
+    strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda", "no", "also no");
+  }
+
+  @Test
+  public void should_fail_if_actual_contain_sequence() {
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                                              "od"))
+                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
+                                                                                                                          "od")
+                                                                                            .create());
+  }
+
+  @Test
+  public void should_fail_if_actual_contain_sequence_in_other_case() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                                              "OD"))
+                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
+                                                                                                                          "OD")
+                                                                                            .create());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_one_of_several_sequences() {
+
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                                              "od", "Yo", "Luke"))
+                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
+                                                                                                                          new CharSequence[] {
+                                                                                                                              "od",
+                                                                                                                              "Yo",
+                                                                                                                              "Luke" },
+                                                                                                                          Sets.newSet("od",
+                                                                                                                                      "Yo"))
+                                                                                            .create());
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_one_of_several_sequence_in_other_case() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                                              "OD", "yo", "Luke"))
+                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
+                                                                                                                          new CharSequence[] {
+                                                                                                                              "OD",
+                                                                                                                              "yo",
+                                                                                                                              "Luke" },
+                                                                                                                          Sets.newSet("OD",
+                                                                                                                                      "yo"))
+                                                                                            .create());
+  }
+
+  @Test
+  public void should_fail_if_values_are_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                               (CharSequence[]) null))
+                                    .withMessage(ErrorMessages.valuesToLookForIsNull());
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), null,
+                                                                                                              "Yoda"))
+                                                   .withMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_throw_error_if_values_is_empty() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(),
+                                                                                                                        "Yoda"))
+                                                             .withMessage(ErrorMessages.arrayOfValuesToLookForIsEmpty());
+  }
+
+  @Test
+  public void should_throw_error_if_values_contains_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
+                                                                                               new CharSequence[] { "1", null }))
+                                    .withMessage("Expecting CharSequence elements not to be null but found one at index 1");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
@@ -14,81 +14,94 @@ package org.assertj.core.internal.strings;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContainIgnoringCase;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.internal.util.collections.Sets.newSet;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.error.ShouldNotContainCharSequence;
 import org.assertj.core.internal.ErrorMessages;
 import org.assertj.core.internal.Strings;
 import org.assertj.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.util.collections.Sets;
 
 /**
  * Tests for <code>{@link Strings#assertDoesNotContainIgnoringCase(AssertionInfo, CharSequence, CharSequence...)}</code>.
  * 
  * @author Brummolix
  */
+@DisplayName("Strings.assertDoesNotContainIgnoringCase")
 public class Strings_assertDoesNotContainIgnoringCase_Test extends StringsBaseTest {
 
   @Test
-  public void should_pass_if_actual_does_not_contain_sequence_ignoring_case() {
+  public void should_pass_if_actual_does_not_contain_value_ignoring_case() {
     strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda", "no");
   }
 
   @Test
-  public void should_pass_if_actual_does_not_contain_sequences_ignoring_case() {
+  public void should_pass_if_actual_does_not_contain_values_ignoring_case() {
     strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda", "no", "also no");
   }
 
   @Test
-  public void should_fail_if_actual_contain_sequence() {
-    assertThatExceptionOfType(AssertionError.class)
-                                                   .isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
-                                                                                                              "od"))
-                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
-                                                                                                                          "od")
-                                                                                            .create());
+  public void should_fail_if_actual_contains_value() {
+    // GIVEN
+    String actual = "Yoda";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> {
+      strings.assertDoesNotContainIgnoringCase(someInfo(), actual, "od");
+    });
+
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainIgnoringCase(actual, "od").create());
   }
 
   @Test
-  public void should_fail_if_actual_contain_sequence_in_other_case() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
-                                                                                                              "OD"))
-                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
-                                                                                                                          "OD")
-                                                                                            .create());
+  public void should_fail_if_actual_contains_value_in_different_case() {
+    // GIVEN
+    String actual = "Yoda";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> {
+      strings.assertDoesNotContainIgnoringCase(someInfo(), actual, "OD");
+    });
+
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainIgnoringCase(actual, "OD").create());
   }
 
   @Test
-  public void should_fail_if_actual_contains_one_of_several_sequences() {
+  public void should_fail_if_actual_contains_one_of_several_values() {
+    // GIVEN
+    String actual = "Yoda";
 
-    assertThatExceptionOfType(AssertionError.class)
-                                                   .isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
-                                                                                                              "od", "Yo", "Luke"))
-                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
-                                                                                                                          new CharSequence[] {
-                                                                                                                              "od",
-                                                                                                                              "Yo",
-                                                                                                                              "Luke" },
-                                                                                                                          Sets.newSet("od",
-                                                                                                                                      "Yo"))
-                                                                                            .create());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> {
+      strings.assertDoesNotContainIgnoringCase(someInfo(), actual, "od", "Yo", "Luke");
+    });
+
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainIgnoringCase(actual, new CharSequence[] { "od", "Yo", "Luke" },
+                                                                 newSet("od", "Yo")).create());
   }
 
   @Test
-  public void should_fail_if_actual_contains_one_of_several_sequence_in_other_case() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), "Yoda",
-                                                                                                              "OD", "yo", "Luke"))
-                                                   .withMessage(ShouldNotContainCharSequence.shouldNotContainIgnoringCase("Yoda",
-                                                                                                                          new CharSequence[] {
-                                                                                                                              "OD",
-                                                                                                                              "yo",
-                                                                                                                              "Luke" },
-                                                                                                                          Sets.newSet("OD",
-                                                                                                                                      "yo"))
-                                                                                            .create());
+  public void should_fail_if_actual_contains_one_of_several_values_in_different_case() {
+    // GIVEN
+    String actual = "Yoda";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> {
+      strings.assertDoesNotContainIgnoringCase(someInfo(), actual, "OD", "yo", "Luke");
+    });
+
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainIgnoringCase(actual, new CharSequence[] { "OD", "yo", "Luke" },
+                                                                 newSet("OD", "yo")).create());
   }
 
   @Test
@@ -100,13 +113,20 @@ public class Strings_assertDoesNotContainIgnoringCase_Test extends StringsBaseTe
 
   @Test
   public void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(), null,
-                                                                                                              "Yoda"))
-                                                   .withMessage(actualIsNull());
+    // GIVEN
+    String actual = null;
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> {
+      strings.assertDoesNotContainIgnoringCase(someInfo(), actual, "Yoda");
+    });
+
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
-  public void should_throw_error_if_values_is_empty() {
+  public void should_throw_error_if_values_are_empty() {
     assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> strings.assertDoesNotContainIgnoringCase(someInfo(),
                                                                                                                         "Yoda"))
                                                              .withMessage(ErrorMessages.arrayOfValuesToLookForIsEmpty());


### PR DESCRIPTION
This PR adds doesNotContainIgnoringCase  to CharSequence Asserts, similar as containsIgnoringCase

#### Check List:
* Fixes - new feature
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


