### PR TITLE
Avoid infinite recursion in StandardRepresentation

### DIFF
--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -108,7 +108,7 @@ public class StandardRepresentation implements Representation {
 
   private static final Map<Class<?>, Function<?, String>> customFormatterByType = new HashMap<>();
   private static final Class<?>[] TYPE_WITH_UNAMBIGUOUS_REPRESENTATION = { Date.class, LocalDateTime.class, ZonedDateTime.class,
-    OffsetDateTime.class, Calendar.class };
+      OffsetDateTime.class, Calendar.class };
 
   protected enum GroupType {
     ITERABLE("iterable"), ARRAY("array");
@@ -305,7 +305,7 @@ public class StandardRepresentation implements Representation {
   protected String toStringOf(ComparatorBasedComparisonStrategy comparatorBasedComparisonStrategy) {
     String comparatorDescription = comparatorBasedComparisonStrategy.getComparatorDescription();
     return comparatorDescription == null ? toStringOf(comparatorBasedComparisonStrategy.getComparator())
-      : quote(comparatorDescription);
+        : quote(comparatorDescription);
   }
 
   protected String toStringOf(Calendar calendar) {
@@ -543,19 +543,20 @@ public class StandardRepresentation implements Representation {
   }
 
   // public String format(Iterable<?> iterable, String start, String end, String elementSeparator, String indentation) {
-  //   return format(iterable, iterable, start, end, elementSeparator, indentation, new TreeSet<>());
+  // return format(iterable, iterable, start, end, elementSeparator, indentation, new TreeSet<>());
   // }
   //
-  // public String format(Iterable<?> iterable,Object originalContainer, String start, String end, String elementSeparator, String indentation,Set<Object> alreadyVisited) {
-  //   if (iterable == null) return null;
-  //   Iterator<?> iterator = iterable.iterator();
-  //   if (!iterator.hasNext()) return start + end;
+  // public String format(Iterable<?> iterable,Object originalContainer, String start, String end, String elementSeparator, String
+  // indentation,Set<Object> alreadyVisited) {
+  // if (iterable == null) return null;
+  // Iterator<?> iterator = iterable.iterator();
+  // if (!iterator.hasNext()) return start + end;
   //
-  //   alreadyVisited.add(iterable);
-  //   List<String> list = stream(iterable)
-  //     .map(element ->toStringOf(originalContainer, GroupType.ITERABLE, element, elementSeparator,indentation, alreadyVisited))
-  //                                       .collect(toList());
-  //   return extracted(iterable, start, end, elementSeparator, indentation, list);
+  // alreadyVisited.add(iterable);
+  // List<String> list = stream(iterable)
+  // .map(element ->toStringOf(originalContainer, GroupType.ITERABLE, element, elementSeparator,indentation, alreadyVisited))
+  // .collect(toList());
+  // return extracted(iterable, start, end, elementSeparator, indentation, list);
   // }
 
   public String format(Iterable<?> iterable, String start, String end, String elementSeparator, String indentation) {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
@@ -138,7 +138,6 @@ public class StandardRepresentation_array_format_Test extends AbstractBaseRepres
     then(formatted).isEqualTo("[\"Hello\", [true, false]]");
   }
 
-  @Disabled
   @Test
   public void should_format_Object_array_with_itself_as_element() {
     // GIVEN

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -200,7 +200,7 @@ public class StandardRepresentation_iterable_format_Test extends AbstractBaseRep
     List<Object> list1 = list("Hello", "World");
     List<Object> list2 = list(list1);
     list1.set(1, list2);
-    assertThat(STANDARD_REPRESENTATION.toStringOf(list1)).isEqualTo("[[\"Hello\", (this iterable)]]");
+    assertThat(STANDARD_REPRESENTATION.toStringOf(list2)).isEqualTo("[[\"Hello\", (this iterable)]]");
   }
 
   private static String stringOfLength(int length) {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -194,7 +194,6 @@ public class StandardRepresentation_iterable_format_Test extends AbstractBaseRep
                                      "    (this iterable)]"));
   }
 
-  @Disabled //
   @Test
   public void should_format_iterable_having_itself_as_element() {
     List<Object> list1 = list("Hello", "World");


### PR DESCRIPTION
#### Check List:
* Fixes #1894 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA

Only useful for `array` case. For `iterable` case, it doesn't work now because neither `HashSet` (hashcode issue leads to a stack overflow) nor `TreeSet` (lead to ClassCastException) can work. I think maybe we can convert an iterable to an array at the beginning. @joel-costigliola 
