### PR TITLE
fix typo in AssertionErrorMessagesAggregrator

### DIFF
--- a/src/main/java/org/assertj/core/api/SoftAssertionError.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionError.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.core.api;
 
-import static org.assertj.core.error.AssertionErrorMessagesAggregrator.aggregrateErrorMessages;
+import static org.assertj.core.error.AssertionErrorMessagesAggregator.aggregateErrorMessages;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public class SoftAssertionError extends AssertionError {
    * @param errors the causal AssertionError error messages in the order that they were thrown
    */
   public SoftAssertionError(List<String> errors) {
-    super(aggregrateErrorMessages(errors));
+    super(aggregateErrorMessages(errors));
     this.errors = errors;
   }
 

--- a/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregator.java
+++ b/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregator.java
@@ -14,13 +14,9 @@ package org.assertj.core.error;
 
 import java.util.List;
 
-/**
- * @deprecated use {@link AssertionErrorMessagesAggregator} instead
- */
-@Deprecated
-public class AssertionErrorMessagesAggregrator {
+public class AssertionErrorMessagesAggregator {
 
-  public static String aggregrateErrorMessages(List<String> errors) {
+  public static String aggregateErrorMessages(List<String> errors) {
     StringBuilder msg = new StringBuilder("%nThe following ");
     countAssertions(errors, msg);
     msg.append(" failed:%n");

--- a/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregator.java
+++ b/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregator.java
@@ -14,9 +14,9 @@ package org.assertj.core.error;
 
 import java.util.List;
 
-public class AssertionErrorMessagesAggregrator {
+public class AssertionErrorMessagesAggregator {
 
-  public static String aggregrateErrorMessages(List<String> errors) {
+  public static String aggregateErrorMessages(List<String> errors) {
     StringBuilder msg = new StringBuilder("%nThe following ");
     countAssertions(errors, msg);
     msg.append(" failed:%n");

--- a/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregrator.java
+++ b/src/main/java/org/assertj/core/error/AssertionErrorMessagesAggregrator.java
@@ -35,5 +35,4 @@ public class AssertionErrorMessagesAggregator {
       msg.append(size).append(" assertions");
     }
   }
-
 }

--- a/src/main/java/org/assertj/core/error/MultipleAssertionsError.java
+++ b/src/main/java/org/assertj/core/error/MultipleAssertionsError.java
@@ -13,7 +13,7 @@
 package org.assertj.core.error;
 
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.error.AssertionErrorMessagesAggregrator.aggregrateErrorMessages;
+import static org.assertj.core.error.AssertionErrorMessagesAggregator.aggregateErrorMessages;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class MultipleAssertionsError extends AssertionError {
     List<String> errorsMessage = errors.stream()
                                        .map(AssertionError::getMessage)
                                        .collect(toList());
-    return aggregrateErrorMessages(errorsMessage);
+    return aggregateErrorMessages(errorsMessage);
   }
 
 }


### PR DESCRIPTION
#### Check List:

* Fix typo in `AssertionErrorMessagesAggregrator` class and `aggregrateErrorMessages()` method
* Unit tests :  NO
* Javadoc with a code example (on API only) : NO


