### PR TITLE
Add OSGi integration testing to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <!-- Dependency versions overriding -->
     <junit.version>4.13</junit.version>
     <junit-jupiter.version>5.6.2</junit-jupiter.version>
+    <junit-platform.version>1.6.2</junit-platform.version>
     <mockito.version>3.5.5</mockito.version>
     <!-- Plugin versions overriding -->
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
@@ -88,23 +89,27 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- required to run JUnit4 tests in eclipse without to explicitly select JUnit 4 runner ... -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-testkit</artifactId>
+      <version>${junit-platform.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -173,6 +178,12 @@
       <version>3.4.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.osgi</artifactId>
+      <version>3.15.300</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -218,6 +229,9 @@
         <configuration>
           <argLine>${argLine}</argLine>
           <trimStackTrace>false</trimStackTrace>
+          <excludes>
+            <exclude>org/assertj/core/osgi/**</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>
@@ -304,6 +318,21 @@
               ]]></bnd>
             </configuration>
           </execution>
+          <!-- Integration Test Configuration -->
+          <execution>
+            <id>bnd-process-tests</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>bnd-process-tests</goal>
+            </goals>
+            <configuration>
+              <includeClassesDir>false</includeClassesDir>
+              <bnd><![CDATA[
+                -includepackage: org.assertj.core.osgi.*
+                -removeheaders: Bnd-LastModified,Private-Package
+              ]]></bnd>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -365,6 +394,21 @@
               <archive>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+              <includes>
+                <include>org/assertj/core/osgi/**</include>
+              </includes>
             </configuration>
           </execution>
         </executions>
@@ -450,14 +494,14 @@
         ]]></footer>
         </configuration>
       </plugin>
+      <!-- Resolve bundles for OSGi integration tests -->
       <plugin>
-        <!-- Verify that additional OSGi package imports didn't sneak in. -->
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-resolver-maven-plugin</artifactId>
         <version>${bnd.version}</version>
         <executions>
           <execution>
-            <id>verify-osgi-metadata</id>
+            <id>osgi-integration-resolving</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>resolve</goal>
@@ -466,8 +510,49 @@
               <bndruns>
                 <bndrun>verify.bndrun</bndrun>
               </bndruns>
+              <bundles>
+                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+              </bundles>
               <failOnChanges>false</failOnChanges>
               <reportOptional>false</reportOptional>
+              <includeDependencyManagement>true</includeDependencyManagement>
+              <scopes>
+                <scope>provided</scope>
+                <scope>compile</scope>
+                <scope>runtime</scope>
+                <scope>test</scope>
+              </scopes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run OSGi integration tests -->
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-testing-maven-plugin</artifactId>
+        <version>${bnd.version}</version>
+        <executions>
+          <execution>
+            <id>osgi-integration-testing</id>
+            <goals>
+              <goal>testing</goal>
+            </goals>
+            <configuration>
+              <bndruns>
+                <bndrun>verify.bndrun</bndrun>
+              </bndruns>
+              <bundles>
+                <bundle>target/${project.build.finalName}-tests.jar</bundle>
+              </bundles>
+              <failOnChanges>false</failOnChanges>
+              <includeDependencyManagement>true</includeDependencyManagement>
+              <resolve>false</resolve>
+              <scopes>
+                <scope>provided</scope>
+                <scope>compile</scope>
+                <scope>runtime</scope>
+                <scope>test</scope>
+              </scopes>
             </configuration>
           </execution>
         </executions>

--- a/src/test/java/org/assertj/core/osgi/soft/CustomSoftAssertionTest.java
+++ b/src/test/java/org/assertj/core/osgi/soft/CustomSoftAssertionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.osgi.soft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.AbstractMapAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ProxyableListAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+// Need PR #1980 for Java 9+
+@DisabledForJreRange(min = JRE.JAVA_9)
+public class CustomSoftAssertionTest {
+
+  @Test
+  void custom_soft_assertions_success() {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+
+    TestSoftAssertions softly = new TestSoftAssertions();
+    softly.assertThat(map).containsKeys("key1", "key1").containsValues("value1", "value2");
+    softly.assertAll();
+  }
+
+  @Test
+  void custom_soft_assertions_failure() {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+
+    TestSoftAssertions softly = new TestSoftAssertions();
+    softly.assertThat(map).containsKeys("key1", "key3").containsValues("value3", "value2");
+    assertThat(softly.wasSuccess()).isFalse();
+    assertThat(softly.errorsCollected()).hasSize(2);
+  }
+
+  public static class TestProxyableMapAssert<KEY, VALUE>
+      extends AbstractMapAssert<TestProxyableMapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
+
+    public TestProxyableMapAssert(Map<KEY, VALUE> actual) {
+      super(actual, TestProxyableMapAssert.class);
+    }
+
+    @Override
+    protected <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> newListAssertInstance(
+        List<? extends ELEMENT> newActual) {
+      return new ProxyableListAssert<>(newActual);
+    }
+  }
+
+  public static class TestSoftAssertions extends AbstractSoftAssertions {
+    public <K, V> TestProxyableMapAssert<K, V> assertThat(Map<K, V> actual) {
+      @SuppressWarnings("unchecked")
+      TestProxyableMapAssert<K, V> softly = proxy(TestProxyableMapAssert.class, Map.class, actual);
+      return softly;
+    }
+  }
+
+}

--- a/src/test/java/org/assertj/core/osgi/soft/SimpleTest.java
+++ b/src/test/java/org/assertj/core/osgi/soft/SimpleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.osgi.soft;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleTest {
+
+  @Test
+  void simple_success() {
+    assertThat("A String").isNotNull().isNotEmpty().contains("A", "String").isEqualTo("A String");
+  }
+
+  @Test
+  void simple_failure() {
+    assertThatCode(() -> assertThat("A String").isNull()).isNotNull();
+  }
+
+}

--- a/verify.bndrun
+++ b/verify.bndrun
@@ -1,5 +1,40 @@
-# It's ok if this version range changes. It's probably
-# because assertj just changed it's version. A future
-# version of bnd will solve this by not writing back
-# -runbundles when being used for verification.
--runbundles: assertj-core;version='[3.17.0,3.17.1)'
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Copyright 2020 the original author or authors.
+
+-tester: biz.aQute.tester.junit-platform
+
+-runfw: org.eclipse.osgi
+-resolve.effective: active
+-runproperties: \
+    org.osgi.framework.bootdelegation=sun.reflect,\
+    osgi.console=
+
+-runrequires: \
+    bnd.identity;id='${project.artifactId}-tests',\
+    bnd.identity;id='junit-jupiter-engine',\
+    bnd.identity;id='junit-platform-launcher'
+
+# This will help us keep -runbundles sorted
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1
+
+# The version ranges will change as the version of
+# AssertJ and/or its dependencies change.
+-runbundles: \
+	assertj-core;version='[3.17.1,3.17.2)',\
+	assertj-core-tests;version='[3.17.1,3.17.2)',\
+	junit-jupiter-api;version='[5.6.2,5.6.3)',\
+	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
+	junit-platform-commons;version='[1.6.2,1.6.3)',\
+	junit-platform-engine;version='[1.6.2,1.6.3)',\
+	junit-platform-launcher;version='[1.6.2,1.6.3)',\
+	org.opentest4j;version='[1.2.0,1.2.1)'


### PR DESCRIPTION
We define a simple test class to verify basic operations and a
test case to verify class loading of soft proxies for custom assertions
from OSGi bundles. The latter tests has been a problem area for which
regular testing will help avoid regressions.

Fixes https://github.com/joel-costigliola/assertj-core/issues/1888