### PR TITLE
fix references to main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,9 @@ It's ok not to follow some of the rules described above if you have a good reaso
 
 [assertj-examples](https://github.com/joel-costigliola/assertj-examples) shows how to efficiently use AssertJ through fun unit test examples, it can be seen as AssertJs living documentation.
 
-## Rebase your PR on master (no merge!)
+## Rebase your PR on main (no merge!)
 
-We prefer integrating PR by squashing all the commits and rebase it to master, if you PR has diverged and needs to integrate with master, please rebase on master but do not merge as it will prevent rebasing later on.
+We prefer integrating PR by squashing all the commits and rebase it to main, if you PR has diverged and needs to integrate with main, please rebase on main but do not merge as it will prevent rebasing later on.
 
 ## Naming conventions with some examples:
 

--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ To help you [**replace JUnit assertions**](http://joel-costigliola.github.io/ass
 
 ## <a name="contributing"/>Want to contribute?
 
-You are encouraged to contribute any missing, useful assertions. To do so, please read the [contributing section](https://github.com/joel-costigliola/assertj-core/blob/master/CONTRIBUTING.md).
+You are encouraged to contribute any missing, useful assertions. To do so, please read the [contributing section](https://github.com/joel-costigliola/assertj-core/blob/main/CONTRIBUTING.md).

--- a/src/main/java/org/assertj/core/presentation/Representation.java
+++ b/src/main/java/org/assertj/core/presentation/Representation.java
@@ -35,7 +35,7 @@ import org.assertj.core.api.Assertions;
  * {@link StandardRepresentation#fallbackToStringOf(Object)}. By doing this all the defaults of AssertJ would be applied and you can apply your own customization</li>
  * </ul>
  * <p>
- * The <a href="https://github.com/joel-costigliola/assertj-examples/tree/master/assertions-examples">assertj-examples</a> project provides a working example of registering a custom representation.
+ * The <a href="https://github.com/joel-costigliola/assertj-examples/tree/main/assertions-examples">assertj-examples</a> project provides a working example of registering a custom representation.
  * <p>
  * Registering a representation has been introduced in AssertJ 2.9.0/3.9.0.  
  * 

--- a/src/test/resources/diffs/5A.txt
+++ b/src/test/resources/diffs/5A.txt
@@ -361,7 +361,7 @@ test_expect_success 'combined diff with autocrlf conversion' '
                 echo >x goodbye &&
                 git commit -m "the other side" x &&
                 git config core.autocrlf true &&
-                test_must_fail git merge master &&
+                test_must_fail git merge main &&
 
                 git diff | sed -e "1,/^@@@/d" >actual &&
                 ! grep "^-" actual

--- a/src/test/resources/diffs/5B.txt
+++ b/src/test/resources/diffs/5B.txt
@@ -369,7 +369,7 @@ test_expect_success 'combined diff with autocrlf conversion' '
                 echo >x goodbye &&
                 git commit -m "the other side" x &&
                 git config core.autocrlf true &&
-                test_must_fail git merge master &&
+                test_must_fail git merge main &&
 
                 git diff | sed -e "1,/^@@@/d" >actual &&
                 ! grep "^-" actual


### PR DESCRIPTION
#### Check List:
* Fixes N/A
* Unit tests : NA
* Javadoc with a code example (on API only) : NA

Seems there was a branch renaming, but some things didn't get renamed, causing broken links and being generally misleading. Not sure if this needs a related issue; nothing in the contrib guide so I just made the PR.
