### PR TITLE
Test improvement: removed resource optimism (test smell)

### DIFF
--- a/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.linesOf;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.junit.Assume.*;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +30,7 @@ public class Assertions_linesOf_Test {
   @Test
   public void should_read_lines_of_file_with_UTF8_charset() {
     File file = new File("src/test/resources/utf8.txt");
+    assumeTrue("src/test/resources/utf8.txt file is blank. Skipping test", file.length() > 0);
     assertThat(linesOf(file, "UTF-8")).isEqualTo(EXPECTED_CONTENT);
     assertThat(linesOf(file, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
   }


### PR DESCRIPTION
#### Check List:
* Fixes NA
* Unit tests: YES
* Javadoc with a code example (on API only): NA

This is a test refactoring.

The resource optimism occurs when a test method makes an optimistic assumption that the external resource (e.g., file), utilized by the test method, exists.

As this test presumes the existence of a file with content to be tested for, It is necessary to ensure the file exists and has content before proceeding with the test steps.

