### PR TITLE
assertContains and assertContainsOnly fail when the actual iterable is not restartable

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -332,9 +332,10 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not contain the given values.
    */
   public void assertContains(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, values)) return;
+    final List<?> actualAsList = newArrayList(actual);
+    if (commonCheckThatIterableAssertionSucceeds(info, actualAsList, values)) return;
     // check for elements in values that are missing in actual.
-    assertIterableContainsGivenValues(actual, values, info);
+    assertIterableContainsGivenValues(actualAsList, values, info);
   }
 
   private void assertIterableContainsGivenValues(Iterable<?> actual, Object[] values, AssertionInfo info) {
@@ -370,14 +371,15 @@ public class Iterables {
    *           {@code Iterable} contains values that are not in the given array.
    */
   public void assertContainsOnly(AssertionInfo info, Iterable<?> actual, Object[] expectedValues) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, expectedValues)) return;
+    final List<?> actualAsList = newArrayList(actual);
+    if (commonCheckThatIterableAssertionSucceeds(info, actualAsList, expectedValues)) return;
 
     // after the for loop, unexpected = expectedValues - actual
-    List<Object> unexpectedValues = newArrayList(actual);
+    List<Object> unexpectedValues = newArrayList(actualAsList);
     // after the for loop, missing = actual - expectedValues
     List<Object> missingValues = newArrayList(expectedValues);
     for (Object expected : expectedValues) {
-      if (iterableContains(actual, expected)) {
+      if (iterableContains(actualAsList, expected)) {
         // since expected was found in actual:
         // -- it does not belong to the missing elements
         iterablesRemove(missingValues, expected);
@@ -387,7 +389,7 @@ public class Iterables {
     }
 
     if (!unexpectedValues.isEmpty() || !missingValues.isEmpty()) {
-      throw failures.failure(info, shouldContainOnly(actual, expectedValues,
+      throw failures.failure(info, shouldContainOnly(actualAsList, expectedValues,
                                                      missingValues, unexpectedValues,
                                                      comparisonStrategy));
     }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Iterator;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Iterables;

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Iterator;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Iterables;

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnly_Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.internal.iterables.Iterables_assertContainsExactly_Test.createSinglyIterable;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -170,4 +171,8 @@ public class Iterables_assertContainsOnly_Test extends IterablesBaseTest {
                                                      comparisonStrategy));
   }
 
+  @Test
+  public void should_pass_if_nonrestartable_actual_contains_only_given_values() {
+    iterables.assertContainsOnly(someInfo(), createSinglyIterable(actual), array("Luke", "Yoda", "Leia"));
+  }
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.internal.iterables.Iterables_assertContainsExactly_Test.createSinglyIterable;
 import static org.assertj.core.test.ObjectArrays.emptyArray;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -72,7 +73,12 @@ public class Iterables_assertContains_Test extends IterablesBaseTest {
     actual.clear();
     iterables.assertContains(someInfo(), actual, array());
   }
-  
+
+  @Test
+  public void should_pass_if_nonrestartable_actual_contains_given_values() {
+    iterables.assertContains(someInfo(), createSinglyIterable(actual), array("Luke", "Yoda", "Leia"));
+  }
+
   @Test
   public void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContains(someInfo(), actual, emptyArray()));


### PR DESCRIPTION
#### Check List:
* Fixes #??? absolutely, assertContains and assertContainsOnly fail if the iterable is not restartable
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA


