### PR TITLE
Remove commented variables, update equals and fix typo method's name 

### DIFF
--- a/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 public class FieldLocation implements Comparable<FieldLocation> {
 
   private String fieldPath;
-  // private boolean whereverInGraph = false;
-  // private boolean matches(Field field, Field parent); ?
 
   @Override
   public int compareTo(final FieldLocation other) {
@@ -32,6 +30,7 @@ public class FieldLocation implements Comparable<FieldLocation> {
 
   @Override
   public boolean equals(final Object other) {
+    if (this == other) { return true; }
     if (!(other instanceof FieldLocation)) return false;
     FieldLocation castOther = (FieldLocation) other;
     return Objects.equals(fieldPath, castOther.fieldPath);
@@ -64,7 +63,15 @@ public class FieldLocation implements Comparable<FieldLocation> {
     return Stream.of(fieldPaths).map(FieldLocation::new).collect(toList());
   }
 
+  /**
+   * @deprecated use {@link #fieldLocation} instead
+   * */
+  @Deprecated
   public static FieldLocation fielLocation(String fieldPath) {
+    return fieldLocation(fieldPath);
+  }
+
+  public static FieldLocation fieldLocation(String fieldPath) {
     return new FieldLocation(fieldPath);
   }
 

--- a/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_equals_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_equals_Test.java
@@ -1,0 +1,78 @@
+package org.assertj.core.api.recursive.comparison;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class FieldLocation_equals_Test {
+
+  private static final String EMPTY__VALUE = "";
+  private static final String FIELD_LOCATION_VALUE = "test_value";
+  private static final String FIELD_LOCATION_OTHER_VALUE = "other_test_value";
+
+  @Test
+  void should_fieldLocation_equals_itself() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(fieldLocation)).isEqualTo(true);
+  }
+
+  @Test
+  void should_empty_fieldLocation_not_equals_null() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(EMPTY__VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(null)).isEqualTo(false);
+  }
+
+  @Test
+  void should_fieldLocation_not_equals_empty() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(null)).isEqualTo(false);
+  }
+
+  @Test
+  void should_string_not_equals_fieldLocation() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(EMPTY__VALUE)).isEqualTo(false);
+  }
+
+  @Test
+  void should_fieldLocation_equals_fieldLocation_with_same_value() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+    FieldLocation other = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(other)).isEqualTo(true);
+  }
+
+  @Test
+  void should_fieldLocation_equals_fieldLocation_with_empty_value() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(EMPTY__VALUE);
+    FieldLocation other = FieldLocation.fieldLocation(EMPTY__VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(other)).isEqualTo(true);
+  }
+
+  @Test
+  void should_fieldLocation_not_equals_fieldLocation_with_diff_value() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+    FieldLocation other = FieldLocation.fieldLocation(FIELD_LOCATION_OTHER_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.equals(other)).isEqualTo(false);
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_fieldLocation_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_fieldLocation_Test.java
@@ -1,0 +1,29 @@
+package org.assertj.core.api.recursive.comparison;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class FieldLocation_fieldLocation_Test {
+
+  private static final String OTHER_VALUE = "other_value";
+  private static final String FIELD_LOCATION_VALUE = "test_value_field_location";
+
+  @Test
+  void should_fieldLocation_same() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation).isEqualTo(FieldLocation.fieldLocation(FIELD_LOCATION_VALUE));
+  }
+
+  @Test
+  void should_fieldLocation_diff() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation).isNotEqualTo(FieldLocation.fieldLocation(OTHER_VALUE));
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_hashCode_Test.java
@@ -1,0 +1,42 @@
+package org.assertj.core.api.recursive.comparison;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class FieldLocation_hashCode_Test {
+
+  private static final String FIELD_LOCATION_VALUE = "test_value";
+
+  @Test
+  void should_fieldLocation_hashCode_equal() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.hashCode()).isEqualTo(fieldLocation.hashCode());
+    then(fieldLocation.equals(fieldLocation)).isEqualTo(true);
+  }
+
+  @Test
+  void should_fieldLocation_hashCode_same_value_equals() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+    FieldLocation other = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+
+    // WHEN & THEN
+    then(fieldLocation.hashCode()).isEqualTo(other.hashCode());
+    then(fieldLocation.equals(other)).isEqualTo(true);
+  }
+
+  @Test
+  void should_fieldLocation_hashCode_diff_value_not_equals() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+    FieldLocation other = FieldLocation.fieldLocation("");
+
+    // WHEN & THEN
+    then(fieldLocation.hashCode()).isNotEqualTo(other.hashCode());
+    then(fieldLocation.equals(other)).isEqualTo(false);
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_toString_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/FieldLocation_toString_Test.java
@@ -1,0 +1,20 @@
+package org.assertj.core.api.recursive.comparison;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class FieldLocation_toString_Test {
+
+  private static final String FIELD_LOCATION_VALUE = "test_value_field_location";
+
+  @Test
+  void should_extract_toString() {
+    // GIVEN
+    FieldLocation fieldLocation = FieldLocation.fieldLocation(FIELD_LOCATION_VALUE);
+    final String expected = "FieldLocation [fieldPath=" + FIELD_LOCATION_VALUE + "]";
+
+    // WHEN & THEN
+    then(fieldLocation.toString()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
1. Remove commented variables
2. Update `equals()` method to check if an object equals to itself 
3. Mark `fielLocation()` method as deprecated and create a new one with the correct name `fieldLocation()`
4. Add unit tests for `equals()`, `hashCode()` and `fieldLocation()`

#### Check List:
* Unit tests:  YES
* Javadoc with a code example (on API only): NO

