### PR TITLE
Add tests for hasNoPath methods in abstractUrlAssert and abstractUriAssert 

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -419,7 +419,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
   }
 
   /**
-   * Verifies that the actual {@link URL} is equivalent to the given one after <b>their parameters are sorted</b>.
+   * Verifies that the actual {@code URL} is equivalent to the given one after <b>their parameters are sorted</b>.
    * <p>
    * Example:
    * <pre><code class='java'> URL url = new URL("http://example.com?a=b&amp;c=d");
@@ -434,7 +434,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * //... and this one fails as domains are different.
    * assertThat(url).isEqualToWithSortedQueryParameters(new URL("http://example2.com?amp;a=b&amp;c=d")); </code></pre>
    *
-   * @param expected the expected {@link URL} to compare actual to.
+   * @param expected the expected {@code URL} to compare actual to.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given URL is {@code null}.
    * @throws AssertionError if the actual {@code URL} is {@code null}.

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -69,7 +69,7 @@ public class Urls {
 
   public void assertHasPath(AssertionInfo info, URL actual, String path) {
     assertNotNull(info, actual);
-    checkArgument(path != null, "Expecting given path not to be null");
+    // checkArgument(path != null, "Expecting given path not to be null");
     if (!Objects.equals(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
   }
 

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -69,7 +69,7 @@ public class Urls {
 
   public void assertHasPath(AssertionInfo info, URL actual, String path) {
     assertNotNull(info, actual);
-    // checkArgument(path != null, "Expecting given path not to be null");
+    checkArgument(path != null, "Expecting given path not to be null");
     if (!Objects.equals(actual.getPath(), path)) throw failures.failure(info, shouldHavePath(actual, path));
   }
 

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoPath_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoPath_Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+public class UriAssert_hasNoPath_Test extends UriAssertBaseTest {
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasNoPath();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasPath(getInfo(assertions), getActual(assertions), null);
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoPath_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoPath_Test.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+public class UrlAssert_hasNoPath_Test extends UrlAssertBaseTest {
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasNoPath();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasPath(getInfo(assertions), getActual(assertions), null);
+    // verify(urls).assertHasPath(getInfo(assertions), getActual(assertions), "");
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoPath_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoPath_Test.java
@@ -26,7 +26,6 @@ public class UrlAssert_hasNoPath_Test extends UrlAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(urls).assertHasPath(getInfo(assertions), getActual(assertions), null);
-    // verify(urls).assertHasPath(getInfo(assertions), getActual(assertions), "");
+    verify(urls).assertHasPath(getInfo(assertions), getActual(assertions), "");
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1887 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA

Even I finished the tests, I am still a little confused about the difference between them as I mentioned in issue #1887. 
