### PR TITLE
Handle soft proxies for custom assert classes in OSGi bundles (#1979)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,37 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- required to resolve
+    These dependencies are required to workaround a bad
+    interaction using includeDependencyManagement=true for
+    the Bnd resolver and testing plugins and the enforcer
+    plugin which causes a false positive from the enforcer
+    plugin. The Bnd 5.2.0 resolver and testing plugins
+    don't have this problem, so these dependencies
+    can be removed when updating bnd.version to 5.2.0 and
+    configuring the Bnd resolver and testing plugins to use
+    includeDependencyManagement=true.
+    -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- required to run JUnit4 tests in eclipse without to explicitly select JUnit 4 runner ... -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
@@ -173,6 +204,12 @@
       <version>3.4.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.osgi</artifactId>
+      <version>3.15.300</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -218,6 +255,9 @@
         <configuration>
           <argLine>${argLine}</argLine>
           <trimStackTrace>false</trimStackTrace>
+          <excludes>
+            <exclude>org/assertj/core/osgi/**</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>
@@ -304,6 +344,21 @@
               ]]></bnd>
             </configuration>
           </execution>
+          <!-- Integration Test Configuration -->
+          <execution>
+            <id>bnd-process-tests</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>bnd-process-tests</goal>
+            </goals>
+            <configuration>
+              <includeClassesDir>false</includeClassesDir>
+              <bnd><![CDATA[
+                -includepackage: org.assertj.core.osgi.*
+                -removeheaders: Bnd-LastModified,Private-Package
+              ]]></bnd>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -365,6 +420,21 @@
               <archive>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+              <includes>
+                <include>org/assertj/core/osgi/**</include>
+              </includes>
             </configuration>
           </execution>
         </executions>
@@ -450,14 +520,14 @@
         ]]></footer>
         </configuration>
       </plugin>
+      <!-- Resolve bundles for OSGi integration tests -->
       <plugin>
-        <!-- Verify that additional OSGi package imports didn't sneak in. -->
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-resolver-maven-plugin</artifactId>
         <version>${bnd.version}</version>
         <executions>
           <execution>
-            <id>verify-osgi-metadata</id>
+            <id>osgi-integration-resolving</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>resolve</goal>
@@ -466,8 +536,49 @@
               <bndruns>
                 <bndrun>verify.bndrun</bndrun>
               </bndruns>
+              <bundles>
+                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+              </bundles>
               <failOnChanges>false</failOnChanges>
               <reportOptional>false</reportOptional>
+              <includeDependencyManagement>false</includeDependencyManagement>
+              <scopes>
+                <scope>provided</scope>
+                <scope>compile</scope>
+                <scope>runtime</scope>
+                <scope>test</scope>
+              </scopes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run OSGi integration tests -->
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-testing-maven-plugin</artifactId>
+        <version>${bnd.version}</version>
+        <executions>
+          <execution>
+            <id>osgi-integration-testing</id>
+            <goals>
+              <goal>testing</goal>
+            </goals>
+            <configuration>
+              <bndruns>
+                <bndrun>verify.bndrun</bndrun>
+              </bndruns>
+              <bundles>
+                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+              </bundles>
+              <failOnChanges>false</failOnChanges>
+              <includeDependencyManagement>false</includeDependencyManagement>
+              <resolve>false</resolve>
+              <scopes>
+                <scope>provided</scope>
+                <scope>compile</scope>
+                <scope>runtime</scope>
+                <scope>test</scope>
+              </scopes>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,9 @@
                   !org.assertj.core.internal.*,\
                   org.assertj.core.*
                 -noclassforname: true
-                -removeheaders: Bnd-LastModified,Private-Package
+                -noextraheaders: true
+                -snapshot: SNAPSHOT
+                -removeheaders: Private-Package
                 -fixupmessages: \
                   "Classes found in the wrong directory...";is:=ignore
               ]]></bnd>
@@ -355,7 +357,9 @@
               <includeClassesDir>false</includeClassesDir>
               <bnd><![CDATA[
                 -includepackage: org.assertj.core.osgi.*
-                -removeheaders: Bnd-LastModified,Private-Package
+                -noextraheaders: true
+                -snapshot: SNAPSHOT
+                -removeheaders: Private-Package
               ]]></bnd>
             </configuration>
           </execution>

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -70,6 +70,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.ClassLoadingStrategyFactory.ClassLoadingStrategyPair;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.assertj.core.util.CheckReturnValue;
@@ -1277,18 +1278,19 @@ public class Assumptions {
   @SuppressWarnings("unchecked")
   private static <ASSERTION> Class<? extends ASSERTION> createAssumptionClass(Class<ASSERTION> assertClass) {
     SimpleKey cacheKey = new SimpleKey(assertClass);
-    return (Class<ASSERTION>) CACHE.findOrInsert(Assumptions.class.getClassLoader(),
+    return (Class<ASSERTION>) CACHE.findOrInsert(assertClass.getClassLoader(),
                                                  cacheKey,
                                                  () -> generateAssumptionClass(assertClass));
   }
 
   protected static <ASSERTION> Class<? extends ASSERTION> generateAssumptionClass(Class<ASSERTION> assertionType) {
+    ClassLoadingStrategyPair strategy = classLoadingStrategy(assertionType);
     return BYTE_BUDDY.subclass(assertionType)
                      // TODO ignore non assertion methods ?
                      .method(any())
                      .intercept(ASSUMPTION)
                      .make()
-                     .load(Assumptions.class.getClassLoader(), classLoadingStrategy(assertionType))
+                     .load(strategy.getClassLoader(), strategy.getClassLoadingStrategy())
                      .getLoaded();
   }
 

--- a/src/main/java/org/assertj/core/api/ClassLoadingStrategyFactory.java
+++ b/src/main/java/org/assertj/core/api/ClassLoadingStrategyFactory.java
@@ -12,9 +12,15 @@
  */
 package org.assertj.core.api;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 
@@ -22,6 +28,8 @@ class ClassLoadingStrategyFactory {
 
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
   private static final Method PRIVATE_LOOKUP_IN;
+  // Class loader of AssertJ
+  static final ClassLoader ASSERTJ_CLASS_LOADER = ClassLoadingStrategyFactory.class.getClassLoader();
 
   static {
     Method privateLookupIn;
@@ -33,12 +41,25 @@ class ClassLoadingStrategyFactory {
     PRIVATE_LOOKUP_IN = privateLookupIn;
   }
 
-  static ClassLoadingStrategy<ClassLoader> classLoadingStrategy(Class<?> assertClass) {
+  static ClassLoadingStrategyPair classLoadingStrategy(Class<?> assertClass) {
+    // Use ClassLoader of assertion class to allow ByteBuddy to always find it.
+    // This is needed in an OSGi runtime when a custom assertion class is
+    // defined in a different OSGi bundle.
+    ClassLoader assertClassLoader = assertClass.getClassLoader();
+    if (assertClassLoader != ASSERTJ_CLASS_LOADER) {
+      // Return a new CompositeClassLoader if the assertClass is from a
+      // different class loader than AssertJ. Otherwise return the class
+      // loader of AssertJ since there is no need to use a composite class
+      // loader.
+      CompositeClassLoader compositeClassLoader = new CompositeClassLoader(assertClassLoader);
+      return new ClassLoadingStrategyPair(compositeClassLoader, compositeClassLoader);
+    }
     if (ClassInjector.UsingReflection.isAvailable()) {
-      return ClassLoadingStrategy.Default.INJECTION;
+      return new ClassLoadingStrategyPair(assertClassLoader, ClassLoadingStrategy.Default.INJECTION);
     } else if (ClassInjector.UsingLookup.isAvailable()) {
       try {
-        return ClassLoadingStrategy.UsingLookup.of(PRIVATE_LOOKUP_IN.invoke(null, assertClass, LOOKUP));
+        return new ClassLoadingStrategyPair(assertClassLoader,
+            ClassLoadingStrategy.UsingLookup.of(PRIVATE_LOOKUP_IN.invoke(null, assertClass, LOOKUP)));
       } catch (Exception e) {
         throw new IllegalStateException("Could not access package of " + assertClass, e);
       }
@@ -47,4 +68,71 @@ class ClassLoadingStrategyFactory {
     }
   }
 
+  // Pair holder of class loader and class loading strategy to use
+  // for ByteBuddy class generation.
+  static class ClassLoadingStrategyPair {
+    private final ClassLoader classLoader;
+    private final ClassLoadingStrategy<ClassLoader> classLoadingStrategy;
+
+    ClassLoadingStrategyPair(ClassLoader classLoader, ClassLoadingStrategy<ClassLoader> classLoadingStrategy) {
+      this.classLoader = classLoader;
+      this.classLoadingStrategy = classLoadingStrategy;
+    }
+
+    ClassLoader getClassLoader() {
+      return classLoader;
+    }
+
+    ClassLoadingStrategy<ClassLoader> getClassLoadingStrategy() {
+      return classLoadingStrategy;
+    }
+  }
+
+  // Composite class loader for when the assert class is from a different
+  // class loader than AssertJ. This can occur in OSGi when the assert class is
+  // from a bundle. The composite class loader provides access to the internal,
+  // non-exported types of AssertJ. ByteBuddy will define the proxy class in the
+  // CompositeClassLoader rather than in the class loader of the assert class.
+  // This means the assert class cannot assume package private access to super
+  // types, interfaces, etc. since the proxy class is defined in a different
+  // class loader (the CompositeClassLoader) than the assert class.
+  static class CompositeClassLoader extends ClassLoader implements ClassLoadingStrategy<ClassLoader> {
+    CompositeClassLoader(ClassLoader parent) {
+      super(parent);
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+      return ASSERTJ_CLASS_LOADER.loadClass(name);
+    }
+
+    @Override
+    protected URL findResource(String name) {
+      return ASSERTJ_CLASS_LOADER.getResource(name);
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+      return ASSERTJ_CLASS_LOADER.getResources(name);
+    }
+
+    @Override
+    public Map<TypeDescription, Class<?>> load(ClassLoader classLoader, Map<TypeDescription, byte[]> types) {
+      Map<TypeDescription, Class<?>> result = new LinkedHashMap<>();
+      for (Map.Entry<TypeDescription, byte[]> entry : types.entrySet()) {
+        TypeDescription typeDescription = entry.getKey();
+        String name = typeDescription.getName();
+        synchronized (getClassLoadingLock(name)) {
+          Class<?> type = findLoadedClass(name);
+          if (type != null) {
+            throw new IllegalStateException("Cannot define already loaded type: " + type);
+          }
+          byte[] typeDefinition = entry.getValue();
+          type = defineClass(name, typeDefinition, 0, typeDefinition.length);
+          result.put(typeDescription, type);
+        }
+      }
+      return result;
+    }
+  }
 }

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -18,13 +18,11 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static org.assertj.core.api.ClassLoadingStrategyFactory.classLoadingStrategy;
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.util.Enumeration;
 import java.util.List;
 
+import org.assertj.core.api.ClassLoadingStrategyFactory.ClassLoadingStrategyPair;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 
 import net.bytebuddy.ByteBuddy;
@@ -139,7 +137,7 @@ class SoftProxies {
   @SuppressWarnings("unchecked")
   private static <ASSERT extends Assert<?, ?>> Class<ASSERT> createSoftAssertionProxyClass(Class<ASSERT> assertClass) {
     SimpleKey cacheKey = new SimpleKey(assertClass);
-    return (Class<ASSERT>) CACHE.findOrInsert(SoftProxies.class.getClassLoader(), cacheKey,
+    return (Class<ASSERT>) CACHE.findOrInsert(assertClass.getClassLoader(), cacheKey,
                                               () -> generateProxyClass(assertClass));
   }
 
@@ -183,6 +181,7 @@ class SoftProxies {
   }
 
   static <V> Class<? extends V> generateProxyClass(Class<V> assertClass) {
+    ClassLoadingStrategyPair strategy = classLoadingStrategy(assertClass);
     return BYTE_BUDDY.subclass(assertClass)
                      .defineField(ProxifyMethodChangingTheObjectUnderTest.FIELD_NAME,
                                   ProxifyMethodChangingTheObjectUnderTest.class,
@@ -198,58 +197,11 @@ class SoftProxies {
                      .intercept(FieldAccessor.ofField(ProxifyMethodChangingTheObjectUnderTest.FIELD_NAME).setsArgumentAt(0)
                                              .andThen(FieldAccessor.ofField(ErrorCollector.FIELD_NAME).setsArgumentAt(1)))
                      .make()
-                     // Use ClassLoader of soft assertion class to allow ByteBuddy to always find it.
-                     // This is needed in an OSGi runtime when a custom soft assertion class is defined
-                     // in a different OSGi bundle.
-                     .load(CompositeClassLoader.getClassLoader(assertClass), classLoadingStrategy(assertClass))
+                     .load(strategy.getClassLoader(), strategy.getClassLoadingStrategy())
                      .getLoaded();
   }
 
   private static Junction<MethodDescription> methodsNamed(String name) {
     return named(name);
-  }
-
-  // Composite class loader for when the assert class is from a different
-  // class loader than AssertJ. This can occur in OSGi when the assert class is
-  // from a bundle. The composite class loader provides access to the internal,
-  // non-exported types of AssertJ. ByteBuddy will define the proxy class in the
-  // CompositeClassLoader rather than in the class loader of the assert class.
-  // This means the assert class cannot assume package private access to super
-  // types, interfaces, etc. since the proxy class is defined in a different
-  // class loader (the CompositeClassLoader) than the assert class.
-  static class CompositeClassLoader extends ClassLoader {
-    // Class loader of AssertJ
-    private static final ClassLoader assertj = SoftProxies.class.getClassLoader();
-
-    // Return a new CompositeClassLoader if the assertClass is from a
-    // different class loader than AssertJ. Otherwise return the class
-    // loader of AssertJ since there is no need to use a composite class
-    // loader.
-    static ClassLoader getClassLoader(Class<?> assertClass) {
-      final ClassLoader other = assertClass.getClassLoader();
-      if (other == assertj) {
-        return other;
-      }
-      return new CompositeClassLoader(other);
-    }
-
-    private CompositeClassLoader(ClassLoader other) {
-      super(other);
-    }
-
-    @Override
-    protected Class<?> findClass(String name) throws ClassNotFoundException {
-      return assertj.loadClass(name);
-    }
-
-    @Override
-    protected URL findResource(String name) {
-      return assertj.getResource(name);
-    }
-
-    @Override
-    protected Enumeration<URL> findResources(String name) throws IOException {
-      return assertj.getResources(name);
-    }
   }
 }

--- a/src/test/java/org/assertj/core/osgi/AssumptionsTest.java
+++ b/src/test/java/org/assertj/core/osgi/AssumptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.osgi;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+class AssumptionsTest {
+
+  @Test
+  void should_ignore_test_when_one_of_the_assumption_fails() {
+    assumeThat("foo").isNotEmpty();
+    assertThatThrownBy(() -> assumeThat("bar").isEmpty()).isInstanceOf(TestAbortedException.class);
+  }
+
+  @Test
+  void should_run_test_when_all_assumptions_are_met() {
+    assertThatCode(() -> {
+      assumeThat("foo").isNotNull()
+                       .isNotEmpty()
+                       .isEqualTo("foo");
+      assumeThat("bar").contains("ar")
+                       .isNotBlank();
+      assumeThat(asList("John", "Doe", "Jane", "Doe")).as("test description")
+                                                      .withFailMessage("error message")
+                                                      .withRepresentation(UNICODE_REPRESENTATION)
+                                                      .usingElementComparator(String.CASE_INSENSITIVE_ORDER)
+                                                      .filteredOn(string -> string.length() == 4)
+                                                      .containsExactly("JOHN", "JANE");
+    }).doesNotThrowAnyException();
+  }
+
+}

--- a/src/test/java/org/assertj/core/osgi/SimpleTest.java
+++ b/src/test/java/org/assertj/core/osgi/SimpleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.osgi;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleTest {
+
+  @Test
+  void simple_success() {
+    assertThat("A String").isNotNull().isNotEmpty().contains("A", "String").isEqualTo("A String");
+  }
+
+  @Test
+  void simple_failure() {
+    assertThatCode(() -> assertThat("A String").isNull()).isInstanceOf(AssertionError.class);
+  }
+
+}

--- a/src/test/java/org/assertj/core/osgi/soft/CustomSoftAssertionTest.java
+++ b/src/test/java/org/assertj/core/osgi/soft/CustomSoftAssertionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.osgi.soft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.AbstractMapAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ProxyableListAssert;
+import org.junit.jupiter.api.Test;
+
+public class CustomSoftAssertionTest {
+
+  @Test
+  void verify_classloaders() {
+    Class<?> assertClass = TestProxyableMapAssert.class;
+    Class<?> superClass = assertClass.getSuperclass();
+    assertThat(assertClass.getClassLoader())
+        .as("Custom assertion class must be from a different class loader than it's super class")
+        .isNotSameAs(superClass.getClassLoader());
+    assertThat(superClass.getClassLoader())
+        .as("Custom assertion super class must be from the assertj-core class loader")
+        .isSameAs(Assertions.class.getClassLoader());
+  }
+
+  @Test
+  void custom_soft_assertions_success() {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+
+    TestSoftAssertions softly = new TestSoftAssertions();
+    softly.assertThat(map).containsKeys("key1", "key2").containsValues("value1", "value2");
+    softly.assertAll();
+  }
+
+  @Test
+  void custom_soft_assertions_failure() {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+
+    TestSoftAssertions softly = new TestSoftAssertions();
+    softly.assertThat(map).containsKeys("key1", "key3").containsValues("value3", "value2");
+    assertThat(softly.wasSuccess()).isFalse();
+    assertThat(softly.errorsCollected()).hasSize(2);
+  }
+
+  public static class TestProxyableMapAssert<KEY, VALUE>
+      extends AbstractMapAssert<TestProxyableMapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
+
+    public TestProxyableMapAssert(Map<KEY, VALUE> actual) {
+      super(actual, TestProxyableMapAssert.class);
+    }
+
+    @Override
+    protected <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> newListAssertInstance(
+        List<? extends ELEMENT> newActual) {
+      return new ProxyableListAssert<>(newActual);
+    }
+  }
+
+  public static class TestSoftAssertions extends AbstractSoftAssertions {
+    public <K, V> TestProxyableMapAssert<K, V> assertThat(Map<K, V> actual) {
+      @SuppressWarnings("unchecked")
+      TestProxyableMapAssert<K, V> softly = proxy(TestProxyableMapAssert.class, Map.class, actual);
+      return softly;
+    }
+  }
+
+}

--- a/verify.bndrun
+++ b/verify.bndrun
@@ -1,5 +1,40 @@
-# It's ok if this version range changes. It's probably
-# because assertj just changed it's version. A future
-# version of bnd will solve this by not writing back
-# -runbundles when being used for verification.
--runbundles: assertj-core;version='[3.17.1,3.17.2)'
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Copyright 2020 the original author or authors.
+
+-tester: biz.aQute.tester.junit-platform
+
+-runfw: org.eclipse.osgi
+-resolve.effective: active
+-runproperties: \
+    org.osgi.framework.bootdelegation=sun.reflect,\
+    osgi.console=
+
+-runrequires: \
+    bnd.identity;id='${project.artifactId}-tests',\
+    bnd.identity;id='junit-jupiter-engine',\
+    bnd.identity;id='junit-platform-launcher'
+
+# This will help us keep -runbundles sorted
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1
+
+# The version ranges will change as the version of
+# AssertJ and/or its dependencies change.
+-runbundles: \
+	assertj-core;version='[3.17.2,3.17.3)',\
+	assertj-core-tests;version='[3.17.2,3.17.3)',\
+	junit-jupiter-api;version='[5.6.2,5.6.3)',\
+	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
+	junit-platform-commons;version='[1.6.2,1.6.3)',\
+	junit-platform-engine;version='[1.6.2,1.6.3)',\
+	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	org.opentest4j;version='[1.2.0,1.2.1)'


### PR DESCRIPTION
When using a composite class loader for defining soft proxies when the
assert class is from a different class loader than the AssertJ classes,
we now use the composite class loader as the ClassLoadingStrategy for
ByteBuddy. This is necessary for Java 9+ to avoid the
ClassLoadingStrategy.UsingLookup default strategy used by AssertJ for
Java 9+. That strategy always defines the proxy classes in the class
loader defining the assert class ignoring the specified class loader.
This change is also beneficial for Java 8 as it avoids the need to
reflectively call the composite class loader to define the proxy
classes.

We refactor the CompositeClassLoader into the
ClassLoadingStrategyFactory class so that we can centralize the logic
for class loader and class loading strategy determination. Assumptions
is updated to use these changes which prepares it for a future where it
could support defining custom assumptions.

Finally, we update the class loader used for the ByteBuddy class caches
to use the class loader of the assert class rather than AssertJ's class
loader as the key. This is important in the OSGi case where multiple
bundles could define custom assertions with the same class name and we
must allow for unique proxy class generation for each bundle.

Fixes https://github.com/joel-costigliola/assertj-core/issues/1979
Fixes #1888 