### PR TITLE
Consolidate error collection for soft assertions into one place

### DIFF
--- a/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
@@ -34,4 +34,23 @@ public interface AssertionErrorCollector extends AfterAssertionErrorCollected {
   default void onAssertionErrorCollected(AssertionError assertionError) {
     // nothing by default
   }
+
+  /**
+   * Indicates that the last assertion was a success.
+   */
+  void succeeded();
+  
+  /**
+   * Returns the result of last soft assertion which can be used to decide what the next one should be.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Person person = ...
+   * SoftAssertions soft = new SoftAssertions();
+   * if (soft.assertThat(person.getAddress()).isNotNull().wasSuccess()) {
+   *     soft.assertThat(person.getAddress().getStreet()).isNotNull();
+   * }</code></pre>
+   *
+   * @return true if the last assertion was a success.
+   */
+  boolean wasSuccess();
 }

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollectorImpl.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollectorImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class AssertionErrorCollectorImpl implements AssertionErrorCollector {
+
+  volatile boolean wasSuccess = true;
+  List<AssertionError> assertionsCollected = Collections.synchronizedList(new ArrayList<>());
+  
+  AfterAssertionErrorCollected callback = this;
+  
+  public AssertionErrorCollectorImpl() {
+    super();
+  }
+
+  @Override
+  public void collectAssertionError(AssertionError error) {
+    assertionsCollected.add(error);
+    wasSuccess = false;
+    callback.onAssertionErrorCollected(error);
+  }
+
+  /**
+   * Returns a copy of list of soft assertions collected errors.
+   * @return a copy of list of soft assertions collected errors.
+   */
+  @Override
+  public List<AssertionError> assertionErrorsCollected() {
+    return Collections.unmodifiableList(assertionsCollected);
+  }
+
+  /**
+   * Register a callback allowing to react after an {@link AssertionError} is collected by the current soft assertion.
+   * <p>
+   * The callback is an instance of {@link AfterAssertionErrorCollected} which can be expressed as lambda.
+   * <p>
+   * Example:
+   * <pre><code class='java'> SoftAssertions softly = new SoftAssertions();
+   * StringBuilder reportBuilder = new StringBuilder(format("Assertions report:%n"));
+  
+   * // register our callback
+   * softly.setAfterAssertionErrorCollected(error -&gt; reportBuilder.append(String.format("------------------%n%s%n", error.getMessage())));
+   *
+   * // the AssertionError corresponding to the failing assertions are registered in the report
+   * softly.assertThat("The Beatles").isEqualTo("The Rolling Stones");
+   * softly.assertThat(123).isEqualTo(123)
+   *                       .isEqualTo(456);</code></pre>
+   * <p>
+   * resulting {@code reportBuilder}:
+   * <pre><code class='java'> Assertions report:
+   * ------------------
+   * Expecting:
+   *  &lt;"The Beatles"&gt;
+   * to be equal to:
+   *  &lt;"The Rolling Stones"&gt;
+   * but was not.
+   * ------------------
+   * Expecting:
+   *  &lt;123&gt;
+   * to be equal to:
+   *  &lt;456&gt;
+   * but was not.</code></pre>
+   * <p>
+   * Alternatively, if you have defined your own SoftAssertions subclass and inherited from {@link AbstractSoftAssertions},
+   * the only thing you have to do is to override {@link AfterAssertionErrorCollected#onAssertionErrorCollected(AssertionError)}.
+   *
+   * @param afterAssertionErrorCollected the callback.
+   *
+   * @since 3.17.0
+   */
+  public void setAfterAssertionErrorCollected(AfterAssertionErrorCollected afterAssertionErrorCollected) {
+    callback = afterAssertionErrorCollected;
+  }
+  
+  @Override
+  public void succeeded() {
+    wasSuccess = true;
+  }
+  
+  @Override
+  public boolean wasSuccess() {
+    return wasSuccess;
+  }
+}

--- a/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
@@ -61,20 +61,6 @@ public interface SoftAssertionsProvider extends AssertionErrorCollector {
   }
 
   /**
-   * Returns the result of last soft assertion which can be used to decide what the next one should be.
-   * <p>
-   * Example :
-   * <pre><code class='java'> Person person = ...
-   * SoftAssertions soft = new SoftAssertions();
-   * if (soft.assertThat(person.getAddress()).isNotNull().wasSuccess()) {
-   *     soft.assertThat(person.getAddress().getStreet()).isNotNull();
-   * }</code></pre>
-   *
-   * @return true if the last assertion was a success.
-   */
-  boolean wasSuccess();
-
-  /**
    * Catch and collect assertion errors coming from standard and <b>custom</b> assertions.
    * <p>
    * Example :
@@ -88,6 +74,7 @@ public interface SoftAssertionsProvider extends AssertionErrorCollector {
   default void check(ThrowingRunnable assertion) {
     try {
       assertion.run();
+      succeeded();
     } catch (AssertionError error) {
       collectAssertionError(error);
     } catch (RuntimeException runtimeException) {

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.ClassLoadingStrategyFactory.classLoadingStrat
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import org.assertj.core.api.ClassLoadingStrategyFactory.ClassLoadingStrategyPair;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
@@ -98,25 +97,8 @@ class SoftProxies {
 
   private ErrorCollector collector;
 
-  public SoftProxies(AfterAssertionErrorCollected afterAssertionErrorCollected) {
-    collector = new ErrorCollector();
-    setAfterAssertionErrorCollected(afterAssertionErrorCollected);
-  }
-
-  void setAfterAssertionErrorCollected(AfterAssertionErrorCollected afterAssertionErrorCollected) {
-    collector.setAfterAssertionErrorCollected(afterAssertionErrorCollected);
-  }
-
-  public boolean wasSuccess() {
-    return collector.wasSuccess();
-  }
-
-  void collectError(AssertionError error) {
-    collector.addError(error);
-  }
-
-  List<AssertionError> errorsCollected() {
-    return collector.errors();
+  public SoftProxies(AssertionErrorCollector assertionErrorCollector) {
+    collector = new ErrorCollector(assertionErrorCollector);
   }
 
   <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF createSoftAssertionProxy(Class<SELF> assertClass,


### PR DESCRIPTION
Refer to the comment in https://github.com/joel-costigliola/assertj-core/issues/1800#issuecomment-680697890

This is a quick spike a put together as a proof-of-concept to consolidate the error collection in one publicly-accessible place. This will make it much easier to make AssertJ interoperate with other soft assertion frameworks (including itself, when it comes to custom soft assertion providers). If it is ok, I will add test cases to directly test the new `AssertionErrorCollectorImpl` class.

One thing I'm not sure about here is the `wasSuccess()` functionality. The changes I've made pass all the tests so hopefully it should all be good.