### PR TITLE
Add field injection to SoftAssertionsExtension

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -30,12 +30,16 @@ public abstract class AbstractSoftAssertions extends AssertionErrorCollectorImpl
     proxies = new SoftProxies(this);
   }
 
-  private final AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
+  private static final AssertionErrorCreator assertionErrorCreator = new AssertionErrorCreator();
 
+  public static void assertAll(AssertionErrorCollector collector) {
+    List<AssertionError> errors = collector.assertionErrorsCollected();
+    if (!errors.isEmpty()) throw assertionErrorCreator.multipleSoftAssertionsError(errors);
+  }
+  
   @Override
   public void assertAll() {
-    List<AssertionError> errors = assertionErrorsCollected();
-    if (!errors.isEmpty()) throw assertionErrorCreator.multipleSoftAssertionsError(errors);
+    assertAll(this);
   }
 
   @Override

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
@@ -19,8 +19,12 @@ public interface AssertionErrorCollector extends AfterAssertionErrorCollected {
 
   /**
    * Optionally sets a "delegate" collector into which the collected assertions
-   * will be deposited
-   * @param delegate
+   * will be deposited. Note that if you set a delegate, this instance will no
+   * longer collect or report assertion errors itself but will forward them all to the
+   * delegate for collection.
+   * 
+   * @param delegate the {@link AssertionErrorCollector} to which the assertions
+   *  will be forwarded.
    */
   default void setDelegate(AssertionErrorCollector delegate) {}
   

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
@@ -34,4 +34,23 @@ public interface AssertionErrorCollector extends AfterAssertionErrorCollected {
   default void onAssertionErrorCollected(AssertionError assertionError) {
     // nothing by default
   }
+
+  /**
+   * Indicates that the last assertion was a success.
+   */
+  void succeeded();
+  
+  /**
+   * Returns the result of last soft assertion which can be used to decide what the next one should be.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Person person = ...
+   * SoftAssertions soft = new SoftAssertions();
+   * if (soft.assertThat(person.getAddress()).isNotNull().wasSuccess()) {
+   *     soft.assertThat(person.getAddress().getStreet()).isNotNull();
+   * }</code></pre>
+   *
+   * @return true if the last assertion was a success.
+   */
+  boolean wasSuccess();
 }

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollector.java
@@ -13,9 +13,21 @@
 package org.assertj.core.api;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AssertionErrorCollector extends AfterAssertionErrorCollected {
 
+  /**
+   * Optionally sets a "delegate" collector into which the collected assertions
+   * will be deposited
+   * @param delegate
+   */
+  default void setDelegate(AssertionErrorCollector delegate) {}
+  
+  default Optional<AssertionErrorCollector> getDelegate() {
+    return Optional.empty();
+  }
+  
   /**
    * This method can be used to collect soft assertion errors.
    * <p>

--- a/src/main/java/org/assertj/core/api/AssertionErrorCollectorImpl.java
+++ b/src/main/java/org/assertj/core/api/AssertionErrorCollectorImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class AssertionErrorCollectorImpl implements AssertionErrorCollector {
+
+  volatile boolean wasSuccess = true;
+  List<AssertionError> assertionsCollected = Collections.synchronizedList(new ArrayList<>());
+  
+  AfterAssertionErrorCollected callback = this;
+  
+  public AssertionErrorCollectorImpl() {
+    super();
+  }
+
+  @Override
+  public void collectAssertionError(AssertionError error) {
+    assertionsCollected.add(error);
+    wasSuccess = false;
+    callback.onAssertionErrorCollected(error);
+  }
+
+  /**
+   * Returns a copy of list of soft assertions collected errors.
+   * @return a copy of list of soft assertions collected errors.
+   */
+  @Override
+  public List<AssertionError> assertionErrorsCollected() {
+    return Collections.unmodifiableList(assertionsCollected);
+  }
+
+  /**
+   * Register a callback allowing to react after an {@link AssertionError} is collected by the current soft assertion.
+   * <p>
+   * The callback is an instance of {@link AfterAssertionErrorCollected} which can be expressed as lambda.
+   * <p>
+   * Example:
+   * <pre><code class='java'> SoftAssertions softly = new SoftAssertions();
+   * StringBuilder reportBuilder = new StringBuilder(format("Assertions report:%n"));
+  
+   * // register our callback
+   * softly.setAfterAssertionErrorCollected(error -&gt; reportBuilder.append(String.format("------------------%n%s%n", error.getMessage())));
+   *
+   * // the AssertionError corresponding to the failing assertions are registered in the report
+   * softly.assertThat("The Beatles").isEqualTo("The Rolling Stones");
+   * softly.assertThat(123).isEqualTo(123)
+   *                       .isEqualTo(456);</code></pre>
+   * <p>
+   * resulting {@code reportBuilder}:
+   * <pre><code class='java'> Assertions report:
+   * ------------------
+   * Expecting:
+   *  &lt;"The Beatles"&gt;
+   * to be equal to:
+   *  &lt;"The Rolling Stones"&gt;
+   * but was not.
+   * ------------------
+   * Expecting:
+   *  &lt;123&gt;
+   * to be equal to:
+   *  &lt;456&gt;
+   * but was not.</code></pre>
+   * <p>
+   * Alternatively, if you have defined your own SoftAssertions subclass and inherited from {@link AbstractSoftAssertions},
+   * the only thing you have to do is to override {@link AfterAssertionErrorCollected#onAssertionErrorCollected(AssertionError)}.
+   *
+   * @param afterAssertionErrorCollected the callback.
+   *
+   * @since 3.17.0
+   */
+  public void setAfterAssertionErrorCollected(AfterAssertionErrorCollected afterAssertionErrorCollected) {
+    callback = afterAssertionErrorCollected;
+  }
+  
+  @Override
+  public void succeeded() {
+    wasSuccess = true;
+  }
+  
+  @Override
+  public boolean wasSuccess() {
+    return wasSuccess;
+  }
+}

--- a/src/main/java/org/assertj/core/api/ErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/ErrorCollector.java
@@ -13,10 +13,7 @@
 package org.assertj.core.api;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.Callable;
 
 import net.bytebuddy.implementation.bind.annotation.FieldValue;
@@ -74,11 +71,11 @@ public class ErrorCollector {
     return assertion;
   }
 
-  void addError(AssertionError error) {
+  private void addError(AssertionError error) {
     assertionErrorCollector.collectAssertionError(error);
   }
 
-  void succeeded() {
+  private void succeeded() {
     assertionErrorCollector.succeeded();
   }
   

--- a/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
@@ -61,20 +61,6 @@ public interface SoftAssertionsProvider extends AssertionErrorCollector {
   }
 
   /**
-   * Returns the result of last soft assertion which can be used to decide what the next one should be.
-   * <p>
-   * Example :
-   * <pre><code class='java'> Person person = ...
-   * SoftAssertions soft = new SoftAssertions();
-   * if (soft.assertThat(person.getAddress()).isNotNull().wasSuccess()) {
-   *     soft.assertThat(person.getAddress().getStreet()).isNotNull();
-   * }</code></pre>
-   *
-   * @return true if the last assertion was a success.
-   */
-  boolean wasSuccess();
-
-  /**
    * Catch and collect assertion errors coming from standard and <b>custom</b> assertions.
    * <p>
    * Example :
@@ -88,6 +74,7 @@ public interface SoftAssertionsProvider extends AssertionErrorCollector {
   default void check(ThrowingRunnable assertion) {
     try {
       assertion.run();
+      succeeded();
     } catch (AssertionError error) {
       collectAssertionError(error);
     } catch (RuntimeException runtimeException) {

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.ClassLoadingStrategyFactory.classLoadingStrat
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import org.assertj.core.api.ClassLoadingStrategyFactory.ClassLoadingStrategyPair;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
@@ -98,25 +97,8 @@ class SoftProxies {
 
   private ErrorCollector collector;
 
-  public SoftProxies(AfterAssertionErrorCollected afterAssertionErrorCollected) {
-    collector = new ErrorCollector();
-    setAfterAssertionErrorCollected(afterAssertionErrorCollected);
-  }
-
-  void setAfterAssertionErrorCollected(AfterAssertionErrorCollected afterAssertionErrorCollected) {
-    collector.setAfterAssertionErrorCollected(afterAssertionErrorCollected);
-  }
-
-  public boolean wasSuccess() {
-    return collector.wasSuccess();
-  }
-
-  void collectError(AssertionError error) {
-    collector.addError(error);
-  }
-
-  List<AssertionError> errorsCollected() {
-    return collector.errors();
+  public SoftProxies(AssertionErrorCollector assertionErrorCollector) {
+    collector = new ErrorCollector(assertionErrorCollector);
   }
 
   <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF createSoftAssertionProxy(Class<SELF> assertClass,

--- a/src/main/java/org/assertj/core/api/junit/jupiter/InjectSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/InjectSoftAssertions.java
@@ -1,0 +1,12 @@
+package org.assertj.core.api.junit.jupiter;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface InjectSoftAssertions {
+}

--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftlyExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftlyExtension.java
@@ -85,8 +85,9 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
  *   }
  * } </code></pre>
  * @author Arthur Mita
+ * @deprecated This functionality has been rolled into {@link SoftAssertionsExtension}
  **/
-@Beta
+@Deprecated
 public class SoftlyExtension implements AfterTestExecutionCallback, TestInstancePostProcessor {
 
   private static final Namespace SOFTLY_EXTENSION_NAMESPACE = Namespace.create(SoftlyExtension.class);

--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftlyExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftlyExtension.java
@@ -52,7 +52,8 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
  *   <li>May exhibit unpredictable behaviour in concurrent test execution</li>
  * </ol>
  * <p>
- * If you hit such limitations, consider using {@link SoftAssertionsExtension} instead.
+ * <i>If you hit such limitations, consider using {@link SoftAssertionsExtension} instead. Since 3.18.0, {@code SoftAssertionsExtension} supports
+ * field injection with neither of these two limitations.</i> 
  * <p>
  * Example:
  * <pre><code> {@literal @}ExtendWith(SoftlyExtension.class)
@@ -85,7 +86,8 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
  *   }
  * } </code></pre>
  * @author Arthur Mita
- * @deprecated This functionality has been rolled into {@link SoftAssertionsExtension}
+ * @deprecated This functionality (and more) has been rolled into {@link SoftAssertionsExtension}
+ * as of AssertJ 3.18.0.
  **/
 @Deprecated
 public class SoftlyExtension implements AfterTestExecutionCallback, TestInstancePostProcessor {

--- a/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertions.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertions.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import java.util.List;
+
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.core.api.ProxyableListAssert;
+
+class CustomSoftAssertions extends AbstractSoftAssertions {
+  public IntegerAssert expectThat(int value) {
+    return proxy(IntegerAssert.class, Integer.class, value);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> ProxyableListAssert<T> expectThat(List<? extends T> actual) {
+    return proxy(ProxyableListAssert.class, List.class, actual);
+  }
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
@@ -16,11 +16,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 
 import java.util.Arrays;
-import java.util.List;
 
-import org.assertj.core.api.AbstractSoftAssertions;
-import org.assertj.core.api.IntegerAssert;
-import org.assertj.core.api.ProxyableListAssert;
 import org.assertj.core.api.SoftAssertionsProvider;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -66,16 +62,7 @@ class CustomSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertion
     return TestInstancePerClassNestedExample.class;
   }
 
-  private static class CustomSoftAssertions extends AbstractSoftAssertions {
-    public IntegerAssert expectThat(int value) {
-      return proxy(IntegerAssert.class, Integer.class, value);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <T> ProxyableListAssert<T> expectThat(List<? extends T> actual) {
-      return proxy(ProxyableListAssert.class, List.class, actual);
-    }
-  }
+  
 
   // -------------------------------------------------------------------------
 

--- a/src/test/java/org/assertj/core/api/junit/jupiter/ExtensionInjector.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/ExtensionInjector.java
@@ -1,0 +1,22 @@
+package org.assertj.core.api.junit.jupiter;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+class ExtensionInjector implements ParameterResolver {
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext) throws ParameterResolutionException {
+    return parameterContext.getParameter().getType() == ExtensionContext.class;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+                                 ExtensionContext extensionContext) throws ParameterResolutionException {
+    return extensionContext;
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/InheritingSoftlyExtensionFieldTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/InheritingSoftlyExtensionFieldTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+@SuppressWarnings("deprecation")
 @DisplayName("SoftlyExtension inheriting SoftAssertions field")
 class InheritingSoftlyExtensionFieldTest extends WithSoftlyExtension {
 

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
@@ -13,9 +13,6 @@
 package org.assertj.core.api.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Lists.list;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
@@ -23,41 +20,22 @@ import static org.junit.platform.testkit.engine.EventConditions.test;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.assertj.core.api.AssertionErrorCollector;
+import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.assertj.core.api.BDDSoftAssertions;
 import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.SoftAssertionsProvider;
 import org.assertj.core.error.AssertJMultipleFailuresError;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
-import org.junit.platform.testkit.engine.EngineTestKit.Builder;
-import org.junit.platform.testkit.engine.Events;
 
 /**
  * Integration tests for the public API functions of {@link SoftAssertionsExtension}.
@@ -66,22 +44,6 @@ import org.junit.platform.testkit.engine.Events;
  * @since 3.18
  */
 class SoftAssertionsExtensionAPIIntegrationTest {
-
-  static class ExtensionInjector implements ParameterResolver {
-
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext,
-                                     ExtensionContext extensionContext) throws ParameterResolutionException {
-      return parameterContext.getParameter().getType() == ExtensionContext.class;
-    }
-
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext,
-                                   ExtensionContext extensionContext) throws ParameterResolutionException {
-      return extensionContext;
-    }
-
-  }
 
   @Disabled("Executed via the JUnit Platform Test Kit")
   @ExtendWith(ExtensionInjector.class)
@@ -115,8 +77,10 @@ class SoftAssertionsExtensionAPIIntegrationTest {
       SoftAssertions provider = SoftAssertionsExtension.getSoftAssertionsProvider(context, SoftAssertions.class);
       provider.assertThat(2).isEqualTo(2);
       assertThat(collector.assertionErrorsCollected()).as("after second").hasSize(2);
-      softly.expectThat(3).isEqualTo(4);
+      provider.assertThat(2).isEqualTo(1);
       assertThat(collector.assertionErrorsCollected()).as("after third").hasSize(3);
+      softly.expectThat(3).isEqualTo(4);
+      assertThat(collector.assertionErrorsCollected()).as("after fourth").hasSize(4);
     }
 
     @Test
@@ -141,25 +105,32 @@ class SoftAssertionsExtensionAPIIntegrationTest {
                  .configurationParameter("junit.jupiter.conditions.deactivate", "*")
                  .execute()
                  .testEvents()
-                 .debug()
                  .assertStatistics(stats -> stats.started(2).succeeded(0).failed(2))
                  .failed()
-                 .debug()
                  // @format:off
                  .assertThatEvents().haveExactly(1,
                                                  event(test("multipleFailuresCustom"),
                                                        finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class),
-                                                                           message(msg -> msg.contains("Multiple Failures (3 failures)")))))
+                                                                           message(msg -> msg.contains("Multiple Failures (4 failures)")))))
                                     .haveExactly(1,
                                                  event(test("multipleFailuresBDD"),
                                                        finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class),
                                                                            message(msg -> msg.contains("Multiple Failures (3 failures)")))));
                  // @format:on
-    List<AssertionError> collected = APITest.map.get("multipleFailuresCustom").assertionErrorsCollected();
-    assertThat(collected).as("size").hasSize(3);
-    assertThat(collected.get(0)).as("zero").hasMessageContaining("something").hasMessageContaining("nothing");
-    assertThat(collected.get(1)).as("one").hasMessageContaining("1").hasMessageContaining("0");
-    assertThat(collected.get(2)).as("two").hasMessageContaining("3").hasMessageContaining("4");
+    try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
+      List<AssertionError> collected = APITest.map.get("multipleFailuresCustom").assertionErrorsCollected();
+      softly.assertThat(collected).as("size").hasSize(4);
+      softly.assertThat(collected.get(0)).as("zero").hasMessageContaining("something").hasMessageContaining("nothing");
+      softly.assertThat(collected.get(1)).as("one").hasMessageContaining("1").hasMessageContaining("0");
+      softly.assertThat(collected.get(2)).as("two").hasMessageContaining("2").hasMessageContaining("1");
+      softly.assertThat(collected.get(3)).as("three").hasMessageContaining("3").hasMessageContaining("4");
+      
+      collected = APITest.map.get("multipleFailuresBDD").assertionErrorsCollected();
+      softly.assertThat(collected).as("size2").hasSize(3);
+      softly.assertThat(collected.get(0)).as("zero2").hasMessageContaining("something").hasMessageContaining("nothing");
+      softly.assertThat(collected.get(1)).as("one2").hasMessageContaining("1").hasMessageContaining("0");
+      softly.assertThat(collected.get(2)).as("two2").hasMessageContaining("3").hasMessageContaining("4");
+    }
   }
 
 }

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.AssertionErrorCollector;
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.assertj.core.error.AssertJMultipleFailuresError;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.EngineTestKit.Builder;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Integration tests for the public API functions of {@link SoftAssertionsExtension}.
+ *
+ * @author Fr Jeremy Krieg
+ * @since 3.18
+ */
+class SoftAssertionsExtensionAPIIntegrationTest {
+
+  static class ExtensionInjector implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext) throws ParameterResolutionException {
+      return parameterContext.getParameter().getType() == ExtensionContext.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext) throws ParameterResolutionException {
+      return extensionContext;
+    }
+
+  }
+
+  @Disabled("Executed via the JUnit Platform Test Kit")
+  @ExtendWith(ExtensionInjector.class)
+  @ExtendWith(SoftAssertionsExtension.class)
+  static class APITest {
+
+    static Map<String, AssertionErrorCollector> map = new HashMap<>();
+
+    @BeforeAll
+    static void beforeAll() {
+      map.clear();
+    }
+
+    @BeforeEach
+    void beforeEach(ExtensionContext context) {
+      SoftAssertions provider = SoftAssertionsExtension.getSoftAssertionsProvider(context, SoftAssertions.class);
+      assertThat(provider.assertionErrorsCollected()).isEmpty();
+      provider.assertThat("something").isEqualTo("nothing");
+      assertThat(provider.assertionErrorsCollected()).as("beforeEach:after assert").hasSize(1);
+      AssertionErrorCollector collector = SoftAssertionsExtension.getAssertionErrorCollector(context);
+      assertThat(provider.getDelegate()).contains(collector);
+      map.put(context.getTestMethod().get().getName(), collector);
+    }
+
+    @Test
+    void multipleFailuresCustom(ExtensionContext context, CustomSoftAssertions softly) {
+      AssertionErrorCollector collector = SoftAssertionsExtension.getAssertionErrorCollector(context);
+      assertThat(collector.assertionErrorsCollected()).as("init").hasSize(1);
+      softly.expectThat(1).isEqualTo(0);
+      assertThat(collector.assertionErrorsCollected()).as("after first").hasSize(2);
+      SoftAssertions provider = SoftAssertionsExtension.getSoftAssertionsProvider(context, SoftAssertions.class);
+      provider.assertThat(2).isEqualTo(2);
+      assertThat(collector.assertionErrorsCollected()).as("after second").hasSize(2);
+      softly.expectThat(3).isEqualTo(4);
+      assertThat(collector.assertionErrorsCollected()).as("after third").hasSize(3);
+    }
+
+    @Test
+    void multipleFailuresBDD(ExtensionContext context, BDDSoftAssertions softly) {
+      AssertionErrorCollector collector = SoftAssertionsExtension.getAssertionErrorCollector(context);
+      assertThat(collector.assertionErrorsCollected()).as("init").hasSize(1);
+      softly.then(1).isEqualTo(0);
+      assertThat(collector.assertionErrorsCollected()).as("after first").hasSize(2);
+      CustomSoftAssertions provider = SoftAssertionsExtension.getSoftAssertionsProvider(context, CustomSoftAssertions.class);
+      provider.expectThat(2).isEqualTo(2);
+      assertThat(collector.assertionErrorsCollected()).as("after second").hasSize(2);
+      softly.then(3).isEqualTo(4);
+      assertThat(collector.assertionErrorsCollected()).as("after third").hasSize(3);
+    }
+
+  }
+
+  @Test
+  void apiTest() {
+    EngineTestKit.engine("junit-jupiter")
+                 .selectors(selectClass(APITest.class))
+                 .configurationParameter("junit.jupiter.conditions.deactivate", "*")
+                 .execute()
+                 .testEvents()
+                 .debug()
+                 .assertStatistics(stats -> stats.started(2).succeeded(0).failed(2))
+                 .failed()
+                 .debug()
+                 // @format:off
+                 .assertThatEvents().haveExactly(1,
+                                                 event(test("multipleFailuresCustom"),
+                                                       finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class),
+                                                                           message(msg -> msg.contains("Multiple Failures (3 failures)")))))
+                                    .haveExactly(1,
+                                                 event(test("multipleFailuresBDD"),
+                                                       finishedWithFailure(instanceOf(AssertJMultipleFailuresError.class),
+                                                                           message(msg -> msg.contains("Multiple Failures (3 failures)")))));
+                 // @format:on
+    List<AssertionError> collected = APITest.map.get("multipleFailuresCustom").assertionErrorsCollected();
+    assertThat(collected).as("size").hasSize(3);
+    assertThat(collected.get(0)).as("zero").hasMessageContaining("something").hasMessageContaining("nothing");
+    assertThat(collected.get(1)).as("one").hasMessageContaining("1").hasMessageContaining("0");
+    assertThat(collected.get(2)).as("two").hasMessageContaining("3").hasMessageContaining("4");
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_InjectionSanityChecking_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_InjectionSanityChecking_Test.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.junit.jupiter.TestKitUtils.assertThatTest;
+
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.SoftAssertionsProvider;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+
+@DisplayName("SoftAssertionsExtension injection sanity checking test")
+class SoftAssertionsExtension_InjectionSanityChecking_Test {
+
+  @ExtendWith(SoftAssertionsExtension.class)
+  static private class TestBase {
+    @Test
+    void myTest() {}
+  }
+
+  class NoDefaultSoftAssertionsProvider extends AbstractSoftAssertions implements SoftAssertionsProvider {
+    public NoDefaultSoftAssertionsProvider(String param) {}
+  }
+
+  @Disabled("Run by the testkit")
+  static class NoDefaultConstructorTest extends TestBase {
+    @InjectSoftAssertions
+    NoDefaultSoftAssertionsProvider usp;
+  }
+
+  @Test
+  void field_with_no_default_constructor_throws_exception() {
+    assertThatTest(NoDefaultConstructorTest.class).isInstanceOf(ExtensionConfigurationException.class)
+                                                  .hasMessage("[usp] SoftAssertionsProvider [%s] does not have a default constructor", NoDefaultSoftAssertionsProvider.class.getName());
+  }
+
+  static abstract class AbstractProvider implements SoftAssertionsProvider {
+  }
+
+  @Disabled("Run by the testkit")
+  static class AbstractProviderTest extends TestBase {
+    @InjectSoftAssertions
+    AbstractProvider usp;
+  }
+
+  @Test
+  void field_with_abstract_provider_throws_exception() {
+    assertThatTest(AbstractProviderTest.class).isInstanceOf(ExtensionConfigurationException.class)
+                                              .hasMessage("[usp] SoftAssertionsProvider [%s] is abstract and cannot be instantiated.", AbstractProvider.class);
+  }
+
+  @Disabled("Run by the testkit")
+  static class FinalField extends TestBase {
+    @InjectSoftAssertions
+    final SoftAssertions usp = null;
+
+    @Override
+    @Test
+    void myTest() {}
+  }
+
+  @Test
+  void final_field__throws_exception() {
+    assertThatTest(FinalField.class).isInstanceOf(ExtensionConfigurationException.class)
+                                    .hasMessageMatching("\\[usp\\] SoftAssertionsProvider field must not be .*final.*");
+  }
+
+  @Disabled("Run by the testkit")
+  static class StaticField extends TestBase {
+    @InjectSoftAssertions
+    static SoftAssertions usp = null;
+
+    @Override
+    @Test
+    void myTest() {}
+  }
+
+  @Test
+  void static_field_throws_exception() {
+    assertThatTest(StaticField.class).isInstanceOf(ExtensionConfigurationException.class)
+                                     .hasMessageMatching("\\[usp\\] SoftAssertionsProvider field must not be .*static.*");
+  }
+
+
+  @Disabled("Run by the testkit")
+  static class WrongType extends TestBase {
+    @InjectSoftAssertions
+    String usp;
+
+    @Override
+    @Test
+    void myTest() {}
+  }
+
+  @Test
+  void wrong_type_throws_exception() {
+    assertThatTest(WrongType.class).isInstanceOf(ExtensionConfigurationException.class)
+                                     .hasMessageMatching("\\[usp\\] field is not a SoftAssertionsProvider [(]java.lang.String[)].");
+  }
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_Injection_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_Injection_Test.java
@@ -14,26 +14,50 @@ package org.assertj.core.api.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.assertj.core.api.BDDSoftAssertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@SuppressWarnings("deprecation")
-@ExtendWith(SoftlyExtension.class)
-@DisplayName("SoftlyExtension")
-class SoftlyExtensionTest {
+@ExtendWith(SoftAssertionsExtension.class)
+@DisplayName("SoftAssertionsExtension injection test")
+class SoftAssertionsExtension_Injection_Test {
 
-  private SoftAssertions softly;
+  // I've used a mix of private and package-private here to test behaviour in the
+  // variety of different circumstances.  
+  @InjectSoftAssertions
+  SoftAssertions softly;
 
+  @InjectSoftAssertions
+  private BDDSoftAssertions deftly;
+  
+  SoftAssertions unannotated;
+  
   @Test
   void should_pass_if_not_null() {
     assertThat(softly).isNotNull();
   }
 
+  @Test
+  void bdd_should_pass_if_not_null() {
+    assertThat(deftly).isNotNull();
+    assertThat(deftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+
+  @Test
+  void should_have_same_collector_as_parameter(CustomSoftAssertions custom) {
+    assertThat(custom.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+  
+  @Test
+  void should_not_inject_into_unannotated_field() {
+    assertThat(unannotated).isNull();
+  }
+  
   @Nested
-  @ExtendWith(SoftlyExtension.class)
+  @ExtendWith(SoftAssertionsExtension.class)
   @DisplayName("nested test class without SoftAssertions field")
   class NestedMethodLifecycle {
 
@@ -44,15 +68,17 @@ class SoftlyExtensionTest {
   }
 
   @Nested
-  @ExtendWith(SoftlyExtension.class)
+  @ExtendWith(SoftAssertionsExtension.class)
   @DisplayName("nested test class with SoftAssertions field")
   class SoftlyNestedMethodLifecycle {
 
-    private SoftAssertions nestedSoftly;
+    @InjectSoftAssertions
+    SoftAssertions nestedSoftly;
 
     @Test
     void should_use_own_SoftAssertions_initialized_field() {
       assertThat(nestedSoftly).isNotNull();
+      assertThat(nestedSoftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
     }
 
   }

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
@@ -1,0 +1,116 @@
+package org.assertj.core.api.junit.jupiter;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.AssertionErrorCollector;
+import org.assertj.core.api.AutoCloseableSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+@DisplayName("SoftAssertionsExtension PER_CLASS concurrent injection test")
+public class SoftAssertionsExtension_PER_CLASS_Concurrency_Test {
+  // Use CountDownLatches to synchronize between the
+  // two parallel running tests to make sure that they
+  // overlap in time.
+  @Disabled("Run by the testkit")
+  @ExtendWith(SoftAssertionsExtension.class)
+  @ExtendWith(ExtensionInjector.class)
+  @Execution(ExecutionMode.CONCURRENT)
+  @TestInstance(Lifecycle.PER_CLASS)
+  static class ConcurrencyTest {
+
+    @InjectSoftAssertions
+    SoftAssertions softly;
+
+    static CountDownLatch[] flags = new CountDownLatch[6];
+    static Map<String, AssertionErrorCollector> map = new HashMap<>();
+
+    @BeforeAll
+    static void beforeAll() {
+      map.clear();
+      for (int i = 0; i < flags.length; i++) {
+        flags[i] = new CountDownLatch(1);
+      }
+    }
+
+    @BeforeEach
+    void beforeEach(ExtensionContext context) {
+      map.put(context.getTestMethod().get().getName(), SoftAssertionsExtension.getAssertionErrorCollector(context));
+    }
+
+    static void waitForFlag(int flagNum) {
+      try {
+        if (!flags[flagNum].await(5000, TimeUnit.MILLISECONDS)) {
+          throw new IllegalStateException("Timed out while waiting for flag " + flagNum);
+        }
+      } catch (InterruptedException e) {
+        throw new IllegalStateException("Interrupted while waiting for flag " + flagNum, e);
+      }
+    }
+
+    @Test
+    void test1(ExtensionContext context) {
+      softly.assertThat(1).isEqualTo(0);
+      flags[0].countDown();
+      waitForFlag(1);
+      softly.assertThat(3).isEqualTo(4);
+      flags[2].countDown();
+      waitForFlag(3);
+      softly.assertThat(5).isEqualTo(6);
+      map.put(context.getTestMethod().get().getName(), SoftAssertionsExtension.getAssertionErrorCollector(context));
+    }
+
+    @Test
+    void test2(ExtensionContext context) throws InterruptedException {
+      waitForFlag(0);
+      softly.assertThat(2).isEqualTo(1);
+      flags[1].countDown();
+      waitForFlag(2);
+      softly.assertThat(4).isEqualTo(5);
+      flags[3].countDown();
+    }
+  }
+
+  @Test
+  void concurrent_tests_with_explicit_per_class_annotation_do_not_interfere() {
+    EngineTestKit.engine("junit-jupiter")
+                 .selectors(selectClass(ConcurrencyTest.class))
+                 .configurationParameter("junit.jupiter.conditions.deactivate", "*")
+                 .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+                 .execute()
+                 .testEvents()
+                 .debug(System.err)
+                 .assertStatistics(stats -> stats.started(2).succeeded(0).failed(2))
+                 .failed();
+    
+    try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
+      List<AssertionError> collected = ConcurrencyTest.map.get("test1").assertionErrorsCollected();
+      softly.assertThat(collected).as("size").hasSize(3);
+      softly.assertThat(collected.get(0)).as("zero").hasMessageContaining("1").hasMessageContaining("0");
+      softly.assertThat(collected.get(1)).as("one").hasMessageContaining("3").hasMessageContaining("4");
+      softly.assertThat(collected.get(2)).as("two").hasMessageContaining("5").hasMessageContaining("6");
+        
+      collected = ConcurrencyTest.map.get("test2").assertionErrorsCollected();
+      softly.assertThat(collected).as("size2").hasSize(2);
+      softly.assertThat(collected.get(0)).as("zero2").hasMessageContaining("2").hasMessageContaining("1");
+      softly.assertThat(collected.get(1)).as("one2").hasMessageContaining("4").hasMessageContaining("5");
+    }
+  }
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Injection_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Injection_Test.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@ExtendWith(SoftAssertionsExtension.class)
+@DisplayName("SoftAssertionsExtension PER_CLASS injection test")
+@TestInstance(Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.SAME_THREAD) // Just in case we move to parallel threads in the future
+class SoftAssertionsExtension_PER_CLASS_Injection_Test {
+
+  // I've used a mix of private and package-private here to test behaviour in the
+  // variety of different circumstances.
+  @InjectSoftAssertions
+  SoftAssertions softly;
+
+  @InjectSoftAssertions
+  private BDDSoftAssertions deftly;
+
+  SoftAssertions unannotated;
+
+  @Test
+  void should_pass_if_not_null() {
+    assertThat(softly).isNotNull();
+  }
+
+  @Test
+  void bdd_should_pass_if_not_null() {
+    assertThat(deftly).isNotNull();
+    assertThat(deftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+
+  @Test
+  void should_have_same_collector_as_parameter(CustomSoftAssertions custom) {
+    assertThat(custom.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+
+  @Test
+  void should_not_inject_into_unannotated_field() {
+    assertThat(unannotated).isNull();
+  }
+
+  @Nested
+  @ExtendWith(SoftAssertionsExtension.class)
+  @DisplayName("nested test class without SoftAssertions field")
+  class NestedMethodLifecycle {
+
+    @Test
+    void should_use_parent_SoftAssertions_initialized_field() {
+      assertThat(softly).isNotNull();
+    }
+  }
+
+  @Nested
+  @ExtendWith(SoftAssertionsExtension.class)
+  @DisplayName("nested test class with SoftAssertions field")
+  class SoftlyNestedMethodLifecycle {
+
+    @InjectSoftAssertions
+    SoftAssertions nestedSoftly;
+
+    @Test
+    void should_use_own_SoftAssertions_initialized_field() {
+      assertThat(nestedSoftly).isNotNull();
+      assertThat(nestedSoftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
+    }
+
+  }
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftlyAssertionsExtensionIntegrationTest.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftlyAssertionsExtensionIntegrationTest.java
@@ -39,6 +39,7 @@ import org.junit.platform.testkit.engine.EventType;
 /**
  * Integration tests for {@link SoftlyExtension}.
  */
+@SuppressWarnings("deprecation")
 @DisplayName("JUnit Jupiter SoftlyExtension integration tests")
 class SoftlyAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 

--- a/src/test/java/org/assertj/core/api/junit/jupiter/TestKitUtils.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/TestKitUtils.java
@@ -1,0 +1,71 @@
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventType.FINISHED;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+public class TestKitUtils {
+
+	private TestKitUtils() {}
+
+	public static void checkClass(Class<?> testClass) {
+		// This is to protect against developer slip-ups that can be costly...
+		if (!Modifier.isStatic(testClass.getModifiers())) {
+			throw new IllegalStateException(
+				"Test class is not static: "
+					+ testClass);
+		}
+	}
+
+	public static AbstractThrowableAssert<?, ? extends Throwable> assertThatTest(Class<?> testClass, String... config) {
+		checkClass(testClass);
+
+		Logger logger = Logger.getLogger("org.junit.jupiter");
+		Level oldLevel = logger.getLevel();
+		try {
+			// Suppress log output while the testkit is running
+			logger.setLevel(Level.OFF);
+			EngineTestKit.Builder builder = EngineTestKit.engine(new JupiterTestEngine())
+				.selectors(selectClass(testClass))
+        .configurationParameter("junit.jupiter.conditions.deactivate", "*");
+			
+			if (config != null) {
+			  if (config.length % 2 != 0) {
+			    throw new IllegalStateException("Odd number of config parameters provided: " + Arrays.toString(config));
+			  }
+	      for (int i = 0; i < config.length; i++) {
+	        builder.configurationParameter(config[i++], config[i]);
+	      }
+			}
+			
+			Event testEvent = builder
+				.execute()
+				.allEvents()
+				.filter(event -> event.getType()
+					.equals(FINISHED))
+				.findAny()
+				.orElseThrow(() -> new IllegalStateException("Test failed to run at all"));
+
+			TestExecutionResult result = testEvent.getPayload(TestExecutionResult.class)
+				.orElseThrow(() -> new IllegalStateException("Test result payload missing"));
+
+			return assertThat(result.getThrowable()
+				.orElse(null));
+		} finally {
+			// Restore the filter to what it was so that we do not interfere
+			// with the parent test
+			logger.setLevel(oldLevel);
+		}
+	}
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/WithSoftlyExtension.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/WithSoftlyExtension.java
@@ -15,6 +15,7 @@ package org.assertj.core.api.junit.jupiter;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+@SuppressWarnings("deprecation")
 @ExtendWith(SoftlyExtension.class)
 class WithSoftlyExtension {
 


### PR DESCRIPTION
Here is an implementation of #1970. It depends on #1977. 

@joel-costigliola , I know you asked for two separate PRs. I found this a bit unworkable as the functionality changes for `SoftAssertionsExtension` depended on the API change. However, I at least added them as two separate commits in this PR so that you can still review them separately if you wish - I hope that's ok. If you still really want separate PRs, I'll see what I can do (it's more work, that's all).

#### Check List:
* Fixes #1970 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NOT YET - I anticipate possible changes to the implementation as part of the review process that might alter the API; prefer to wait for that process to finish before proceeding.

#### Feature divergence from SoftlyExtension

Some of the features of the proposed field injection diverge from the implementation in `SoftlyExtension`. The intent is for these divergences to be seen as enhancements, but I'm open to other opinions. :smile:

* `PER_CLASS` lifecycle support: Unlike `SoftlyExtension` (which uses the instance creation callback to construct the soft assertions instance), this implementation uses the `BeforeEachCallback` hook to do the injection. This means that the restriction on test class lifecycle in `SoftlyExtension` to prohibit use with `PER_CLASS` lifecycle semantics can be (and has been) lifted.
* Unlike `SoftlyExtension`, multiple `SoftAssertionsProvider` instances are supported. Errors from the multiple providers will be aggregated, in-order, into the same base error collector class, so that when the extension asserts after the test has run it will contain all assertion failures registered against all soft assertions providers in the order that they were executed. The same is true if you mix parameter injection with field injection. This is, I think, a big improvement over what we've had up until now, courtesy of the `AssertionErrorCollector` abstraction and the use of the delegate feature.
* `SoftAssertionsExtension` will refuse to inject into a field that is private, final or static. This follows a policy set by the Jupiter implementation. However, strictly it is a departure from `SoftlyExtension` which allowed injection on final or private fields.

Most of the changes are backwards compatible. Those that aren't I'm not too concerned about, as `SoftlyAssertion`, is still marked as beta. 

#### Known issues/for discussion

* `PER_CLASS` will not mix well with `CONCURRENT` execution mode. At the moment there is no check. I have raised junit-team/junit5/issues/2396 to discuss this. Failing any progress on that point (and for earlier versions of JUnit), there is an alternative I can look at to try and do this kind of sanity check.
* Pending the above issue, it may also be possible to allow injection into a `ThreadLocal<? extends SoftAssertion>` instance if you are combining `PER_CLASS` and `CONCURRENT`.
* With the current implementation, if you annotate a nested class with `SoftAssertionsExtension`, it will also try and inject into all of the enclosing instances if they have a `SoftAssertionsProvider` field present. This is true even if the enclosing types are not annotated with `SoftAssertionsExtension`. This was necessary to make the test class (which I ported from `SoftlyExtension
* The current implementation is technically a breaking change, as any existing classes that use the extension and have a `SoftAssertionsProvider` field will suddenly find the extension attempting to inject into it whereas before it didn't. Worse, in cases where you may have marked the field as static, final or private, the test will suddenly start to fail with a complaint about this. I'm not sure how widespread these usage patterns are to know whether or not this is a major concern. If it is, there are a couple of possible workarounds:
** Don't attempt to set the field if it is not null. This approach will not work with `PER_CLASS` functionality though.
** Require an annotation on the field to flag it as being for injection. This is the approach we settled on in osgi-test and it seems to work well (eg, to inject a `BundleContext` instance using the `BundleContextExtension`, it is necessary to annotate it with `@InjectBundleContext`) - allowing people to mix their own soft assertions fields with ones intended for injection. It is a little more verbose on the usage side, however.
* `AssertionErrorCollector.getDelegate()` currently returns `Optional<AssertionErrorCollector>`, not sure if it would be better to return `AssertionErrorCollector`.
* Should `SoftlyExtension` be deprecated in favour of this new functionality?