### PR TITLE
Update equals() and hashCode() for Percentage class

### DIFF
--- a/src/main/java/org/assertj/core/data/Percentage.java
+++ b/src/main/java/org/assertj/core/data/Percentage.java
@@ -14,9 +14,6 @@ package org.assertj.core.data;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.assertj.core.util.Objects.HASH_CODE_PRIME;
-import static org.assertj.core.util.Objects.areEqual;
-import static org.assertj.core.util.Objects.hashCodeFor;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 /**
@@ -25,6 +22,7 @@ import static org.assertj.core.util.Preconditions.checkArgument;
  * @author Alexander Bishcof
  */
 public class Percentage {
+
   public final double value;
 
   /**
@@ -46,19 +44,18 @@ public class Percentage {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    Percentage other = (Percentage) obj;
-    return areEqual(value, other.value);
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+
+    Percentage that = (Percentage) o;
+
+    return Double.compare(that.value, value) == 0;
   }
 
   @Override
   public int hashCode() {
-    int result = 1;
-    result = HASH_CODE_PRIME * result + hashCodeFor(value);
-    return result;
+    return Double.hashCode(value);
   }
 
   @Override


### PR DESCRIPTION
1. As the `equals()` uses a `double` value to check the equality, no need to use `deepEquals()`
2. As the `value` variable is a `double` we can use `Double.hashCode()` to get the hashCode for the double value and no Need to use `hashCodeFor()` [Oracle#Double##hashCode](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#hashCode-double-)

#### Check List:
* Unit tests: NO
* Javadoc with a code example (on API only): NO