### PR TITLE
Add assertThatNoException() method

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -1368,6 +1368,20 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
+   * Entry point to check that no exception of any type is thrown by a given {@code throwingCallable}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThatNoException().isThrownBy(() -&gt; { System.out.println("OK"); });</code></pre>
+   *
+   * This method is more or less the same of {@code assertThatCode(...).doesNotThrowAnyException();} but in a more natural way.
+   * @return the created {@link NotThrownAssert}.
+   * @since 3.17.0
+   */
+  public static NotThrownAssert assertThatNoException() {
+    return AssertionsForClassTypes.assertThatNoException();
+  }
+
+  /**
    * Alias for {@link #assertThatExceptionOfType(Class)} for {@link NullPointerException}.
    *
    * @return the created {@link ThrowableTypeAssert}.

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -789,6 +789,20 @@ public class AssertionsForClassTypes {
   }
 
   /**
+   * Entry point to check that no exception of any type is thrown by a given {@code throwingCallable}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThatNoException().isThrownBy(() -&gt; { System.out.println("OK"); });</code></pre>
+   *
+   * This method is more or less the same of {@code assertThatCode(...).doesNotThrowAnyException();} but in a more natural way.
+   * @return the created {@link NotThrownAssert}.
+   * @since 3.17.0
+   */
+  public static NotThrownAssert assertThatNoException() {
+    return new NotThrownAssert();
+  }
+
+  /**
    * Allows to capture and then assert on a {@link Throwable} more easily when used with Java 8 lambdas.
    *
    * <p>

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -1621,6 +1621,21 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Entry point to check that no exception of any type is thrown by a given {@code throwingCallable}.
+   * <p>
+   * <p>
+   * Example:
+   * <pre><code class='java'>thenNoException().isThrownBy(() -&gt; { System.out.println("OK"); });</code></pre>
+   *
+   * This method is more or less the same of {@code assertThatCode(...).doesNotThrowAnyException();} but in a more natural way.
+   * @return the created {@link NotThrownAssert}.
+   * @since 3.17.0
+   */
+  public static NotThrownAssert thenNoException() {
+    return assertThatNoException();
+  }
+
+  /**
    * Alias for {@link #thenExceptionOfType(Class)} for {@link NullPointerException}.
    *
    * @return the created {@link ThrowableTypeAssert}.

--- a/src/main/java/org/assertj/core/api/NotThrownAssert.java
+++ b/src/main/java/org/assertj/core/api/NotThrownAssert.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.description.Description;
+import org.assertj.core.util.CheckReturnValue;
+
+/**
+ * Assertion class checking a {@link ThrowingCallable} throws no exception.
+ * <p>
+ * The class itself does not do much, it delegates the work to {@link ThrowableAssert} after calling {@link #isThrownBy(ThrowableAssert.ThrowingCallable)}.
+ *
+ * @since 3.17.0
+ * @see ThrowableTypeAssert
+ */
+public class NotThrownAssert implements Descriptable<NotThrownAssert> {
+
+  protected Description description;
+
+  /**
+   * Assert that no exception of any type is thrown by the {@code throwingCallable}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThatNoException().isThrownBy(() -&gt; { System.out.println("OK"); });</code></pre>
+   *
+   * @param throwingCallable code throwing no exception of any type
+   */
+  public void isThrownBy(final ThrowingCallable throwingCallable) {
+    Throwable throwable = ThrowableAssert.catchThrowable(throwingCallable);
+    assertThat(throwable).as(description).doesNotThrowAnyException();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @CheckReturnValue
+  public NotThrownAssert describedAs(Description description) {
+    this.description = description;
+    return this;
+  }
+}

--- a/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
@@ -26,6 +26,7 @@ import org.assertj.core.util.VisibleForTesting;
  * The class itself does not do much, it delegates the work to {@link ThrowableAssertAlternative} after calling {@link #isThrownBy(ThrowableAssert.ThrowingCallable)}.
  *
  * @param <T> type of throwable to be thrown.
+ * @see NotThrownAssert
  */
 public class ThrowableTypeAssert<T extends Throwable> implements Descriptable<ThrowableTypeAssert<T>> {
 

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -2618,6 +2618,21 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
+   * Entry point to check that no exception of any type is thrown by a given {@code throwingCallable}.
+   * <p>
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThatNoException().isThrownBy(() -&gt; { System.out.println("OK"); });</code></pre>
+   *
+   * This method is more or less the same of {@code assertThatCode(...).doesNotThrowAnyException();} but in a more natural way.
+   * @return the created {@link NotThrownAssert}.
+   * @since 3.17.0
+   */
+  default NotThrownAssert assertThatNoException() {
+	  return Assertions.assertThatNoException();
+  }
+
+  /**
    * Alias for {@link #assertThatExceptionOfType(Class)} for {@link NullPointerException}.
    *
    * @return the created {@link ThrowableTypeAssert}.

--- a/src/test/java/org/assertj/core/api/Assertions_assertThatNoException_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThatNoException_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+public class Assertions_assertThatNoException_Test {
+
+  @Test
+  public void should_fail_when_asserting_no_exception_raised_but_exception_occurs() {
+    // Given
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+
+    // Expect
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->{
+      // When;
+      assertThatNoException().isThrownBy(boom);
+    }).withMessage(shouldNotHaveThrown(exception).create());
+  }
+
+  @Test
+  public void can_use_description_in_error_message() {
+    // Given
+    ThrowingCallable boom = raisingException("boom");
+
+    // Expect
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatNoException().as("Test")
+                                                                                         .isThrownBy(boom))
+                                                   .withMessageStartingWith("[Test]");
+  }
+
+  @Test
+  public void error_message_contains_stacktrace() {
+    // Given
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+
+    // Then
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatNoException().isThrownBy(boom))
+                                                   .withMessageContaining("java.lang.Exception: %s", "boom")
+                                                   .withMessageContaining("at org.assertj.core.api.Assertions_assertThatNoException_Test.error_message_contains_stacktrace");
+  }
+
+  private ThrowingCallable raisingException(final String reason) {
+    return raisingException(new Exception(reason));
+  }
+
+  private ThrowingCallable raisingException(final Exception exception) {
+    return () -> {
+      throw exception;
+    };
+  }
+}

--- a/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.BDDAssertions.thenExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.thenIOException;
 import static org.assertj.core.api.BDDAssertions.thenIllegalArgumentException;
 import static org.assertj.core.api.BDDAssertions.thenIllegalStateException;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenNullPointerException;
 import static org.assertj.core.api.BDDAssertions.thenObject;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
@@ -50,6 +51,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.stubbing.answers.ThrowsException;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.BDDAssertions#then(String)}</code>.
@@ -374,6 +376,11 @@ public class BDDAssertions_then_Test {
   }
 
   @Test
+  void should_build_NotThrownAssert_with_thowable_not_thrown() throws Exception {
+    thenNoException().isThrownBy(()  -> methodNotThrowing());
+  }
+
+  @Test
   void should_build_ThrowableTypeAssert_with_NullPointerException_thrown() {
     thenNullPointerException().isThrownBy(() -> methodThrowing(new NullPointerException("something was wrong")))
                               .withMessage("something was wrong");
@@ -399,5 +406,8 @@ public class BDDAssertions_then_Test {
 
   private static void methodThrowing(Throwable throwable) throws Throwable {
     throw throwable;
+  }
+
+  private static void methodNotThrowing() throws Throwable {
   }
 }

--- a/src/test/java/org/assertj/core/api/throwable/NotThrownAssert_description_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/NotThrownAssert_description_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.NotThrownAssert;
+import org.assertj.core.description.TextDescription;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class NotThrownAssert_description_Test {
+
+  @BeforeAll
+  static void beforeAll() {
+    Assertions.setRemoveAssertJRelatedElementsFromStackTrace(false);
+  }
+
+  static Stream<Function<NotThrownAssert, NotThrownAssert>> parameters() {
+    return Stream.of(
+                     t -> t.as("test description"),
+                     t -> t.describedAs("test description"),
+                     t -> t.as(new TextDescription("%s description", "test")),
+                     t -> t.describedAs(new TextDescription("%s description", "test")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters")
+  void should_contain_provided_description_if_exception_is_thrown_by_lambda(Function<NotThrownAssert, NotThrownAssert> descriptionAdder) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> descriptionAdder.apply(assertThatNoException())
+                                                                                     .isThrownBy(() -> {
+                                                                                       throw new IllegalArgumentException();
+                                                                                     }))
+                                                   .withMessageStartingWith(format("[test description] %n" +
+                                                                                   "Expecting code not to raise a throwable but caught%n" +
+                                                                                   "  <\"java.lang.IllegalArgumentException"));
+  }
+}


### PR DESCRIPTION
Add an `assertThatNoException()` method that can be used as an
alternative to `assertThatCode(...).doesNotThrowAnyException().

#### Check List:
* Fixes #1962
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


