### PR TITLE
SonarCloud fixes for SoftAssertionsExtension

### DIFF
--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
@@ -268,8 +268,8 @@ public class SoftAssertionsExtension
       tlec.setDelegate(collector);
     } else {
       // Make sure that all of the soft assertion provider instances have their delegate initialised to the assertion error
-      // collector for the current context. Also check parents (in the case of nested tests).
-      while (initialiseDelegate(context, collector)) {
+      // collector for the current context. Also check enclosing contexts (in the case of nested tests).
+      while (initialiseDelegate(context, collector) && context.getParent().isPresent()) {
         context = context.getParent().get();
       }
     }
@@ -324,8 +324,7 @@ public class SoftAssertionsExtension
     AssertionErrorCollector collector;
     if (isPerClassConcurrent(extensionContext)) {
       ThreadLocalErrorCollector tlec = getThreadLocalCollector(extensionContext);
-      collector = tlec.getDelegate().get();
-      // Clear the tlec just in case this thread gets re-used.
+      collector = tlec.getDelegate().orElseThrow(() -> new IllegalStateException("Expecting delegate to be present for current context"));
       tlec.reset();
     } else {
       collector = getAssertionErrorCollector(extensionContext);

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_InjectionSanityChecking_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_InjectionSanityChecking_Test.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 class SoftAssertionsExtension_InjectionSanityChecking_Test {
 
   @ExtendWith(SoftAssertionsExtension.class)
-  static private class TestBase {
+  static abstract class TestBase {
     @Test
     void myTest() {}
   }


### PR DESCRIPTION
None of these were bugs in practice, but it is easy to keep SonarCloud happy so let's do it. That way real bugs won't be masked by the false alarms.

In particular, the alleged bug in the sanity checking test - that the test class was private - was actually intentional so that JUnit 5 *wouldn't* run it directly - it was meant to be run via its subclasses. Made it abstract instead which achieves the same thing.